### PR TITLE
Add MQTT cover stop tilt

### DIFF
--- a/homeassistant/components/cover/device_action.py
+++ b/homeassistant/components/cover/device_action.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
-    SERVICE_STOP_COVER_TILT,
 )
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -140,8 +139,6 @@ async def async_call_action_from_config(
     elif config[CONF_TYPE] == "set_tilt_position":
         service = SERVICE_SET_COVER_TILT_POSITION
         service_data[ATTR_TILT_POSITION] = config["position"]
-    elif config[CONF_TYPE] == "stop_tilt":
-        service = SERVICE_STOP_COVER_TILT
 
     await hass.services.async_call(
         DOMAIN, service, service_data, blocking=True, context=context

--- a/homeassistant/components/cover/device_action.py
+++ b/homeassistant/components/cover/device_action.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
+    SERVICE_STOP_COVER_TILT,
 )
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -139,6 +140,8 @@ async def async_call_action_from_config(
     elif config[CONF_TYPE] == "set_tilt_position":
         service = SERVICE_SET_COVER_TILT_POSITION
         service_data[ATTR_TILT_POSITION] = config["position"]
+    elif config[CONF_TYPE] == "stop_tilt":
+        service = SERVICE_STOP_COVER_TILT
 
     await hass.services.async_call(
         DOMAIN, service, service_data, blocking=True, context=context

--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -150,6 +150,7 @@ ABBREVIATIONS = {
     "pl_rst_pct": "payload_reset_percentage",
     "pl_rst_pr_mode": "payload_reset_preset_mode",
     "pl_stop": "payload_stop",
+    "pl_stop_tilt": "payload_stop_tilt",
     "pl_strt": "payload_start",
     "pl_ret": "payload_return_to_base",
     "pl_toff": "payload_turn_off",

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -596,7 +596,6 @@ class MqttCover(MqttEntity, CoverEntity):
             self._attr_current_cover_tilt_position = tilt_percentage
             self.async_write_ha_state()
 
-
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop moving the cover tilt."""
         await self.async_publish_with_config(

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -81,11 +81,13 @@ CONF_TILT_STATUS_TOPIC = "tilt_status_topic"
 CONF_TILT_STATUS_TEMPLATE = "tilt_status_template"
 
 CONF_STATE_STOPPED = "state_stopped"
+CONF_PAYLOAD_STOP_TILT = "payload_stop_tilt"
 CONF_TILT_CLOSED_POSITION = "tilt_closed_value"
 CONF_TILT_MAX = "tilt_max"
 CONF_TILT_MIN = "tilt_min"
 CONF_TILT_OPEN_POSITION = "tilt_opened_value"
 CONF_TILT_STATE_OPTIMISTIC = "tilt_optimistic"
+
 
 TILT_PAYLOAD = "tilt"
 COVER_PAYLOAD = "cover"
@@ -203,6 +205,9 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_GET_POSITION_TEMPLATE): cv.template,
         vol.Optional(CONF_TILT_COMMAND_TEMPLATE): cv.template,
+        vol.Optional(CONF_PAYLOAD_STOP_TILT, default=DEFAULT_PAYLOAD_STOP): vol.Any(
+            cv.string, None
+        ),
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
@@ -596,7 +601,7 @@ class MqttCover(MqttEntity, CoverEntity):
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop moving the cover tilt."""
         await self.async_publish_with_config(
-            self._config[CONF_TILT_COMMAND_TOPIC], self._config[CONF_PAYLOAD_STOP]
+            self._config[CONF_TILT_COMMAND_TOPIC], self._config[CONF_PAYLOAD_STOP_TILT]
         )
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -592,6 +592,16 @@ class MqttCover(MqttEntity, CoverEntity):
             self._attr_current_cover_tilt_position = tilt_percentage
             self.async_write_ha_state()
 
+
+    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+        """Stop the device.
+
+        This method is a coroutine.
+        """
+        await self.async_publish_with_config(
+            self._config[CONF_TILT_COMMAND_TOPIC], self._config[CONF_PAYLOAD_STOP]
+        )
+
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position_percentage = kwargs[ATTR_POSITION]

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -594,10 +594,7 @@ class MqttCover(MqttEntity, CoverEntity):
 
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
-        """Stop the device.
-
-        This method is a coroutine.
-        """
+        """Stop moving the cover tilt."""
         await self.async_publish_with_config(
             self._config[CONF_TILT_COMMAND_TOPIC], self._config[CONF_PAYLOAD_STOP]
         )

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -88,7 +88,6 @@ CONF_TILT_MIN = "tilt_min"
 CONF_TILT_OPEN_POSITION = "tilt_opened_value"
 CONF_TILT_STATE_OPTIMISTIC = "tilt_optimistic"
 
-
 TILT_PAYLOAD = "tilt"
 COVER_PAYLOAD = "cover"
 

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -938,23 +938,41 @@ async def test_send_stop_cover_command(
 
 
 @pytest.mark.parametrize(
-    "hass_config",
+    ("hass_config", "payload_stop"),
     [
-        {
-            mqtt.DOMAIN: {
-                cover.DOMAIN: {
-                    "name": "test",
-                    "state_topic": "state-topic",
-                    "tilt_command_topic": "tilt-command-topic",
-                    "payload_stop_tilt": "TILT_STOP",
-                    "qos": 2,
+        (
+            {
+                mqtt.DOMAIN: {
+                    cover.DOMAIN: {
+                        "name": "test",
+                        "state_topic": "state-topic",
+                        "tilt_command_topic": "tilt-command-topic",
+                        "payload_stop_tilt": "TILT_STOP",
+                        "qos": 2,
+                    }
                 }
-            }
-        }
+            },
+            "TILT_STOP",
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    cover.DOMAIN: {
+                        "name": "test",
+                        "state_topic": "state-topic",
+                        "tilt_command_topic": "tilt-command-topic",
+                        "qos": 2,
+                    }
+                }
+            },
+            "STOP",
+        ),
     ],
 )
 async def test_send_stop_tilt_command(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    payload_stop: str,
 ) -> None:
     """Test the sending of stop_cover_tilt."""
     mqtt_mock = await mqtt_mock_entry()

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -37,6 +37,7 @@ from homeassistant.const import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
+    SERVICE_STOP_COVER_TILT,
     SERVICE_TOGGLE,
     SERVICE_TOGGLE_COVER_TILT,
     STATE_CLOSED,
@@ -934,6 +935,44 @@ async def test_send_stop_cover_command(
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "STOP", 2, False)
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "command_topic": "command-topic",
+                    "tilt_command_topic": "command-topic",
+                    "qos": 2,
+                }
+            }
+        }
+    ],
+)
+async def test_send_stop_tilt_command(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test the sending of stop_cover."""
+    mqtt_mock = await mqtt_mock_entry()
+
+    state = hass.states.get("cover.test")
+    assert state.state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        cover.DOMAIN,
+        SERVICE_STOP_COVER_TILT,
+        {ATTR_ENTITY_ID: "cover.test"},
+        blocking=True,
+    )
+
+    mqtt_mock.async_publish.assert_called_once_with("command-topic", "STOP", 2, False)
+    state = hass.states.get("cover.test")
+    assert state.state == STATE_UNKNOWN
+
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -945,8 +945,8 @@ async def test_send_stop_cover_command(
                 cover.DOMAIN: {
                     "name": "test",
                     "state_topic": "state-topic",
-                    "command_topic": "command-topic",
-                    "tilt_command_topic": "command-topic",
+                    "tilt_command_topic": "tilt-command-topic",
+                    "payload_stop_tilt": "TILT_STOP",
                     "qos": 2,
                 }
             }
@@ -969,10 +969,11 @@ async def test_send_stop_tilt_command(
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("command-topic", "STOP", 2, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "TILT_STOP", 2, False
+    )
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN
-
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -956,7 +956,7 @@ async def test_send_stop_cover_command(
 async def test_send_stop_tilt_command(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the sending of stop_cover."""
+    """Test the sending of stop_cover_tilt."""
     mqtt_mock = await mqtt_mock_entry()
 
     state = hass.states.get("cover.test")

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -970,7 +970,7 @@ async def test_send_stop_tilt_command(
     )
 
     mqtt_mock.async_publish.assert_called_once_with(
-        "tilt-command-topic", "TILT_STOP", 2, False
+        "tilt-command-topic", payload_stop, 2, False
     )
     state = hass.states.get("cover.test")
     assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For MQTT blinds up-down  and tilt can be controlled.
Also up/down can be stopped, but support to stop tilt is missing.
![screen](https://github.com/user-attachments/assets/69412ec3-014a-4a31-9a3b-2acf454fb5a7)

This PR I a add tilt stop function to MQTT covers.

When tilt is stopped, a `stop` payload is sent via `tilt_command_topic`. The stop payload can be customized via the `payload_stop_tilt` option.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37857
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
