### PR TITLE
New action for Squeezebox to return calls from api via response variables

### DIFF
--- a/homeassistant/components/squeezebox/icons.json
+++ b/homeassistant/components/squeezebox/icons.json
@@ -26,6 +26,9 @@
       "service": "mdi:console"
     },
     "call_query": {
+      "service": "mdi:database-alert"
+    },
+    "call_query_response": {
       "service": "mdi:database"
     }
   }

--- a/homeassistant/components/squeezebox/icons.json
+++ b/homeassistant/components/squeezebox/icons.json
@@ -28,7 +28,7 @@
     "call_query": {
       "service": "mdi:database-alert"
     },
-    "call_query_response": {
+    "query": {
       "service": "mdi:database"
     }
   }

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -85,16 +85,6 @@ SERVICE_CALL_QUERY_RESPONSE = "call_query_response"
 ATTR_QUERY_RESULT = "query_result"
 ATTR_PARAMETERS = "parameters"
 
-QUERY_RESPONSE_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_COMMAND): cv.string,
-        vol.Optional(ATTR_PARAMETERS): vol.All(
-            cv.ensure_list, vol.Length(min=1), [cv.string]
-        ),
-    }
-)
-
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -81,7 +81,7 @@ if TYPE_CHECKING:
 
 SERVICE_CALL_METHOD = "call_method"
 SERVICE_CALL_QUERY = "call_query"
-SERVICE_CALL_QUERY_RESPONSE = "call_query_response"
+SERVICE_CALL_QUERY_RESPONSE = "query"
 ATTR_QUERY_RESULT = "query_result"
 ATTR_PARAMETERS = "parameters"
 
@@ -141,12 +141,12 @@ async def async_setup_entry(
         async_dispatcher_connect(hass, SIGNAL_PLAYER_DISCOVERED, _player_discovered)
     )
 
-    async def async_call_query_response_helper(
+    async def async_query_helper(
         entity: SqueezeBoxMediaPlayerEntity, call: ServiceCall
     ) -> ServiceResponse:
         """Call Squeezebox JSON/RPC method where we care about the result."""
 
-        return await entity.async_call_query_response(call)
+        return await entity.async_query_response(call)
 
     # Register entity services
     platform = entity_platform.async_get_current_platform()
@@ -178,7 +178,7 @@ async def async_setup_entry(
                 cv.ensure_list, vol.Length(min=1), [cv.string]
             ),
         },
-        async_call_query_response_helper,
+        async_query_helper,
         supports_response=SupportsResponse.ONLY,
     )
     # Start server discovery task if not already running
@@ -633,15 +633,19 @@ class SqueezeBoxMediaPlayerEntity(
             self.hass,
             DOMAIN,
             "Call query deprecation",
-            breaks_in_ha_version="2025.3.0",
+            breaks_in_ha_version="2025.10.0",
             is_fixable=False,
             is_persistent=False,
             learn_more_url="https://www.home-assistant.io/integrations/squeezebox/#:~:text=Copy-,ACTION%20CALL_QUERY,-Call%20a%20custom",
             severity=ir.IssueSeverity.WARNING,
             translation_key="call_query_deprecation",
         )
+        _LOGGER.warning(
+            "You have called the Squeezebox call_query action for command '%s'.  This action is deprecated and will be removed in 2025.10.  Please replace with the Squeezebox query action",
+            command,
+        )
 
-    async def async_call_query_response(self, call: ServiceCall) -> ServiceResponse:
+    async def async_query_response(self, call: ServiceCall) -> ServiceResponse:
         """Call Squeezebox JSON/RPC method where we care about the result.
 
         Additional parameters are added to the command to form the list of

--- a/homeassistant/components/squeezebox/services.yaml
+++ b/homeassistant/components/squeezebox/services.yaml
@@ -30,3 +30,19 @@ call_query:
       advanced: true
       selector:
         object:
+call_query_response:
+  target:
+    entity:
+      integration: squeezebox
+      domain: media_player
+  fields:
+    command:
+      required: true
+      example: "albums"
+      selector:
+        text:
+    parameters:
+      example: '["0", "20", "search:Revolver"]'
+      advanced: true
+      selector:
+        object:

--- a/homeassistant/components/squeezebox/services.yaml
+++ b/homeassistant/components/squeezebox/services.yaml
@@ -30,7 +30,7 @@ call_query:
       advanced: true
       selector:
         object:
-call_query_response:
+query:
   target:
     entity:
       integration: squeezebox

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -48,8 +48,22 @@
       }
     },
     "call_query": {
-      "name": "Call query",
-      "description": "Calls a custom Squeezebox JSONRPC API. Result will be stored in 'query_result' attribute of the Squeezebox entity.",
+      "name": "Call query (deprecated)",
+      "description": "Calls a custom Squeezebox JSONRPC API. Result will be stored in 'query_result' attribute of the Squeezebox entity.  This action is deprecated and replaced by call_query_response.",
+      "fields": {
+        "command": {
+          "name": "Command",
+          "description": "[%key:component::squeezebox::services::call_method::fields::command::description%]"
+        },
+        "parameters": {
+          "name": "Parameters",
+          "description": "[%key:component::squeezebox::services::call_method::fields::parameters::description%]"
+        }
+      }
+    },
+    "call_query_response": {
+      "name": "Call query response",
+      "description": "Calls a custom Squeezebox JSONRPC API and returns the result in the response variable.",
       "fields": {
         "command": {
           "name": "Command",
@@ -117,6 +131,12 @@
           "volume_step": "Amount to adjust the volume when turning volume up or down."
         }
       }
+    }
+  },
+  "issues": {
+    "call_query_deprecation": {
+      "title": "Call query deprecation",
+      "description": "The call_query action is deprecated and will be removed in 2025.10.0.  These call should be replaced with the call_query_response action, which returns its result in a response variable."
     }
   }
 }

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -49,7 +49,7 @@
     },
     "call_query": {
       "name": "Call query (deprecated)",
-      "description": "Calls a custom Squeezebox JSONRPC API. Result will be stored in 'query_result' attribute of the Squeezebox entity.  This action is deprecated and replaced by call_query_response.",
+      "description": "Calls a custom Squeezebox JSONRPC API. Result will be stored in 'query_result' attribute of the Squeezebox entity.  This action is deprecated and replaced by the query action.",
       "fields": {
         "command": {
           "name": "Command",
@@ -61,8 +61,8 @@
         }
       }
     },
-    "call_query_response": {
-      "name": "Call query response",
+    "query": {
+      "name": "Query",
       "description": "Calls a custom Squeezebox JSONRPC API and returns the result in the response variable.",
       "fields": {
         "command": {
@@ -136,7 +136,7 @@
   "issues": {
     "call_query_deprecation": {
       "title": "Call query deprecation",
-      "description": "The call_query action is deprecated and will be removed in 2025.10.0.  These call should be replaced with the call_query_response action, which returns its result in a response variable."
+      "description": "The call_query action is deprecated and will be removed in 2025.10.0.  These call should be replaced with the query action, which returns its result in a response variable."
     }
   }
 }


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The Squeezebox integration currently has an action call_query which returns results from calls to the api via an attribute, query_response.  This PR create a new action call_query_response, which instead returns results via a response variable.  In addition, it begins the process of deprecating call_query, creating a repair issue if call_query is called.

This is part of a broader process on improving these calls with @andrewsayre , and adding some single use actions which will then return values in the same way as the new query action, rather than via attributes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
