### PR TITLE
Make helpers.frame.report_usage work when called from any thread

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -81,6 +81,7 @@ from .helpers import (
     entity,
     entity_registry,
     floor_registry,
+    frame,
     issue_registry,
     label_registry,
     recorder,
@@ -441,9 +442,10 @@ async def async_load_base_functionality(hass: core.HomeAssistant) -> None:
     if DATA_REGISTRIES_LOADED in hass.data:
         return
     hass.data[DATA_REGISTRIES_LOADED] = None
-    translation.async_setup(hass)
     entity.async_setup(hass)
+    frame.async_setup(hass)
     template.async_setup(hass)
+    translation.async_setup(hass)
     await asyncio.gather(
         create_eager_task(get_internal_store_manager(hass).async_initialize()),
         create_eager_task(area_registry.async_load(hass)),

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -10,23 +10,39 @@ import functools
 import linecache
 import logging
 import sys
+import threading
 from types import FrameType
 from typing import Any, cast
 
 from propcache.api import cached_property
 
-from homeassistant.core import HomeAssistant, async_get_hass_or_none
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import (
     Integration,
     async_get_issue_integration,
     async_suggest_report_issue,
 )
+from homeassistant.util.async_ import run_callback_threadsafe
 
 _LOGGER = logging.getLogger(__name__)
 
 # Keep track of integrations already reported to prevent flooding
 _REPORTED_INTEGRATIONS: set[str] = set()
+
+
+class _Hass(threading.local):
+    """Container which makes a HomeAssistant instance available to frame helper."""
+
+    hass: HomeAssistant | None = None
+
+
+_hass = _Hass()
+
+
+def async_setup(hass: HomeAssistant) -> None:
+    """Set up the frame helper."""
+    _hass.hass = hass
 
 
 @dataclass(kw_only=True)
@@ -204,16 +220,49 @@ def report_usage(
     :param integration_domain: fallback for identifying the integration if the
     frame is not found
     """
+    if _hass.hass is None:
+        raise RuntimeError("Frame helper not set up")
+    _report_usage_partial = functools.partial(
+        _report_usage,
+        what,
+        breaks_in_ha_version=breaks_in_ha_version,
+        core_behavior=core_behavior,
+        core_integration_behavior=core_integration_behavior,
+        custom_integration_behavior=custom_integration_behavior,
+        exclude_integrations=exclude_integrations,
+        integration_domain=integration_domain,
+        level=level,
+    )
+    if _hass.hass.loop_thread_id != threading.get_ident():
+        future = run_callback_threadsafe(_hass.hass.loop, _report_usage_partial)
+        future.result()
+        return
+    _report_usage_partial()
+
+
+def _report_usage(
+    what: str,
+    *,
+    breaks_in_ha_version: str | None,
+    core_behavior: ReportBehavior,
+    core_integration_behavior: ReportBehavior,
+    custom_integration_behavior: ReportBehavior,
+    exclude_integrations: set[str] | None,
+    integration_domain: str | None,
+    level: int,
+) -> None:
+    """Report incorrect code usage.
+
+    Must be called from the event loop.
+    """
     try:
         integration_frame = get_integration_frame(
             exclude_integrations=exclude_integrations
         )
     except MissingIntegrationFrame as err:
-        if integration := async_get_issue_integration(
-            hass := async_get_hass_or_none(), integration_domain
-        ):
+        if integration := async_get_issue_integration(_hass.hass, integration_domain):
             _report_integration_domain(
-                hass,
+                _hass.hass,
                 what,
                 breaks_in_ha_version,
                 integration,
@@ -316,7 +365,7 @@ def _report_integration_frame(
     _REPORTED_INTEGRATIONS.add(key)
 
     report_issue = async_suggest_report_issue(
-        async_get_hass_or_none(),
+        _hass.hass,
         integration_domain=integration_frame.integration,
         module=integration_frame.module,
     )

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -122,6 +122,7 @@ async def test_setup_multiple_states(
         },
     ],
 )
+@pytest.mark.usefixtures("hass")
 def test_setup_invalid_config(config) -> None:
     """Test the history statistics sensor setup with invalid config."""
 

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -1,5 +1,6 @@
 """Test pool."""
 
+import asyncio
 import threading
 
 import pytest
@@ -8,6 +9,7 @@ from sqlalchemy.orm import sessionmaker
 
 from homeassistant.components.recorder.const import DB_WORKER_PREFIX
 from homeassistant.components.recorder.pool import RecorderPool
+from homeassistant.core import HomeAssistant
 
 
 async def test_recorder_pool_called_from_event_loop() -> None:
@@ -22,7 +24,9 @@ async def test_recorder_pool_called_from_event_loop() -> None:
         sessionmaker(bind=engine)().connection()
 
 
-def test_recorder_pool(caplog: pytest.LogCaptureFixture) -> None:
+async def test_recorder_pool(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test RecorderPool gives the same connection in the creating thread."""
     recorder_and_worker_thread_ids: set[int] = set()
     engine = create_engine(
@@ -34,6 +38,8 @@ def test_recorder_pool(caplog: pytest.LogCaptureFixture) -> None:
     shutdown = False
     connections = []
     add_thread = False
+
+    event = asyncio.Event()
 
     def _get_connection_twice():
         if add_thread:
@@ -48,33 +54,42 @@ def test_recorder_pool(caplog: pytest.LogCaptureFixture) -> None:
         session = get_session()
         connections.append(session.connection().connection.driver_connection)
         session.close()
+        hass.loop.call_soon_threadsafe(event.set)
 
     caplog.clear()
+    event.clear()
     new_thread = threading.Thread(target=_get_connection_twice)
     new_thread.start()
+    await event.wait()
     new_thread.join()
     assert "accesses the database without the database executor" in caplog.text
     assert connections[0] != connections[1]
 
     add_thread = True
     caplog.clear()
+    event.clear()
     new_thread = threading.Thread(target=_get_connection_twice, name=DB_WORKER_PREFIX)
     new_thread.start()
+    await event.wait()
     new_thread.join()
     assert "accesses the database without the database executor" not in caplog.text
     assert connections[2] == connections[3]
 
     caplog.clear()
+    event.clear()
     new_thread = threading.Thread(target=_get_connection_twice, name="Recorder")
     new_thread.start()
+    await event.wait()
     new_thread.join()
     assert "accesses the database without the database executor" not in caplog.text
     assert connections[4] == connections[5]
 
     shutdown = True
     caplog.clear()
+    event.clear()
     new_thread = threading.Thread(target=_get_connection_twice, name=DB_WORKER_PREFIX)
     new_thread.start()
+    await event.wait()
     new_thread.join()
     assert "accesses the database without the database executor" not in caplog.text
     assert connections[6] != connections[7]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
     floor_registry as fr,
+    frame,
     issue_registry as ir,
     label_registry as lr,
     recorder as recorder_helper,
@@ -432,6 +433,7 @@ def reset_hass_threading_local_object() -> Generator[None]:
     """Reset the _Hass threading.local object for every test case."""
     yield
     ha._hass.__dict__.clear()
+    frame.async_setup(None)
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -598,6 +600,7 @@ async def hass(
     async with async_test_home_assistant(loop, load_registries) as hass:
         orig_exception_handler = loop.get_exception_handler()
         loop.set_exception_handler(exc_handle)
+        frame.async_setup(hass)
 
         yield hass
 

--- a/tests/helpers/snapshots/test_frame.ambr
+++ b/tests/helpers/snapshots/test_frame.ambr
@@ -110,7 +110,7 @@
 # ---
 # name: test_report_usage_find_issue_tracker_other_thread[custom integration]
   list([
-    "Detected that custom integration 'test_custom_integration' test_report_string at custom_components/test_custom_integration/light.py, line 23: self.light.is_on. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+test_custom_integration%22",
+    "Detected that custom integration 'test_custom_integration' test_report_string at custom_components/test_custom_integration/light.py, line 23: self.light.is_on. Please create a bug report at https://blablabla.com",
   ])
 # ---
 # name: test_report_usage_find_issue_tracker_other_thread[unknown custom integration]

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -2080,6 +2080,7 @@ async def test_multiple_zones(hass: HomeAssistant) -> None:
     assert not test(hass)
 
 
+@pytest.mark.usefixtures("hass")
 async def test_extract_entities() -> None:
     """Test extracting entities."""
     assert condition.async_extract_entities(
@@ -2153,6 +2154,7 @@ async def test_extract_entities() -> None:
     }
 
 
+@pytest.mark.usefixtures("hass")
 async def test_extract_devices() -> None:
     """Test extracting devices."""
     assert condition.async_extract_devices(

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -773,6 +773,7 @@ async def test_dynamic_template_no_hass(hass: HomeAssistant) -> None:
         await hass.async_add_executor_job(schema, value)
 
 
+@pytest.mark.usefixtures("hass")
 def test_template_complex() -> None:
     """Test template_complex validator."""
     schema = vol.Schema(cv.template_complex)
@@ -1414,6 +1415,7 @@ def test_key_value_schemas() -> None:
         schema({"mode": mode, "data": data})
 
 
+@pytest.mark.usefixtures("hass")
 def test_key_value_schemas_with_default() -> None:
     """Test key value schemas."""
     schema = vol.Schema(
@@ -1492,6 +1494,7 @@ def test_key_value_schemas_with_default() -> None:
         ),
     ],
 )
+@pytest.mark.usefixtures("hass")
 def test_script(caplog: pytest.LogCaptureFixture, config: dict, error: str) -> None:
     """Test script validation is user friendly."""
     with pytest.raises(vol.Invalid, match=error):
@@ -1570,6 +1573,7 @@ def test_language() -> None:
         assert schema(value)
 
 
+@pytest.mark.usefixtures("hass")
 def test_positive_time_period_template() -> None:
     """Test positive time period template validation."""
     schema = vol.Schema(cv.positive_time_period_template)

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -254,6 +254,13 @@ async def test_report_usage(
     assert reports == snapshot
 
 
+async def test_report_usage_no_hass() -> None:
+    """Test report_usage when frame helper is not set up."""
+
+    with pytest.raises(RuntimeError, match="Frame helper not set up"):
+        frame.report_usage("blablabla")
+
+
 @pytest.mark.parametrize(
     "integration_frame_path",
     [

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -36,8 +36,8 @@ async def test_get_integration_logger(
     assert logger.name == "homeassistant.components.hue"
 
 
-@pytest.mark.usefixtures("enable_custom_integrations")
-async def test_extract_frame_resolve_module(hass: HomeAssistant) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations", "hass")
+async def test_extract_frame_resolve_module() -> None:
     """Test extracting the current frame from integration context."""
     # pylint: disable-next=import-outside-toplevel
     from custom_components.test_integration_frame import call_get_integration_frame
@@ -53,8 +53,8 @@ async def test_extract_frame_resolve_module(hass: HomeAssistant) -> None:
     )
 
 
-@pytest.mark.usefixtures("enable_custom_integrations")
-async def test_get_integration_logger_resolve_module(hass: HomeAssistant) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations", "hass")
+async def test_get_integration_logger_resolve_module() -> None:
     """Test getting the logger from integration context."""
     # pylint: disable-next=import-outside-toplevel
     from custom_components.test_integration_frame import call_get_integration_logger
@@ -228,7 +228,7 @@ async def test_get_integration_logger_no_integration(
         ),
     ],
 )
-@pytest.mark.usefixtures("mock_integration_frame")
+@pytest.mark.usefixtures("hass", "mock_integration_frame")
 async def test_report_usage(
     caplog: pytest.LogCaptureFixture,
     snapshot: SnapshotAssertion,
@@ -370,8 +370,9 @@ async def test_report_usage_find_issue_tracker_other_thread(
 
 
 @patch.object(frame, "_REPORTED_INTEGRATIONS", set())
+@pytest.mark.usefixtures("hass", "mock_integration_frame")
 async def test_prevent_flooding(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
+    caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
 ) -> None:
     """Test to ensure a report is only written once to the log."""
 
@@ -401,8 +402,9 @@ async def test_prevent_flooding(
 
 
 @patch.object(frame, "_REPORTED_INTEGRATIONS", set())
+@pytest.mark.usefixtures("hass", "mock_integration_frame")
 async def test_breaks_in_ha_version(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
+    caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
 ) -> None:
     """Test to ensure a report is only written once to the log."""
 
@@ -422,6 +424,7 @@ async def test_breaks_in_ha_version(
     assert expected_message in caplog.text
 
 
+@pytest.mark.usefixtures("hass")
 async def test_report_missing_integration_frame(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -445,6 +448,7 @@ async def test_report_missing_integration_frame(
 @pytest.mark.parametrize("run_count", [1, 2])
 # Run this twice to make sure the flood check does not
 # kick in when error_if_integration=True
+@pytest.mark.usefixtures("hass")
 async def test_report_error_if_integration(
     caplog: pytest.LogCaptureFixture, run_count: int
 ) -> None:
@@ -545,7 +549,7 @@ async def test_report_error_if_integration(
         ),
     ],
 )
-@pytest.mark.usefixtures("mock_integration_frame")
+@pytest.mark.usefixtures("hass", "mock_integration_frame")
 async def test_report(
     caplog: pytest.LogCaptureFixture,
     snapshot: SnapshotAssertion,

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -980,6 +980,7 @@ def test_datetime_selector_schema(schema, valid_selections, invalid_selections) 
     ("schema", "valid_selections", "invalid_selections"),
     [({}, ("abc123", "{{ now() }}"), (None, "{{ incomplete }", "{% if True %}Hi!"))],
 )
+@pytest.mark.usefixtures("hass")
 def test_template_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test template selector."""
     _test_selector("template", schema, valid_selections, invalid_selections)

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -149,6 +149,7 @@ async def test_template_render_info_collision(hass: HomeAssistant) -> None:
         template_obj.async_render_to_info()
 
 
+@pytest.mark.usefixtures("hass")
 def test_template_equality() -> None:
     """Test template comparison and hashing."""
     template_one = template.Template("{{ template_one }}")
@@ -5166,6 +5167,7 @@ def test_iif(hass: HomeAssistant) -> None:
     assert tpl.async_render() == "no"
 
 
+@pytest.mark.usefixtures("hass")
 async def test_cache_garbage_collection() -> None:
     """Test caching a template."""
     template_string = (

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5995,7 +5995,7 @@ async def test_async_wait_component_startup(hass: HomeAssistant) -> None:
     "integration_frame_path",
     ["homeassistant/components/my_integration", "homeassistant.core"],
 )
-@pytest.mark.usefixtures("mock_integration_frame")
+@pytest.mark.usefixtures("hass", "mock_integration_frame")
 async def test_options_flow_with_config_entry_core() -> None:
     """Test that OptionsFlowWithConfigEntry cannot be used in core."""
     entry = MockConfigEntry(
@@ -6009,7 +6009,7 @@ async def test_options_flow_with_config_entry_core() -> None:
 
 
 @pytest.mark.parametrize("integration_frame_path", ["custom_components/my_integration"])
-@pytest.mark.usefixtures("mock_integration_frame")
+@pytest.mark.usefixtures("hass", "mock_integration_frame")
 @patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_options_flow_with_config_entry(caplog: pytest.LogCaptureFixture) -> None:
     """Test that OptionsFlowWithConfigEntry doesn't mutate entry options."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make `helpers.frame.report_usage` fully work when called from any thread

The `helpers.frame.report_usage` is used to report deprecated or unsafe behavior by integrations. It's called both from the asyncio event loop thread and from other threads. When called from other threads than the `asyncio` event loop, we can't use `homeassistant.core.async_get_hass_or_none` to get hold of the Home Assistant instance, which is needed to find the issue tracker of the offending integration.

This PR solves this by storing a reference to the Home Assistant instance in the frame helper.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
