### PR TITLE
Fail recorder.backup.async_pre_backup if Home Assistant is not running

### DIFF
--- a/homeassistant/components/recorder/backup.py
+++ b/homeassistant/components/recorder/backup.py
@@ -2,7 +2,7 @@
 
 from logging import getLogger
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from .util import async_migration_in_progress, get_instance
@@ -14,6 +14,8 @@ async def async_pre_backup(hass: HomeAssistant) -> None:
     """Perform operations before a backup starts."""
     _LOGGER.info("Backup start notification, locking database for writes")
     instance = get_instance(hass)
+    if hass.state is not CoreState.running:
+        raise HomeAssistantError("Home Assistant is not running")
     if async_migration_in_progress(hass):
         raise HomeAssistantError("Database migration in progress")
     await instance.lock_database()

--- a/tests/components/recorder/test_backup.py
+++ b/tests/components/recorder/test_backup.py
@@ -1,12 +1,13 @@
 """Test backup platform for the Recorder integration."""
 
+from contextlib import AbstractContextManager, nullcontext as does_not_raise
 from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.backup import async_post_backup, async_pre_backup
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 
@@ -17,6 +18,41 @@ async def test_async_pre_backup(recorder_mock: Recorder, hass: HomeAssistant) ->
     ) as lock_mock:
         await async_pre_backup(hass)
         assert lock_mock.called
+
+
+RAISES_HASS_NOT_RUNNING = pytest.raises(
+    HomeAssistantError, match="Home Assistant is not running"
+)
+
+
+@pytest.mark.parametrize(
+    ("core_state", "expected_result", "lock_calls"),
+    [
+        (CoreState.final_write, RAISES_HASS_NOT_RUNNING, 0),
+        (CoreState.not_running, RAISES_HASS_NOT_RUNNING, 0),
+        (CoreState.running, does_not_raise(), 1),
+        (CoreState.starting, RAISES_HASS_NOT_RUNNING, 0),
+        (CoreState.stopped, RAISES_HASS_NOT_RUNNING, 0),
+        (CoreState.stopping, RAISES_HASS_NOT_RUNNING, 0),
+    ],
+)
+async def test_async_pre_backup_core_state(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    core_state: CoreState,
+    expected_result: AbstractContextManager,
+    lock_calls: int,
+) -> None:
+    """Test pre backup in different core states."""
+    hass.set_state(core_state)
+    with (  # pylint: disable=confusing-with-statement
+        patch(
+            "homeassistant.components.recorder.core.Recorder.lock_database"
+        ) as lock_mock,
+        expected_result,
+    ):
+        await async_pre_backup(hass)
+    assert len(lock_mock.mock_calls) == lock_calls
 
 
 async def test_async_pre_backup_with_timeout(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fail `recorder.backup.async_pre_backup` if Home Assistant is not running

Rationale: Initiating a backup while Home Assistant is starting makes the startup process hang because of this deadlock situation:
- Creating a backup spawns a task, which the startup sequence waits for here https://github.com/home-assistant/core/blob/fa629f294d24d8427b7d9ac09bf336a5efbb9a32/homeassistant/bootstrap.py#L961-L962
- The backup task will call recorder's `async_pre_backup` https://github.com/home-assistant/core/blob/fa629f294d24d8427b7d9ac09bf336a5efbb9a32/homeassistant/components/recorder/backup.py#L13 which schedules a job on the recorder
- The recorder waits for startup to finish before it starts processing events https://github.com/home-assistant/core/blob/fa629f294d24d8427b7d9ac09bf336a5efbb9a32/homeassistant/components/recorder/core.py#L763

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
