### PR TITLE
Simplify lint-only config (2) [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,7 +197,9 @@ jobs:
           if [[ "${{ github.event.inputs.lint-only }}" == "true" ]] \
             || [[ "${{ github.event.inputs.pylint-only }}" == "true" ]] \
             || [[ "${{ github.event.inputs.mypy-only }}" == "true" ]] \
-            || [[ "${{ github.event.inputs.audit-licenses-only }}" == "true" ]];
+            || [[ "${{ github.event.inputs.audit-licenses-only }}" == "true" ]] \
+            || [[ "${{ github.event_name }}" == "push" \
+              && "${{ github.event.repository.full_name }}" != "home-assistant/core" ]];
           then
             lint_only="true"
             skip_coverage="true"
@@ -842,8 +844,7 @@ jobs:
   prepare-pytest-full:
     runs-on: ubuntu-24.04
     if: |
-      (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
-      && needs.info.outputs.lint_only != 'true'
+      needs.info.outputs.lint_only != 'true'
       && needs.info.outputs.test_full_suite == 'true'
     needs:
       - info
@@ -896,8 +897,7 @@ jobs:
   pytest-full:
     runs-on: ubuntu-24.04
     if: |
-      (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
-      && needs.info.outputs.lint_only != 'true'
+      needs.info.outputs.lint_only != 'true'
       && needs.info.outputs.test_full_suite == 'true'
     needs:
       - info
@@ -1023,8 +1023,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
         options: --health-cmd="mysqladmin ping -uroot -ppassword" --health-interval=5s --health-timeout=2s --health-retries=3
     if: |
-      (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
-      && needs.info.outputs.lint_only != 'true'
+      needs.info.outputs.lint_only != 'true'
       && needs.info.outputs.mariadb_groups != '[]'
     needs:
       - info
@@ -1156,8 +1155,7 @@ jobs:
           POSTGRES_PASSWORD: password
         options: --health-cmd="pg_isready -hlocalhost -Upostgres" --health-interval=5s --health-timeout=2s --health-retries=3
     if: |
-      (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
-      && needs.info.outputs.lint_only != 'true'
+      needs.info.outputs.lint_only != 'true'
       && needs.info.outputs.postgresql_groups != '[]'
     needs:
       - info
@@ -1309,8 +1307,7 @@ jobs:
   pytest-partial:
     runs-on: ubuntu-24.04
     if: |
-      (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
-      && needs.info.outputs.lint_only != 'true'
+      needs.info.outputs.lint_only != 'true'
       && needs.info.outputs.tests_glob
       && needs.info.outputs.test_full_suite == 'false'
     needs:


### PR DESCRIPTION
## Proposed change
Followup to #139748

Set `lint-only` and `skip-coverage` for push events on forks. At the moment this is checked for every job individually which is prone to errors if it's missed. E.g. the `upload-test-results` job is still run on forks even though it's useless there and will always fail.
https://github.com/home-assistant/core/blob/83dd1af6d2bfc5d662c4ede364e328fd26c485be/.github/workflows/ci.yaml#L1451-L1455

_It doesn't effect the other coverage jobs aa they don't use `!cancelled()` and are therefore skipped if the pytest job is skipped as well._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
