### PR TITLE
Add abstract class to trigger based template entities

### DIFF
--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -125,6 +125,10 @@ async def _async_resolve_blueprints(
             for prop in (CONF_NAME, CONF_UNIQUE_ID):
                 if prop in config:
                     config[platform][prop] = config.pop(prop)
+            # For regular template entities, CONF_VARIABLES should be removed because they just
+            # house input results for template entities.  For Trigger based template entities
+            # CONF_VARIABLES should not be removed because the variables are always
+            # executed between the trigger and action.
             if CONF_TRIGGER not in config and CONF_VARIABLES in config:
                 config[platform][CONF_VARIABLES] = config.pop(CONF_VARIABLES)
         raw_config = dict(config)

--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -122,9 +122,11 @@ async def _async_resolve_blueprints(
             raise vol.Invalid("more than one platform defined per blueprint")
         if len(platforms) == 1:
             platform = platforms.pop()
-            for prop in (CONF_NAME, CONF_UNIQUE_ID, CONF_VARIABLES):
+            for prop in (CONF_NAME, CONF_UNIQUE_ID):
                 if prop in config:
                     config[platform][prop] = config.pop(prop)
+            if CONF_TRIGGER not in config and CONF_VARIABLES in config:
+                config[platform][CONF_VARIABLES] = config.pop(CONF_VARIABLES)
         raw_config = dict(config)
 
     template_config = TemplateConfig(CONFIG_SECTION_SCHEMA(config))

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -2,12 +2,14 @@
 
 from collections.abc import Callable, Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.components.blueprint import CONF_USE_BLUEPRINT
+from homeassistant.const import CONF_PATH, CONF_VARIABLES, EVENT_HOMEASSISTANT_START
 from homeassistant.core import Context, CoreState, Event, HomeAssistant, callback
 from homeassistant.helpers import condition, discovery, trigger as trigger_helper
 from homeassistant.helpers.script import Script
+from homeassistant.helpers.script_variables import ScriptVariables
 from homeassistant.helpers.trace import trace_get
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -22,7 +24,7 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
 
     REMOVE_TRIGGER = object()
 
-    def __init__(self, hass: HomeAssistant, config: dict[str, Any]) -> None:
+    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
         """Instantiate trigger data."""
         super().__init__(
             hass, _LOGGER, config_entry=None, name="Trigger Update Coordinator"
@@ -32,6 +34,18 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
         self._unsub_start: Callable[[], None] | None = None
         self._unsub_trigger: Callable[[], None] | None = None
         self._script: Script | None = None
+        self._run_variables: ScriptVariables | None = None
+        self._blueprint_inputs: dict | None = None
+        if config is not None:
+            self._run_variables = config.get(CONF_VARIABLES)
+            self._blueprint_inputs = getattr(config, "raw_blueprint_inputs", None)
+
+    @property
+    def referenced_blueprint(self) -> str | None:
+        """Return referenced blueprint or None."""
+        if self._blueprint_inputs is None:
+            return None
+        return cast(str, self._blueprint_inputs[CONF_USE_BLUEPRINT][CONF_PATH])
 
     @property
     def unique_id(self) -> str | None:
@@ -104,6 +118,10 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
     async def _handle_triggered_with_script(
         self, run_variables: TemplateVarsType, context: Context | None = None
     ) -> None:
+        # Render run variables after the trigger, before checking conditions.
+        if self._run_variables:
+            run_variables = self._run_variables.async_render(self.hass, run_variables)
+
         if not self._check_condition(run_variables):
             return
         # Create a context referring to the trigger context.
@@ -119,6 +137,9 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
     async def _handle_triggered(
         self, run_variables: TemplateVarsType, context: Context | None = None
     ) -> None:
+        if self._run_variables:
+            run_variables = self._run_variables.async_render(self.hass, run_variables)
+
         if not self._check_condition(run_variables):
             return
         self._execute_update(run_variables, context)

--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.singleton import singleton
 
 from .const import DOMAIN, TEMPLATE_BLUEPRINT_SCHEMA
 from .entity import AbstractTemplateEntity
-from .template_entity import TemplateEntity
 
 DATA_BLUEPRINTS = "template_blueprints"
 
@@ -24,7 +23,7 @@ def templates_with_blueprint(hass: HomeAssistant, blueprint_path: str) -> list[s
         entity_id
         for platform in async_get_platforms(hass, DOMAIN)
         for entity_id, template_entity in platform.entities.items()
-        if isinstance(template_entity, (AbstractTemplateEntity, TemplateEntity))
+        if isinstance(template_entity, AbstractTemplateEntity)
         and template_entity.referenced_blueprint == blueprint_path
     ]
 
@@ -35,7 +34,7 @@ def blueprint_in_template(hass: HomeAssistant, entity_id: str) -> str | None:
     for platform in async_get_platforms(hass, DOMAIN):
         if isinstance(
             (template_entity := platform.entities.get(entity_id)),
-            (AbstractTemplateEntity, TemplateEntity),
+            AbstractTemplateEntity,
         ):
             return template_entity.referenced_blueprint
     return None

--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.entity_platform import async_get_platforms
 from homeassistant.helpers.singleton import singleton
 
 from .const import DOMAIN, TEMPLATE_BLUEPRINT_SCHEMA
+from .entity import AbstractTemplateEntity
 from .template_entity import TemplateEntity
 
 DATA_BLUEPRINTS = "template_blueprints"
@@ -23,7 +24,7 @@ def templates_with_blueprint(hass: HomeAssistant, blueprint_path: str) -> list[s
         entity_id
         for platform in async_get_platforms(hass, DOMAIN)
         for entity_id, template_entity in platform.entities.items()
-        if isinstance(template_entity, TemplateEntity)
+        if isinstance(template_entity, (AbstractTemplateEntity, TemplateEntity))
         and template_entity.referenced_blueprint == blueprint_path
     ]
 
@@ -33,7 +34,8 @@ def blueprint_in_template(hass: HomeAssistant, entity_id: str) -> str | None:
     """Return the blueprint the template entity is based on or None."""
     for platform in async_get_platforms(hass, DOMAIN):
         if isinstance(
-            (template_entity := platform.entities.get(entity_id)), TemplateEntity
+            (template_entity := platform.entities.get(entity_id)),
+            (AbstractTemplateEntity, TemplateEntity),
         ):
             return template_entity.referenced_blueprint
     return None

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -31,7 +31,6 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
-from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
@@ -237,7 +236,7 @@ class TriggerNumberEntity(TriggerEntity, NumberEntity):
         super().__init__(hass, coordinator, config)
 
         name = self._rendered.get(CONF_NAME, DEFAULT_NAME)
-        self.add_script(hass, CONF_SET_VALUE, config[CONF_SET_VALUE], name, DOMAIN)
+        self.add_script(CONF_SET_VALUE, config[CONF_SET_VALUE], name, DOMAIN)
 
         self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
 
@@ -272,7 +271,7 @@ class TriggerNumberEntity(TriggerEntity, NumberEntity):
         if self._config[CONF_OPTIMISTIC]:
             self._attr_native_value = value
             self.async_write_ha_state()
-        if (set_value := self._action_scripts.get(CONF_SET_VALUE)) is not None:
+        if set_value := self._action_scripts.get(CONF_SET_VALUE):
             await self.async_run_script(
                 set_value,
                 run_variables={ATTR_VALUE: value},

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -236,12 +236,8 @@ class TriggerNumberEntity(TriggerEntity, NumberEntity):
         """Initialize the entity."""
         super().__init__(hass, coordinator, config)
 
-        self._command_set_value = Script(
-            hass,
-            config[CONF_SET_VALUE],
-            self._rendered.get(CONF_NAME, DEFAULT_NAME),
-            DOMAIN,
-        )
+        name = self._rendered.get(CONF_NAME, DEFAULT_NAME)
+        self.add_script(hass, CONF_SET_VALUE, config[CONF_SET_VALUE], name, DOMAIN)
 
         self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
 
@@ -276,6 +272,9 @@ class TriggerNumberEntity(TriggerEntity, NumberEntity):
         if self._config[CONF_OPTIMISTIC]:
             self._attr_native_value = value
             self.async_write_ha_state()
-        await self._command_set_value.async_run(
-            {ATTR_VALUE: value}, context=self._context
-        )
+        if (set_value := self._action_scripts.get(CONF_SET_VALUE)) is not None:
+            await self.async_run_script(
+                set_value,
+                run_variables={ATTR_VALUE: value},
+                context=self._context,
+            )

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -28,7 +28,6 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
-from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
@@ -200,7 +199,6 @@ class TriggerSelectEntity(TriggerEntity, SelectEntity):
         super().__init__(hass, coordinator, config)
         if select_option := config.get(CONF_SELECT_OPTION):
             self.add_script(
-                hass,
                 CONF_SELECT_OPTION,
                 select_option,
                 self._rendered.get(CONF_NAME, DEFAULT_NAME),
@@ -222,7 +220,7 @@ class TriggerSelectEntity(TriggerEntity, SelectEntity):
         if self._config[CONF_OPTIMISTIC]:
             self._attr_current_option = option
             self.async_write_ha_state()
-        if (select_option := self._action_scripts.get(CONF_SELECT_OPTION)) is not None:
+        if select_option := self._action_scripts.get(CONF_SELECT_OPTION):
             await self.async_run_script(
                 select_option,
                 run_variables={ATTR_OPTION: option},

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -8,10 +8,13 @@ from homeassistant.helpers.trigger_template_entity import TriggerBaseEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import TriggerUpdateCoordinator
+from .entity import AbstractTemplateEntity
 
 
 class TriggerEntity(  # pylint: disable=hass-enforce-class-module
-    TriggerBaseEntity, CoordinatorEntity[TriggerUpdateCoordinator]
+    TriggerBaseEntity,
+    CoordinatorEntity[TriggerUpdateCoordinator],
+    AbstractTemplateEntity,
 ):
     """Template entity based on trigger data."""
 
@@ -24,6 +27,7 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
         """Initialize the entity."""
         CoordinatorEntity.__init__(self, coordinator)
         TriggerBaseEntity.__init__(self, hass, config)
+        AbstractTemplateEntity.__init__(self)
 
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""
@@ -37,6 +41,16 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
             self._unique_id = f"{self.coordinator.unique_id}-{unique_id}"
         else:
             self._unique_id = unique_id
+
+    @property
+    def referenced_blueprint(self) -> str | None:
+        """Return referenced blueprint or None."""
+        return self.coordinator.referenced_blueprint
+
+    @callback
+    def _render_script_variables(self) -> dict:
+        """Render configured variables."""
+        return self.coordinator.data["run_variables"]
 
     @callback
     def _process_data(self) -> None:

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -27,7 +27,7 @@ class TriggerEntity(  # pylint: disable=hass-enforce-class-module
         """Initialize the entity."""
         CoordinatorEntity.__init__(self, coordinator)
         TriggerBaseEntity.__init__(self, hass, config)
-        AbstractTemplateEntity.__init__(self)
+        AbstractTemplateEntity.__init__(self, hass)
 
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""

--- a/tests/components/template/test_blueprint.py
+++ b/tests/components/template/test_blueprint.py
@@ -16,10 +16,10 @@ from homeassistant.components.blueprint import (
     DomainBlueprints,
 )
 from homeassistant.components.template import DOMAIN, SERVICE_RELOAD
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
-from homeassistant.util import yaml as yaml_util
+from homeassistant.util import dt as dt_util, yaml as yaml_util
 
 from tests.common import async_mock_service
 
@@ -212,6 +212,61 @@ async def test_reload_template_when_blueprint_changes(hass: HomeAssistant) -> No
     assert not_inverted.state == "on"
 
 
+async def test_trigger_event_sensor(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test event sensor blueprint."""
+    blueprint = "test_event_sensor.yaml"
+    assert await async_setup_component(
+        hass,
+        "template",
+        {
+            "template": [
+                {
+                    "use_blueprint": {
+                        "path": blueprint,
+                        "input": {
+                            "event_type": "my_custom_event",
+                            "event_data": {"foo": "bar"},
+                        },
+                    },
+                    "name": "My Custom Event",
+                },
+            ]
+        },
+    )
+
+    context = Context()
+    now = dt_util.utcnow()
+    with patch("homeassistant.util.dt.now", return_value=now):
+        hass.bus.async_fire(
+            "my_custom_event", {"foo": "bar", "beer": 2}, context=context
+        )
+        await hass.async_block_till_done()
+
+    date_state = hass.states.get("sensor.my_custom_event")
+    assert date_state is not None
+    assert date_state.state == now.isoformat(timespec="seconds")
+    data = date_state.attributes.get("data")
+    assert data is not None
+    assert data != ""
+    assert data.get("foo") == "bar"
+    assert data.get("beer") == 2
+
+    inverted_foo_template = template.helpers.blueprint_in_template(
+        hass, "sensor.my_custom_event"
+    )
+    assert inverted_foo_template == blueprint
+
+    inverted_binary_sensor_blueprint_entity_ids = (
+        template.helpers.templates_with_blueprint(hass, blueprint)
+    )
+    assert len(inverted_binary_sensor_blueprint_entity_ids) == 1
+
+    with pytest.raises(BlueprintInUse):
+        await template.async_get_blueprints(hass).async_remove_blueprint(blueprint)
+
+
 async def test_domain_blueprint(hass: HomeAssistant) -> None:
     """Test DomainBlueprint services."""
     reload_handler_calls = async_mock_service(hass, DOMAIN, SERVICE_RELOAD)
@@ -262,7 +317,8 @@ async def test_invalid_blueprint(
         )
 
     assert "more than one platform defined per blueprint" in caplog.text
-    assert await template.async_get_blueprints(hass).async_get_blueprints() == {}
+    blueprints = await template.async_get_blueprints(hass).async_get_blueprints()
+    assert "invalid.yaml" not in blueprints
 
 
 async def test_no_blueprint(hass: HomeAssistant) -> None:

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -330,7 +330,10 @@ async def test_trigger_number(hass: HomeAssistant) -> None:
                             "max": "{{ trigger.event.data.max_beers }}",
                             "step": "{{ trigger.event.data.step }}",
                             "unit_of_measurement": "beer",
-                            "set_value": {"event": "test_number_event"},
+                            "set_value": {
+                                "event": "test_number_event",
+                                "event_data": {"entity_id": "{{ this.entity_id }}"},
+                            },
                             "optimistic": True,
                         },
                     ],
@@ -379,6 +382,9 @@ async def test_trigger_number(hass: HomeAssistant) -> None:
     )
     assert len(events) == 1
     assert events[0].event_type == "test_number_event"
+    entity_id = events[0].data.get("entity_id")
+    assert entity_id is not None
+    assert entity_id == "number.hello_name"
 
 
 def _verify(

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -280,7 +280,10 @@ async def test_trigger_select(hass: HomeAssistant) -> None:
                             "unique_id": "hello_name-id",
                             "state": "{{ trigger.event.data.beer }}",
                             "options": "{{ trigger.event.data.beers }}",
-                            "select_option": {"event": "test_number_event"},
+                            "select_option": {
+                                "event": "test_number_event",
+                                "event_data": {"entity_id": "{{ this.entity_id }}"},
+                            },
                             "optimistic": True,
                         },
                     ],
@@ -316,6 +319,9 @@ async def test_trigger_select(hass: HomeAssistant) -> None:
     )
     assert len(events) == 1
     assert events[0].event_type == "test_number_event"
+    entity_id = events[0].data.get("entity_id")
+    assert entity_id is not None
+    assert entity_id == "select.hello_name"
 
 
 def _verify(

--- a/tests/components/template/test_trigger_entity.py
+++ b/tests/components/template/test_trigger_entity.py
@@ -1,0 +1,13 @@
+"""Test trigger template entity."""
+
+from homeassistant.components.template import trigger_entity
+from homeassistant.components.template.coordinator import TriggerUpdateCoordinator
+from homeassistant.core import HomeAssistant
+
+
+async def test_reference_blueprints_is_none(hass: HomeAssistant) -> None:
+    """Test template entity requires hass to be set before accepting templates."""
+    coordinator = TriggerUpdateCoordinator(hass, {})
+    entity = trigger_entity.TriggerEntity(hass, coordinator, {})
+
+    assert entity.referenced_blueprint is None

--- a/tests/testing_config/blueprints/template/test_event_sensor.yaml
+++ b/tests/testing_config/blueprints/template/test_event_sensor.yaml
@@ -1,0 +1,27 @@
+blueprint:
+  name: Create Sensor from Event
+  description: Creates a timestamp sensor from an event
+  domain: template
+  source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/template/blueprints/event_sensor.yaml
+  input:
+    event_type:
+      name: Name of the event_type
+      description: The event_type for the event trigger
+      selector:
+        text:
+    event_data:
+      name: The data for the event
+      description: The event_data for the event trigger
+      selector:
+        object:
+trigger:
+  - trigger: event
+    event_type: !input event_type
+    event_data: !input event_data
+variables:
+  event_data: "{{ trigger.event.data }}"
+sensor:
+  state: "{{ now() }}"
+  device_class: timestamp
+  attributes:
+    data: "{{ event_data }}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Creates an abstract class for TriggerEntity to inherit from.

This will fix inconsistencies with the this variable in trigger based template entities scripts/actions
This will allows us to resolve the following blueprint issues:

https://github.com/home-assistant/core/issues/130330

https://github.com/home-assistant/core/issues/131004

This will allow trigger based template entities to use variables between triggers and conditions, just like automations.

This PR originally came from from https://github.com/home-assistant/core/pull/136564. 136564 has been split into 2 PRs: This PR and https://github.com/home-assistant/core/pull/139645. ~~This PR is waiting for https://github.com/home-assistant/core/pull/139645 to get merged.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
