### PR TITLE
Add snapshot tests for OpenWeatherMap sensors

### DIFF
--- a/homeassistant/components/openweathermap/coordinator.py
+++ b/homeassistant/components/openweathermap/coordinator.py
@@ -91,13 +91,18 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Update the data."""
+        weather_report = await self._get_weather_report()
+        return self._convert_weather_response(weather_report)
+
+    async def _get_weather_report(self) -> WeatherReport:
+        """Get the weather report from the OWM client."""
         try:
             weather_report = await self._owm_client.get_weather(
                 self._latitude, self._longitude
             )
         except RequestError as error:
             raise UpdateFailed(error) from error
-        return self._convert_weather_response(weather_report)
+        return weather_report
 
     def _convert_weather_response(self, weather_report: WeatherReport):
         """Format the weather response correctly."""

--- a/homeassistant/components/openweathermap/coordinator.py
+++ b/homeassistant/components/openweathermap/coordinator.py
@@ -91,18 +91,13 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Update the data."""
-        weather_report = await self._get_weather_report()
-        return self._convert_weather_response(weather_report)
-
-    async def _get_weather_report(self) -> WeatherReport:
-        """Get the weather report from the OWM client."""
         try:
             weather_report = await self._owm_client.get_weather(
                 self._latitude, self._longitude
             )
         except RequestError as error:
             raise UpdateFailed(error) from error
-        return weather_report
+        return self._convert_weather_response(weather_report)
 
     def _convert_weather_response(self, weather_report: WeatherReport):
         """Format the weather response correctly."""

--- a/tests/components/openweathermap/__init__.py
+++ b/tests/components/openweathermap/__init__.py
@@ -1,34 +1,20 @@
 """Shared utilities for OpenWeatherMap tests."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .test_config_flow import _create_static_weather_report
-
-from tests.common import AsyncMock, MockConfigEntry
-
-static_weather_report = _create_static_weather_report()
-
-
-def _create_mocked_owm_factory() -> MagicMock:
-    """Create a mocked OWM client."""
-    mocked_owm_client = MagicMock()
-    mocked_owm_client.get_weather = AsyncMock(return_value=static_weather_report)
-    return mocked_owm_client
+from tests.common import MockConfigEntry
 
 
 async def setup_platform(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    owm_client_mock: MagicMock,
     platforms: list[Platform],
 ):
     """Set up the OpenWeatherMap platform."""
-    owm_client_mock.return_value = _create_mocked_owm_factory()
-
     config_entry.add_to_hass(hass)
     with (
         patch("homeassistant.components.openweathermap.PLATFORMS", platforms),

--- a/tests/components/openweathermap/__init__.py
+++ b/tests/components/openweathermap/__init__.py
@@ -27,8 +27,7 @@ async def setup_platform(
     platforms: list[Platform],
 ):
     """Set up the OpenWeatherMap platform."""
-    mock = _create_mocked_owm_factory()
-    owm_client_mock.return_value = mock
+    owm_client_mock.return_value = _create_mocked_owm_factory()
 
     config_entry.add_to_hass(hass)
     with (

--- a/tests/components/openweathermap/__init__.py
+++ b/tests/components/openweathermap/__init__.py
@@ -1,1 +1,29 @@
-"""Tests for the OpenWeatherMap integration."""
+"""Shared utilities for OpenWeatherMap tests."""
+
+from unittest.mock import patch
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .test_config_flow import _create_static_weather_report
+
+from tests.common import AsyncMock
+
+static_weather_report = _create_static_weather_report()
+
+
+async def setup_platform(hass: HomeAssistant, config_entry, platforms: list[Platform]):
+    """Set up the OpenWeatherMap platform."""
+    config_entry.add_to_hass(hass)
+    with (
+        patch("homeassistant.components.openweathermap.PLATFORMS", platforms),
+        patch(
+            "homeassistant.components.openweathermap.coordinator.WeatherUpdateCoordinator._get_weather_report",
+            new_callable=AsyncMock,
+            return_value=static_weather_report,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/openweathermap/conftest.py
+++ b/tests/components/openweathermap/conftest.py
@@ -1,5 +1,18 @@
 """Configure tests for the OpenWeatherMap integration."""
 
+from collections.abc import Generator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+from pyopenweathermap import (
+    CurrentWeather,
+    DailyTemperature,
+    DailyWeatherForecast,
+    MinutelyWeatherForecast,
+    WeatherCondition,
+    WeatherReport,
+)
+from pyopenweathermap.client.owm_abstract_client import OWMClient
 import pytest
 
 from homeassistant.components.openweathermap.const import DEFAULT_LANGUAGE, DOMAIN
@@ -43,13 +56,91 @@ def mock_config_entry(mode: str) -> MockConfigEntry:
         },
         entry_id="test",
         version=5,
+        unique_id=f"{LATITUDE}-{LONGITUDE}",
     )
 
 
 @pytest.fixture
-def owm_client_mock():
+def owm_client_mock() -> Generator[AsyncMock]:
     """Mock OWMClient."""
-    with patch(
-        "homeassistant.components.openweathermap.create_owm_client",
-    ) as mock:
-        yield mock
+    client = AsyncMock(spec=OWMClient, autospec=True)
+    current_weather = CurrentWeather(
+        date_time=datetime.fromtimestamp(1714063536, tz=UTC),
+        temperature=6.84,
+        feels_like=2.07,
+        pressure=1000,
+        humidity=82,
+        dew_point=3.99,
+        uv_index=0.13,
+        cloud_coverage=75,
+        visibility=10000,
+        wind_speed=9.83,
+        wind_bearing=199,
+        wind_gust=None,
+        rain={"1h": 1.21},
+        snow=None,
+        condition=WeatherCondition(
+            id=803,
+            main="Clouds",
+            description="broken clouds",
+            icon="04d",
+        ),
+    )
+    daily_weather_forecast = DailyWeatherForecast(
+        date_time=datetime.fromtimestamp(1714063536, tz=UTC),
+        summary="There will be clear sky until morning, then partly cloudy",
+        temperature=DailyTemperature(
+            day=18.76,
+            min=8.11,
+            max=21.26,
+            night=13.06,
+            evening=20.51,
+            morning=8.47,
+        ),
+        feels_like=DailyTemperature(
+            day=18.76,
+            min=8.11,
+            max=21.26,
+            night=13.06,
+            evening=20.51,
+            morning=8.47,
+        ),
+        pressure=1015,
+        humidity=62,
+        dew_point=11.34,
+        wind_speed=8.14,
+        wind_bearing=168,
+        wind_gust=11.81,
+        condition=WeatherCondition(
+            id=803,
+            main="Clouds",
+            description="broken clouds",
+            icon="04d",
+        ),
+        cloud_coverage=84,
+        precipitation_probability=0,
+        uv_index=4.06,
+        rain=0,
+        snow=0,
+    )
+    minutely_weather_forecast = [
+        MinutelyWeatherForecast(date_time=1728672360, precipitation=0),
+        MinutelyWeatherForecast(date_time=1728672420, precipitation=1.23),
+        MinutelyWeatherForecast(date_time=1728672480, precipitation=4.5),
+        MinutelyWeatherForecast(date_time=1728672540, precipitation=0),
+    ]
+    client.get_weather.return_value = WeatherReport(
+        current_weather, minutely_weather_forecast, [], [daily_weather_forecast]
+    )
+    client.validate_key.return_value = True
+    with (
+        patch(
+            "homeassistant.components.openweathermap.create_owm_client",
+            return_value=client,
+        ),
+        patch(
+            "homeassistant.components.openweathermap.utils.create_owm_client",
+            return_value=client,
+        ),
+    ):
+        yield client

--- a/tests/components/openweathermap/conftest.py
+++ b/tests/components/openweathermap/conftest.py
@@ -1,5 +1,7 @@
 """Configure tests for the OpenWeatherMap integration."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from homeassistant.components.openweathermap.const import DEFAULT_LANGUAGE, DOMAIN
@@ -12,7 +14,7 @@ from homeassistant.const import (
     CONF_NAME,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, patch
 
 API_KEY = "test_api_key"
 LATITUDE = 12.34
@@ -44,3 +46,12 @@ def mock_config_entry(mode: str) -> MockConfigEntry:
         entry_id="test",
         version=5,
     )
+
+
+@pytest.fixture
+def owm_client_mock() -> MagicMock:
+    """Mock OWMClient."""
+    with patch(
+        "homeassistant.components.openweathermap.create_owm_client",
+    ) as mock:
+        yield mock

--- a/tests/components/openweathermap/conftest.py
+++ b/tests/components/openweathermap/conftest.py
@@ -1,19 +1,14 @@
 """Configure tests for the OpenWeatherMap integration."""
 
 from collections.abc import Generator
-from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.openweathermap.const import (
     DEFAULT_LANGUAGE,
     DOMAIN,
-    OWM_MODE_FREE_CURRENT,
-    OWM_MODE_FREE_FORECAST,
-    OWM_MODE_V30,
     OWM_MODES,
 )
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_LANGUAGE,
@@ -21,21 +16,14 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_MODE,
     CONF_NAME,
-    Platform,
 )
-from homeassistant.core import HomeAssistant
 
-from .test_config_flow import _create_static_weather_report
-
-from tests.common import AsyncMock, MockConfigEntry
+from tests.common import MockConfigEntry
 
 API_KEY = "test_api_key"
 LATITUDE = 12.34
 LONGITUDE = 56.78
 NAME = "openweathermap"
-
-# Define test data for mocked weather report
-static_weather_report = _create_static_weather_report()
 
 
 @pytest.fixture(params=OWM_MODES)
@@ -62,31 +50,3 @@ def mock_config_entry(mode: str) -> MockConfigEntry:
         entry_id="test",
         version=5,
     )
-
-
-def get_weather(mode: str) -> str:
-    """Return get_weather function."""
-    if mode in (OWM_MODE_FREE_CURRENT, OWM_MODE_FREE_FORECAST):
-        return "pyopenweathermap.client.free_client.OWMFreeClient.get_weather"
-    if mode == OWM_MODE_V30:
-        return "pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather"
-    pytest.fail("Invalid mode")
-
-
-async def setup_platform(
-    hass: HomeAssistant, config_entry: MockConfigEntry, platforms: list[Platform]
-):
-    """Set up the OpenWeatherMap platform."""
-    config_entry.add_to_hass(hass)
-    mode = config_entry.options[CONF_MODE]
-    with (
-        patch("homeassistant.components.openweathermap.PLATFORMS", platforms),
-        patch(
-            get_weather(mode),
-            new_callable=AsyncMock,
-            return_value=static_weather_report,
-        ),
-    ):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-        assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/openweathermap/conftest.py
+++ b/tests/components/openweathermap/conftest.py
@@ -1,5 +1,7 @@
 """Configure tests for the OpenWeatherMap integration."""
 
+from unittest.mock import patch
+
 from homeassistant.components.openweathermap.const import DEFAULT_LANGUAGE, DOMAIN
 from homeassistant.const import (
     CONF_API_KEY,
@@ -8,7 +10,9 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_MODE,
     CONF_NAME,
+    Platform,
 )
+from homeassistant.core import HomeAssistant
 
 from .test_config_flow import _create_static_weather_report
 
@@ -37,3 +41,14 @@ def mock_config_entry(mode: str) -> MockConfigEntry:
         entry_id="test",
         version=5,
     )
+
+
+async def setup_platform(
+    hass: HomeAssistant, config_entry: MockConfigEntry, platforms: list[Platform]
+):
+    """Set up the OpenWeatherMap platform."""
+    config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.openweathermap.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/components/openweathermap/conftest.py
+++ b/tests/components/openweathermap/conftest.py
@@ -1,0 +1,42 @@
+"""Configure tests for the OpenWeatherMap integration."""
+
+# import pytest
+# from syrupy import SnapshotAssertion
+
+from homeassistant.components.openweathermap.const import DEFAULT_LANGUAGE, DOMAIN
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LANGUAGE,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_MODE,
+    CONF_NAME,
+)
+
+from .test_config_flow import _create_static_weather_report
+
+from tests.common import MockConfigEntry
+
+API_KEY = "test_api_key"
+LATITUDE = 12.34
+LONGITUDE = 56.78
+NAME = "openweathermap"
+
+# Define test data for mocked weather report
+static_weather_report = _create_static_weather_report()
+
+
+def mock_config_entry(mode: str) -> MockConfigEntry:
+    """Create a mock OpenWeatherMap config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: API_KEY,
+            CONF_LATITUDE: LATITUDE,
+            CONF_LONGITUDE: LONGITUDE,
+            CONF_NAME: NAME,
+        },
+        options={CONF_MODE: mode, CONF_LANGUAGE: DEFAULT_LANGUAGE},
+        entry_id="test",
+        version=5,
+    )

--- a/tests/components/openweathermap/conftest.py
+++ b/tests/components/openweathermap/conftest.py
@@ -1,7 +1,5 @@
 """Configure tests for the OpenWeatherMap integration."""
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from homeassistant.components.openweathermap.const import DEFAULT_LANGUAGE, DOMAIN
@@ -49,7 +47,7 @@ def mock_config_entry(mode: str) -> MockConfigEntry:
 
 
 @pytest.fixture
-def owm_client_mock() -> MagicMock:
+def owm_client_mock():
     """Mock OWMClient."""
     with patch(
         "homeassistant.components.openweathermap.create_owm_client",

--- a/tests/components/openweathermap/conftest.py
+++ b/tests/components/openweathermap/conftest.py
@@ -1,8 +1,5 @@
 """Configure tests for the OpenWeatherMap integration."""
 
-# import pytest
-# from syrupy import SnapshotAssertion
-
 from homeassistant.components.openweathermap.const import DEFAULT_LANGUAGE, DOMAIN
 from homeassistant.const import (
     CONF_API_KEY,

--- a/tests/components/openweathermap/conftest.py
+++ b/tests/components/openweathermap/conftest.py
@@ -1,8 +1,19 @@
 """Configure tests for the OpenWeatherMap integration."""
 
+from collections.abc import Generator
 from unittest.mock import patch
 
-from homeassistant.components.openweathermap.const import DEFAULT_LANGUAGE, DOMAIN
+import pytest
+
+from homeassistant.components.openweathermap.const import (
+    DEFAULT_LANGUAGE,
+    DOMAIN,
+    OWM_MODE_FREE_CURRENT,
+    OWM_MODE_FREE_FORECAST,
+    OWM_MODE_V30,
+    OWM_MODES,
+)
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_LANGUAGE,
@@ -16,7 +27,7 @@ from homeassistant.core import HomeAssistant
 
 from .test_config_flow import _create_static_weather_report
 
-from tests.common import MockConfigEntry
+from tests.common import AsyncMock, MockConfigEntry
 
 API_KEY = "test_api_key"
 LATITUDE = 12.34
@@ -27,8 +38,15 @@ NAME = "openweathermap"
 static_weather_report = _create_static_weather_report()
 
 
+@pytest.fixture(params=OWM_MODES)
+def mode(request: pytest.FixtureRequest) -> Generator[str]:
+    """Return every mode."""
+    return request.param
+
+
+@pytest.fixture
 def mock_config_entry(mode: str) -> MockConfigEntry:
-    """Create a mock OpenWeatherMap config entry."""
+    """Fixture for creating a mock OpenWeatherMap config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -37,10 +55,22 @@ def mock_config_entry(mode: str) -> MockConfigEntry:
             CONF_LONGITUDE: LONGITUDE,
             CONF_NAME: NAME,
         },
-        options={CONF_MODE: mode, CONF_LANGUAGE: DEFAULT_LANGUAGE},
+        options={
+            CONF_MODE: mode,
+            CONF_LANGUAGE: DEFAULT_LANGUAGE,
+        },
         entry_id="test",
         version=5,
     )
+
+
+def get_weather(mode: str) -> str:
+    """Return get_weather function."""
+    if mode in (OWM_MODE_FREE_CURRENT, OWM_MODE_FREE_FORECAST):
+        return "pyopenweathermap.client.free_client.OWMFreeClient.get_weather"
+    if mode == OWM_MODE_V30:
+        return "pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather"
+    pytest.fail("Invalid mode")
 
 
 async def setup_platform(
@@ -48,7 +78,15 @@ async def setup_platform(
 ):
     """Set up the OpenWeatherMap platform."""
     config_entry.add_to_hass(hass)
-
-    with patch("homeassistant.components.openweathermap.PLATFORMS", platforms):
-        await hass.config_entries.async_setup(config_entry.entry_id)
+    mode = config_entry.options[CONF_MODE]
+    with (
+        patch("homeassistant.components.openweathermap.PLATFORMS", platforms),
+        patch(
+            get_weather(mode),
+            new_callable=AsyncMock,
+            return_value=static_weather_report,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
+        assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/openweathermap/conftest.py
+++ b/tests/components/openweathermap/conftest.py
@@ -1,14 +1,8 @@
 """Configure tests for the OpenWeatherMap integration."""
 
-from collections.abc import Generator
-
 import pytest
 
-from homeassistant.components.openweathermap.const import (
-    DEFAULT_LANGUAGE,
-    DOMAIN,
-    OWM_MODES,
-)
+from homeassistant.components.openweathermap.const import DEFAULT_LANGUAGE, DOMAIN
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_LANGUAGE,
@@ -26,9 +20,9 @@ LONGITUDE = 56.78
 NAME = "openweathermap"
 
 
-@pytest.fixture(params=OWM_MODES)
-def mode(request: pytest.FixtureRequest) -> Generator[str]:
-    """Return every mode."""
+@pytest.fixture
+def mode(request: pytest.FixtureRequest) -> str:
+    """Return mode passed in parameter."""
     return request.param
 
 

--- a/tests/components/openweathermap/snapshots/test_sensor.ambr
+++ b/tests/components/openweathermap/snapshots/test_sensor.ambr
@@ -725,7 +725,7 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT_ANGLE: 'measurement_angle'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -744,7 +744,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.WIND_DIRECTION: 'wind_direction'>,
     'original_icon': None,
     'original_name': 'openweathermap Wind bearing',
     'platform': 'openweathermap',
@@ -759,8 +759,9 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'wind_direction',
       'friendly_name': 'openweathermap Wind bearing',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT_ANGLE: 'measurement_angle'>,
       'unit_of_measurement': '°',
     }),
     'context': <ANY>,
@@ -1553,7 +1554,7 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT_ANGLE: 'measurement_angle'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -1572,7 +1573,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.WIND_DIRECTION: 'wind_direction'>,
     'original_icon': None,
     'original_name': 'openweathermap Wind bearing',
     'platform': 'openweathermap',
@@ -1587,8 +1588,9 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'wind_direction',
       'friendly_name': 'openweathermap Wind bearing',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'state_class': <SensorStateClass.MEASUREMENT_ANGLE: 'measurement_angle'>,
       'unit_of_measurement': '°',
     }),
     'context': <ANY>,

--- a/tests/components/openweathermap/snapshots/test_sensor.ambr
+++ b/tests/components/openweathermap/snapshots/test_sensor.ambr
@@ -31,7 +31,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-clouds',
+    'unique_id': '12.34-56.78-clouds',
     'unit_of_measurement': '%',
   })
 # ---
@@ -81,7 +81,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-condition',
+    'unique_id': '12.34-56.78-condition',
     'unit_of_measurement': None,
   })
 # ---
@@ -131,7 +131,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-dew_point',
+    'unique_id': '12.34-56.78-dew_point',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -184,7 +184,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-feels_like_temperature',
+    'unique_id': '12.34-56.78-feels_like_temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -237,7 +237,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-humidity',
+    'unique_id': '12.34-56.78-humidity',
     'unit_of_measurement': '%',
   })
 # ---
@@ -288,7 +288,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-precipitation_kind',
+    'unique_id': '12.34-56.78-precipitation_kind',
     'unit_of_measurement': None,
   })
 # ---
@@ -338,7 +338,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-pressure',
+    'unique_id': '12.34-56.78-pressure',
     'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
   })
 # ---
@@ -391,7 +391,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-rain',
+    'unique_id': '12.34-56.78-rain',
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
@@ -444,7 +444,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-snow',
+    'unique_id': '12.34-56.78-snow',
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
@@ -497,7 +497,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-temperature',
+    'unique_id': '12.34-56.78-temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -550,7 +550,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-uv_index',
+    'unique_id': '12.34-56.78-uv_index',
     'unit_of_measurement': 'UV index',
   })
 # ---
@@ -602,7 +602,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-visibility_distance',
+    'unique_id': '12.34-56.78-visibility_distance',
     'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
   })
 # ---
@@ -653,7 +653,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-weather',
+    'unique_id': '12.34-56.78-weather',
     'unit_of_measurement': None,
   })
 # ---
@@ -701,7 +701,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-weather_code',
+    'unique_id': '12.34-56.78-weather_code',
     'unit_of_measurement': None,
   })
 # ---
@@ -751,7 +751,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-wind_bearing',
+    'unique_id': '12.34-56.78-wind_bearing',
     'unit_of_measurement': '°',
   })
 # ---
@@ -807,7 +807,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-wind_speed',
+    'unique_id': '12.34-56.78-wind_speed',
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
@@ -860,7 +860,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-clouds',
+    'unique_id': '12.34-56.78-clouds',
     'unit_of_measurement': '%',
   })
 # ---
@@ -910,7 +910,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-condition',
+    'unique_id': '12.34-56.78-condition',
     'unit_of_measurement': None,
   })
 # ---
@@ -960,7 +960,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-dew_point',
+    'unique_id': '12.34-56.78-dew_point',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -1013,7 +1013,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-feels_like_temperature',
+    'unique_id': '12.34-56.78-feels_like_temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -1066,7 +1066,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-humidity',
+    'unique_id': '12.34-56.78-humidity',
     'unit_of_measurement': '%',
   })
 # ---
@@ -1117,7 +1117,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-precipitation_kind',
+    'unique_id': '12.34-56.78-precipitation_kind',
     'unit_of_measurement': None,
   })
 # ---
@@ -1167,7 +1167,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-pressure',
+    'unique_id': '12.34-56.78-pressure',
     'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
   })
 # ---
@@ -1220,7 +1220,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-rain',
+    'unique_id': '12.34-56.78-rain',
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
@@ -1273,7 +1273,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-snow',
+    'unique_id': '12.34-56.78-snow',
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
@@ -1326,7 +1326,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-temperature',
+    'unique_id': '12.34-56.78-temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -1379,7 +1379,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-uv_index',
+    'unique_id': '12.34-56.78-uv_index',
     'unit_of_measurement': 'UV index',
   })
 # ---
@@ -1431,7 +1431,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-visibility_distance',
+    'unique_id': '12.34-56.78-visibility_distance',
     'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
   })
 # ---
@@ -1482,7 +1482,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-weather',
+    'unique_id': '12.34-56.78-weather',
     'unit_of_measurement': None,
   })
 # ---
@@ -1530,7 +1530,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-weather_code',
+    'unique_id': '12.34-56.78-weather_code',
     'unit_of_measurement': None,
   })
 # ---
@@ -1580,7 +1580,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-wind_bearing',
+    'unique_id': '12.34-56.78-wind_bearing',
     'unit_of_measurement': '°',
   })
 # ---
@@ -1636,7 +1636,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None-wind_speed',
+    'unique_id': '12.34-56.78-wind_speed',
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---

--- a/tests/components/openweathermap/snapshots/test_sensor.ambr
+++ b/tests/components/openweathermap/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_cloud_coverage-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_cloud_coverage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -35,7 +35,7 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_cloud_coverage-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_cloud_coverage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -51,7 +51,7 @@
     'state': '75',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_condition-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_condition-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -85,7 +85,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_condition-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_condition-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -99,7 +99,7 @@
     'state': 'cloudy',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_dew_point-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_dew_point-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -135,7 +135,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_dew_point-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_dew_point-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -152,7 +152,7 @@
     'state': '3.99',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_feels_like_temperature-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_feels_like_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -188,7 +188,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_feels_like_temperature-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_feels_like_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -205,7 +205,7 @@
     'state': '2.07',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_humidity-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_humidity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -241,7 +241,7 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_humidity-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_humidity-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -258,7 +258,7 @@
     'state': '82',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_precipitation_kind-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_precipitation_kind-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -292,7 +292,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_precipitation_kind-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_precipitation_kind-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -306,7 +306,7 @@
     'state': 'Rain',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_pressure-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_pressure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -342,7 +342,7 @@
     'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_pressure-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_pressure-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -359,7 +359,7 @@
     'state': '1000',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_rain-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_rain-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -395,7 +395,7 @@
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_rain-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_rain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -412,7 +412,7 @@
     'state': '1.21',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_snow-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_snow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -448,7 +448,7 @@
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_snow-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_snow-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -465,7 +465,7 @@
     'state': '0',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_temperature-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -501,7 +501,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_temperature-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -518,7 +518,7 @@
     'state': '6.84',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_uv_index-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_uv_index-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -554,7 +554,7 @@
     'unit_of_measurement': 'UV index',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_uv_index-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_uv_index-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -570,7 +570,7 @@
     'state': '0.13',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_visibility-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_visibility-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -606,7 +606,7 @@
     'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_visibility-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_visibility-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -623,7 +623,7 @@
     'state': '10000',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -657,7 +657,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -671,7 +671,7 @@
     'state': 'broken clouds',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather_code-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather_code-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -705,7 +705,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather_code-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -719,7 +719,7 @@
     'state': '803',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_bearing-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_bearing-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -755,7 +755,7 @@
     'unit_of_measurement': '°',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_bearing-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_bearing-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -771,7 +771,7 @@
     'state': '199',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_speed-current-entry]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_speed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -810,7 +810,7 @@
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_speed-current-state]
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -827,130 +827,7 @@
     'state': '35.39',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][weather.openweathermap-current-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'weather',
-    'entity_category': None,
-    'entity_id': 'weather.openweathermap',
-    'has_entity_name': False,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'openweathermap',
-    'platform': 'openweathermap',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'None',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][weather.openweathermap-current-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'apparent_temperature': 2.1,
-      'attribution': 'Data provided by OpenWeatherMap',
-      'cloud_coverage': 75,
-      'dew_point': 4.0,
-      'friendly_name': 'openweathermap',
-      'humidity': 82,
-      'precipitation_unit': <UnitOfPrecipitationDepth.MILLIMETERS: 'mm'>,
-      'pressure': 1000.0,
-      'pressure_unit': <UnitOfPressure.HPA: 'hPa'>,
-      'temperature': 6.8,
-      'temperature_unit': <UnitOfTemperature.CELSIUS: '°C'>,
-      'visibility_unit': <UnitOfLength.KILOMETERS: 'km'>,
-      'wind_bearing': 199,
-      'wind_speed': 35.39,
-      'wind_speed_unit': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'weather.openweathermap',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'cloudy',
-  })
-# ---
-# name: test_sensor_states[forecast-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return1][weather.openweathermap-forecast-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'weather',
-    'entity_category': None,
-    'entity_id': 'weather.openweathermap',
-    'has_entity_name': False,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'openweathermap',
-    'platform': 'openweathermap',
-    'previous_unique_id': None,
-    'supported_features': <WeatherEntityFeature: 2>,
-    'translation_key': None,
-    'unique_id': 'None',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor_states[forecast-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return1][weather.openweathermap-forecast-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'apparent_temperature': 2.1,
-      'attribution': 'Data provided by OpenWeatherMap',
-      'cloud_coverage': 75,
-      'dew_point': 4.0,
-      'friendly_name': 'openweathermap',
-      'humidity': 82,
-      'precipitation_unit': <UnitOfPrecipitationDepth.MILLIMETERS: 'mm'>,
-      'pressure': 1000.0,
-      'pressure_unit': <UnitOfPressure.HPA: 'hPa'>,
-      'supported_features': <WeatherEntityFeature: 2>,
-      'temperature': 6.8,
-      'temperature_unit': <UnitOfTemperature.CELSIUS: '°C'>,
-      'visibility_unit': <UnitOfLength.KILOMETERS: 'km'>,
-      'wind_bearing': 199,
-      'wind_speed': 35.39,
-      'wind_speed_unit': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'weather.openweathermap',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'cloudy',
-  })
-# ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_cloud_coverage-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_cloud_coverage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -986,7 +863,7 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_cloud_coverage-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_cloud_coverage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1002,7 +879,7 @@
     'state': '75',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_condition-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_condition-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1036,7 +913,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_condition-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_condition-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1050,7 +927,7 @@
     'state': 'cloudy',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_dew_point-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_dew_point-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1086,7 +963,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_dew_point-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_dew_point-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1103,7 +980,7 @@
     'state': '3.99',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_feels_like_temperature-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_feels_like_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1139,7 +1016,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_feels_like_temperature-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_feels_like_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1156,7 +1033,7 @@
     'state': '2.07',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_humidity-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_humidity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1192,7 +1069,7 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_humidity-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_humidity-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1209,7 +1086,7 @@
     'state': '82',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_precipitation_kind-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_precipitation_kind-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1243,7 +1120,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_precipitation_kind-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_precipitation_kind-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1257,7 +1134,7 @@
     'state': 'Rain',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_pressure-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_pressure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1293,7 +1170,7 @@
     'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_pressure-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_pressure-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1310,7 +1187,7 @@
     'state': '1000',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_rain-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_rain-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1346,7 +1223,7 @@
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_rain-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_rain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1363,7 +1240,7 @@
     'state': '1.21',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_snow-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_snow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1399,7 +1276,7 @@
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_snow-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_snow-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1416,7 +1293,7 @@
     'state': '0',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_temperature-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1452,7 +1329,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_temperature-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1469,7 +1346,7 @@
     'state': '6.84',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_uv_index-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_uv_index-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1505,7 +1382,7 @@
     'unit_of_measurement': 'UV index',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_uv_index-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_uv_index-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1521,7 +1398,7 @@
     'state': '0.13',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_visibility-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_visibility-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1557,7 +1434,7 @@
     'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_visibility-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_visibility-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1574,7 +1451,7 @@
     'state': '10000',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_weather-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_weather-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1608,7 +1485,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_weather-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_weather-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1622,7 +1499,7 @@
     'state': 'broken clouds',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_weather_code-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_weather_code-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1656,7 +1533,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_weather_code-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_weather_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1670,7 +1547,7 @@
     'state': '803',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_wind_bearing-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_wind_bearing-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1706,7 +1583,7 @@
     'unit_of_measurement': '°',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_wind_bearing-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_wind_bearing-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1722,7 +1599,7 @@
     'state': '199',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_wind_speed-v3.0-entry]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_wind_speed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1761,7 +1638,7 @@
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_wind_speed-v3.0-state]
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_wind_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1776,67 +1653,5 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '35.39',
-  })
-# ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][weather.openweathermap-v3.0-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'weather',
-    'entity_category': None,
-    'entity_id': 'weather.openweathermap',
-    'has_entity_name': False,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'openweathermap',
-    'platform': 'openweathermap',
-    'previous_unique_id': None,
-    'supported_features': <WeatherEntityFeature: 3>,
-    'translation_key': None,
-    'unique_id': 'None',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][weather.openweathermap-v3.0-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'apparent_temperature': 2.1,
-      'attribution': 'Data provided by OpenWeatherMap',
-      'cloud_coverage': 75,
-      'dew_point': 4.0,
-      'friendly_name': 'openweathermap',
-      'humidity': 82,
-      'precipitation_unit': <UnitOfPrecipitationDepth.MILLIMETERS: 'mm'>,
-      'pressure': 1000.0,
-      'pressure_unit': <UnitOfPressure.HPA: 'hPa'>,
-      'supported_features': <WeatherEntityFeature: 3>,
-      'temperature': 6.8,
-      'temperature_unit': <UnitOfTemperature.CELSIUS: '°C'>,
-      'visibility_unit': <UnitOfLength.KILOMETERS: 'km'>,
-      'wind_bearing': 199,
-      'wind_speed': 35.39,
-      'wind_speed_unit': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'weather.openweathermap',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'cloudy',
   })
 # ---

--- a/tests/components/openweathermap/snapshots/test_sensor.ambr
+++ b/tests/components/openweathermap/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_cloud_coverage-entry]
+# name: test_sensor_states[current][sensor.openweathermap_cloud_coverage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -35,7 +35,7 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_cloud_coverage-state]
+# name: test_sensor_states[current][sensor.openweathermap_cloud_coverage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -51,7 +51,7 @@
     'state': '75',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_condition-entry]
+# name: test_sensor_states[current][sensor.openweathermap_condition-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -85,7 +85,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_condition-state]
+# name: test_sensor_states[current][sensor.openweathermap_condition-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -99,7 +99,7 @@
     'state': 'cloudy',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_dew_point-entry]
+# name: test_sensor_states[current][sensor.openweathermap_dew_point-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -135,7 +135,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_dew_point-state]
+# name: test_sensor_states[current][sensor.openweathermap_dew_point-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -152,7 +152,7 @@
     'state': '3.99',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_feels_like_temperature-entry]
+# name: test_sensor_states[current][sensor.openweathermap_feels_like_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -188,7 +188,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_feels_like_temperature-state]
+# name: test_sensor_states[current][sensor.openweathermap_feels_like_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -205,7 +205,7 @@
     'state': '2.07',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_humidity-entry]
+# name: test_sensor_states[current][sensor.openweathermap_humidity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -241,7 +241,7 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_humidity-state]
+# name: test_sensor_states[current][sensor.openweathermap_humidity-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -258,7 +258,7 @@
     'state': '82',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_precipitation_kind-entry]
+# name: test_sensor_states[current][sensor.openweathermap_precipitation_kind-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -292,7 +292,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_precipitation_kind-state]
+# name: test_sensor_states[current][sensor.openweathermap_precipitation_kind-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -306,7 +306,7 @@
     'state': 'Rain',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_pressure-entry]
+# name: test_sensor_states[current][sensor.openweathermap_pressure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -342,7 +342,7 @@
     'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_pressure-state]
+# name: test_sensor_states[current][sensor.openweathermap_pressure-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -359,7 +359,7 @@
     'state': '1000',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_rain-entry]
+# name: test_sensor_states[current][sensor.openweathermap_rain-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -395,7 +395,7 @@
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_rain-state]
+# name: test_sensor_states[current][sensor.openweathermap_rain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -412,7 +412,7 @@
     'state': '1.21',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_snow-entry]
+# name: test_sensor_states[current][sensor.openweathermap_snow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -448,7 +448,7 @@
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_snow-state]
+# name: test_sensor_states[current][sensor.openweathermap_snow-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -465,7 +465,7 @@
     'state': '0',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_temperature-entry]
+# name: test_sensor_states[current][sensor.openweathermap_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -501,7 +501,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_temperature-state]
+# name: test_sensor_states[current][sensor.openweathermap_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -518,7 +518,7 @@
     'state': '6.84',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_uv_index-entry]
+# name: test_sensor_states[current][sensor.openweathermap_uv_index-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -554,7 +554,7 @@
     'unit_of_measurement': 'UV index',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_uv_index-state]
+# name: test_sensor_states[current][sensor.openweathermap_uv_index-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -570,7 +570,7 @@
     'state': '0.13',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_visibility-entry]
+# name: test_sensor_states[current][sensor.openweathermap_visibility-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -606,7 +606,7 @@
     'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_visibility-state]
+# name: test_sensor_states[current][sensor.openweathermap_visibility-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -623,7 +623,7 @@
     'state': '10000',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather-entry]
+# name: test_sensor_states[current][sensor.openweathermap_weather-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -657,7 +657,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather-state]
+# name: test_sensor_states[current][sensor.openweathermap_weather-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -671,7 +671,7 @@
     'state': 'broken clouds',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather_code-entry]
+# name: test_sensor_states[current][sensor.openweathermap_weather_code-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -705,7 +705,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather_code-state]
+# name: test_sensor_states[current][sensor.openweathermap_weather_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -719,7 +719,7 @@
     'state': '803',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_bearing-entry]
+# name: test_sensor_states[current][sensor.openweathermap_wind_bearing-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -755,7 +755,7 @@
     'unit_of_measurement': '°',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_bearing-state]
+# name: test_sensor_states[current][sensor.openweathermap_wind_bearing-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -771,7 +771,7 @@
     'state': '199',
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_speed-entry]
+# name: test_sensor_states[current][sensor.openweathermap_wind_speed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -810,7 +810,7 @@
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
-# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_speed-state]
+# name: test_sensor_states[current][sensor.openweathermap_wind_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -827,7 +827,7 @@
     'state': '35.39',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_cloud_coverage-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_cloud_coverage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -863,7 +863,7 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_cloud_coverage-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_cloud_coverage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -879,7 +879,7 @@
     'state': '75',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_condition-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_condition-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -913,7 +913,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_condition-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_condition-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -927,7 +927,7 @@
     'state': 'cloudy',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_dew_point-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_dew_point-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -963,7 +963,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_dew_point-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_dew_point-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -980,7 +980,7 @@
     'state': '3.99',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_feels_like_temperature-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_feels_like_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1016,7 +1016,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_feels_like_temperature-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_feels_like_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1033,7 +1033,7 @@
     'state': '2.07',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_humidity-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_humidity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1069,7 +1069,7 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_humidity-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_humidity-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1086,7 +1086,7 @@
     'state': '82',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_precipitation_kind-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_precipitation_kind-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1120,7 +1120,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_precipitation_kind-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_precipitation_kind-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1134,7 +1134,7 @@
     'state': 'Rain',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_pressure-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_pressure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1170,7 +1170,7 @@
     'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_pressure-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_pressure-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1187,7 +1187,7 @@
     'state': '1000',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_rain-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_rain-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1223,7 +1223,7 @@
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_rain-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_rain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1240,7 +1240,7 @@
     'state': '1.21',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_snow-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_snow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1276,7 +1276,7 @@
     'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_snow-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_snow-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1293,7 +1293,7 @@
     'state': '0',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_temperature-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1329,7 +1329,7 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_temperature-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1346,7 +1346,7 @@
     'state': '6.84',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_uv_index-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_uv_index-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1382,7 +1382,7 @@
     'unit_of_measurement': 'UV index',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_uv_index-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_uv_index-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1398,7 +1398,7 @@
     'state': '0.13',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_visibility-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_visibility-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1434,7 +1434,7 @@
     'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_visibility-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_visibility-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1451,7 +1451,7 @@
     'state': '10000',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_weather-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_weather-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1485,7 +1485,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_weather-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_weather-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1499,7 +1499,7 @@
     'state': 'broken clouds',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_weather_code-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_weather_code-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1533,7 +1533,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_weather_code-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_weather_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1547,7 +1547,7 @@
     'state': '803',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_wind_bearing-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_wind_bearing-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1583,7 +1583,7 @@
     'unit_of_measurement': '°',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_wind_bearing-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_wind_bearing-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',
@@ -1599,7 +1599,7 @@
     'state': '199',
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_wind_speed-entry]
+# name: test_sensor_states[v3.0][sensor.openweathermap_wind_speed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1638,7 +1638,7 @@
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
-# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return1][sensor.openweathermap_wind_speed-state]
+# name: test_sensor_states[v3.0][sensor.openweathermap_wind_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by OpenWeatherMap',

--- a/tests/components/openweathermap/snapshots/test_sensor.ambr
+++ b/tests/components/openweathermap/snapshots/test_sensor.ambr
@@ -1,0 +1,1842 @@
+# serializer version: 1
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_cloud_coverage-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_cloud_coverage',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Cloud coverage',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-clouds',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_cloud_coverage-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Cloud coverage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_cloud_coverage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '75',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_condition-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_condition',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Condition',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-condition',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_condition-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Condition',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_condition',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cloudy',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_dew_point-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_dew_point',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Dew Point',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-dew_point',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_dew_point-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'temperature',
+      'friendly_name': 'openweathermap Dew Point',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_dew_point',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.99',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_feels_like_temperature-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_feels_like_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Feels like temperature',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-feels_like_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_feels_like_temperature-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'temperature',
+      'friendly_name': 'openweathermap Feels like temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_feels_like_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.07',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_humidity-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_humidity',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Humidity',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_humidity-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'humidity',
+      'friendly_name': 'openweathermap Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '82',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_precipitation_kind-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_precipitation_kind',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Precipitation kind',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-precipitation_kind',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_precipitation_kind-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Precipitation kind',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_precipitation_kind',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Rain',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_pressure-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_pressure',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Pressure',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-pressure',
+    'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_pressure-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'pressure',
+      'friendly_name': 'openweathermap Pressure',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1000',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_rain-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_rain',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION_INTENSITY: 'precipitation_intensity'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Rain',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-rain',
+    'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_rain-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'precipitation_intensity',
+      'friendly_name': 'openweathermap Rain',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.21',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_snow-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_snow',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION_INTENSITY: 'precipitation_intensity'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Snow',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-snow',
+    'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_snow-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'precipitation_intensity',
+      'friendly_name': 'openweathermap Snow',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_snow',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_temperature-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Temperature',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_temperature-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'temperature',
+      'friendly_name': 'openweathermap Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6.84',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_uv_index-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_uv_index',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap UV Index',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-uv_index',
+    'unit_of_measurement': 'UV index',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_uv_index-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap UV Index',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'UV index',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_uv_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.13',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_visibility-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_visibility',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Visibility',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-visibility_distance',
+    'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_visibility-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'distance',
+      'friendly_name': 'openweathermap Visibility',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_visibility',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10000',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_weather',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Weather',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-weather',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Weather',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_weather',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'broken clouds',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather_code-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_weather_code',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Weather Code',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-weather_code',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_weather_code-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Weather Code',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_weather_code',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '803',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_bearing-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_wind_bearing',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Wind bearing',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-wind_bearing',
+    'unit_of_measurement': '°',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_bearing-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Wind bearing',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '°',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_wind_bearing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '199',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_speed-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_wind_speed',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Wind speed',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-wind_speed',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][sensor.openweathermap_wind_speed-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'wind_speed',
+      'friendly_name': 'openweathermap Wind speed',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_wind_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '35.39',
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][weather.openweathermap-current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'weather',
+    'entity_category': None,
+    'entity_id': 'weather.openweathermap',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][weather.openweathermap-current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'apparent_temperature': 2.1,
+      'attribution': 'Data provided by OpenWeatherMap',
+      'cloud_coverage': 75,
+      'dew_point': 4.0,
+      'friendly_name': 'openweathermap',
+      'humidity': 82,
+      'precipitation_unit': <UnitOfPrecipitationDepth.MILLIMETERS: 'mm'>,
+      'pressure': 1000.0,
+      'pressure_unit': <UnitOfPressure.HPA: 'hPa'>,
+      'temperature': 6.8,
+      'temperature_unit': <UnitOfTemperature.CELSIUS: '°C'>,
+      'visibility_unit': <UnitOfLength.KILOMETERS: 'km'>,
+      'wind_bearing': 199,
+      'wind_speed': 35.39,
+      'wind_speed_unit': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'weather.openweathermap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cloudy',
+  })
+# ---
+# name: test_sensor_states[forecast-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return1][weather.openweathermap-forecast-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'weather',
+    'entity_category': None,
+    'entity_id': 'weather.openweathermap',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': <WeatherEntityFeature: 2>,
+    'translation_key': None,
+    'unique_id': 'None',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[forecast-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return1][weather.openweathermap-forecast-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'apparent_temperature': 2.1,
+      'attribution': 'Data provided by OpenWeatherMap',
+      'cloud_coverage': 75,
+      'dew_point': 4.0,
+      'friendly_name': 'openweathermap',
+      'humidity': 82,
+      'precipitation_unit': <UnitOfPrecipitationDepth.MILLIMETERS: 'mm'>,
+      'pressure': 1000.0,
+      'pressure_unit': <UnitOfPressure.HPA: 'hPa'>,
+      'supported_features': <WeatherEntityFeature: 2>,
+      'temperature': 6.8,
+      'temperature_unit': <UnitOfTemperature.CELSIUS: '°C'>,
+      'visibility_unit': <UnitOfLength.KILOMETERS: 'km'>,
+      'wind_bearing': 199,
+      'wind_speed': 35.39,
+      'wind_speed_unit': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'weather.openweathermap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cloudy',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_cloud_coverage-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_cloud_coverage',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Cloud coverage',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-clouds',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_cloud_coverage-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Cloud coverage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_cloud_coverage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '75',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_condition-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_condition',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Condition',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-condition',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_condition-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Condition',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_condition',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cloudy',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_dew_point-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_dew_point',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Dew Point',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-dew_point',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_dew_point-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'temperature',
+      'friendly_name': 'openweathermap Dew Point',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_dew_point',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.99',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_feels_like_temperature-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_feels_like_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Feels like temperature',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-feels_like_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_feels_like_temperature-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'temperature',
+      'friendly_name': 'openweathermap Feels like temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_feels_like_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.07',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_humidity-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_humidity',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Humidity',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_humidity-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'humidity',
+      'friendly_name': 'openweathermap Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '82',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_precipitation_kind-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_precipitation_kind',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Precipitation kind',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-precipitation_kind',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_precipitation_kind-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Precipitation kind',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_precipitation_kind',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Rain',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_pressure-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_pressure',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Pressure',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-pressure',
+    'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_pressure-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'pressure',
+      'friendly_name': 'openweathermap Pressure',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1000',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_rain-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_rain',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION_INTENSITY: 'precipitation_intensity'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Rain',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-rain',
+    'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_rain-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'precipitation_intensity',
+      'friendly_name': 'openweathermap Rain',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.21',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_snow-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_snow',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION_INTENSITY: 'precipitation_intensity'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Snow',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-snow',
+    'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_snow-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'precipitation_intensity',
+      'friendly_name': 'openweathermap Snow',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_snow',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_temperature-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Temperature',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_temperature-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'temperature',
+      'friendly_name': 'openweathermap Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6.84',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_uv_index-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_uv_index',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap UV Index',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-uv_index',
+    'unit_of_measurement': 'UV index',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_uv_index-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap UV Index',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'UV index',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_uv_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.13',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_visibility-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_visibility',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Visibility',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-visibility_distance',
+    'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_visibility-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'distance',
+      'friendly_name': 'openweathermap Visibility',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_visibility',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10000',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_weather-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_weather',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Weather',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-weather',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_weather-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Weather',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_weather',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'broken clouds',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_weather_code-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_weather_code',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Weather Code',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-weather_code',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_weather_code-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Weather Code',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_weather_code',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '803',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_wind_bearing-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_wind_bearing',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap Wind bearing',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-wind_bearing',
+    'unit_of_measurement': '°',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_wind_bearing-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'friendly_name': 'openweathermap Wind bearing',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '°',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_wind_bearing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '199',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_wind_speed-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.openweathermap_wind_speed',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'openweathermap Wind speed',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None-wind_speed',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][sensor.openweathermap_wind_speed-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by OpenWeatherMap',
+      'device_class': 'wind_speed',
+      'friendly_name': 'openweathermap Wind speed',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.openweathermap_wind_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '35.39',
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][weather.openweathermap-v3.0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'weather',
+    'entity_category': None,
+    'entity_id': 'weather.openweathermap',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': <WeatherEntityFeature: 3>,
+    'translation_key': None,
+    'unique_id': 'None',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][weather.openweathermap-v3.0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'apparent_temperature': 2.1,
+      'attribution': 'Data provided by OpenWeatherMap',
+      'cloud_coverage': 75,
+      'dew_point': 4.0,
+      'friendly_name': 'openweathermap',
+      'humidity': 82,
+      'precipitation_unit': <UnitOfPrecipitationDepth.MILLIMETERS: 'mm'>,
+      'pressure': 1000.0,
+      'pressure_unit': <UnitOfPressure.HPA: 'hPa'>,
+      'supported_features': <WeatherEntityFeature: 3>,
+      'temperature': 6.8,
+      'temperature_unit': <UnitOfTemperature.CELSIUS: '°C'>,
+      'visibility_unit': <UnitOfLength.KILOMETERS: 'km'>,
+      'wind_bearing': 199,
+      'wind_speed': 35.39,
+      'wind_speed_unit': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'weather.openweathermap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cloudy',
+  })
+# ---

--- a/tests/components/openweathermap/snapshots/test_weather.ambr
+++ b/tests/components/openweathermap/snapshots/test_weather.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_get_minute_forecast[mock_service_response]
+# name: test_get_minute_forecast[v3.0][mock_service_response]
   dict({
     'weather.openweathermap': dict({
       'forecast': list([
@@ -23,7 +23,7 @@
     }),
   })
 # ---
-# name: test_weather_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][weather.openweathermap-entry]
+# name: test_weather_states[current][weather.openweathermap-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -57,7 +57,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_weather_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][weather.openweathermap-state]
+# name: test_weather_states[current][weather.openweathermap-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'apparent_temperature': 2.1,
@@ -84,7 +84,7 @@
     'state': 'cloudy',
   })
 # ---
-# name: test_weather_states[forecast-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return1][weather.openweathermap-entry]
+# name: test_weather_states[forecast][weather.openweathermap-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -118,7 +118,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_weather_states[forecast-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return1][weather.openweathermap-state]
+# name: test_weather_states[forecast][weather.openweathermap-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'apparent_temperature': 2.1,
@@ -146,7 +146,7 @@
     'state': 'cloudy',
   })
 # ---
-# name: test_weather_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][weather.openweathermap-entry]
+# name: test_weather_states[v3.0][weather.openweathermap-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -180,7 +180,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_weather_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][weather.openweathermap-state]
+# name: test_weather_states[v3.0][weather.openweathermap-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'apparent_temperature': 2.1,

--- a/tests/components/openweathermap/snapshots/test_weather.ambr
+++ b/tests/components/openweathermap/snapshots/test_weather.ambr
@@ -23,3 +23,188 @@
     }),
   })
 # ---
+# name: test_weather_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][weather.openweathermap-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'weather',
+    'entity_category': None,
+    'entity_id': 'weather.openweathermap',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'None',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_weather_states[current-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return0][weather.openweathermap-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'apparent_temperature': 2.1,
+      'attribution': 'Data provided by OpenWeatherMap',
+      'cloud_coverage': 75,
+      'dew_point': 4.0,
+      'friendly_name': 'openweathermap',
+      'humidity': 82,
+      'precipitation_unit': <UnitOfPrecipitationDepth.MILLIMETERS: 'mm'>,
+      'pressure': 1000.0,
+      'pressure_unit': <UnitOfPressure.HPA: 'hPa'>,
+      'temperature': 6.8,
+      'temperature_unit': <UnitOfTemperature.CELSIUS: '°C'>,
+      'visibility_unit': <UnitOfLength.KILOMETERS: 'km'>,
+      'wind_bearing': 199,
+      'wind_speed': 35.39,
+      'wind_speed_unit': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'weather.openweathermap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cloudy',
+  })
+# ---
+# name: test_weather_states[forecast-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return1][weather.openweathermap-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'weather',
+    'entity_category': None,
+    'entity_id': 'weather.openweathermap',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': <WeatherEntityFeature: 2>,
+    'translation_key': None,
+    'unique_id': 'None',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_weather_states[forecast-pyopenweathermap.client.free_client.OWMFreeClient.get_weather-mock_return1][weather.openweathermap-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'apparent_temperature': 2.1,
+      'attribution': 'Data provided by OpenWeatherMap',
+      'cloud_coverage': 75,
+      'dew_point': 4.0,
+      'friendly_name': 'openweathermap',
+      'humidity': 82,
+      'precipitation_unit': <UnitOfPrecipitationDepth.MILLIMETERS: 'mm'>,
+      'pressure': 1000.0,
+      'pressure_unit': <UnitOfPressure.HPA: 'hPa'>,
+      'supported_features': <WeatherEntityFeature: 2>,
+      'temperature': 6.8,
+      'temperature_unit': <UnitOfTemperature.CELSIUS: '°C'>,
+      'visibility_unit': <UnitOfLength.KILOMETERS: 'km'>,
+      'wind_bearing': 199,
+      'wind_speed': 35.39,
+      'wind_speed_unit': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'weather.openweathermap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cloudy',
+  })
+# ---
+# name: test_weather_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][weather.openweathermap-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'weather',
+    'entity_category': None,
+    'entity_id': 'weather.openweathermap',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'openweathermap',
+    'platform': 'openweathermap',
+    'previous_unique_id': None,
+    'supported_features': <WeatherEntityFeature: 3>,
+    'translation_key': None,
+    'unique_id': 'None',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_weather_states[v3.0-pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather-mock_return2][weather.openweathermap-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'apparent_temperature': 2.1,
+      'attribution': 'Data provided by OpenWeatherMap',
+      'cloud_coverage': 75,
+      'dew_point': 4.0,
+      'friendly_name': 'openweathermap',
+      'humidity': 82,
+      'precipitation_unit': <UnitOfPrecipitationDepth.MILLIMETERS: 'mm'>,
+      'pressure': 1000.0,
+      'pressure_unit': <UnitOfPressure.HPA: 'hPa'>,
+      'supported_features': <WeatherEntityFeature: 3>,
+      'temperature': 6.8,
+      'temperature_unit': <UnitOfTemperature.CELSIUS: '°C'>,
+      'visibility_unit': <UnitOfLength.KILOMETERS: 'km'>,
+      'wind_bearing': 199,
+      'wind_speed': 35.39,
+      'wind_speed_unit': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'weather.openweathermap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cloudy',
+  })
+# ---

--- a/tests/components/openweathermap/snapshots/test_weather.ambr
+++ b/tests/components/openweathermap/snapshots/test_weather.ambr
@@ -53,7 +53,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'None',
+    'unique_id': '12.34-56.78',
     'unit_of_measurement': None,
   })
 # ---
@@ -114,7 +114,7 @@
     'previous_unique_id': None,
     'supported_features': <WeatherEntityFeature: 2>,
     'translation_key': None,
-    'unique_id': 'None',
+    'unique_id': '12.34-56.78',
     'unit_of_measurement': None,
   })
 # ---
@@ -176,7 +176,7 @@
     'previous_unique_id': None,
     'supported_features': <WeatherEntityFeature: 3>,
     'translation_key': None,
-    'unique_id': 'None',
+    'unique_id': '12.34-56.78',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/openweathermap/test_config_flow.py
+++ b/tests/components/openweathermap/test_config_flow.py
@@ -1,6 +1,6 @@
 """Define tests for the OpenWeatherMap config flow."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from pyopenweathermap import RequestError
 import pytest
@@ -37,15 +37,6 @@ CONFIG = {
 }
 
 VALID_YAML_CONFIG = {CONF_API_KEY: "foo"}
-
-
-@pytest.fixture(name="config_flow_owm_client_mock")
-def mock_config_flow_owm_client():
-    """Mock config_flow OWMClient."""
-    with patch(
-        "homeassistant.components.openweathermap.utils.create_owm_client",
-    ) as mock:
-        yield mock
 
 
 async def test_successful_config_flow(

--- a/tests/components/openweathermap/test_config_flow.py
+++ b/tests/components/openweathermap/test_config_flow.py
@@ -1,17 +1,8 @@
 """Define tests for the OpenWeatherMap config flow."""
 
-from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
-from pyopenweathermap import (
-    CurrentWeather,
-    DailyTemperature,
-    DailyWeatherForecast,
-    MinutelyWeatherForecast,
-    RequestError,
-    WeatherCondition,
-    WeatherReport,
-)
+from pyopenweathermap import RequestError
 import pytest
 
 from homeassistant.components.openweathermap.const import (
@@ -32,111 +23,20 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from .conftest import LATITUDE, LONGITUDE
+
 from tests.common import MockConfigEntry
 
 CONFIG = {
     CONF_NAME: "openweathermap",
     CONF_API_KEY: "foo",
-    CONF_LATITUDE: 50,
-    CONF_LONGITUDE: 40,
+    CONF_LATITUDE: LATITUDE,
+    CONF_LONGITUDE: LONGITUDE,
     CONF_LANGUAGE: DEFAULT_LANGUAGE,
     CONF_MODE: OWM_MODE_V30,
 }
 
 VALID_YAML_CONFIG = {CONF_API_KEY: "foo"}
-
-
-def _create_static_weather_report() -> WeatherReport:
-    """Create a static WeatherReport."""
-
-    current_weather = CurrentWeather(
-        date_time=datetime.fromtimestamp(1714063536, tz=UTC),
-        temperature=6.84,
-        feels_like=2.07,
-        pressure=1000,
-        humidity=82,
-        dew_point=3.99,
-        uv_index=0.13,
-        cloud_coverage=75,
-        visibility=10000,
-        wind_speed=9.83,
-        wind_bearing=199,
-        wind_gust=None,
-        rain={"1h": 1.21},
-        snow=None,
-        condition=WeatherCondition(
-            id=803,
-            main="Clouds",
-            description="broken clouds",
-            icon="04d",
-        ),
-    )
-    daily_weather_forecast = DailyWeatherForecast(
-        date_time=datetime.fromtimestamp(1714063536, tz=UTC),
-        summary="There will be clear sky until morning, then partly cloudy",
-        temperature=DailyTemperature(
-            day=18.76,
-            min=8.11,
-            max=21.26,
-            night=13.06,
-            evening=20.51,
-            morning=8.47,
-        ),
-        feels_like=DailyTemperature(
-            day=18.76,
-            min=8.11,
-            max=21.26,
-            night=13.06,
-            evening=20.51,
-            morning=8.47,
-        ),
-        pressure=1015,
-        humidity=62,
-        dew_point=11.34,
-        wind_speed=8.14,
-        wind_bearing=168,
-        wind_gust=11.81,
-        condition=WeatherCondition(
-            id=803,
-            main="Clouds",
-            description="broken clouds",
-            icon="04d",
-        ),
-        cloud_coverage=84,
-        precipitation_probability=0,
-        uv_index=4.06,
-        rain=0,
-        snow=0,
-    )
-    minutely_weather_forecast = [
-        MinutelyWeatherForecast(date_time=1728672360, precipitation=0),
-        MinutelyWeatherForecast(date_time=1728672420, precipitation=1.23),
-        MinutelyWeatherForecast(date_time=1728672480, precipitation=4.5),
-        MinutelyWeatherForecast(date_time=1728672540, precipitation=0),
-    ]
-    return WeatherReport(
-        current_weather, minutely_weather_forecast, [], [daily_weather_forecast]
-    )
-
-
-def _create_mocked_owm_factory(is_valid: bool):
-    """Create a mocked OWM client."""
-
-    weather_report = _create_static_weather_report()
-    mocked_owm_client = MagicMock()
-    mocked_owm_client.validate_key = AsyncMock(return_value=is_valid)
-    mocked_owm_client.get_weather = AsyncMock(return_value=weather_report)
-
-    return mocked_owm_client
-
-
-@pytest.fixture(name="owm_client_mock")
-def mock_owm_client():
-    """Mock config_flow OWMClient."""
-    with patch(
-        "homeassistant.components.openweathermap.create_owm_client",
-    ) as mock:
-        yield mock
 
 
 @pytest.fixture(name="config_flow_owm_client_mock")
@@ -150,14 +50,9 @@ def mock_config_flow_owm_client():
 
 async def test_successful_config_flow(
     hass: HomeAssistant,
-    owm_client_mock,
-    config_flow_owm_client_mock,
+    owm_client_mock: AsyncMock,
 ) -> None:
     """Test that the form is served with valid input."""
-    mock = _create_mocked_owm_factory(True)
-    owm_client_mock.return_value = mock
-    config_flow_owm_client_mock.return_value = mock
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -187,39 +82,32 @@ async def test_successful_config_flow(
     assert result["data"][CONF_API_KEY] == CONFIG[CONF_API_KEY]
 
 
+@pytest.mark.parametrize("mode", [OWM_MODE_V30], indirect=True)
 async def test_abort_config_flow(
     hass: HomeAssistant,
-    owm_client_mock,
-    config_flow_owm_client_mock,
+    owm_client_mock: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that the form is served with same data."""
-    mock = _create_mocked_owm_factory(True)
-    owm_client_mock.return_value = mock
-    config_flow_owm_client_mock.return_value = mock
-
+    mock_config_entry.add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
+        DOMAIN, context={"source": SOURCE_USER}
     )
-    await hass.async_block_till_done()
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
-    )
-    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], CONFIG)
 
     assert result["type"] is FlowResultType.ABORT
 
 
 async def test_config_flow_options_change(
     hass: HomeAssistant,
-    owm_client_mock,
-    config_flow_owm_client_mock,
+    owm_client_mock: AsyncMock,
 ) -> None:
     """Test that the options form."""
-    mock = _create_mocked_owm_factory(True)
-    owm_client_mock.return_value = mock
-    config_flow_owm_client_mock.return_value = mock
-
     config_entry = MockConfigEntry(
         domain=DOMAIN, unique_id="openweathermap_unique_id", data=CONFIG
     )
@@ -274,10 +162,10 @@ async def test_config_flow_options_change(
 
 async def test_form_invalid_api_key(
     hass: HomeAssistant,
-    config_flow_owm_client_mock,
+    owm_client_mock: AsyncMock,
 ) -> None:
     """Test that the form is served with no input."""
-    config_flow_owm_client_mock.return_value = _create_mocked_owm_factory(False)
+    owm_client_mock.validate_key.return_value = False
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
     )
@@ -285,7 +173,7 @@ async def test_form_invalid_api_key(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_api_key"}
 
-    config_flow_owm_client_mock.return_value = _create_mocked_owm_factory(True)
+    owm_client_mock.validate_key.return_value = True
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=CONFIG
     )
@@ -295,11 +183,10 @@ async def test_form_invalid_api_key(
 
 async def test_form_api_call_error(
     hass: HomeAssistant,
-    config_flow_owm_client_mock,
+    owm_client_mock: AsyncMock,
 ) -> None:
     """Test setting up with api call error."""
-    config_flow_owm_client_mock.return_value = _create_mocked_owm_factory(True)
-    config_flow_owm_client_mock.side_effect = RequestError("oops")
+    owm_client_mock.validate_key.side_effect = RequestError("oops")
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
     )
@@ -307,7 +194,7 @@ async def test_form_api_call_error(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
-    config_flow_owm_client_mock.side_effect = None
+    owm_client_mock.validate_key.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=CONFIG
     )

--- a/tests/components/openweathermap/test_sensor.py
+++ b/tests/components/openweathermap/test_sensor.py
@@ -30,7 +30,7 @@ async def test_sensor_states(
 ) -> None:
     """Test sensor states are correctly collected from library with different modes and mocked function responses."""
 
-    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.SENSOR])
+    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
@@ -45,5 +45,5 @@ async def test_mode_no_sensor(
 ) -> None:
     """Test modes that do not provide any sensor."""
 
-    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.SENSOR])
+    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
     assert len(entity_registry.entities) == 0

--- a/tests/components/openweathermap/test_sensor.py
+++ b/tests/components/openweathermap/test_sensor.py
@@ -1,5 +1,7 @@
 """Tests for OpenWeatherMap sensors."""
 
+from unittest.mock import MagicMock
+
 import pytest
 from syrupy import SnapshotAssertion
 
@@ -23,11 +25,12 @@ async def test_sensor_states(
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
+    owm_client_mock: MagicMock,
     mode: str,
 ) -> None:
     """Test sensor states are correctly collected from library with different modes and mocked function responses."""
 
-    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
+    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.SENSOR])
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
@@ -37,9 +40,10 @@ async def test_mode_no_sensor(
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
+    owm_client_mock: MagicMock,
     mode: str,
 ) -> None:
     """Test modes that do not provide any sensor."""
 
-    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
+    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.SENSOR])
     assert len(entity_registry.entities) == 0

--- a/tests/components/openweathermap/test_sensor.py
+++ b/tests/components/openweathermap/test_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import setup_platform
+from . import setup_platform
 
 from tests.common import MockConfigEntry, snapshot_platform
 

--- a/tests/components/openweathermap/test_sensor.py
+++ b/tests/components/openweathermap/test_sensor.py
@@ -1,54 +1,32 @@
 """Tests for OpenWeatherMap sensors."""
 
-from pyopenweathermap import WeatherReport
-import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.openweathermap.const import (
-    OWM_MODE_FREE_CURRENT,
-    OWM_MODE_V30,
-)
+from homeassistant.components.openweathermap.const import OWM_MODE_FREE_FORECAST
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import mock_config_entry, setup_platform
-from .test_config_flow import _create_static_weather_report
+from .conftest import setup_platform
 
-from tests.common import AsyncMock, patch, snapshot_platform
-
-# Define test data for mocked weather report
-static_weather_report = _create_static_weather_report()
+from tests.common import MockConfigEntry, snapshot_platform
 
 
-@pytest.mark.parametrize(
-    ("mode", "patched_function", "mock_return"),
-    [
-        (
-            OWM_MODE_FREE_CURRENT,
-            "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
-            static_weather_report,
-        ),
-        (
-            OWM_MODE_V30,
-            "pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather",
-            static_weather_report,
-        ),
-    ],
-)
 async def test_sensor_states(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
     mode: str,
-    patched_function: str,
-    mock_return: WeatherReport,
 ) -> None:
     """Test sensor states are correctly collected from library with different modes and mocked function responses."""
 
-    entry = mock_config_entry(mode)
+    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
 
-    with patch(patched_function, new_callable=AsyncMock, return_value=mock_return):
-        await setup_platform(hass, entry, [Platform.SENSOR])
-
-    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+    if mode == OWM_MODE_FREE_FORECAST:
+        # Free forecast mode does not support sensors
+        assert len(entity_registry.entities) == 0
+    else:
+        await snapshot_platform(
+            hass, entity_registry, snapshot, mock_config_entry.entry_id
+        )

--- a/tests/components/openweathermap/test_sensor.py
+++ b/tests/components/openweathermap/test_sensor.py
@@ -1,0 +1,71 @@
+"""Tests for OpenWeatherMap sensors."""
+
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.openweathermap.const import (
+    OWM_MODE_FREE_CURRENT,
+    OWM_MODE_FREE_FORECAST,
+    OWM_MODE_V30,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import mock_config_entry
+from .test_config_flow import _create_static_weather_report
+
+from tests.common import AsyncMock, patch
+
+# Define test data for mocked weather report
+static_weather_report = _create_static_weather_report()
+
+# Define test parameters with different modes and corresponding mock return values
+TEST_CASES = [
+    (
+        OWM_MODE_FREE_CURRENT,
+        "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
+        static_weather_report,
+    ),
+    (
+        OWM_MODE_FREE_FORECAST,
+        "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
+        static_weather_report,
+    ),
+    (
+        OWM_MODE_V30,
+        "pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather",
+        static_weather_report,
+    ),
+]
+
+
+@pytest.mark.parametrize(("mode", "patched_function", "mock_return"), TEST_CASES)
+async def test_sensor_states(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mode,
+    patched_function,
+    mock_return,
+) -> None:
+    """Test sensor states are correctly collected from library with different modes and mocked function responses."""
+
+    with patch(patched_function, new_callable=AsyncMock, return_value=mock_return):
+        entry = mock_config_entry(mode)
+        entry.add_to_hass(hass)
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        entity_entries = er.async_entries_for_config_entry(
+            entity_registry, entry.entry_id
+        )
+
+        assert entity_entries
+        for entity_entry in entity_entries:
+            assert entity_entry == snapshot(
+                name=f"{entity_entry.entity_id}-{mode}-entry"
+            )
+            assert hass.states.get(entity_entry.entity_id) == snapshot(
+                name=f"{entity_entry.entity_id}-{mode}-state"
+            )

--- a/tests/components/openweathermap/test_sensor.py
+++ b/tests/components/openweathermap/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for OpenWeatherMap sensors."""
 
+from pyopenweathermap import WeatherReport
 import pytest
 from syrupy import SnapshotAssertion
 
@@ -19,34 +20,34 @@ from tests.common import AsyncMock, patch
 # Define test data for mocked weather report
 static_weather_report = _create_static_weather_report()
 
-# Define test parameters with different modes and corresponding mock return values
-TEST_CASES = [
-    (
-        OWM_MODE_FREE_CURRENT,
-        "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
-        static_weather_report,
-    ),
-    (
-        OWM_MODE_FREE_FORECAST,
-        "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
-        static_weather_report,
-    ),
-    (
-        OWM_MODE_V30,
-        "pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather",
-        static_weather_report,
-    ),
-]
 
-
-@pytest.mark.parametrize(("mode", "patched_function", "mock_return"), TEST_CASES)
+@pytest.mark.parametrize(
+    ("mode", "patched_function", "mock_return"),
+    [
+        (
+            OWM_MODE_FREE_CURRENT,
+            "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
+            static_weather_report,
+        ),
+        (
+            OWM_MODE_FREE_FORECAST,
+            "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
+            static_weather_report,
+        ),
+        (
+            OWM_MODE_V30,
+            "pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather",
+            static_weather_report,
+        ),
+    ],
+)
 async def test_sensor_states(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
-    mode,
-    patched_function,
-    mock_return,
+    mode: str,
+    patched_function: str,
+    mock_return: WeatherReport,
 ) -> None:
     """Test sensor states are correctly collected from library with different modes and mocked function responses."""
 

--- a/tests/components/openweathermap/test_sensor.py
+++ b/tests/components/openweathermap/test_sensor.py
@@ -51,22 +51,18 @@ async def test_sensor_states(
 ) -> None:
     """Test sensor states are correctly collected from library with different modes and mocked function responses."""
 
-    with patch(patched_function, new_callable=AsyncMock, return_value=mock_return):
-        entry = mock_config_entry(mode)
-        entry.add_to_hass(hass)
+    entry = mock_config_entry(mode)
+    entry.add_to_hass(hass)
 
+    with patch(patched_function, new_callable=AsyncMock, return_value=mock_return):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        entity_entries = er.async_entries_for_config_entry(
-            entity_registry, entry.entry_id
-        )
+    entity_entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
 
-        assert entity_entries
-        for entity_entry in entity_entries:
-            assert entity_entry == snapshot(
-                name=f"{entity_entry.entity_id}-{mode}-entry"
-            )
-            assert hass.states.get(entity_entry.entity_id) == snapshot(
-                name=f"{entity_entry.entity_id}-{mode}-state"
-            )
+    assert entity_entries
+    for entity_entry in entity_entries:
+        assert entity_entry == snapshot(name=f"{entity_entry.entity_id}-{mode}-entry")
+        assert hass.states.get(entity_entry.entity_id) == snapshot(
+            name=f"{entity_entry.entity_id}-{mode}-state"
+        )

--- a/tests/components/openweathermap/test_sensor.py
+++ b/tests/components/openweathermap/test_sensor.py
@@ -1,8 +1,13 @@
 """Tests for OpenWeatherMap sensors."""
 
+import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.openweathermap.const import OWM_MODE_FREE_FORECAST
+from homeassistant.components.openweathermap.const import (
+    OWM_MODE_FREE_CURRENT,
+    OWM_MODE_FREE_FORECAST,
+    OWM_MODE_V30,
+)
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -12,6 +17,7 @@ from . import setup_platform
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.parametrize("mode", [OWM_MODE_V30, OWM_MODE_FREE_CURRENT], indirect=True)
 async def test_sensor_states(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -22,11 +28,18 @@ async def test_sensor_states(
     """Test sensor states are correctly collected from library with different modes and mocked function responses."""
 
     await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
-    if mode == OWM_MODE_FREE_FORECAST:
-        # Free forecast mode does not support sensors
-        assert len(entity_registry.entities) == 0
-    else:
-        await snapshot_platform(
-            hass, entity_registry, snapshot, mock_config_entry.entry_id
-        )
+
+@pytest.mark.parametrize("mode", [OWM_MODE_FREE_FORECAST], indirect=True)
+async def test_mode_no_sensor(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mode: str,
+) -> None:
+    """Test modes that do not provide any sensor."""
+
+    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
+    assert len(entity_registry.entities) == 0

--- a/tests/components/openweathermap/test_weather.py
+++ b/tests/components/openweathermap/test_weather.py
@@ -1,5 +1,7 @@
 """Test the OpenWeatherMap weather entity."""
 
+from unittest.mock import MagicMock
+
 import pytest
 from syrupy import SnapshotAssertion
 
@@ -28,11 +30,12 @@ async def test_get_minute_forecast(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
     mock_config_entry: MockConfigEntry,
+    owm_client_mock: MagicMock,
     mode: str,
 ) -> None:
     """Test the get_minute_forecast Service call."""
 
-    await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
+    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.WEATHER])
     result = await hass.services.async_call(
         DOMAIN,
         SERVICE_GET_MINUTE_FORECAST,
@@ -50,11 +53,12 @@ async def test_get_minute_forecast_unavailable(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
     mock_config_entry: MockConfigEntry,
+    owm_client_mock: MagicMock,
     mode: str,
 ) -> None:
     """Test that Minute forecasting fails when mode is not v3.0."""
 
-    await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
+    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.WEATHER])
     with pytest.raises(
         ServiceValidationError,
         match="Minute forecast is available only when OpenWeatherMap mode is set to v3.0",
@@ -74,8 +78,9 @@ async def test_weather_states(
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
+    owm_client_mock: MagicMock,
 ) -> None:
     """Test weather states are correctly collected from library with different modes and mocked function responses."""
 
-    await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
+    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.WEATHER])
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)

--- a/tests/components/openweathermap/test_weather.py
+++ b/tests/components/openweathermap/test_weather.py
@@ -34,7 +34,7 @@ async def test_get_minute_forecast(
 ) -> None:
     """Test the get_minute_forecast Service call."""
 
-    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.WEATHER])
+    await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
     result = await hass.services.async_call(
         DOMAIN,
         SERVICE_GET_MINUTE_FORECAST,
@@ -57,7 +57,7 @@ async def test_get_minute_forecast_unavailable(
 ) -> None:
     """Test that Minute forecasting fails when mode is not v3.0."""
 
-    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.WEATHER])
+    await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
     with pytest.raises(
         ServiceValidationError,
         match="Minute forecast is available only when OpenWeatherMap mode is set to v3.0",
@@ -83,5 +83,5 @@ async def test_weather_states(
 ) -> None:
     """Test weather states are correctly collected from library with different modes and mocked function responses."""
 
-    await setup_platform(hass, mock_config_entry, owm_client_mock, [Platform.WEATHER])
+    await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)

--- a/tests/components/openweathermap/test_weather.py
+++ b/tests/components/openweathermap/test_weather.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import setup_platform
+from . import setup_platform
 
 from tests.common import MockConfigEntry, snapshot_platform
 

--- a/tests/components/openweathermap/test_weather.py
+++ b/tests/components/openweathermap/test_weather.py
@@ -4,51 +4,24 @@ import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.openweathermap.const import (
-    DEFAULT_LANGUAGE,
     DOMAIN,
     OWM_MODE_FREE_CURRENT,
     OWM_MODE_V30,
 )
 from homeassistant.components.openweathermap.weather import SERVICE_GET_MINUTE_FORECAST
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_LANGUAGE,
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_MODE,
-    CONF_NAME,
-)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
+from .conftest import mock_config_entry
 from .test_config_flow import _create_static_weather_report
 
 from tests.common import AsyncMock, MockConfigEntry, patch
 
 ENTITY_ID = "weather.openweathermap"
-API_KEY = "test_api_key"
-LATITUDE = 12.34
-LONGITUDE = 56.78
-NAME = "openweathermap"
 
 # Define test data for mocked weather report
 static_weather_report = _create_static_weather_report()
-
-
-def mock_config_entry(mode: str) -> MockConfigEntry:
-    """Create a mock OpenWeatherMap config entry."""
-    return MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_API_KEY: API_KEY,
-            CONF_LATITUDE: LATITUDE,
-            CONF_LONGITUDE: LONGITUDE,
-            CONF_NAME: NAME,
-        },
-        options={CONF_MODE: mode, CONF_LANGUAGE: DEFAULT_LANGUAGE},
-        version=5,
-    )
 
 
 @pytest.fixture

--- a/tests/components/openweathermap/test_weather.py
+++ b/tests/components/openweathermap/test_weather.py
@@ -3,7 +3,13 @@
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.openweathermap.const import DOMAIN, OWM_MODE_V30
+from homeassistant.components.openweathermap.const import (
+    DOMAIN,
+    OWM_MODE_FREE_CURRENT,
+    OWM_MODE_FREE_FORECAST,
+    OWM_MODE_V30,
+    OWM_MODES,
+)
 from homeassistant.components.openweathermap.weather import SERVICE_GET_MINUTE_FORECAST
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -17,6 +23,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 ENTITY_ID = "weather.openweathermap"
 
 
+@pytest.mark.parametrize("mode", [OWM_MODE_V30], indirect=True)
 async def test_get_minute_forecast(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -26,30 +33,42 @@ async def test_get_minute_forecast(
     """Test the get_minute_forecast Service call."""
 
     await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
+    result = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_MINUTE_FORECAST,
+        {"entity_id": ENTITY_ID},
+        blocking=True,
+        return_response=True,
+    )
+    assert result == snapshot(name="mock_service_response")
 
-    if mode == OWM_MODE_V30:
-        result = await hass.services.async_call(
+
+@pytest.mark.parametrize(
+    "mode", [OWM_MODE_FREE_CURRENT, OWM_MODE_FREE_FORECAST], indirect=True
+)
+async def test_get_minute_forecast_unavailable(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    mode: str,
+) -> None:
+    """Test that Minute forecasting fails when mode is not v3.0."""
+
+    await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
+    with pytest.raises(
+        ServiceValidationError,
+        match="Minute forecast is available only when OpenWeatherMap mode is set to v3.0",
+    ):
+        await hass.services.async_call(
             DOMAIN,
             SERVICE_GET_MINUTE_FORECAST,
             {"entity_id": ENTITY_ID},
             blocking=True,
             return_response=True,
         )
-        assert result == snapshot(name="mock_service_response")
-    else:
-        with pytest.raises(
-            ServiceValidationError,
-            match="Minute forecast is available only when OpenWeatherMap mode is set to v3.0",
-        ):
-            await hass.services.async_call(
-                DOMAIN,
-                SERVICE_GET_MINUTE_FORECAST,
-                {"entity_id": ENTITY_ID},
-                blocking=True,
-                return_response=True,
-            )
 
 
+@pytest.mark.parametrize("mode", OWM_MODES, indirect=True)
 async def test_weather_states(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -59,5 +78,4 @@ async def test_weather_states(
     """Test weather states are correctly collected from library with different modes and mocked function responses."""
 
     await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
-
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)

--- a/tests/components/openweathermap/test_weather.py
+++ b/tests/components/openweathermap/test_weather.py
@@ -10,7 +10,6 @@ from homeassistant.components.openweathermap.const import (
     OWM_MODE_FREE_CURRENT,
     OWM_MODE_FREE_FORECAST,
     OWM_MODE_V30,
-    OWM_MODES,
 )
 from homeassistant.components.openweathermap.weather import SERVICE_GET_MINUTE_FORECAST
 from homeassistant.const import Platform
@@ -72,7 +71,9 @@ async def test_get_minute_forecast_unavailable(
         )
 
 
-@pytest.mark.parametrize("mode", OWM_MODES, indirect=True)
+@pytest.mark.parametrize(
+    "mode", [OWM_MODE_V30, OWM_MODE_FREE_CURRENT, OWM_MODE_FREE_FORECAST], indirect=True
+)
 async def test_weather_states(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,

--- a/tests/components/openweathermap/test_weather.py
+++ b/tests/components/openweathermap/test_weather.py
@@ -1,22 +1,26 @@
 """Test the OpenWeatherMap weather entity."""
 
+from pyopenweathermap import WeatherReport
 import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.openweathermap.const import (
     DOMAIN,
     OWM_MODE_FREE_CURRENT,
+    OWM_MODE_FREE_FORECAST,
     OWM_MODE_V30,
 )
 from homeassistant.components.openweathermap.weather import SERVICE_GET_MINUTE_FORECAST
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
 
-from .conftest import mock_config_entry
+from .conftest import mock_config_entry, setup_platform
 from .test_config_flow import _create_static_weather_report
 
-from tests.common import AsyncMock, MockConfigEntry, patch
+from tests.common import AsyncMock, MockConfigEntry, patch, snapshot_platform
 
 ENTITY_ID = "weather.openweathermap"
 
@@ -92,3 +96,41 @@ async def test_mode_fail(
             blocking=True,
             return_response=True,
         )
+
+
+@pytest.mark.parametrize(
+    ("mode", "patched_function", "mock_return"),
+    [
+        (
+            OWM_MODE_FREE_CURRENT,
+            "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
+            static_weather_report,
+        ),
+        (
+            OWM_MODE_FREE_FORECAST,
+            "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
+            static_weather_report,
+        ),
+        (
+            OWM_MODE_V30,
+            "pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather",
+            static_weather_report,
+        ),
+    ],
+)
+async def test_weather_states(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mode: str,
+    patched_function: str,
+    mock_return: WeatherReport,
+) -> None:
+    """Test weather states are correctly collected from library with different modes and mocked function responses."""
+
+    entry = mock_config_entry(mode)
+
+    with patch(patched_function, new_callable=AsyncMock, return_value=mock_return):
+        await setup_platform(hass, entry, [Platform.WEATHER])
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)

--- a/tests/components/openweathermap/test_weather.py
+++ b/tests/components/openweathermap/test_weather.py
@@ -1,136 +1,63 @@
 """Test the OpenWeatherMap weather entity."""
 
-from pyopenweathermap import WeatherReport
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.openweathermap.const import (
-    DOMAIN,
-    OWM_MODE_FREE_CURRENT,
-    OWM_MODE_FREE_FORECAST,
-    OWM_MODE_V30,
-)
+from homeassistant.components.openweathermap.const import DOMAIN, OWM_MODE_V30
 from homeassistant.components.openweathermap.weather import SERVICE_GET_MINUTE_FORECAST
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import mock_config_entry, setup_platform
-from .test_config_flow import _create_static_weather_report
+from .conftest import setup_platform
 
-from tests.common import AsyncMock, MockConfigEntry, patch, snapshot_platform
+from tests.common import MockConfigEntry, snapshot_platform
 
 ENTITY_ID = "weather.openweathermap"
 
-# Define test data for mocked weather report
-static_weather_report = _create_static_weather_report()
 
-
-@pytest.fixture
-def mock_config_entry_free_current() -> MockConfigEntry:
-    """Create a mock OpenWeatherMap FREE_CURRENT config entry."""
-    return mock_config_entry(OWM_MODE_FREE_CURRENT)
-
-
-@pytest.fixture
-def mock_config_entry_v30() -> MockConfigEntry:
-    """Create a mock OpenWeatherMap v3.0 config entry."""
-    return mock_config_entry(OWM_MODE_V30)
-
-
-async def setup_mock_config_entry(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
-):
-    """Set up the MockConfigEntry and assert it is loaded correctly."""
-    mock_config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-    assert hass.states.get(ENTITY_ID)
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-
-
-@patch(
-    "pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather",
-    AsyncMock(return_value=static_weather_report),
-)
 async def test_get_minute_forecast(
     hass: HomeAssistant,
-    mock_config_entry_v30: MockConfigEntry,
     snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    mode: str,
 ) -> None:
     """Test the get_minute_forecast Service call."""
-    await setup_mock_config_entry(hass, mock_config_entry_v30)
 
-    result = await hass.services.async_call(
-        DOMAIN,
-        SERVICE_GET_MINUTE_FORECAST,
-        {"entity_id": ENTITY_ID},
-        blocking=True,
-        return_response=True,
-    )
-    assert result == snapshot(name="mock_service_response")
+    await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
 
-
-@patch(
-    "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
-    AsyncMock(return_value=static_weather_report),
-)
-async def test_mode_fail(
-    hass: HomeAssistant,
-    mock_config_entry_free_current: MockConfigEntry,
-) -> None:
-    """Test that Minute forecasting fails when mode is not v3.0."""
-    await setup_mock_config_entry(hass, mock_config_entry_free_current)
-
-    # Expect a ServiceValidationError when mode is not OWM_MODE_V30
-    with pytest.raises(
-        ServiceValidationError,
-        match="Minute forecast is available only when OpenWeatherMap mode is set to v3.0",
-    ):
-        await hass.services.async_call(
+    if mode == OWM_MODE_V30:
+        result = await hass.services.async_call(
             DOMAIN,
             SERVICE_GET_MINUTE_FORECAST,
             {"entity_id": ENTITY_ID},
             blocking=True,
             return_response=True,
         )
+        assert result == snapshot(name="mock_service_response")
+    else:
+        with pytest.raises(
+            ServiceValidationError,
+            match="Minute forecast is available only when OpenWeatherMap mode is set to v3.0",
+        ):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GET_MINUTE_FORECAST,
+                {"entity_id": ENTITY_ID},
+                blocking=True,
+                return_response=True,
+            )
 
 
-@pytest.mark.parametrize(
-    ("mode", "patched_function", "mock_return"),
-    [
-        (
-            OWM_MODE_FREE_CURRENT,
-            "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
-            static_weather_report,
-        ),
-        (
-            OWM_MODE_FREE_FORECAST,
-            "pyopenweathermap.client.free_client.OWMFreeClient.get_weather",
-            static_weather_report,
-        ),
-        (
-            OWM_MODE_V30,
-            "pyopenweathermap.client.onecall_client.OWMOneCallClient.get_weather",
-            static_weather_report,
-        ),
-    ],
-)
 async def test_weather_states(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
-    mode: str,
-    patched_function: str,
-    mock_return: WeatherReport,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test weather states are correctly collected from library with different modes and mocked function responses."""
 
-    entry = mock_config_entry(mode)
+    await setup_platform(hass, mock_config_entry, [Platform.WEATHER])
 
-    with patch(patched_function, new_callable=AsyncMock, return_value=mock_return):
-        await setup_platform(hass, entry, [Platform.WEATHER])
-
-    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
## Proposed change

Add snpashot non-regression testing to OpenWeatherMap.
This will facilitate the validation of other pull requests currently open on OWM.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
