### PR TITLE
Motion blind type list

### DIFF
--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -83,7 +83,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Connect to motion gateway
     multicast = hass.data[DOMAIN][KEY_MULTICAST_LISTENER]
     connect_gateway_class = ConnectMotionGateway(hass, multicast)
-    if not await connect_gateway_class.async_connect_gateway(host, key, blind_type_list):
+    if not await connect_gateway_class.async_connect_gateway(
+        host, key, blind_type_list
+    ):
         raise ConfigEntryNotReady
     motion_gateway = connect_gateway_class.gateway_device
     api_lock = asyncio.Lock()

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import (
+    CONF_BLIND_TYPE_LIST,
     CONF_INTERFACE,
     CONF_WAIT_FOR_PUSH,
     DEFAULT_INTERFACE,
@@ -39,6 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     key = entry.data[CONF_API_KEY]
     multicast_interface = entry.data.get(CONF_INTERFACE, DEFAULT_INTERFACE)
     wait_for_push = entry.options.get(CONF_WAIT_FOR_PUSH, DEFAULT_WAIT_FOR_PUSH)
+    blind_type_list = entry.data.get(CONF_BLIND_TYPE_LIST)
 
     # Create multicast Listener
     async with setup_lock:
@@ -81,7 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Connect to motion gateway
     multicast = hass.data[DOMAIN][KEY_MULTICAST_LISTENER]
     connect_gateway_class = ConnectMotionGateway(hass, multicast)
-    if not await connect_gateway_class.async_connect_gateway(host, key):
+    if not await connect_gateway_class.async_connect_gateway(host, key, blind_type_list):
         raise ConfigEntryNotReady
     motion_gateway = connect_gateway_class.gateway_device
     api_lock = asyncio.Lock()
@@ -94,6 +96,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = DataUpdateCoordinatorMotionBlinds(
         hass, entry, _LOGGER, coordinator_info
     )
+
+    # store blind type list for next time
+    if entry.data.get(CONF_BLIND_TYPE_LIST) != motion_gateway.blind_type_list:
+        data = {
+            **entry.data,
+            CONF_BLIND_TYPE_LIST: motion_gateway.blind_type_list,
+        }
+        hass.config_entries.async_update_entry(entry, data=data)
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -156,6 +156,7 @@ class MotionBlindsFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             key = user_input[CONF_API_KEY]
+            assert self._host
 
             connect_gateway_class = ConnectMotionGateway(self.hass)
             if not await connect_gateway_class.async_connect_gateway(self._host, key):

--- a/homeassistant/components/motion_blinds/const.py
+++ b/homeassistant/components/motion_blinds/const.py
@@ -8,6 +8,7 @@ DEFAULT_GATEWAY_NAME = "Motionblinds Gateway"
 
 PLATFORMS = [Platform.BUTTON, Platform.COVER, Platform.SENSOR]
 
+CONF_BLIND_TYPE_LIST = "blind_type_list"
 CONF_WAIT_FOR_PUSH = "wait_for_push"
 CONF_INTERFACE = "interface"
 DEFAULT_WAIT_FOR_PUSH = False

--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -46,7 +46,7 @@ class ConnectMotionGateway:
         self,
         host: str,
         key: str,
-        blind_type_list: dict[str, int],
+        blind_type_list: dict[str, int] | None = None,
     ) -> bool:
         """Connect to the Motion Gateway."""
         _LOGGER.debug("Initializing with host %s (key %s)", host, key[:3])

--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -42,11 +42,16 @@ class ConnectMotionGateway:
         for blind in self.gateway_device.device_list.values():
             blind.Update_from_cache()
 
-    async def async_connect_gateway(self, host, key):
+    async def async_connect_gateway(
+        self,
+        host: str,
+        key: str,
+        blind_type_list: dict[str, int],
+    ) -> bool:
         """Connect to the Motion Gateway."""
         _LOGGER.debug("Initializing with host %s (key %s)", host, key[:3])
         self._gateway_device = MotionGateway(
-            ip=host, key=key, multicast=self._multicast
+            ip=host, key=key, multicast=self._multicast, blind_type_list=blind_type_list
         )
         try:
             # update device info and get the connected sub devices

--- a/homeassistant/components/motion_blinds/manifest.json
+++ b/homeassistant/components/motion_blinds/manifest.json
@@ -21,5 +21,5 @@
   "documentation": "https://www.home-assistant.io/integrations/motion_blinds",
   "iot_class": "local_push",
   "loggers": ["motionblinds"],
-  "requirements": ["motionblinds==0.6.25"]
+  "requirements": ["motionblinds==0.6.26"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1432,7 +1432,7 @@ monzopy==1.4.2
 mopeka-iot-ble==0.8.0
 
 # homeassistant.components.motion_blinds
-motionblinds==0.6.25
+motionblinds==0.6.26
 
 # homeassistant.components.motionblinds_ble
 motionblindsble==0.1.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1204,7 +1204,7 @@ monzopy==1.4.2
 mopeka-iot-ble==0.8.0
 
 # homeassistant.components.motion_blinds
-motionblinds==0.6.25
+motionblinds==0.6.26
 
 # homeassistant.components.motionblinds_ble
 motionblindsble==0.1.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Store and re-store the motion blinds blind_type for each blind connected to a gateway.
On some models, the blind stops sending the blind_type (probably a bug in the firmware of that blind).
This makes sure the blind_type will not change suddenly if it becomes missing.
Resolves: https://github.com/home-assistant/core/issues/136189

Needs version bump PR: https://github.com/home-assistant/core/pull/139591

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/136189
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
