### PR TITLE
Add ability to mark type hints as compulsory on specific functions

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -50,9 +50,9 @@ class TypeHintMatch:
     kwargs_type: str | None = None
     """kwargs_type is for the special case `**kwargs`"""
     has_async_counterpart: bool = False
-    """Used to check both `function_name` and `async_function_name` functions"""
+    """`function_name` and `async_function_name` share arguments and return type"""
     compulsory: bool = False
-    """Used to bypass ignore_missing_annotations"""
+    """bypass ignore_missing_annotations"""
 
     def need_to_check_function(self, node: nodes.FunctionDef) -> bool:
         """Confirm if function should be checked."""

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -50,6 +50,9 @@ class TypeHintMatch:
     kwargs_type: str | None = None
     """kwargs_type is for the special case `**kwargs`"""
     has_async_counterpart: bool = False
+    """Used to check both `function_name` and `async_function_name` functions"""
+    compulsory: bool = False
+    """Used to bypass ignore_missing_annotations"""
 
     def need_to_check_function(self, node: nodes.FunctionDef) -> bool:
         """Confirm if function should be checked."""
@@ -184,6 +187,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
             },
             return_type="bool",
             has_async_counterpart=True,
+            compulsory=True,
         ),
         TypeHintMatch(
             function_name="async_setup_entry",
@@ -192,6 +196,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
             },
             return_type="bool",
+            compulsory=True,
         ),
         TypeHintMatch(
             function_name="async_remove_entry",
@@ -200,6 +205,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
             },
             return_type=None,
+            compulsory=True,
         ),
         TypeHintMatch(
             function_name="async_unload_entry",
@@ -208,6 +214,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
             },
             return_type="bool",
+            compulsory=True,
         ),
         TypeHintMatch(
             function_name="async_migrate_entry",
@@ -216,6 +223,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
             },
             return_type="bool",
+            compulsory=True,
         ),
         TypeHintMatch(
             function_name="async_remove_config_entry_device",
@@ -225,6 +233,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 2: "DeviceEntry",
             },
             return_type="bool",
+            compulsory=True,
         ),
         TypeHintMatch(
             function_name="async_reset_platform",
@@ -233,6 +242,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "str",
             },
             return_type=None,
+            compulsory=True,
         ),
     ],
     "__any_platform__": [
@@ -246,6 +256,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
             },
             return_type=None,
             has_async_counterpart=True,
+            compulsory=True,
         ),
         TypeHintMatch(
             function_name="async_setup_entry",
@@ -255,6 +266,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 2: "AddConfigEntryEntitiesCallback",
             },
             return_type=None,
+            compulsory=True,
         ),
     ],
     "application_credentials": [
@@ -3195,8 +3207,11 @@ class HassTypeHintChecker(BaseChecker):
 
         self._class_matchers.reverse()
 
-    def _ignore_function(
-        self, node: nodes.FunctionDef, annotations: list[nodes.NodeNG | None]
+    def _ignore_function_match(
+        self,
+        node: nodes.FunctionDef,
+        annotations: list[nodes.NodeNG | None],
+        match: TypeHintMatch,
     ) -> bool:
         """Check if we can skip the function validation."""
         return (
@@ -3204,6 +3219,8 @@ class HassTypeHintChecker(BaseChecker):
             not self._in_test_module
             # some modules have checks forced
             and self._module_platform not in _FORCE_ANNOTATION_PLATFORMS
+            # some matches have checks forced
+            and not match.compulsory
             # other modules are only checked ignore_missing_annotations
             and self.linter.config.ignore_missing_annotations
             and node.returns is None
@@ -3246,7 +3263,7 @@ class HassTypeHintChecker(BaseChecker):
                     continue
 
                 annotations = _get_all_annotations(function_node)
-                if self._ignore_function(function_node, annotations):
+                if self._ignore_function_match(function_node, annotations, match):
                     continue
 
                 self._check_function(function_node, match, annotations)
@@ -3255,8 +3272,6 @@ class HassTypeHintChecker(BaseChecker):
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Apply relevant type hint checks on a FunctionDef node."""
         annotations = _get_all_annotations(node)
-        if self._ignore_function(node, annotations):
-            return
 
         # Check method or function matchers.
         if node.is_method():
@@ -3277,14 +3292,15 @@ class HassTypeHintChecker(BaseChecker):
             matchers = self._function_matchers
 
         # Check that common arguments are correctly typed.
-        for arg_name, expected_type in _COMMON_ARGUMENTS.items():
-            arg_node, annotation = _get_named_annotation(node, arg_name)
-            if arg_node and not _is_valid_type(expected_type, annotation):
-                self.add_message(
-                    "hass-argument-type",
-                    node=arg_node,
-                    args=(arg_name, expected_type, node.name),
-                )
+        if not self.linter.config.ignore_missing_annotations:
+            for arg_name, expected_type in _COMMON_ARGUMENTS.items():
+                arg_node, annotation = _get_named_annotation(node, arg_name)
+                if arg_node and not _is_valid_type(expected_type, annotation):
+                    self.add_message(
+                        "hass-argument-type",
+                        node=arg_node,
+                        args=(arg_name, expected_type, node.name),
+                    )
 
         for match in matchers:
             if not match.need_to_check_function(node):
@@ -3299,6 +3315,8 @@ class HassTypeHintChecker(BaseChecker):
         match: TypeHintMatch,
         annotations: list[nodes.NodeNG | None],
     ) -> None:
+        if self._ignore_function_match(node, annotations, match):
+            return
         # Check that all positional arguments are correctly annotated.
         if match.arg_types:
             for key, expected_type in match.arg_types.items():

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -51,7 +51,7 @@ class TypeHintMatch:
     """kwargs_type is for the special case `**kwargs`"""
     has_async_counterpart: bool = False
     """`function_name` and `async_function_name` share arguments and return type"""
-    compulsory: bool = False
+    mandatory: bool = False
     """bypass ignore_missing_annotations"""
 
     def need_to_check_function(self, node: nodes.FunctionDef) -> bool:
@@ -187,7 +187,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
             },
             return_type="bool",
             has_async_counterpart=True,
-            compulsory=True,
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_setup_entry",
@@ -196,7 +196,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
             },
             return_type="bool",
-            compulsory=True,
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_remove_entry",
@@ -205,7 +205,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
             },
             return_type=None,
-            compulsory=True,
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_unload_entry",
@@ -214,7 +214,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
             },
             return_type="bool",
-            compulsory=True,
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_migrate_entry",
@@ -223,7 +223,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
             },
             return_type="bool",
-            compulsory=True,
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_remove_config_entry_device",
@@ -233,7 +233,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 2: "DeviceEntry",
             },
             return_type="bool",
-            compulsory=True,
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_reset_platform",
@@ -242,7 +242,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "str",
             },
             return_type=None,
-            compulsory=True,
+            mandatory=True,
         ),
     ],
     "__any_platform__": [
@@ -256,7 +256,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
             },
             return_type=None,
             has_async_counterpart=True,
-            compulsory=True,
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_setup_entry",
@@ -266,7 +266,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 2: "AddConfigEntryEntitiesCallback",
             },
             return_type=None,
-            compulsory=True,
+            mandatory=True,
         ),
     ],
     "application_credentials": [
@@ -3220,7 +3220,7 @@ class HassTypeHintChecker(BaseChecker):
             # some modules have checks forced
             and self._module_platform not in _FORCE_ANNOTATION_PLATFORMS
             # some matches have checks forced
-            and not match.compulsory
+            and not match.mandatory
             # other modules are only checked ignore_missing_annotations
             and self.linter.config.ignore_missing_annotations
             and node.returns is None

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -99,7 +99,7 @@ def test_regex_a_or_b(
     "code",
     [
         """
-    async def setup( #@
+    async def async_turn_on( #@
         arg1, arg2
     ):
         pass
@@ -115,7 +115,7 @@ def test_ignore_no_annotations(
 
     func_node = astroid.extract_node(
         code,
-        "homeassistant.components.pylint_test",
+        "homeassistant.components.pylint_test.light",
     )
     type_hint_checker.visit_module(func_node.parent)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add ability to mark common functions as compulsory in the pylint "enforce type hints" plugin

Architecture discussion (approved): https://github.com/home-assistant/architecture/discussions/1234

See sample run with "available" property marked as compulsory:
https://github.com/home-assistant/core/actions/runs/13649240836/job/38153933609?pr=139734

```console
************* Module homeassistant.components.syncthing.sensor
Warning: homeassistant/components/syncthing/sensor.py:114:4: W7432: Return type should be bool in available (hass-return-type)
Warning: homeassistant/components/syncthing/sensor.py:114:4: W7432: Return type should be bool in available (hass-return-type)
************* Module homeassistant.components.supervisord.sensor
Warning: homeassistant/components/supervisord/sensor.py:74:4: W7432: Return type should be bool in available (hass-return-type)
Warning: homeassistant/components/supervisord/sensor.py:74:4: W7432: Return type should be bool in available (hass-return-type)
************* Module homeassistant.components.osramlightify.light
Warning: homeassistant/components/osramlightify/light.py:282:4: W7432: Return type should be bool in available (hass-return-type)
Warning: homeassistant/components/osramlightify/light.py:282:4: W7432: Return type should be bool in available (hass-return-type)
************* Module homeassistant.components.xiaomi_miio.light
Warning: homeassistant/components/xiaomi_miio/light.py:274:4: W7432: Return type should be bool in available (hass-return-type)
Warning: homeassistant/components/xiaomi_miio/light.py:274:4: W7432: Return type should be bool in available (hass-return-type)
Warning: homeassistant/components/xiaomi_miio/light.py:1030:4: W7432: Return type should be bool in available (hass-return-type)
Warning: homeassistant/components/xiaomi_miio/light.py:1030:4: W7432: Return type should be bool in available (hass-return-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
