### PR TITLE
Simplify error handling in BackupAgent when a backup is not found

### DIFF
--- a/homeassistant/components/backup/agent.py
+++ b/homeassistant/components/backup/agent.py
@@ -41,6 +41,8 @@ class BackupAgent(abc.ABC):
     ) -> AsyncIterator[bytes]:
         """Download a backup file.
 
+        Raises BackupNotFound if the backup does not exist.
+
         :param backup_id: The ID of the backup that was returned in async_list_backups.
         :return: An async iterator that yields bytes.
         """
@@ -67,6 +69,8 @@ class BackupAgent(abc.ABC):
     ) -> None:
         """Delete a backup file.
 
+        Raises BackupNotFound if the backup does not exist.
+
         :param backup_id: The ID of the backup that was returned in async_list_backups.
         """
 
@@ -80,7 +84,10 @@ class BackupAgent(abc.ABC):
         backup_id: str,
         **kwargs: Any,
     ) -> AgentBackup | None:
-        """Return a backup."""
+        """Return a backup.
+
+        Raises BackupNotFound if the backup does not exist.
+        """
 
 
 class LocalBackupAgent(BackupAgent):

--- a/tests/components/backup/common.py
+++ b/tests/components/backup/common.py
@@ -67,15 +67,20 @@ async def aiter_from_iter(iterable: Iterable) -> AsyncIterator:
 def mock_backup_agent(name: str, backups: list[AgentBackup] | None = None) -> Mock:
     """Create a mock backup agent."""
 
+    async def delete_backup(backup_id: str, **kwargs: Any) -> None:
+        """Mock delete."""
+        get_backup(backup_id)
+
     async def download_backup(backup_id: str, **kwargs: Any) -> AsyncIterator[bytes]:
         """Mock download."""
-        if not await get_backup(backup_id):
-            raise BackupNotFound
         return aiter_from_iter((backups_data.get(backup_id, b"backup data"),))
 
-    async def get_backup(backup_id: str, **kwargs: Any) -> AgentBackup | None:
+    async def get_backup(backup_id: str, **kwargs: Any) -> AgentBackup:
         """Get a backup."""
-        return next((b for b in backups if b.backup_id == backup_id), None)
+        backup = next((b for b in backups if b.backup_id == backup_id), None)
+        if backup is None:
+            raise BackupNotFound
+        return backup
 
     async def upload_backup(
         *,
@@ -99,7 +104,7 @@ def mock_backup_agent(name: str, backups: list[AgentBackup] | None = None) -> Mo
     mock_agent.unique_id = name
     type(mock_agent).agent_id = BackupAgent.agent_id
     mock_agent.async_delete_backup = AsyncMock(
-        spec_set=[BackupAgent.async_delete_backup]
+        side_effect=delete_backup, spec_set=[BackupAgent.async_delete_backup]
     )
     mock_agent.async_download_backup = AsyncMock(
         side_effect=download_backup, spec_set=[BackupAgent.async_download_backup]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify error handling in `BackupAgent` when a backup is not found to make all methods raise `BackupNotFound` when a backup can't be found.

#### Background

Without this PR, different `BackupAgent` methods behave differently when a backup is not found:
`BackupAgent.async_delete_backup` - Do nothing
`BackupAgent.async_download_backup` - Raise `BackupNotFound`
`BackupAgent.async_get_backup` - Return None

If the change is accepted, the developer documentation needs to be updated, and we should mention the change in a blog post.

In follow-up PRs:
- Update backup integrations
- Log warnings asking users to open an issue on custom integrations which are not updated

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2588
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
