### PR TITLE
Add template function: typeof

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2760,6 +2760,11 @@ def shuffle(*args: Any, seed: Any = None) -> MutableSequence[Any]:
     return items
 
 
+def typeof(value: Any) -> Any:
+    """Return the type of value passed to debug types."""
+    return value.__class__.__name__
+
+
 class TemplateContextManager(AbstractContextManager):
     """Context manager to store template being parsed or rendered in a ContextVar."""
 
@@ -2961,6 +2966,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["version"] = version
         self.filters["contains"] = contains
         self.filters["shuffle"] = shuffle
+        self.filters["typeof"] = typeof
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
         self.globals["cos"] = cosine
@@ -2999,6 +3005,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["version"] = version
         self.globals["zip"] = zip
         self.globals["shuffle"] = shuffle
+        self.globals["typeof"] = typeof
         self.tests["is_number"] = is_number
         self.tests["list"] = _is_list
         self.tests["set"] = _is_set

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -6724,3 +6724,30 @@ def test_shuffle(hass: HomeAssistant) -> None:
 
     with pytest.raises(TemplateError):
         template.Template("{{ shuffle() }}", hass).async_render()
+
+
+def test_typeof(hass: HomeAssistant) -> None:
+    """Test the typeof debug filter/function."""
+    assert template.Template("{{ True | typeof }}", hass).async_render() == "bool"
+    assert template.Template("{{ typeof(True) }}", hass).async_render() == "bool"
+
+    assert template.Template("{{ [1, 2, 3] | typeof }}", hass).async_render() == "list"
+    assert template.Template("{{ typeof([1, 2, 3]) }}", hass).async_render() == "list"
+
+    assert template.Template("{{ 1 | typeof }}", hass).async_render() == "int"
+    assert template.Template("{{ typeof(1) }}", hass).async_render() == "int"
+
+    assert template.Template("{{ 1.1 | typeof }}", hass).async_render() == "float"
+    assert template.Template("{{ typeof(1.1) }}", hass).async_render() == "float"
+
+    assert template.Template("{{ None | typeof }}", hass).async_render() == "NoneType"
+    assert template.Template("{{ typeof(None) }}", hass).async_render() == "NoneType"
+
+    assert (
+        template.Template("{{ 'Home Assistant' | typeof }}", hass).async_render()
+        == "str"
+    )
+    assert (
+        template.Template("{{ typeof('Home Assistant') }}", hass).async_render()
+        == "str"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a new template function & filter: `typeof`

Port of: https://spook.boo/typeof

When working with templates, it can be useful to determine the type of the returned value from a method or the type of a variable at times.

For this, Home Assistant provides the `typeof()` template function and filter, which is inspired by the [JavaScript](https://en.wikipedia.org/wiki/JavaScript) `typeof` operator. It reveals the type of the given value.

This is mostly useful when you are debugging or playing with templates in the developer tools of Home Assistant. However, it might be useful in some other cases as well.

Some examples:

```shell
{{ typeof(42) }} # renders as `int`
{{ typeof(42.0) }} # renders as `float`
{{ typeof("42") }} # renders as `str`
{{ typeof([1, 2, 3]) }} # renders as `list`
{{ typeof({"key": "value"}) }} # renders as `dict`
{{ typeof(True) }} # renders as `bool`
{{ typeof(None) }} # renders as `NoneType`

{{ 42 | typeof }} # renders as `int`
{{ 42.0 | typeof }} # renders as `float`
{{ "42" | typeof }} # renders as `str`
{{ [1, 2, 3] | typeof }} # renders as `list`
{{ {"key": "value"} | typeof }} # renders as `dict`
{{ True | typeof }} # renders as `bool`
{{ None | typeof }} # renders as `NoneType`

{{ some_variable | typeof }} # renders the type of `some_variable`
{{ states("sensor.living_room") | typeof }} # renders the type of the result of `states()` function
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37872
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
