### PR TITLE
Remove deprecated import from configuration.yaml from opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -354,12 +354,6 @@
       }
     }
   },
-  "issues": {
-    "deprecated_import_from_configuration_yaml": {
-      "title": "Deprecated configuration",
-      "description": "Configuration of the OpenTherm Gateway integration through configuration.yaml is deprecated. Your configuration has been migrated to config entries. Please remove any OpenTherm Gateway configuration from your configuration.yaml."
-    }
-  },
   "options": {
     "step": {
       "init": {

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -54,30 +54,6 @@ async def test_form_user(
     assert mock_pyotgw.return_value.disconnect.await_count == 1
 
 
-# Deprecated import from configuration.yaml, can be removed in 2025.4.0
-async def test_form_import(
-    hass: HomeAssistant,
-    mock_pyotgw: MagicMock,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test import from existing config."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={CONF_ID: "legacy_gateway", CONF_DEVICE: "/dev/ttyUSB1"},
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "legacy_gateway"
-    assert result["data"] == {
-        CONF_NAME: "legacy_gateway",
-        CONF_DEVICE: "/dev/ttyUSB1",
-        CONF_ID: "legacy_gateway",
-    }
-    assert mock_pyotgw.return_value.connect.await_count == 1
-    assert mock_pyotgw.return_value.disconnect.await_count == 1
-
-
 async def test_form_duplicate_entries(
     hass: HomeAssistant,
     mock_pyotgw: MagicMock,

--- a/tests/components/opentherm_gw/test_init.py
+++ b/tests/components/opentherm_gw/test_init.py
@@ -4,18 +4,13 @@ from unittest.mock import MagicMock
 
 from pyotgw.vars import OTGW, OTGW_ABOUT
 
-from homeassistant import setup
 from homeassistant.components.opentherm_gw.const import (
     DOMAIN,
     OpenThermDeviceIdentifier,
 )
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    device_registry as dr,
-    entity_registry as er,
-    issue_registry as ir,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import MOCK_GATEWAY_ID, VERSION_TEST
 
@@ -152,26 +147,4 @@ async def test_climate_entity_migration(
     assert (
         updated_entry.unique_id
         == f"{mock_config_entry.data[CONF_ID]}-{OpenThermDeviceIdentifier.THERMOSTAT}-thermostat_entity"
-    )
-
-
-# Deprecation test, can be removed in 2025.4.0
-async def test_configuration_yaml_deprecation(
-    hass: HomeAssistant,
-    issue_registry: ir.IssueRegistry,
-    mock_config_entry: MockConfigEntry,
-    mock_pyotgw: MagicMock,
-) -> None:
-    """Test that existing configuration in configuration.yaml creates an issue."""
-
-    await setup.async_setup_component(
-        hass, DOMAIN, {DOMAIN: {"legacy_gateway": {"device": "/dev/null"}}}
-    )
-
-    await hass.async_block_till_done()
-    assert (
-        issue_registry.async_get_issue(
-            DOMAIN, "deprecated_import_from_configuration_yaml"
-        )
-        is not None
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
In #125045 we deprecated the configuration import from `configuration.yaml` for the opentherm_gw integration. If users have not acted on the issue that was created, this PR will break their setup until they remove the obsolete opentherm_gw config from their configuration.yaml.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #125045 we deprecated the configuration import from `configuration.yaml` for the opentherm_gw integration. This PR follows up on that by removing the deprecated code and related tests entirely.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
