### PR TITLE
Make the Tuya backend library compatible with the newer paho mqtt client.

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
+from urllib.parse import urlsplit
 
 from tuya_sharing import (
     CustomerDevice,
@@ -11,6 +12,7 @@ from tuya_sharing import (
     SharingDeviceListener,
     SharingTokenListener,
 )
+from tuya_sharing.mq import SharingMQ, SharingMQConfig
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -45,13 +47,73 @@ class HomeAssistantTuyaData(NamedTuple):
     listener: SharingDeviceListener
 
 
+if TYPE_CHECKING:
+    import paho.mqtt.client as mqtt
+
+
+class CompatManager(Manager):
+    """Compatibility Manager for Tuya.
+
+    This code can be removed when https://github.com/tuya/tuya-device-sharing-sdk/pull/25
+    is merged. It patches the `tuya_sharing.Manager` class to use the correct
+    `paho.mqtt.client` calls to ensure compatibility with the newer versions
+    of the `paho-mqtt` library.
+    """
+
+    def refresh_mq(self):
+        """Refresh the MQTT connection."""
+        if self.mq is not None:
+            self.mq.stop()
+            self.mq = None
+
+        home_ids = [home.id for home in self.user_homes]
+        device = [
+            device
+            for device in self.device_map.values()
+            if hasattr(device, "id") and getattr(device, "set_up", False)
+        ]
+
+        sharing_mq = CompatSharingMQ(self.customer_api, home_ids, device)
+        sharing_mq.start()
+        sharing_mq.add_message_listener(self.on_message)
+        self.mq = sharing_mq
+
+
+class CompatSharingMQ(SharingMQ):
+    """Compatibility wrapper for Tuya SharingMQ class."""
+
+    def _start(self, mq_config: SharingMQConfig) -> mqtt.Client:
+        """Start the MQTT client."""
+        # We don't import on the top because some integrations
+        # should be able to optionally rely on MQTT.
+        import paho.mqtt.client as mqtt  # pylint: disable=import-outside-toplevel
+
+        mqttc = mqtt.Client(client_id=mq_config.client_id)
+        mqttc.username_pw_set(mq_config.username, mq_config.password)
+        mqttc.user_data_set({"mqConfig": mq_config})
+        mqttc.on_connect = self._on_connect
+        mqttc.on_message = self._on_message
+        mqttc.on_subscribe = self._on_subscribe
+        mqttc.on_log = self._on_log
+        mqttc.on_disconnect = self._on_disconnect
+
+        url = urlsplit(mq_config.url)
+        if url.scheme == "ssl":
+            mqttc.tls_set()
+
+        mqttc.connect(url.hostname, url.port)
+
+        mqttc.loop_start()
+        return mqttc
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool:
     """Async setup hass config entry."""
     if CONF_APP_TYPE in entry.data:
         raise ConfigEntryAuthFailed("Authentication failed. Please re-authenticate.")
 
     token_listener = TokenListener(hass, entry)
-    manager = Manager(
+    manager = CompatManager(
         TUYA_CLIENT_ID,
         entry.data[CONF_USER_CODE],
         entry.data[CONF_TERMINAL_ID],

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -51,13 +51,14 @@ if TYPE_CHECKING:
     import paho.mqtt.client as mqtt
 
 
-class CompatManager(Manager):
-    """Compatibility Manager for Tuya.
+class ManagerCompat(Manager):
+    """Extended Manager class from the Tuya device sharing SDK.
 
-    This code can be removed when https://github.com/tuya/tuya-device-sharing-sdk/pull/25
-    is merged. It patches the `tuya_sharing.Manager` class to use the correct
-    `paho.mqtt.client` calls to ensure compatibility with the newer versions
-    of the `paho-mqtt` library.
+    The extension ensures compatibility a paho-mqtt client version >= 2.1.0.
+    It overrides extend refresh_mq method to ensure correct paho.mqtt client calls.
+
+    This code can be removed when a version of tuya-device-sharing with
+    https://github.com/tuya/tuya-device-sharing-sdk/pull/25 is available.
     """
 
     def refresh_mq(self):
@@ -73,14 +74,21 @@ class CompatManager(Manager):
             if hasattr(device, "id") and getattr(device, "set_up", False)
         ]
 
-        sharing_mq = CompatSharingMQ(self.customer_api, home_ids, device)
+        sharing_mq = SharingMQCompat(self.customer_api, home_ids, device)
         sharing_mq.start()
         sharing_mq.add_message_listener(self.on_message)
         self.mq = sharing_mq
 
 
-class CompatSharingMQ(SharingMQ):
-    """Compatibility wrapper for Tuya SharingMQ class."""
+class SharingMQCompat(SharingMQ):
+    """Extended SharingMQ class from the Tuya device sharing SDK.
+
+    The extension ensures compatibility a paho-mqtt client version >= 2.1.0.
+    It overrides _start method to ensure correct paho.mqtt client calls.
+
+    This code can be removed when a version of tuya-device-sharing with
+    https://github.com/tuya/tuya-device-sharing-sdk/pull/25 is available.
+    """
 
     def _start(self, mq_config: SharingMQConfig) -> mqtt.Client:
         """Start the MQTT client."""
@@ -113,7 +121,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
         raise ConfigEntryAuthFailed("Authentication failed. Please re-authenticate.")
 
     token_listener = TokenListener(hass, entry)
-    manager = CompatManager(
+    manager = ManagerCompat(
         TUYA_CLIENT_ID,
         entry.data[CONF_USER_CODE],
         entry.data[CONF_TERMINAL_ID],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the imcompatibility with the new paho-mqtt client. The current `tuya-device-sharing-sdk` does not pin the `paho-mqtt-client`. A compatibility wrapper is added to ensure the new MQTT library works with the existing libary.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/139377
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
