### PR TITLE
Make sure supported features work in Blueprints

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -117,7 +117,9 @@ def _validate_supported_feature(supported_feature: str) -> int:
         raise vol.Invalid(f"Unknown supported feature '{supported_feature}'") from exc
 
 
-def _validate_supported_features(supported_features: int | list[str]) -> int:
+def _validate_supported_features(
+    supported_features: int | list[str] | list[int],
+) -> int:
     """Validate a supported feature and resolve an enum string to its value."""
 
     if isinstance(supported_features, int):
@@ -126,7 +128,10 @@ def _validate_supported_features(supported_features: int | list[str]) -> int:
     feature_mask = 0
 
     for supported_feature in supported_features:
-        feature_mask |= _validate_supported_feature(supported_feature)
+        if isinstance(supported_feature, int):
+            feature_mask |= supported_feature
+        else:
+            feature_mask |= _validate_supported_feature(supported_feature)
 
     return feature_mask
 
@@ -141,7 +146,7 @@ ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA = vol.Schema(
         vol.Optional("device_class"): vol.All(cv.ensure_list, [str]),
         # Features supported by the entity
         vol.Optional("supported_features"): [
-            vol.All(cv.ensure_list, [str], _validate_supported_features)
+            vol.All(cv.ensure_list, _validate_supported_features)
         ],
     }
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make sure supported features work in Blueprints.

Apparently this does not work currently. 

Example blueprint:
https://gist.githubusercontent.com/joostlek/a714ff5120e5c633231efd45f86a6b4a/raw/4eed237c4d7f64712b6b12251afcb8e88ebbfb8d/test.yml

```yaml
blueprint:
  name: Motion-activated Light
  domain: automation
  input:
    motion_entity:
      name: Motion Sensor
      selector:
        entity:
          domain: binary_sensor
          device_class: motion
    light_entity:
      name: Light
      selector:
        entity:
          filter:
            domain: light
            supported_features: [light.LightEntityFeature.EFFECT]

# If motion is detected within the 120s delay,
# we restart the script.
mode: restart
max_exceeded: silent
```

In theory this is a valid blueprint. The blueprint importer, imports this and changes the supported_features to

```yaml
    light_entity:
      name: Light
      selector:
        entity:
          filter:
          - domain:
            - light
            supported_features:
            - 4
          multiple: false
```
and that is a list of `int` instead of a list of `str`. In theory our automations should be backwards compatible, but, since you are not able to save an automation with the supported_features like this, it might be save to say that there are no blueprints that use this since this is unusable. So a second option would be to update the logic in the blueprint importer where we make sure we put back the list of supported features.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #103431
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
