### PR TITLE
Prioritize integration_domain passed to helper.frame.report_usage

### DIFF
--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -260,7 +260,7 @@ def _report_usage(
     """
     if integration_domain:
         if integration := async_get_issue_integration(hass, integration_domain):
-            _report_integration_domain(
+            _report_usage_integration_domain(
                 hass,
                 what,
                 breaks_in_ha_version,
@@ -270,7 +270,7 @@ def _report_usage(
                 level,
             )
             return
-        _report_no_integration(what, core_behavior, breaks_in_ha_version, None)
+        _report_usage_no_integration(what, core_behavior, breaks_in_ha_version, None)
         return
 
     try:
@@ -278,7 +278,7 @@ def _report_usage(
             exclude_integrations=exclude_integrations
         )
     except MissingIntegrationFrame as err:
-        _report_no_integration(what, core_behavior, breaks_in_ha_version, err)
+        _report_usage_no_integration(what, core_behavior, breaks_in_ha_version, err)
         return
 
     integration_behavior = core_integration_behavior
@@ -286,7 +286,7 @@ def _report_usage(
         integration_behavior = custom_integration_behavior
 
     if integration_behavior is not ReportBehavior.IGNORE:
-        _report_integration_frame(
+        _report_usage_integration_frame(
             hass,
             what,
             breaks_in_ha_version,
@@ -296,7 +296,7 @@ def _report_usage(
         )
 
 
-def _report_integration_domain(
+def _report_usage_integration_domain(
     hass: HomeAssistant | None,
     what: str,
     breaks_in_ha_version: str | None,
@@ -346,7 +346,7 @@ def _report_integration_domain(
         )
 
 
-def _report_integration_frame(
+def _report_usage_integration_frame(
     hass: HomeAssistant,
     what: str,
     breaks_in_ha_version: str | None,
@@ -395,13 +395,13 @@ def _report_integration_frame(
     )
 
 
-def _report_no_integration(
+def _report_usage_no_integration(
     what: str,
     core_behavior: ReportBehavior,
     breaks_in_ha_version: str | None,
     err: MissingIntegrationFrame | None,
 ) -> None:
-    """Report incorrect usage when no integration could be identified.
+    """Report incorrect usage without an integration.
 
     This could happen because the offending call happened outside of an integration,
     or because the integration could not be identified.

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -270,7 +270,7 @@ def _report_usage(
                 level,
             )
             return
-        _report_integration_unknown(what, core_behavior, breaks_in_ha_version, None)
+        _report_no_integration(what, core_behavior, breaks_in_ha_version, None)
         return
 
     try:
@@ -278,7 +278,7 @@ def _report_usage(
             exclude_integrations=exclude_integrations
         )
     except MissingIntegrationFrame as err:
-        _report_integration_unknown(what, core_behavior, breaks_in_ha_version, err)
+        _report_no_integration(what, core_behavior, breaks_in_ha_version, err)
         return
 
     integration_behavior = core_integration_behavior
@@ -395,13 +395,17 @@ def _report_integration_frame(
     )
 
 
-def _report_integration_unknown(
+def _report_no_integration(
     what: str,
     core_behavior: ReportBehavior,
     breaks_in_ha_version: str | None,
     err: MissingIntegrationFrame | None,
 ) -> None:
-    """Report incorrect usage when an integration is not identified."""
+    """Report incorrect usage when no integration could be identified.
+
+    This could happen because the offending call happened outside of an integration,
+    or because the integration could not be identified.
+    """
     msg = f"Detected code that {what}. Please report this issue"
     if core_behavior is ReportBehavior.ERROR:
         raise RuntimeError(msg) from err

--- a/tests/components/alarm_control_panel/test_init.py
+++ b/tests/components/alarm_control_panel/test_init.py
@@ -292,13 +292,13 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_state_prop
     assert state is not None
 
     assert (
-        "Detected that custom integration 'alarm_control_panel' is setting state"
-        " directly. Entity None (<class 'tests.components.alarm_control_panel."
+        "Detected that custom integration 'test' is setting state "
+        "directly. Entity None (<class 'tests.components.alarm_control_panel."
         "test_init.test_alarm_control_panel_log_deprecated_state_warning_using"
         "_state_prop.<locals>.MockLegacyAlarmControlPanel'>) should implement"
         " the 'alarm_state' property and return its state using the AlarmControlPanelState"
-        " enum at test_init.py, line 123: yield. This will stop working in Home Assistant"
-        " 2025.11, please create a bug report at" in caplog.text
+        " enum. This will stop working in Home Assistant 2025.11, please report it to"
+        " the author of the 'test' custom integration" in caplog.text
     )
 
 
@@ -345,6 +345,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
             async_setup_entry=help_async_setup_entry_init,
             async_unload_entry=help_async_unload_entry,
         ),
+        built_in=False,
     )
     setup_test_component_platform(
         hass, ALARM_CONTROL_PANEL_DOMAIN, [entity], from_config_entry=True
@@ -355,7 +356,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
     assert state is not None
 
     assert (
-        "Detected that custom integration 'alarm_control_panel' is setting state directly."
+        "Detected that custom integration 'test' is setting state directly."
         not in caplog.text
     )
 
@@ -364,14 +365,14 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
     )
 
     assert (
-        "Detected that custom integration 'alarm_control_panel' is setting state directly."
+        "Detected that custom integration 'test' is setting state directly."
         " Entity alarm_control_panel.test_alarm_control_panel"
         " (<class 'tests.components.alarm_control_panel.test_init."
         "test_alarm_control_panel_log_deprecated_state_warning_using_attr_state_attr."
         "<locals>.MockLegacyAlarmControlPanel'>) should implement the 'alarm_state' property"
-        " and return its state using the AlarmControlPanelState enum at test_init.py, line 123:"
-        " yield. This will stop working in Home Assistant 2025.11,"
-        " please create a bug report at" in caplog.text
+        " and return its state using the AlarmControlPanelState enum. "
+        "This will stop working in Home Assistant 2025.11, please report "
+        "it to the author of the 'test' custom integration" in caplog.text
     )
     caplog.clear()
     await help_test_async_alarm_control_panel_service(
@@ -379,7 +380,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
     )
     # Test we only log once
     assert (
-        "Detected that custom integration 'alarm_control_panel' is setting state directly."
+        "Detected that custom integration 'test' is setting state directly."
         not in caplog.text
     )
 
@@ -428,6 +429,7 @@ async def test_alarm_control_panel_deprecated_state_does_not_break_state(
             async_setup_entry=help_async_setup_entry_init,
             async_unload_entry=help_async_unload_entry,
         ),
+        built_in=False,
     )
     setup_test_component_platform(
         hass, ALARM_CONTROL_PANEL_DOMAIN, [entity], from_config_entry=True

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -356,6 +356,7 @@ async def test_vacuum_log_deprecated_state_warning_using_state_prop(
             async_setup_entry=help_async_setup_entry_init,
             async_unload_entry=help_async_unload_entry,
         ),
+        built_in=False,
     )
     setup_test_component_platform(hass, VACUUM_DOMAIN, [entity], from_config_entry=True)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -399,6 +400,7 @@ async def test_vacuum_log_deprecated_state_warning_using_attr_state_attr(
             async_setup_entry=help_async_setup_entry_init,
             async_unload_entry=help_async_unload_entry,
         ),
+        built_in=False,
     )
     setup_test_component_platform(hass, VACUUM_DOMAIN, [entity], from_config_entry=True)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -463,6 +465,7 @@ async def test_vacuum_deprecated_state_does_not_break_state(
             async_setup_entry=help_async_setup_entry_init,
             async_unload_entry=help_async_unload_entry,
         ),
+        built_in=False,
     )
     setup_test_component_platform(hass, VACUUM_DOMAIN, [entity], from_config_entry=True)
     assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -623,21 +623,21 @@ async def test_report(
             False,
             id="custom integration",
         ),
-        # Assert integration found in stack frame has priority over integration_domain
+        # Assert integration_domain has priority over integration found in stack frame
         pytest.param(
             "core_integration_behavior",
             "sensor",
             "homeassistant/components/hue",
-            "that integration 'hue'",
+            "that integration 'sensor'",
             False,
             id="core integration stack mismatch",
         ),
-        # Assert integration found in stack frame has priority over integration_domain
+        # Assert integration_domain has priority over integration found in stack frame
         pytest.param(
             "custom_integration_behavior",
             "test_package",
             "custom_components/hue",
-            "that custom integration 'hue'",
+            "that custom integration 'test_package'",
             False,
             id="custom integration stack mismatch",
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prioritize `integration_domain` passed to `helper.frame.report_usage` instead of domain found by searching the stack frame

This matches with the intention in all existing use of the `integration_domain` parameter:

https://github.com/home-assistant/core/blob/99451102e3db6657017bc62a9ef2f77703908e28/homeassistant/config_entries.py#L1639-L1646
https://github.com/home-assistant/core/blob/99451102e3db6657017bc62a9ef2f77703908e28/homeassistant/config_entries.py#L3207-L3213
https://github.com/home-assistant/core/blob/99451102e3db6657017bc62a9ef2f77703908e28/homeassistant/components/alarm_control_panel/__init__.py#L190-L199
https://github.com/home-assistant/core/blob/99451102e3db6657017bc62a9ef2f77703908e28/homeassistant/components/light/__init__.py#L1012-L1024
https://github.com/home-assistant/core/blob/99451102e3db6657017bc62a9ef2f77703908e28/homeassistant/components/light/__init__.py#L1050-L1062
https://github.com/home-assistant/core/blob/99451102e3db6657017bc62a9ef2f77703908e28/homeassistant/components/light/__init__.py#L1070-L1082
https://github.com/home-assistant/core/blob/99451102e3db6657017bc62a9ef2f77703908e28/homeassistant/components/vacuum/__init__.py#L287-L296

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
