### PR TITLE
Correctly retrieve only loaded Google Generative AI config_entries

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -65,9 +65,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         prompt_parts = [call.data[CONF_PROMPT]]
 
-        config_entry: GoogleGenerativeAIConfigEntry = hass.config_entries.async_entries(
-            DOMAIN
-        )[0]
+        config_entry: GoogleGenerativeAIConfigEntry = (
+            hass.config_entries.async_loaded_entries(DOMAIN)[0]
+        )
 
         client = config_entry.runtime_data
 

--- a/tests/components/google_generative_ai_conversation/snapshots/test_init.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_init.ambr
@@ -31,3 +31,18 @@
     ),
   ])
 # ---
+# name: test_load_entry_with_unloaded_entries
+  list([
+    tuple(
+      '',
+      tuple(
+      ),
+      dict({
+        'contents': list([
+          'Write an opening speech for a Home Assistant release party',
+        ]),
+        'model': 'models/gemini-2.0-flash',
+      }),
+    ),
+  ])
+# ---

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -9,6 +9,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component
 
 from . import CLIENT_ERROR_500, CLIENT_ERROR_API_KEY_INVALID
 
@@ -224,3 +225,52 @@ async def test_config_entry_error(
         await hass.async_block_till_done()
         assert mock_config_entry.state == state
         assert any(mock_config_entry.async_get_active_flows(hass, {"reauth"})) == reauth
+
+
+@pytest.mark.usefixtures("mock_init_component")
+async def test_load_entry_with_unloaded_entries(
+    hass: HomeAssistant, snapshot: SnapshotAssertion
+) -> None:
+    """Test loading an entry with unloaded entries."""
+    config_entries = hass.config_entries.async_entries(
+        "google_generative_ai_conversation"
+    )
+    runtime_data = config_entries[0].runtime_data
+    await hass.config_entries.async_unload(config_entries[0].entry_id)
+
+    entry = MockConfigEntry(
+        domain="google_generative_ai_conversation",
+        title="Google Generative AI Conversation",
+        data={
+            "api_key": "bla",
+        },
+        state=ConfigEntryState.LOADED,
+    )
+    entry.runtime_data = runtime_data
+    entry.add_to_hass(hass)
+
+    stubbed_generated_content = (
+        "I'm thrilled to welcome you all to the release "
+        "party for the latest version of Home Assistant!"
+    )
+
+    with patch(
+        "google.genai.models.AsyncModels.generate_content",
+        return_value=Mock(
+            text=stubbed_generated_content,
+            prompt_feedback=None,
+            candidates=[Mock()],
+        ),
+    ) as mock_generate:
+        response = await hass.services.async_call(
+            "google_generative_ai_conversation",
+            "generate_content",
+            {"prompt": "Write an opening speech for a Home Assistant release party"},
+            blocking=True,
+            return_response=True,
+        )
+
+    assert response == {
+        "text": stubbed_generated_content,
+    }
+    assert [tuple(mock_call) for mock_call in mock_generate.mock_calls] == snapshot

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -9,7 +9,6 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.setup import async_setup_component
 
 from . import CLIENT_ERROR_500, CLIENT_ERROR_API_KEY_INVALID
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #139922 by correctly retrieving only loaded entries on the `generate_content` action.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #139922 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
