### PR TITLE
Check operation state on Home Connect program sensor update

### DIFF
--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -386,6 +386,13 @@ class HomeConnectProgramSensor(HomeConnectSensor):
 
     def update_native_value(self) -> None:
         """Update the program sensor's status."""
+        self.program_running = (
+            status := self.appliance.status.get(StatusKey.BSH_COMMON_OPERATION_STATE)
+        ) is not None and status.value in [
+            BSH_OPERATION_STATE_RUN,
+            BSH_OPERATION_STATE_PAUSE,
+            BSH_OPERATION_STATE_FINISHED,
+        ]
         event = self.appliance.events.get(cast(EventKey, self.bsh_key))
         if event:
             self._update_native_value(event.value)

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -27,7 +27,7 @@ from homeassistant.components.home_connect.const import (
     DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -302,7 +302,7 @@ ENTITY_ID_STATES = {
         )
     ),
 )
-async def test_event_sensors(
+async def test_program_sensors(
     client: MagicMock,
     appliance_ha_id: str,
     states: tuple,
@@ -313,7 +313,7 @@ async def test_event_sensors(
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     setup_credentials: None,
 ) -> None:
-    """Test sequence for sensors that are only available after an event happens."""
+    """Test sequence for sensors that expose information about a program."""
     entity_ids = ENTITY_ID_STATES.keys()
 
     time_to_freeze = "2021-01-09 12:00:00+00:00"
@@ -355,6 +355,82 @@ async def test_event_sensors(
     )
     await hass.async_block_till_done()
     for entity_id, state in zip(entity_ids, states, strict=False):
+        assert hass.states.is_state(entity_id, state)
+
+
+@pytest.mark.parametrize("appliance_ha_id", [TEST_HC_APP], indirect=True)
+@pytest.mark.parametrize(
+    ("initial_operation_state", "initial_state", "event_order", "entity_states"),
+    [
+        (
+            "BSH.Common.EnumType.OperationState.Ready",
+            STATE_UNAVAILABLE,
+            (EventType.STATUS, EventType.EVENT),
+            (STATE_UNKNOWN, "60"),
+        ),
+        (
+            "BSH.Common.EnumType.OperationState.Run",
+            STATE_UNKNOWN,
+            (EventType.EVENT, EventType.STATUS),
+            ("60", "60"),
+        ),
+    ],
+)
+async def test_program_sensor_edge_case(
+    initial_operation_state: str,
+    initial_state: str,
+    event_order: tuple[EventType, EventType],
+    entity_states: tuple[str, str],
+    appliance_ha_id: str,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    setup_credentials: None,
+    client: MagicMock,
+) -> None:
+    """Test edge case for the program related entities."""
+    entity_id = "sensor.dishwasher_program_progress"
+    client.get_status = AsyncMock(
+        return_value=ArrayOfStatus(
+            [
+                Status(
+                    StatusKey.BSH_COMMON_OPERATION_STATE,
+                    StatusKey.BSH_COMMON_OPERATION_STATE.value,
+                    initial_operation_state,
+                )
+            ]
+        )
+    )
+
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert await integration_setup(client)
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    assert hass.states.is_state(entity_id, initial_state)
+
+    for event_type, state in zip(event_order, entity_states, strict=True):
+        await client.add_events(
+            [
+                EventMessage(
+                    appliance_ha_id,
+                    event_type,
+                    ArrayOfEvents(
+                        [
+                            Event(
+                                key=event_key,
+                                raw_key=event_key.value,
+                                timestamp=0,
+                                level="",
+                                handling="",
+                                value=value,
+                            )
+                        ],
+                    ),
+                )
+                for event_key, value in EVENT_PROG_RUN[event_type].items()
+            ]
+        )
+        await hass.async_block_till_done()
         assert hass.states.is_state(entity_id, state)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Program related sensors were set as unavailable when the integration was loaded while an appliance is running because Home Connect doesn't send an event about the operation state until it changes so the availability never changed

This PR attempts to fix that issue by updating the value in which the availability is based (`program_running`) whenever an event for a sensor receives an event (or at the integration start-up).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #139654
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
