### PR TITLE
Prepare code for addition of OpenWeatherMap AirPollution Sensors 

### DIFF
--- a/homeassistant/components/openweathermap/__init__.py
+++ b/homeassistant/components/openweathermap/__init__.py
@@ -10,6 +10,7 @@ from pyopenweathermap import create_owm_client
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_LANGUAGE, CONF_MODE, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import CONFIG_FLOW_VERSION, DEFAULT_OWM_MODE, OWM_MODES, PLATFORMS
 from .coordinator import WeatherUpdateCoordinator
@@ -27,7 +28,7 @@ class OpenweathermapData:
 
     name: str
     mode: str
-    coordinator: WeatherUpdateCoordinator
+    coordinator: DataUpdateCoordinator
 
 
 async def async_setup_entry(
@@ -45,13 +46,13 @@ async def async_setup_entry(
         async_delete_issue(hass, entry.entry_id)
 
     owm_client = create_owm_client(api_key, mode, lang=language)
-    weather_coordinator = WeatherUpdateCoordinator(hass, entry, owm_client)
+    owm_coordinator = WeatherUpdateCoordinator(hass, entry, owm_client)
 
-    await weather_coordinator.async_config_entry_first_refresh()
+    await owm_coordinator.async_config_entry_first_refresh()
 
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
-    entry.runtime_data = OpenweathermapData(name, mode, weather_coordinator)
+    entry.runtime_data = OpenweathermapData(name, mode, owm_coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/openweathermap/const.py
+++ b/homeassistant/components/openweathermap/const.py
@@ -54,11 +54,6 @@ ATTR_API_DAILY_FORECAST = "daily_forecast"
 UPDATE_LISTENER = "update_listener"
 PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
 
-FORECAST_MODE_HOURLY = "hourly"
-FORECAST_MODE_DAILY = "daily"
-FORECAST_MODE_FREE_DAILY = "freedaily"
-FORECAST_MODE_ONECALL_HOURLY = "onecall_hourly"
-FORECAST_MODE_ONECALL_DAILY = "onecall_daily"
 OWM_MODE_FREE_CURRENT = "current"
 OWM_MODE_FREE_FORECAST = "forecast"
 OWM_MODE_V30 = "v3.0"

--- a/homeassistant/components/openweathermap/coordinator.py
+++ b/homeassistant/components/openweathermap/coordinator.py
@@ -1,4 +1,4 @@
-"""Weather data coordinator for the OpenWeatherMap (OWM) service."""
+"""Data coordinator for the OpenWeatherMap (OWM) service."""
 
 from __future__ import annotations
 

--- a/homeassistant/components/openweathermap/sensor.py
+++ b/homeassistant/components/openweathermap/sensor.py
@@ -159,7 +159,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up OpenWeatherMap sensor entities based on a config entry."""
     domain_data = config_entry.runtime_data
-    name = domain_data.name
     coordinator = domain_data.coordinator
 
     if domain_data.mode == OWM_MODE_FREE_FORECAST:
@@ -172,8 +171,7 @@ async def async_setup_entry(
     else:
         async_add_entities(
             OpenWeatherMapSensor(
-                name,
-                f"{config_entry.unique_id}-{description.key}",
+                config_entry,
                 description,
                 coordinator,
             )
@@ -186,11 +184,11 @@ class AbstractOpenWeatherMapSensor(SensorEntity):
 
     _attr_should_poll = False
     _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
 
     def __init__(
         self,
-        name: str,
-        unique_id: str,
+        config_entry: OpenweathermapConfigEntry,
         description: SensorEntityDescription,
         coordinator: DataUpdateCoordinator,
     ) -> None:
@@ -198,12 +196,10 @@ class AbstractOpenWeatherMapSensor(SensorEntity):
         self.entity_description = description
         self._coordinator = coordinator
 
-        self._attr_name = f"{name} {description.name}"
-        self._attr_unique_id = unique_id
-        split_unique_id = unique_id.split("-")
+        self._attr_unique_id = f"{config_entry.unique_id}-{description.key}"
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, f"{split_unique_id[0]}-{split_unique_id[1]}")},
+            identifiers={(DOMAIN, str(config_entry.unique_id))},
             manufacturer=MANUFACTURER,
             name=DEFAULT_NAME,
         )

--- a/homeassistant/components/openweathermap/sensor.py
+++ b/homeassistant/components/openweathermap/sensor.py
@@ -184,7 +184,6 @@ class AbstractOpenWeatherMapSensor(SensorEntity):
 
     _attr_should_poll = False
     _attr_attribution = ATTRIBUTION
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -196,6 +195,7 @@ class AbstractOpenWeatherMapSensor(SensorEntity):
         self.entity_description = description
         self._coordinator = coordinator
 
+        self._attr_name = f"{config_entry.runtime_data.name} {description.name}"
         self._attr_unique_id = f"{config_entry.unique_id}-{description.key}"
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,

--- a/homeassistant/components/openweathermap/sensor.py
+++ b/homeassistant/components/openweathermap/sensor.py
@@ -50,7 +50,6 @@ from .const import (
     MANUFACTURER,
     OWM_MODE_FREE_FORECAST,
 )
-from .coordinator import WeatherUpdateCoordinator
 
 WEATHER_SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
@@ -161,7 +160,7 @@ async def async_setup_entry(
     """Set up OpenWeatherMap sensor entities based on a config entry."""
     domain_data = config_entry.runtime_data
     name = domain_data.name
-    weather_coordinator = domain_data.coordinator
+    coordinator = domain_data.coordinator
 
     if domain_data.mode == OWM_MODE_FREE_FORECAST:
         entity_registry = er.async_get(hass)
@@ -176,7 +175,7 @@ async def async_setup_entry(
                 name,
                 f"{config_entry.unique_id}-{description.key}",
                 description,
-                weather_coordinator,
+                coordinator,
             )
             for description in WEATHER_SENSOR_TYPES
         )
@@ -228,20 +227,7 @@ class AbstractOpenWeatherMapSensor(SensorEntity):
 class OpenWeatherMapSensor(AbstractOpenWeatherMapSensor):
     """Implementation of an OpenWeatherMap sensor."""
 
-    def __init__(
-        self,
-        name: str,
-        unique_id: str,
-        description: SensorEntityDescription,
-        weather_coordinator: WeatherUpdateCoordinator,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(name, unique_id, description, weather_coordinator)
-        self._weather_coordinator = weather_coordinator
-
     @property
     def native_value(self) -> StateType:
         """Return the state of the device."""
-        return self._weather_coordinator.data[ATTR_API_CURRENT].get(
-            self.entity_description.key
-        )
+        return self._coordinator.data[ATTR_API_CURRENT].get(self.entity_description.key)

--- a/homeassistant/components/openweathermap/weather.py
+++ b/homeassistant/components/openweathermap/weather.py
@@ -19,6 +19,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import OpenweathermapConfigEntry
 from .const import (
@@ -44,7 +45,6 @@ from .const import (
     OWM_MODE_FREE_FORECAST,
     OWM_MODE_V30,
 )
-from .coordinator import WeatherUpdateCoordinator
 
 SERVICE_GET_MINUTE_FORECAST = "get_minute_forecast"
 
@@ -74,7 +74,7 @@ async def async_setup_entry(
     )
 
 
-class OpenWeatherMapWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
+class OpenWeatherMapWeather(SingleCoordinatorWeatherEntity[DataUpdateCoordinator]):
     """Implementation of an OpenWeatherMap sensor."""
 
     _attr_attribution = ATTRIBUTION
@@ -91,10 +91,10 @@ class OpenWeatherMapWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordina
         name: str,
         unique_id: str,
         mode: str,
-        weather_coordinator: WeatherUpdateCoordinator,
+        coordinator: DataUpdateCoordinator,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(weather_coordinator)
+        super().__init__(coordinator)
         self._attr_name = name
         self._attr_unique_id = unique_id
         self._attr_device_info = DeviceInfo(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The aim of this PR is to prepare the OpenWeatherMap integration code for the addition of Air Pollution sensors by simplifying and making the code more generic.
This PR does not impact the functionality of the integration.

More specifically the changes : 
- Replaces most uses of WeatherUpdateCoordinator by the more generic DataUpdateCoordinator, to prepare for another subclass to be created
- Simplifies the creation of unique_id and name for sensors to prepare for the addition of more sensors
- Remove some unused constants in const.py

This PR is a pre requisite to PR https://github.com/home-assistant/core/pull/137949 to support AirPollution sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
