### PR TITLE
Pass to LLM the name of the mobile device if on app

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -359,20 +359,9 @@ class AssistAPI(API):
             device = device_reg.async_get(llm_context.device_id)
 
             if device:
-                is_mobile_app_device = False
-
-                for config_entry_id in device.config_entries:
-                    entry = self.hass.config_entries.async_get_entry(config_entry_id)
-                    if entry and entry.domain == "mobile_app":
-                        is_mobile_app_device = True
-                        break
-
-                if is_mobile_app_device:
-                    device_name = device.name_by_user or device.name
-                    prompt.append(
-                        f"User is interacting with you from a mobile app device "
-                        f"called {device_name}."
-                    )
+                device_name = device.name_by_user or device.name
+                if device_name:
+                    prompt.append(f"User is interacting with you from a device called {device_name}.")
 
                 area_reg = ar.async_get(self.hass)
                 if device.area_id and (area := area_reg.async_get_area(device.area_id)):

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -372,7 +372,9 @@ class AssistAPI(API):
         if area:
             location_prompt = []
             if device_name:
-                location_prompt.append(f"User is interacting with you via {device_name}")
+                location_prompt.append(
+                    f"User is interacting with you via {device_name}"
+                )
             else:
                 location_prompt.append("You are")
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -370,21 +370,17 @@ class AssistAPI(API):
                         floor = floor_reg.async_get_floor(area.floor_id)
 
         if area:
-            location_prompt = []
             if device_name:
-                location_prompt.append(
-                    f"User is interacting with you via {device_name}"
-                )
+                prefix = f"User is interacting with you via {device_name}"
             else:
-                location_prompt.append("You are")
+                prefix = "You are"
 
-            area_info = f" in area {area.name}"
+            area_info = f"in area {area.name}"
             if floor:
                 area_info += f" (floor {floor.name})"
             area_info += " and all generic commands like 'turn on the lights' should target this area."
 
-            location_prompt.append(area_info)
-            prompt.extend(location_prompt)
+            prompt.append(f"{prefix} {area_info}")
         else:
             if device_name:
                 prompt.append(f"User is interacting with you via {device_name}.")

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -359,6 +359,21 @@ class AssistAPI(API):
             device = device_reg.async_get(llm_context.device_id)
 
             if device:
+                is_mobile_app_device = False
+
+                for config_entry_id in device.config_entries:
+                    entry = self.hass.config_entries.async_get_entry(config_entry_id)
+                    if entry and entry.domain == "mobile_app":
+                        is_mobile_app_device = True
+                        break
+
+                if is_mobile_app_device:
+                    device_name = device.name_by_user or device.name
+                    prompt.append(
+                        f"User is interacting with you from a mobile app device "
+                        f"called {device_name}."
+                    )
+
                 area_reg = ar.async_get(self.hass)
                 if device.area_id and (area := area_reg.async_get_area(device.area_id)):
                     floor_reg = fr.async_get(self.hass)

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -354,7 +354,7 @@ class AssistAPI(API):
         ]
         area: ar.AreaEntry | None = None
         floor: fr.FloorEntry | None = None
-        device_name_prompt = None
+        device_name: str | None = None
 
         if llm_context.device_id:
             device_reg = dr.async_get(self.hass)
@@ -362,7 +362,6 @@ class AssistAPI(API):
 
             if device:
                 device_name = device.name_by_user or device.name
-                device_name_prompt = f"User is interacting with you via {device_name}"
 
                 area_reg = ar.async_get(self.hass)
                 if device.area_id and (area := area_reg.async_get_area(device.area_id)):
@@ -372,8 +371,8 @@ class AssistAPI(API):
 
         if area:
             location_prompt = []
-            if device_name_prompt:
-                location_prompt.append(device_name_prompt)
+            if device_name:
+                location_prompt.append(f"User is interacting with you via {device_name}")
             else:
                 location_prompt.append("You are")
 
@@ -385,8 +384,8 @@ class AssistAPI(API):
             location_prompt.append(area_info)
             prompt.extend(location_prompt)
         else:
-            if device_name_prompt:
-                prompt.append(f"{device_name_prompt}.")
+            if device_name:
+                prompt.append(f"User is interacting with you via {device_name}.")
 
             prompt.append(
                 "When a user asks to turn on all devices of a specific type, "

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -654,7 +654,7 @@ async def test_assist_api_prompt(
 
     # Test with device that has no area
     llm_context.device_id = device_no_area.id
-    device_prompt = f"User is interacting with you via No Area Device."
+    device_prompt = "User is interacting with you via No Area Device."
     api = await llm.async_get_api(hass, "assist", llm_context)
     assert api.api_prompt == (
         f"""{first_part_prompt}
@@ -667,9 +667,9 @@ async def test_assist_api_prompt(
     # Fake that request is made from a specific device ID with an area
     llm_context.device_id = device.id
     device_area_prompt = (
-        f"User is interacting with you via Living Room Device"
-        f" in area Test Area and all generic commands like 'turn on the lights' "
-        f"should target this area."
+        "User is interacting with you via Living Room Device"
+        " in area Test Area and all generic commands like 'turn on the lights' "
+        "should target this area."
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
     assert api.api_prompt == (
@@ -683,9 +683,9 @@ async def test_assist_api_prompt(
     floor = floor_registry.async_create("2")
     area_registry.async_update(area.id, floor_id=floor.floor_id)
     device_area_floor_prompt = (
-        f"User is interacting with you via Living Room Device"
-        f" in area Test Area (floor 2) and all generic commands like 'turn on the lights' "
-        f"should target this area."
+        "User is interacting with you via Living Room Device"
+        " in area Test Area (floor 2) and all generic commands like 'turn on the lights' "
+        "should target this area."
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
     assert api.api_prompt == (
@@ -715,8 +715,8 @@ async def test_assist_api_prompt(
     )
     llm_context.device_id = device.id
     no_name_area_floor_prompt = (
-        f"You are in area Test Area (floor 2) and all generic commands like 'turn on the lights' "
-        f"should target this area."
+        "You are in area Test Area (floor 2) and all generic commands like 'turn on the lights' "
+        "should target this area."
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
     assert api.api_prompt == (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When Voice Assistant is called from phone, I can often easily say who is the user interacting just by checking the device name. Of course it would be best to pass the name of the user logged in on the mobile app, but this change is minor and is in accordance with how assistants know e.g. about Voice PE devices because these often have area set.
By passing the name of the mobile device, the custom prompt can make sure that when I ask for "my calendar" it will fetch different calendars for me and other users.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #138968
- This PR is related to issue: #140709
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
