### PR TITLE
Update Bluetooth remote config entries if the MAC is corrected

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -318,6 +318,7 @@ async def async_update_device(
     # so if the address has been corrected, make
     # sure the device entry reflects the correct
     # address
+    _LOGGER.warning("Update devices: %s", details)
     for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
         for conn_type, conn_value in device.connections:
             if conn_type == dr.CONNECTION_BLUETOOTH and conn_value != address:

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -318,7 +318,6 @@ async def async_update_device(
     # so if the address has been corrected, make
     # sure the device entry reflects the correct
     # address
-    _LOGGER.warning("Update devices: %s", details)
     for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
         for conn_type, conn_value in device.connections:
             if conn_type == dr.CONNECTION_BLUETOOTH and conn_value != address:

--- a/homeassistant/components/bluetooth/config_flow.py
+++ b/homeassistant/components/bluetooth/config_flow.py
@@ -186,11 +186,12 @@ class BluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by an external scanner."""
         source = user_input[CONF_SOURCE]
         await self.async_set_unique_id(source)
+        source_config_entry_id = user_input[CONF_SOURCE_CONFIG_ENTRY_ID]
         data = {
             CONF_SOURCE: source,
             CONF_SOURCE_MODEL: user_input[CONF_SOURCE_MODEL],
             CONF_SOURCE_DOMAIN: user_input[CONF_SOURCE_DOMAIN],
-            CONF_SOURCE_CONFIG_ENTRY_ID: user_input[CONF_SOURCE_CONFIG_ENTRY_ID],
+            CONF_SOURCE_CONFIG_ENTRY_ID: source_config_entry_id,
             CONF_SOURCE_DEVICE_ID: user_input[CONF_SOURCE_DEVICE_ID],
         }
         self._abort_if_unique_id_configured(updates=data)
@@ -198,8 +199,7 @@ class BluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
             # If the mac address needs to be corrected, migrate
             # the config entry to the new mac address
             if (
-                entry.data.get(CONF_SOURCE_CONFIG_ENTRY_ID)
-                == user_input[CONF_SOURCE_CONFIG_ENTRY_ID]
+                entry.data.get(CONF_SOURCE_CONFIG_ENTRY_ID) == source_config_entry_id
                 and entry.unique_id != source
             ):
                 self.hass.config_entries.async_update_entry(
@@ -207,8 +207,7 @@ class BluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
                 self.hass.config_entries.async_schedule_reload(entry.entry_id)
                 return self.async_abort(reason="already_configured")
-        manager = get_manager()
-        scanner = manager.async_scanner_by_source(source)
+        scanner = get_manager().async_scanner_by_source(source)
         assert scanner is not None
         return self.async_create_entry(title=scanner.name, data=data)
 

--- a/homeassistant/components/bluetooth/config_flow.py
+++ b/homeassistant/components/bluetooth/config_flow.py
@@ -205,6 +205,7 @@ class BluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.hass.config_entries.async_update_entry(
                     entry, unique_id=source, data={**entry.data, **data}
                 )
+                self.hass.config_entries.async_schedule_reload(entry.entry_id)
                 return self.async_abort(reason="already_configured")
         manager = get_manager()
         scanner = manager.async_scanner_by_source(source)

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -3273,30 +3273,54 @@ async def test_title_updated_if_mac_address(
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
-async def test_cleanup_orphened_remote_scanner_config_entry(
+async def test_fix_incorrect_mac_remote_scanner_config_entry(
     hass: HomeAssistant,
 ) -> None:
-    """Test the remote scanner config entries get cleaned up when orphened."""
+    """Test the remote scanner config entries can replace a incorrect mac."""
+    source_entry = MockConfigEntry(domain="test")
+    source_entry.add_to_hass(hass)
     connector = (
         HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
     )
-    scanner = FakeRemoteScanner("esp32", "esp32", connector, True)
-
+    scanner = FakeRemoteScanner("AA:BB:CC:DD:EE:FF", "esp32", connector, True)
+    assert scanner.source == "AA:BB:CC:DD:EE:FF"
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_SOURCE: scanner.source,
             CONF_SOURCE_DOMAIN: "test",
             CONF_SOURCE_MODEL: "test",
-            CONF_SOURCE_CONFIG_ENTRY_ID: "no_longer_exists",
+            CONF_SOURCE_CONFIG_ENTRY_ID: source_entry.entry_id,
         },
         unique_id=scanner.source,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    assert hass.config_entries.async_entry_for_domain_unique_id(
+        "bluetooth", scanner.source
+    )
+    await hass.config_entries.async_unload(entry.entry_id)
 
-    # Orphened remote scanner config entry should be cleaned up
+    new_scanner = FakeRemoteScanner("AA:BB:CC:DD:EE:AA", "esp32", connector, True)
+    assert new_scanner.source == "AA:BB:CC:DD:EE:AA"
+    new_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SOURCE: new_scanner.source,
+            CONF_SOURCE_DOMAIN: "test",
+            CONF_SOURCE_MODEL: "test",
+            CONF_SOURCE_CONFIG_ENTRY_ID: source_entry.entry_id,
+        },
+        unique_id=scanner.source,
+    )
+    new_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(new_entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.config_entries.async_entry_for_domain_unique_id(
+        "bluetooth", new_scanner.source
+    )
+    # Incorrect connection should be removed
     assert not hass.config_entries.async_entry_for_domain_unique_id(
         "bluetooth", scanner.source
     )

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -3304,18 +3304,13 @@ async def test_fix_incorrect_mac_remote_scanner_config_entry(
 
     new_scanner = FakeRemoteScanner("AA:BB:CC:DD:EE:AA", "esp32", connector, True)
     assert new_scanner.source == "AA:BB:CC:DD:EE:AA"
-    new_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_SOURCE: new_scanner.source,
-            CONF_SOURCE_DOMAIN: "test",
-            CONF_SOURCE_MODEL: "test",
-            CONF_SOURCE_CONFIG_ENTRY_ID: source_entry.entry_id,
-        },
-        unique_id=scanner.source,
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, CONF_SOURCE: new_scanner.source},
+        unique_id=new_scanner.source,
     )
-    new_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(new_entry.entry_id)
+
+    await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     assert hass.config_entries.async_entry_for_domain_unique_id(
         "bluetooth", new_scanner.source


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
ESPHome and Shelly currently pass the network (WiFi or Ethernet) MAC address to `bluetooth` because we didn't have the Bluetooth MAC.  Now that both integrations will have a way to get the Bluetooth MAC, the MAC needs to be migrated to the correct mac before we bump the libs that will cause the MAC addresses to change when registering the scanners to avoid having orphaned devices.  Update the `bluetooth` integration to be able to do that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
