### PR TITLE
Prevent ipv6 discovery messages for Sonos

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -212,7 +212,7 @@ class SonosDiscoveryManager:
         try:
             _ = IPv4Address(ip_address)
         except AddressValueError:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Sonos integration only supports IPv4 addresses, invalid ip_address received: %s",
                 ip_address,
             )

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 import datetime
 from functools import partial
+from ipaddress import AddressValueError, IPv4Address
 import logging
 import socket
 from typing import Any, cast
@@ -208,6 +209,14 @@ class SonosDiscoveryManager:
 
     async def async_subscribe_to_zone_updates(self, ip_address: str) -> None:
         """Test subscriptions and create SonosSpeakers based on results."""
+        try:
+            _ = IPv4Address(ip_address)
+        except AddressValueError:
+            _LOGGER.warning(
+                "Sonos integration only supports IPv4 addresses, invalid ip_address received: %s",
+                ip_address,
+            )
+            return
         soco = SoCo(ip_address)
         # Cache now to avoid household ID lookup during first ZoneGroupState processing
         await self.hass.async_add_executor_job(

--- a/homeassistant/components/sonos/config_flow.py
+++ b/homeassistant/components/sonos/config_flow.py
@@ -31,6 +31,8 @@ class SonosDiscoveryFlowHandler(DiscoveryFlowHandler[Awaitable[bool]], domain=DO
         hostname = discovery_info.hostname
         if hostname is None or not hostname.lower().startswith("sonos"):
             return self.async_abort(reason="not_sonos_device")
+        if discovery_info.ip_address.version != 4:
+            return self.async_abort(reason="not_ipv4_address")
         if discovery_manager := self.hass.data.get(DATA_SONOS_DISCOVERY_MANAGER):
             host = discovery_info.host
             mdns_name = discovery_info.name

--- a/homeassistant/components/sonos/strings.json
+++ b/homeassistant/components/sonos/strings.json
@@ -8,7 +8,8 @@
     "abort": {
       "not_sonos_device": "Discovered device is not a Sonos device",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "not_ipv4_address": "No IPv4 address in SSDP discovery information"
     }
   },
   "issues": {

--- a/tests/components/sonos/test_config_flow.py
+++ b/tests/components/sonos/test_config_flow.py
@@ -123,6 +123,22 @@ async def test_zeroconf_form(
     assert len(mock_manager.mock_calls) == 2
 
 
+async def test_zeroconf_form_not_ipv4(
+    hass: HomeAssistant, zeroconf_payload: ZeroconfServiceInfo
+) -> None:
+    """Test we pass Zeroconf discoveries to the manager."""
+    mock_manager = hass.data[DATA_SONOS_DISCOVERY_MANAGER] = MagicMock()
+    zeroconf_payload.ip_address = ip_address("2001:db8:3333:4444:5555:6666:7777:8888")
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=zeroconf_payload,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_ipv4_address"
+    assert mock_manager.call_count == 0
+
+
 async def test_ssdp_discovery(hass: HomeAssistant, soco) -> None:
     """Test that SSDP discoveries create a config flow."""
 

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -455,3 +455,32 @@ async def test_async_poll_manual_hosts_8(
     assert "media_player.garage" in entity_registry.entities
     assert "media_player.studio" in entity_registry.entities
     await hass.async_block_till_done(wait_background_tasks=True)
+
+
+async def _setup_hass_ipv6_address_not_supported(hass: HomeAssistant):
+    await async_setup_component(
+        hass,
+        sonos.DOMAIN,
+        {
+            "sonos": {
+                "media_player": {
+                    "interface_addr": "127.0.0.1",
+                    "hosts": ["2001:db8:3333:4444:5555:6666:7777:8888"],
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+async def test_ipv6_not_supported(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tests that invalid ipv4 addresses do not generate stack dump."""
+    with caplog.at_level(logging.WARNING):
+        caplog.clear()
+        await _setup_hass_ipv6_address_not_supported(hass)
+        await hass.async_block_till_done()
+    assert "invalid ip_address received" in caplog.text
+    assert "2001:db8:3333:4444:5555:6666:7777:8888" in caplog.text

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -478,7 +478,7 @@ async def test_ipv6_not_supported(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Tests that invalid ipv4 addresses do not generate stack dump."""
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         caplog.clear()
         await _setup_hass_ipv6_address_not_supported(hass)
         await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
Sonos Integration does not support ipv6.  Ipv6 discovery messages were causing error and stack dump.

- reject autodiscovery messages with ipv6 addresses
- log warnings if ipv6 addresses are received (for example from the Sonos network topology messages)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #139617
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
