### PR TITLE
Fix :@ in ONVIF stream source URL when there is no username and password

### DIFF
--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -204,8 +204,10 @@ class ONVIFCameraEntity(ONVIFBaseEntity, Camera):
                 self._stream_uri_future.set_exception(err)
             raise
         url = URL(uri_no_auth)
-        url = url.with_user(self.device.username)
-        url = url.with_password(self.device.password)
+        if self.device.username:
+            url = url.with_user(self.device.username)
+        if self.device.password:
+            url = url.with_password(self.device.password)
         self._stream_uri = str(url)
         self._stream_uri_future.set_result(self._stream_uri)
         return self._stream_uri

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -204,10 +204,8 @@ class ONVIFCameraEntity(ONVIFBaseEntity, Camera):
                 self._stream_uri_future.set_exception(err)
             raise
         url = URL(uri_no_auth)
-        if self.device.username:
-            url = url.with_user(self.device.username)
-        if self.device.password:
-            url = url.with_password(self.device.password)
+        url = url.with_user(self.device.username or None)
+        url = url.with_password(self.device.password or None)
         self._stream_uri = str(url)
         self._stream_uri_future.set_result(self._stream_uri)
         return self._stream_uri

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -204,8 +204,9 @@ class ONVIFCameraEntity(ONVIFBaseEntity, Camera):
                 self._stream_uri_future.set_exception(err)
             raise
         url = URL(uri_no_auth)
-        url = url.with_user(self.device.username or None)
-        url = url.with_password(self.device.password or None)
+        if self.device.username or self.device.password:
+            url = url.with_user(self.device.username)
+            url = url.with_password(self.device.password)
         self._stream_uri = str(url)
         self._stream_uri_future.set_result(self._stream_uri)
         return self._stream_uri


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the camera/ONVIF server is added with no username and password, the stream URL generated by the integration has `:@` before the host which is unideal.

I noticed this issue with the following error:

```log
Logger: homeassistant.components.websocket_api.http.connection
Source: components/go2rtc/__init__.py:250
integration: Home Assistant WebSocket API (documentation, issues)
First occurred: 1:20:32 AM (1 occurrences)
Last logged: 1:20:32 AM

[140415868285088] Error handling message: Unknown error (unknown_error) Felipe Santos from 192.168.1.15 (Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36)
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/go2rtc_client/exceptions.py", line 56, in _func
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/go2rtc_client/rest.py", line 131, in add
    await self._client.request(
    ...<3 lines>...
    )
  File "/usr/local/lib/python3.13/site-packages/go2rtc_client/rest.py", line 67, in request
    resp.raise_for_status()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client_reqrep.py", line 1161, in raise_for_status
    raise ClientResponseError(
    ...<5 lines>...
    )
aiohttp.client_exceptions.ClientResponseError: 400, message='Bad Request', url='http://ccab4aaf-frigate:1984/api/streams?name=camera.go2rtc_birdseye&src=rtsp://:@ccab4aaf-frigate:8554/birdseye&src=ffmpeg:camera.go2rtc_birdseye%23audio%3Dopus%23query%3Dlog_level%3Ddebug'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 28, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/camera/webrtc.py", line 253, in validate
    await func(connection, msg, camera)
  File "/usr/src/homeassistant/homeassistant/components/camera/webrtc.py", line 303, in ws_webrtc_offer
    await camera.async_handle_async_webrtc_offer(offer, session_id, send_message)
  File "/usr/src/homeassistant/homeassistant/components/camera/__init__.py", line 692, in async_handle_async_webrtc_offer
    await self._webrtc_provider.async_handle_async_webrtc_offer(
        self, offer_sdp, session_id, send_message
    )
  File "/usr/src/homeassistant/homeassistant/components/go2rtc/__init__.py", line 250, in async_handle_async_webrtc_offer
    await self._rest_client.streams.add(
    ...<8 lines>...
    )
  File "/usr/local/lib/python3.13/site-packages/go2rtc_client/exceptions.py", line 66, in _func
    raise Go2RtcClientError from exc
go2rtc_client.exceptions.Go2RtcClientError
```

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
  - NOTE: This Python module had not tests.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
       Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
       Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
