### PR TITLE
Fix alert not respecting can_acknowledge setting

### DIFF
--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -195,14 +195,12 @@ class AlertEntity(Entity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Async Acknowledge alert."""
-        if self._can_ack:
-            LOGGER.debug("Acknowledged Alert: %s", self._attr_name)
-            self._ack = True
-            self.async_write_ha_state()
-        else:
+        if not self._can_ack:
             raise ServiceValidationError(
                 "Cannot acknowledge alert with can_acknowledge set to False"
             )
+        self._ack = True
+        self.async_write_ha_state()
 
     async def async_toggle(self, **kwargs: Any) -> None:
         """Async toggle alert."""

--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -200,7 +200,7 @@ class AlertEntity(Entity):
             self._ack = True
             self.async_write_ha_state()
         else:
-            LOGGER.debug("Alert Acknowledgement Blocked: %s", self._attr_name)
+            LOGGER.warning("Alert Acknowledgement Blocked: %s", self._attr_name)
 
     async def async_toggle(self, **kwargs: Any) -> None:
         """Async toggle alert."""

--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -196,9 +196,7 @@ class AlertEntity(Entity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Async Acknowledge alert."""
         if not self._can_ack:
-            raise ServiceValidationError(
-                "This alert cannot be acknowledged"
-            )
+            raise ServiceValidationError("This alert cannot be acknowledged")
         self._ack = True
         self.async_write_ha_state()
 

--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -195,9 +195,12 @@ class AlertEntity(Entity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Async Acknowledge alert."""
-        LOGGER.debug("Acknowledged Alert: %s", self._attr_name)
-        self._ack = True
-        self.async_write_ha_state()
+        if self._can_ack:
+            LOGGER.debug("Acknowledged Alert: %s", self._attr_name)
+            self._ack = True
+            self.async_write_ha_state()
+        else:
+            LOGGER.debug("Alert Acknowledgement Blocked: %s", self._attr_name)
 
     async def async_toggle(self, **kwargs: Any) -> None:
         """Async toggle alert."""

--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -197,7 +197,7 @@ class AlertEntity(Entity):
         """Async Acknowledge alert."""
         if not self._can_ack:
             raise ServiceValidationError(
-                "Cannot acknowledge alert with can_acknowledge set to False"
+                "This alert cannot be acknowledged"
             )
         self._ack = True
         self.async_write_ha_state()

--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -14,7 +14,7 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import STATE_IDLE, STATE_OFF, STATE_ON
 from homeassistant.core import Event, EventStateChangedData, HassJob, HomeAssistant
-from homeassistant.exceptions import ServiceNotFound
+from homeassistant.exceptions import ServiceNotFound, ServiceValidationError
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_point_in_time,
@@ -200,7 +200,9 @@ class AlertEntity(Entity):
             self._ack = True
             self.async_write_ha_state()
         else:
-            LOGGER.warning("Alert Acknowledgement Blocked: %s", self._attr_name)
+            raise ServiceValidationError(
+                "Cannot acknowledge alert with can_acknowledge set to False"
+            )
 
     async def async_toggle(self, **kwargs: Any) -> None:
         """Async toggle alert."""

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockEntityPlatform, async_mock_service
@@ -132,12 +133,13 @@ async def test_silence_can_acknowledge_false(hass: HomeAssistant) -> None:
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
     # Attempt to acknowledge
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: ENTITY_ID},
-        blocking=True,
-    )
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
     await hass.async_block_till_done()
 
     # The state should still be ON because can_acknowledge=False

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -116,6 +116,34 @@ async def test_silence(hass: HomeAssistant, mock_notifier: list[ServiceCall]) ->
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
 
+async def test_silence_can_acknowledge_false(hass: HomeAssistant) -> None:
+    """Test that attempting to silence an alert with can_acknowledge=False will not silence."""
+    # Create copy of config where can_acknowledge is False
+    config = deepcopy(TEST_CONFIG)
+    config[DOMAIN][NAME]["can_acknowledge"] = False
+
+    # Setup the alert component
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    # Ensure the alert is currently on
+    hass.states.async_set(ENTITY_ID, STATE_ON)
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_ID).state == STATE_ON
+
+    # Attempt to acknowledge
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # The state should still be ON because can_acknowledge=False
+    assert hass.states.get(ENTITY_ID).state == STATE_ON
+
+
 async def test_reset(hass: HomeAssistant, mock_notifier: list[ServiceCall]) -> None:
     """Test resetting the alert."""
     assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The alert component was not respecting the `can_acknowledge` property. This PR adds a check for that prior to acking the alert
Fixes #139481 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #139481 

### Testing / Validation
```yaml
test_alert_ackable:
  name: Test Alert Ackable
  entity_id: input_boolean.test_alerting
  repeat: 1
  can_acknowledge: true

test_alert_not_ackable:
  name: Test Alert Not Ackable
  entity_id: input_boolean.test_alerting
  repeat: 1
  can_acknowledge: false
```

```yaml
type: grid
cards:
  - type: tile
    entity: alert.test_alert_ackable
    tap_action:
      action: toggle
  - type: tile
    entity: alert.test_alert_not_ackable
    tap_action:
      action: toggle
  - type: tile
    entity: input_boolean.test_alerting
    tap_action:
      action: toggle
```
Following screen recordings show that the "Can Ack" entity can still be acked while the "Can't Ack" can't. Also shows that they both still respect the input helper driving their alert status. There is two copies of the alerts so that you can see that "can't ack" never actually gets acked and the toggle showing it as off is only the visual assuming the call would work.
![before](https://github.com/user-attachments/assets/eb2a04a2-ab6a-42a4-b832-ca23620b2bd9)
![after](https://github.com/user-attachments/assets/53525a39-5653-40e9-9d8f-6721d75c9a87)


New Pytest with old code:
![image](https://github.com/user-attachments/assets/51f026f7-a8da-4081-921c-d530d888c719)

New Pytest with new code:
![image](https://github.com/user-attachments/assets/5e36169b-b76b-486a-8f26-e97462e20ad2)



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
