### PR TITLE
Improve Home Connect appliances test fixture

### DIFF
--- a/tests/components/home_connect/__init__.py
+++ b/tests/components/home_connect/__init__.py
@@ -2,13 +2,10 @@
 
 from typing import Any
 
-from aiohomeconnect.model import ArrayOfHomeAppliances, ArrayOfStatus
+from aiohomeconnect.model import ArrayOfStatus
 
 from tests.common import load_json_object_fixture
 
-MOCK_APPLIANCES = ArrayOfHomeAppliances.from_dict(
-    load_json_object_fixture("home_connect/appliances.json")["data"]  # type: ignore[arg-type]
-)
 MOCK_PROGRAMS: dict[str, Any] = load_json_object_fixture("home_connect/programs.json")
 MOCK_SETTINGS: dict[str, Any] = load_json_object_fixture("home_connect/settings.json")
 MOCK_STATUS = ArrayOfStatus.from_dict(

--- a/tests/components/home_connect/fixtures/appliances.json
+++ b/tests/components/home_connect/fixtures/appliances.json
@@ -1,123 +1,121 @@
 {
-  "data": {
-    "homeappliances": [
-      {
-        "name": "FridgeFreezer",
-        "brand": "SIEMENS",
-        "vib": "HCS05FRF1",
-        "connected": true,
-        "type": "FridgeFreezer",
-        "enumber": "HCS05FRF1/03",
-        "haId": "SIEMENS-HCS05FRF1-304F4F9E541D"
-      },
-      {
-        "name": "Dishwasher",
-        "brand": "SIEMENS",
-        "vib": "HCS02DWH1",
-        "connected": true,
-        "type": "Dishwasher",
-        "enumber": "HCS02DWH1/03",
-        "haId": "SIEMENS-HCS02DWH1-6BE58C26DCC1"
-      },
-      {
-        "name": "Oven",
-        "brand": "BOSCH",
-        "vib": "HCS01OVN1",
-        "connected": true,
-        "type": "Oven",
-        "enumber": "HCS01OVN1/03",
-        "haId": "BOSCH-HCS01OVN1-43E0065FE245"
-      },
-      {
-        "name": "Washer",
-        "brand": "SIEMENS",
-        "vib": "HCS03WCH1",
-        "connected": true,
-        "type": "Washer",
-        "enumber": "HCS03WCH1/03",
-        "haId": "SIEMENS-HCS03WCH1-7BC6383CF794"
-      },
-      {
-        "name": "Dryer",
-        "brand": "BOSCH",
-        "vib": "HCS04DYR1",
-        "connected": true,
-        "type": "Dryer",
-        "enumber": "HCS04DYR1/03",
-        "haId": "BOSCH-HCS04DYR1-831694AE3C5A"
-      },
-      {
-        "name": "CoffeeMaker",
-        "brand": "BOSCH",
-        "vib": "HCS06COM1",
-        "connected": true,
-        "type": "CoffeeMaker",
-        "enumber": "HCS06COM1/03",
-        "haId": "BOSCH-HCS06COM1-D70390681C2C"
-      },
-      {
-        "name": "WasherDryer",
-        "brand": "BOSCH",
-        "vib": "HCS000001",
-        "connected": true,
-        "type": "WasherDryer",
-        "enumber": "HCS000000/01",
-        "haId": "BOSCH-HCS000000-D00000000001"
-      },
-      {
-        "name": "Refrigerator",
-        "brand": "BOSCH",
-        "vib": "HCS000002",
-        "connected": true,
-        "type": "Refrigerator",
-        "enumber": "HCS000000/02",
-        "haId": "BOSCH-HCS000000-D00000000002"
-      },
-      {
-        "name": "Freezer",
-        "brand": "BOSCH",
-        "vib": "HCS000003",
-        "connected": true,
-        "type": "Freezer",
-        "enumber": "HCS000000/03",
-        "haId": "BOSCH-HCS000000-D00000000003"
-      },
-      {
-        "name": "Hood",
-        "brand": "BOSCH",
-        "vib": "HCS000004",
-        "connected": true,
-        "type": "Hood",
-        "enumber": "HCS000000/04",
-        "haId": "BOSCH-HCS000000-D00000000004"
-      },
-      {
-        "name": "Hob",
-        "brand": "BOSCH",
-        "vib": "HCS000005",
-        "connected": true,
-        "type": "Hob",
-        "enumber": "HCS000000/05",
-        "haId": "BOSCH-HCS000000-D00000000005"
-      },
-      {
-        "name": "CookProcessor",
-        "brand": "BOSCH",
-        "vib": "HCS000006",
-        "connected": true,
-        "type": "CookProcessor",
-        "enumber": "HCS000000/06",
-        "haId": "BOSCH-HCS000000-D00000000006"
-      },
-      {
-        "name": "DNE",
-        "brand": "BOSCH",
-        "vib": "HCS000000",
-        "connected": true,
-        "type": "DNE",
-        "enumber": "HCS000000/00",
-        "haId": "BOSCH-000000000-000000000000"
-      }
-    ]
-  }
+  "homeappliances": [
+    {
+      "name": "FridgeFreezer",
+      "brand": "SIEMENS",
+      "vib": "HCS05FRF1",
+      "connected": true,
+      "type": "FridgeFreezer",
+      "enumber": "HCS05FRF1/03",
+      "haId": "SIEMENS-HCS05FRF1-304F4F9E541D"
+    },
+    {
+      "name": "Dishwasher",
+      "brand": "SIEMENS",
+      "vib": "HCS02DWH1",
+      "connected": true,
+      "type": "Dishwasher",
+      "enumber": "HCS02DWH1/03",
+      "haId": "SIEMENS-HCS02DWH1-6BE58C26DCC1"
+    },
+    {
+      "name": "Oven",
+      "brand": "BOSCH",
+      "vib": "HCS01OVN1",
+      "connected": true,
+      "type": "Oven",
+      "enumber": "HCS01OVN1/03",
+      "haId": "BOSCH-HCS01OVN1-43E0065FE245"
+    },
+    {
+      "name": "Washer",
+      "brand": "SIEMENS",
+      "vib": "HCS03WCH1",
+      "connected": true,
+      "type": "Washer",
+      "enumber": "HCS03WCH1/03",
+      "haId": "SIEMENS-HCS03WCH1-7BC6383CF794"
+    },
+    {
+      "name": "Dryer",
+      "brand": "BOSCH",
+      "vib": "HCS04DYR1",
+      "connected": true,
+      "type": "Dryer",
+      "enumber": "HCS04DYR1/03",
+      "haId": "BOSCH-HCS04DYR1-831694AE3C5A"
+    },
+    {
+      "name": "CoffeeMaker",
+      "brand": "BOSCH",
+      "vib": "HCS06COM1",
+      "connected": true,
+      "type": "CoffeeMaker",
+      "enumber": "HCS06COM1/03",
+      "haId": "BOSCH-HCS06COM1-D70390681C2C"
+    },
+    {
+      "name": "WasherDryer",
+      "brand": "BOSCH",
+      "vib": "HCS000001",
+      "connected": true,
+      "type": "WasherDryer",
+      "enumber": "HCS000000/01",
+      "haId": "BOSCH-HCS000000-D00000000001"
+    },
+    {
+      "name": "Refrigerator",
+      "brand": "BOSCH",
+      "vib": "HCS000002",
+      "connected": true,
+      "type": "Refrigerator",
+      "enumber": "HCS000000/02",
+      "haId": "BOSCH-HCS000000-D00000000002"
+    },
+    {
+      "name": "Freezer",
+      "brand": "BOSCH",
+      "vib": "HCS000003",
+      "connected": true,
+      "type": "Freezer",
+      "enumber": "HCS000000/03",
+      "haId": "BOSCH-HCS000000-D00000000003"
+    },
+    {
+      "name": "Hood",
+      "brand": "BOSCH",
+      "vib": "HCS000004",
+      "connected": true,
+      "type": "Hood",
+      "enumber": "HCS000000/04",
+      "haId": "BOSCH-HCS000000-D00000000004"
+    },
+    {
+      "name": "Hob",
+      "brand": "BOSCH",
+      "vib": "HCS000005",
+      "connected": true,
+      "type": "Hob",
+      "enumber": "HCS000000/05",
+      "haId": "BOSCH-HCS000000-D00000000005"
+    },
+    {
+      "name": "CookProcessor",
+      "brand": "BOSCH",
+      "vib": "HCS000006",
+      "connected": true,
+      "type": "CookProcessor",
+      "enumber": "HCS000000/06",
+      "haId": "BOSCH-HCS000000-D00000000006"
+    },
+    {
+      "name": "DNE",
+      "brand": "BOSCH",
+      "vib": "HCS000000",
+      "connected": true,
+      "type": "DNE",
+      "enumber": "HCS000000/00",
+      "haId": "BOSCH-000000000-000000000000"
+    }
+  ]
 }

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -1,19 +1,20 @@
 """Test for Home Connect coordinator."""
 
 from collections.abc import Awaitable, Callable
-import copy
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohomeconnect.model import (
     ArrayOfEvents,
+    ArrayOfHomeAppliances,
     ArrayOfSettings,
     ArrayOfStatus,
     Event,
     EventKey,
     EventMessage,
     EventType,
+    HomeAppliance,
 )
 from aiohomeconnect.model.error import (
     EventStreamInterruptedError,
@@ -40,8 +41,6 @@ from homeassistant.core import (
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
-
-from . import MOCK_APPLIANCES
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -81,16 +80,21 @@ async def test_coordinator_update_failing_get_appliances(
 
 @pytest.mark.usefixtures("setup_credentials")
 @pytest.mark.parametrize("platforms", [("binary_sensor",)])
-@pytest.mark.parametrize("appliance_ha_id", ["Washer"], indirect=True)
+@pytest.mark.parametrize("appliance", ["Washer"], indirect=True)
 async def test_coordinator_failure_refresh_and_stream(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     client: MagicMock,
     freezer: FrozenDateTimeFactory,
-    appliance_ha_id: str,
+    appliance: HomeAppliance,
 ) -> None:
     """Test entity available state via coordinator refresh and event stream."""
+    appliance_data = (
+        cast(str, appliance.to_json())
+        .replace("ha_id", "haId")
+        .replace("e_number", "enumber")
+    )
     entity_id_1 = "binary_sensor.washer_remote_control"
     entity_id_2 = "binary_sensor.washer_remote_start"
     await async_setup_component(hass, "homeassistant", {})
@@ -121,7 +125,9 @@ async def test_coordinator_failure_refresh_and_stream(
     # Test that the entity becomes available again after a successful update.
 
     client.get_home_appliances.side_effect = None
-    client.get_home_appliances.return_value = copy.deepcopy(MOCK_APPLIANCES)
+    client.get_home_appliances.return_value = ArrayOfHomeAppliances(
+        [HomeAppliance.from_json(appliance_data)]
+    )
 
     # Move time forward to pass the debounce time.
     freezer.tick(timedelta(hours=1))
@@ -166,11 +172,13 @@ async def test_coordinator_failure_refresh_and_stream(
 
     # Now make the entity available again.
     client.get_home_appliances.side_effect = None
-    client.get_home_appliances.return_value = copy.deepcopy(MOCK_APPLIANCES)
+    client.get_home_appliances.return_value = ArrayOfHomeAppliances(
+        [HomeAppliance.from_json(appliance_data)]
+    )
 
     # One event should make all entities for this appliance available again.
     event_message = EventMessage(
-        appliance_ha_id,
+        appliance.ha_id,
         EventType.STATUS,
         ArrayOfEvents(
             [
@@ -399,6 +407,9 @@ async def test_event_listener_error(
     assert not config_entry._background_tasks
 
 
+@pytest.mark.usefixtures("setup_credentials")
+@pytest.mark.parametrize("platforms", [("sensor",)])
+@pytest.mark.parametrize("appliance", ["Washer"], indirect=True)
 @pytest.mark.parametrize(
     "exception",
     [HomeConnectRequestError(), EventStreamInterruptedError()],
@@ -429,11 +440,10 @@ async def test_event_listener_resilience(
     after_event_expected_state: str,
     exception: HomeConnectError,
     hass: HomeAssistant,
+    appliance: HomeAppliance,
+    client: MagicMock,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
-    setup_credentials: None,
-    client: MagicMock,
-    appliance_ha_id: str,
 ) -> None:
     """Test that the event listener is resilient to interruptions."""
     future = hass.loop.create_future()
@@ -467,7 +477,7 @@ async def test_event_listener_resilience(
     await client.add_events(
         [
             EventMessage(
-                appliance_ha_id,
+                appliance.ha_id,
                 EventType.STATUS,
                 ArrayOfEvents(
                     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Improve the appliances test fixture to make it easier to specify which appliance to use.
- Also reuse the mashumaro dataclass serialization features of the library when creating the fixtures instances.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
