### PR TITLE
Fix duplicate unique id issue in Sensibo

### DIFF
--- a/homeassistant/components/sensibo/binary_sensor.py
+++ b/homeassistant/components/sensibo/binary_sensor.py
@@ -133,6 +133,7 @@ async def async_setup_entry(
         new_devices, remove_devices, new_added_devices = coordinator.get_devices(
             added_devices
         )
+        added_devices = new_added_devices
 
         if LOGGER.isEnabledFor(logging.DEBUG):
             LOGGER.debug(
@@ -169,7 +170,6 @@ async def async_setup_entry(
                 )
             )
             async_add_entities(entities)
-            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/binary_sensor.py
+++ b/homeassistant/components/sensibo/binary_sensor.py
@@ -130,7 +130,7 @@ async def async_setup_entry(
         """Handle additions of devices and sensors."""
         entities: list[SensiboMotionSensor | SensiboDeviceSensor] = []
         nonlocal added_devices
-        new_devices, remove_devices, added_devices = coordinator.get_devices(
+        new_devices, remove_devices, new_added_devices = coordinator.get_devices(
             added_devices
         )
 
@@ -168,8 +168,8 @@ async def async_setup_entry(
                     device_data.model, DEVICE_SENSOR_TYPES
                 )
             )
-
-        async_add_entities(entities)
+            async_add_entities(entities)
+            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/button.py
+++ b/homeassistant/components/sensibo/button.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
     def _add_remove_devices() -> None:
         """Handle additions of devices and sensors."""
         nonlocal added_devices
-        new_devices, _, added_devices = coordinator.get_devices(added_devices)
+        new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
 
         if new_devices:
             async_add_entities(
@@ -54,6 +54,7 @@ async def async_setup_entry(
                 for device_id in coordinator.data.parsed
                 if device_id in new_devices
             )
+            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/button.py
+++ b/homeassistant/components/sensibo/button.py
@@ -47,6 +47,7 @@ async def async_setup_entry(
         """Handle additions of devices and sensors."""
         nonlocal added_devices
         new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
+        added_devices = new_added_devices
 
         if new_devices:
             async_add_entities(
@@ -54,7 +55,6 @@ async def async_setup_entry(
                 for device_id in coordinator.data.parsed
                 if device_id in new_devices
             )
-            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -150,6 +150,7 @@ async def async_setup_entry(
         """Handle additions of devices and sensors."""
         nonlocal added_devices
         new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
+        added_devices = new_added_devices
 
         if new_devices:
             async_add_entities(
@@ -157,7 +158,6 @@ async def async_setup_entry(
                 for device_id in coordinator.data.parsed
                 if device_id in new_devices
             )
-            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -149,7 +149,7 @@ async def async_setup_entry(
     def _add_remove_devices() -> None:
         """Handle additions of devices and sensors."""
         nonlocal added_devices
-        new_devices, _, added_devices = coordinator.get_devices(added_devices)
+        new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
 
         if new_devices:
             async_add_entities(
@@ -157,6 +157,7 @@ async def async_setup_entry(
                 for device_id in coordinator.data.parsed
                 if device_id in new_devices
             )
+            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/coordinator.py
+++ b/homeassistant/components/sensibo/coordinator.py
@@ -56,18 +56,31 @@ class SensiboDataUpdateCoordinator(DataUpdateCoordinator[SensiboData]):
     ) -> tuple[set[str], set[str], set[str]]:
         """Addition and removal of devices."""
         data = self.data
-        motion_sensors = {
+        current_motion_sensors = {
             sensor_id
             for device_data in data.parsed.values()
             if device_data.motion_sensors
             for sensor_id in device_data.motion_sensors
         }
-        devices: set[str] = set(data.parsed)
-        new_devices: set[str] = motion_sensors | devices - added_devices
-        remove_devices = added_devices - devices - motion_sensors
-        added_devices = (added_devices - remove_devices) | new_devices
+        current_devices: set[str] = set(data.parsed)
+        LOGGER.debug(
+            "Current devices: %s, moption sensors: %s",
+            current_devices,
+            current_motion_sensors,
+        )
+        new_devices: set[str] = (
+            current_motion_sensors | current_devices
+        ) - added_devices
+        remove_devices = added_devices - current_devices - current_motion_sensors
+        new_added_devices = (added_devices - remove_devices) | new_devices
 
-        return (new_devices, remove_devices, added_devices)
+        LOGGER.debug(
+            "New devices: %s, Removed devices: %s, Added devices: %s",
+            new_devices,
+            remove_devices,
+            new_added_devices,
+        )
+        return (new_devices, remove_devices, new_added_devices)
 
     async def _async_update_data(self) -> SensiboData:
         """Fetch data from Sensibo."""

--- a/homeassistant/components/sensibo/number.py
+++ b/homeassistant/components/sensibo/number.py
@@ -77,6 +77,7 @@ async def async_setup_entry(
         """Handle additions of devices and sensors."""
         nonlocal added_devices
         new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
+        added_devices = new_added_devices
 
         if new_devices:
             async_add_entities(
@@ -85,7 +86,6 @@ async def async_setup_entry(
                 for description in DEVICE_NUMBER_TYPES
                 if device_id in new_devices
             )
-            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/number.py
+++ b/homeassistant/components/sensibo/number.py
@@ -76,7 +76,7 @@ async def async_setup_entry(
     def _add_remove_devices() -> None:
         """Handle additions of devices and sensors."""
         nonlocal added_devices
-        new_devices, _, added_devices = coordinator.get_devices(added_devices)
+        new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
 
         if new_devices:
             async_add_entities(
@@ -85,6 +85,7 @@ async def async_setup_entry(
                 for description in DEVICE_NUMBER_TYPES
                 if device_id in new_devices
             )
+            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/select.py
+++ b/homeassistant/components/sensibo/select.py
@@ -115,7 +115,7 @@ async def async_setup_entry(
     def _add_remove_devices() -> None:
         """Handle additions of devices and sensors."""
         nonlocal added_devices
-        new_devices, _, added_devices = coordinator.get_devices(added_devices)
+        new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
 
         if new_devices:
             async_add_entities(
@@ -125,6 +125,7 @@ async def async_setup_entry(
                 for description in DEVICE_SELECT_TYPES
                 if description.key in device_data.full_features
             )
+            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/select.py
+++ b/homeassistant/components/sensibo/select.py
@@ -116,6 +116,7 @@ async def async_setup_entry(
         """Handle additions of devices and sensors."""
         nonlocal added_devices
         new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
+        added_devices = new_added_devices
 
         if new_devices:
             async_add_entities(
@@ -125,7 +126,6 @@ async def async_setup_entry(
                 for description in DEVICE_SELECT_TYPES
                 if description.key in device_data.full_features
             )
-            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/sensor.py
+++ b/homeassistant/components/sensibo/sensor.py
@@ -254,6 +254,7 @@ async def async_setup_entry(
         entities: list[SensiboMotionSensor | SensiboDeviceSensor] = []
         nonlocal added_devices
         new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
+        added_devices = new_added_devices
 
         if new_devices:
             entities.extend(
@@ -275,7 +276,6 @@ async def async_setup_entry(
                 )
             )
             async_add_entities(entities)
-            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/sensor.py
+++ b/homeassistant/components/sensibo/sensor.py
@@ -253,9 +253,7 @@ async def async_setup_entry(
 
         entities: list[SensiboMotionSensor | SensiboDeviceSensor] = []
         nonlocal added_devices
-        new_devices, remove_devices, added_devices = coordinator.get_devices(
-            added_devices
-        )
+        new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
 
         if new_devices:
             entities.extend(
@@ -277,6 +275,7 @@ async def async_setup_entry(
                 )
             )
             async_add_entities(entities)
+            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/switch.py
+++ b/homeassistant/components/sensibo/switch.py
@@ -90,6 +90,7 @@ async def async_setup_entry(
         """Handle additions of devices and sensors."""
         nonlocal added_devices
         new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
+        added_devices = new_added_devices
 
         if new_devices:
             async_add_entities(
@@ -100,7 +101,6 @@ async def async_setup_entry(
                     device_data.model, DEVICE_SWITCH_TYPES
                 )
             )
-            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/switch.py
+++ b/homeassistant/components/sensibo/switch.py
@@ -89,7 +89,7 @@ async def async_setup_entry(
     def _add_remove_devices() -> None:
         """Handle additions of devices and sensors."""
         nonlocal added_devices
-        new_devices, _, added_devices = coordinator.get_devices(added_devices)
+        new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
 
         if new_devices:
             async_add_entities(
@@ -100,6 +100,7 @@ async def async_setup_entry(
                     device_data.model, DEVICE_SWITCH_TYPES
                 )
             )
+            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/update.py
+++ b/homeassistant/components/sensibo/update.py
@@ -56,7 +56,7 @@ async def async_setup_entry(
     def _add_remove_devices() -> None:
         """Handle additions of devices and sensors."""
         nonlocal added_devices
-        new_devices, _, added_devices = coordinator.get_devices(added_devices)
+        new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
 
         if new_devices:
             async_add_entities(
@@ -66,6 +66,7 @@ async def async_setup_entry(
                 for description in DEVICE_SENSOR_TYPES
                 if description.value_available(device_data) is not None
             )
+            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/homeassistant/components/sensibo/update.py
+++ b/homeassistant/components/sensibo/update.py
@@ -57,6 +57,7 @@ async def async_setup_entry(
         """Handle additions of devices and sensors."""
         nonlocal added_devices
         new_devices, _, new_added_devices = coordinator.get_devices(added_devices)
+        added_devices = new_added_devices
 
         if new_devices:
             async_add_entities(
@@ -66,7 +67,6 @@ async def async_setup_entry(
                 for description in DEVICE_SENSOR_TYPES
                 if description.value_available(device_data) is not None
             )
-            added_devices = new_added_devices
 
     entry.async_on_unload(coordinator.async_add_listener(_add_remove_devices))
     _add_remove_devices()

--- a/tests/components/sensibo/test_coordinator.py
+++ b/tests/components/sensibo/test_coordinator.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 from freezegun.api import FrozenDateTimeFactory
 from pysensibo.exceptions import AuthenticationError, SensiboError
 from pysensibo.model import SensiboData
+import pytest
 
 from homeassistant.components.climate import HVACMode
 from homeassistant.components.sensibo.const import DOMAIN
@@ -25,6 +26,7 @@ async def test_coordinator(
     mock_client: MagicMock,
     get_data: tuple[SensiboData, dict[str, Any], dict[str, Any]],
     freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the Sensibo coordinator with errors."""
     config_entry = MockConfigEntry(
@@ -87,3 +89,5 @@ async def test_coordinator(
     mock_data.assert_called_once()
     state = hass.states.get("climate.hallway")
     assert state.state == STATE_UNAVAILABLE
+
+    assert "Platform sensibo does not generate unique IDs" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix issue in Sensibo for creating duplicate entities for motion sensors.

Some minor changes in unrelated platforms for consistency

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #138098
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 