### PR TITLE
Remove deprecated device migration from opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -88,23 +88,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][config_entry.data[CONF_ID]] = gateway
 
     # Migration can be removed in 2025.4.0
-    dev_reg = dr.async_get(hass)
-    if (
-        migrate_device := dev_reg.async_get_device(
-            {(DOMAIN, config_entry.data[CONF_ID])}
-        )
-    ) is not None:
-        dev_reg.async_update_device(
-            migrate_device.id,
-            new_identifiers={
-                (
-                    DOMAIN,
-                    f"{config_entry.data[CONF_ID]}-{OpenThermDeviceIdentifier.GATEWAY}",
-                )
-            },
-        )
-
-    # Migration can be removed in 2025.4.0
     ent_reg = er.async_get(hass)
     if (
         entity_id := ent_reg.async_get_entity_id(

--- a/tests/components/opentherm_gw/test_init.py
+++ b/tests/components/opentherm_gw/test_init.py
@@ -71,59 +71,6 @@ async def test_device_registry_update(
     assert gw_dev.sw_version == VERSION_NEW
 
 
-# Device migration test can be removed in 2025.4.0
-async def test_device_migration(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    mock_config_entry: MockConfigEntry,
-    mock_pyotgw: MagicMock,
-) -> None:
-    """Test that the device registry is updated correctly."""
-    mock_config_entry.add_to_hass(hass)
-
-    device_registry.async_get_or_create(
-        config_entry_id=mock_config_entry.entry_id,
-        identifiers={
-            (DOMAIN, MOCK_GATEWAY_ID),
-        },
-        name="Mock Gateway",
-        manufacturer="Schelte Bron",
-        model="OpenTherm Gateway",
-        sw_version=VERSION_TEST,
-    )
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, MOCK_GATEWAY_ID)})
-        is None
-    )
-
-    gw_dev = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.GATEWAY}")}
-    )
-    assert gw_dev is not None
-
-    assert (
-        device_registry.async_get_device(
-            identifiers={
-                (DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.BOILER}")
-            }
-        )
-        is not None
-    )
-
-    assert (
-        device_registry.async_get_device(
-            identifiers={
-                (DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.THERMOSTAT}")
-            }
-        )
-        is not None
-    )
-
-
 # Entity migration test can be removed in 2025.4.0
 async def test_climate_entity_migration(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
In 2f7a39677806302e3427535aac740b26df783e27 we split the entities of the opentherm_gw integration between 3 devices (boiler, thermostat and gateway) rather than 1 (just the gateway). In this process, we changed the device identifier of the gateway device and implemented a migration mechanism. Users upgrading from a version before 2024.10.0 to 2025.4.0 or later will end up with an orphaned device and its orphaned entities in their setup. These should then be removed manually.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In 2f7a39677806302e3427535aac740b26df783e27 we split the entities of the opentherm_gw integration between 3 devices (boiler, thermostat and gateway) rather than 1 (just the gateway). This PR removes the migration mechanism and related tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
