### PR TITLE
Delete refresh after a non-breaking error at event stream at Home Connect

### DIFF
--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -47,8 +47,6 @@ _LOGGER = logging.getLogger(__name__)
 
 type HomeConnectConfigEntry = ConfigEntry[HomeConnectCoordinator]
 
-EVENT_STREAM_RECONNECT_DELAY = 30
-
 
 @dataclass(frozen=True, kw_only=True)
 class HomeConnectApplianceData:
@@ -157,9 +155,11 @@ class HomeConnectCoordinator(
 
     async def _event_listener(self) -> None:
         """Match event with listener for event type."""
+        retry_time = 10
         while True:
             try:
                 async for event_message in self.client.stream_all_events():
+                    retry_time = 10
                     event_message_ha_id = event_message.ha_id
                     match event_message.type:
                         case EventType.STATUS:
@@ -256,20 +256,18 @@ class HomeConnectCoordinator(
             except (EventStreamInterruptedError, HomeConnectRequestError) as error:
                 _LOGGER.debug(
                     "Non-breaking error (%s) while listening for events,"
-                    " continuing in 30 seconds",
+                    " continuing in %s seconds",
                     type(error).__name__,
+                    retry_time,
                 )
-                await asyncio.sleep(EVENT_STREAM_RECONNECT_DELAY)
+                await asyncio.sleep(retry_time)
+                retry_time = min(retry_time * 2, 3600)
             except HomeConnectApiError as error:
                 _LOGGER.error("Error while listening for events: %s", error)
                 self.hass.config_entries.async_schedule_reload(
                     self.config_entry.entry_id
                 )
                 break
-            # if there was a non-breaking error, we continue listening
-            # but we need to refresh the data to get the possible changes
-            # that happened while the event stream was interrupted
-            await self.async_refresh()
 
     @callback
     def _call_event_listener(self, event_message: EventMessage) -> None:

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -1,6 +1,7 @@
 """Test for Home Connect coordinator."""
 
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -38,8 +39,9 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture
@@ -306,9 +308,6 @@ async def test_event_listener_error(
         ),
     ],
 )
-@patch(
-    "homeassistant.components.home_connect.coordinator.EVENT_STREAM_RECONNECT_DELAY", 0
-)
 async def test_event_listener_resilience(
     entity_id: str,
     initial_state: str,
@@ -351,6 +350,7 @@ async def test_event_listener_resilience(
     await hass.async_block_till_done()
     future.set_exception(exception)
     await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     assert client.stream_all_events.call_count == 2

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -13,8 +13,6 @@ from aiohomeconnect.model import (
     EventKey,
     EventMessage,
     EventType,
-    Status,
-    StatusKey,
 )
 from aiohomeconnect.model.error import (
     EventStreamInterruptedError,
@@ -25,7 +23,6 @@ from aiohomeconnect.model.error import (
 import pytest
 
 from homeassistant.components.home_connect.const import (
-    BSH_DOOR_STATE_LOCKED,
     BSH_DOOR_STATE_OPEN,
     BSH_EVENT_PRESENT_STATE_PRESENT,
     BSH_POWER_OFF,
@@ -288,9 +285,6 @@ async def test_event_listener_error(
     (
         "entity_id",
         "initial_state",
-        "status_key",
-        "status_value",
-        "after_refresh_expected_state",
         "event_key",
         "event_value",
         "after_event_expected_state",
@@ -299,9 +293,6 @@ async def test_event_listener_error(
         (
             "sensor.washer_door",
             "closed",
-            StatusKey.BSH_COMMON_DOOR_STATE,
-            BSH_DOOR_STATE_LOCKED,
-            "locked",
             EventKey.BSH_COMMON_STATUS_DOOR_STATE,
             BSH_DOOR_STATE_OPEN,
             "open",
@@ -311,9 +302,6 @@ async def test_event_listener_error(
 async def test_event_listener_resilience(
     entity_id: str,
     initial_state: str,
-    status_key: StatusKey,
-    status_value: Any,
-    after_refresh_expected_state: str,
     event_key: EventKey,
     event_value: Any,
     after_event_expected_state: str,
@@ -344,9 +332,6 @@ async def test_event_listener_resilience(
 
     assert hass.states.is_state(entity_id, initial_state)
 
-    client.get_status.return_value = ArrayOfStatus(
-        [Status(key=status_key, raw_key=status_key.value, value=status_value)],
-    )
     await hass.async_block_till_done()
     future.set_exception(exception)
     await hass.async_block_till_done()
@@ -354,7 +339,6 @@ async def test_event_listener_resilience(
     await hass.async_block_till_done()
 
     assert client.stream_all_events.call_count == 2
-    assert hass.states.is_state(entity_id, after_refresh_expected_state)
 
     await client.add_events(
         [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

After some discussion with @MartinHjelmare, removing temporally the refresh after non-breaking error in the even stream have been decided.

The main reasons is that after the event stream finish non-abruptly, we don't wait to continue, so probably nothing changes while the even stream is not running. With that we could have move the refresh to the `EventStreamInterruptedError`, `HomeConnectRequestError` error handles, but there are some cases where after those kind of errors, the CONNECTED event was received and we refreshed twice the appliances.

We plan to bring it back in the future, but we need to improve how the API rate limits are handled

Additionally, a backoff retry logic was added

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
