### PR TITLE
Improve config flow for GIOS

### DIFF
--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -76,7 +76,6 @@ class GiosFlowHandler(ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_STATION_ID): SelectSelector(
                     SelectSelectorConfig(
                         options=options,
-                        multiple=False,
                         sort=True,
                         mode=SelectSelectorMode.DROPDOWN,
                     ),

--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -12,6 +12,12 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from .const import API_TIMEOUT, CONF_STATION_ID, DOMAIN
 
@@ -27,18 +33,21 @@ class GiosFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         errors = {}
 
+        websession = async_get_clientsession(self.hass)
+
         if user_input is not None:
+            station_id = user_input[CONF_STATION_ID]
+
             try:
-                await self.async_set_unique_id(
-                    str(user_input[CONF_STATION_ID]), raise_on_progress=False
-                )
+                await self.async_set_unique_id(station_id, raise_on_progress=False)
                 self._abort_if_unique_id_configured()
 
-                websession = async_get_clientsession(self.hass)
-
                 async with asyncio.timeout(API_TIMEOUT):
-                    gios = await Gios.create(websession, user_input[CONF_STATION_ID])
+                    gios = await Gios.create(websession, int(station_id))
                     await gios.async_update()
+
+                # GIOS treats station ID as int
+                user_input[CONF_STATION_ID] = int(station_id)
 
                 assert gios.station_name is not None
                 return self.async_create_entry(
@@ -47,20 +56,35 @@ class GiosFlowHandler(ConfigFlow, domain=DOMAIN):
                 )
             except (ApiError, ClientConnectorError, TimeoutError):
                 errors["base"] = "cannot_connect"
-            except NoStationError:
-                errors[CONF_STATION_ID] = "wrong_station_id"
             except InvalidSensorsDataError:
                 errors[CONF_STATION_ID] = "invalid_sensors_data"
 
+        try:
+            gios = await Gios.create(websession)
+        except (ApiError, ClientConnectorError, NoStationError):
+            return self.async_abort(reason="cannot_connect")
+
+        options: list[SelectOptionDict] = [
+            SelectOptionDict(value=str(station.id), label=station.name)
+            for station in gios.measurement_stations.values()
+        ]
+
+        schema: vol.Schema = vol.Schema(
+            {
+                vol.Required(CONF_STATION_ID): SelectSelector(
+                    SelectSelectorConfig(
+                        options=options,
+                        multiple=False,
+                        sort=True,
+                        mode=SelectSelectorMode.DROPDOWN,
+                    ),
+                ),
+                vol.Optional(CONF_NAME, default=self.hass.config.location_name): str,
+            }
+        )
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_STATION_ID): int,
-                    vol.Optional(
-                        CONF_NAME, default=self.hass.config.location_name
-                    ): str,
-                }
-            ),
+            data_schema=schema,
             errors=errors,
         )

--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aiohttp.client_exceptions import ClientConnectorError
 from gios import ApiError, Gios, InvalidSensorsDataError, NoStationError
@@ -49,7 +49,9 @@ class GiosFlowHandler(ConfigFlow, domain=DOMAIN):
                 # GIOS treats station ID as int
                 user_input[CONF_STATION_ID] = int(station_id)
 
-                assert gios.station_name is not None
+                if TYPE_CHECKING:
+                    assert gios.station_name is not None
+
                 return self.async_create_entry(
                     title=gios.station_name,
                     data=user_input,

--- a/homeassistant/components/gios/strings.json
+++ b/homeassistant/components/gios/strings.json
@@ -10,7 +10,6 @@
       }
     },
     "error": {
-      "wrong_station_id": "ID of the measuring station is not correct.",
       "invalid_sensors_data": "Invalid sensors' data for this measuring station.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },

--- a/homeassistant/components/gios/strings.json
+++ b/homeassistant/components/gios/strings.json
@@ -5,7 +5,7 @@
         "title": "GIO\u015a (Polish Chief Inspectorate Of Environmental Protection)",
         "data": {
           "name": "[%key:common::config_flow::data::name%]",
-          "station_id": "ID of the measuring station"
+          "station_id": "Measuring station"
         }
       }
     },

--- a/homeassistant/components/gios/strings.json
+++ b/homeassistant/components/gios/strings.json
@@ -14,7 +14,8 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_location%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_location%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
   },
   "system_health": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes the GIOS config flow more user friendly. Instead of providing a measurement station ID, the user can select a station from a list.

![obraz](https://github.com/user-attachments/assets/b9ae4c7b-048f-4534-b345-86f939642ca6)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37835
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
