### PR TITLE
Revert polling changes to HomeKit Controller

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -154,7 +154,6 @@ class HKDevice:
         self._pending_subscribes: set[tuple[int, int]] = set()
         self._subscribe_timer: CALLBACK_TYPE | None = None
         self._load_platforms_lock = asyncio.Lock()
-        self._full_update_requested: bool = False
 
     @property
     def entity_map(self) -> Accessories:
@@ -841,48 +840,11 @@ class HKDevice:
 
     async def async_request_update(self, now: datetime | None = None) -> None:
         """Request an debounced update from the accessory."""
-        self._full_update_requested = True
         await self._debounced_update.async_call()
 
     async def async_update(self, now: datetime | None = None) -> None:
         """Poll state of all entities attached to this bridge/accessory."""
         to_poll = self.pollable_characteristics
-        accessories = self.entity_map.accessories
-
-        if (
-            not self._full_update_requested
-            and len(accessories) == 1
-            and self.available
-            and not (to_poll - self.watchable_characteristics)
-            and self.pairing.is_available
-            and await self.pairing.controller.async_reachable(
-                self.unique_id, timeout=5.0
-            )
-        ):
-            # If its a single accessory and all chars are watchable,
-            # only poll the firmware version to keep the connection alive
-            # https://github.com/home-assistant/core/issues/123412
-            #
-            # Firmware revision is used here since iOS does this to keep camera
-            # connections alive, and the goal is to not regress
-            # https://github.com/home-assistant/core/issues/116143
-            # by polling characteristics that are not normally polled frequently
-            # and may not be tested by the device vendor.
-            #
-            _LOGGER.debug(
-                "Accessory is reachable, limiting poll to firmware version: %s",
-                self.unique_id,
-            )
-            first_accessory = accessories[0]
-            accessory_info = first_accessory.services.first(
-                service_type=ServicesTypes.ACCESSORY_INFORMATION
-            )
-            assert accessory_info is not None
-            firmware_iid = accessory_info[CharacteristicsTypes.FIRMWARE_REVISION].iid
-            to_poll = {(first_accessory.aid, firmware_iid)}
-
-        self._full_update_requested = False
-
         if not to_poll:
             self.async_update_available_state()
             _LOGGER.debug(

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -375,9 +375,9 @@ async def test_poll_firmware_version_only_all_watchable_accessory_mode(
         state = await helper.poll_and_get_state()
         assert state.state == STATE_OFF
         assert mock_get_characteristics.call_count == 2
-        # Verify only firmware version is polled
-        assert mock_get_characteristics.call_args_list[0][0][0] == {(1, 7)}
-        assert mock_get_characteristics.call_args_list[1][0][0] == {(1, 7)}
+        # Verify everything is polled
+        assert mock_get_characteristics.call_args_list[0][0][0] == {(1, 10), (1, 11)}
+        assert mock_get_characteristics.call_args_list[1][0][0] == {(1, 10), (1, 11)}
 
         # Test device goes offline
         helper.pairing.available = False
@@ -429,8 +429,8 @@ async def test_manual_poll_all_chars(
     ) as mock_get_characteristics:
         # Initial state is that the light is off
         await helper.poll_and_get_state()
-        # Verify only firmware version is polled
-        assert mock_get_characteristics.call_args_list[0][0][0] == {(1, 7)}
+        # Verify poll polls all chars
+        assert len(mock_get_characteristics.call_args_list[0][0][0]) > 1
 
         # Now do a manual poll to ensure all chars are polled
         mock_get_characteristics.reset_mock()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reverts #116200 (and a some parts of the followup PRs)

We changed the polling logic to avoid polling if all chars are marked as watchable to avoid crashing the firmware on a very limited set of devices as it was more in line with what iOS does. In the end, the user ended up stop using HK for the device in #116143 because it turned out to be unreliable in other ways. The vendor has since issued a firmware update that may resolve the problem with all of these devices.

In practice it turns out many more devices report that chars are evented and never send events. After a few months of data and reports the trade-off does not seem worth it since users are having to set up manual polling on a wide range of devices. The amount of devices with evented chars that do not actually send state vastly exceeds the number of devices that might crash if they are polled too often so restore the previous behavior

fixes #100331
fixes #124529
fixes #123456
fixes #130763
fixes #124099
fixes #124916
fixes #135434
fixes #125273
fixes #124099
fixes #119617
fixes #138561 (unless the device is not actually updating the char at all)
fixes #102258 (unless there is also a connection issue there that hasn't been fixed in the last year)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
