### PR TITLE
Add Fronius current and voltage for up to 4 MPP trackers

### DIFF
--- a/homeassistant/components/fronius/icons.json
+++ b/homeassistant/components/fronius/icons.json
@@ -4,13 +4,13 @@
       "current_dc": {
         "default": "mdi:current-dc"
       },
-      "current_dc_2": {
+      "current_dc_mppt_no": {
         "default": "mdi:current-dc"
       },
       "voltage_dc": {
         "default": "mdi:current-dc"
       },
-      "voltage_dc_2": {
+      "voltage_dc_mppt_no": {
         "default": "mdi:current-dc"
       },
       "co2_factor": {

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -168,6 +168,26 @@ INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="current_dc_mppt_no",
+        translation_placeholders={"mppt_no": "2"},
+    ),
+    FroniusSensorEntityDescription(
+        key="current_dc_3",
+        default_value=0,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="current_dc_mppt_no",
+        translation_placeholders={"mppt_no": "3"},
+    ),
+    FroniusSensorEntityDescription(
+        key="current_dc_4",
+        default_value=0,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="current_dc_mppt_no",
+        translation_placeholders={"mppt_no": "4"},
     ),
     FroniusSensorEntityDescription(
         key="power_ac",
@@ -197,6 +217,26 @@ INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="voltage_dc_mppt_no",
+        translation_placeholders={"mppt_no": "2"},
+    ),
+    FroniusSensorEntityDescription(
+        key="voltage_dc_3",
+        default_value=0,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="voltage_dc_mppt_no",
+        translation_placeholders={"mppt_no": "3"},
+    ),
+    FroniusSensorEntityDescription(
+        key="voltage_dc_4",
+        default_value=0,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="voltage_dc_mppt_no",
+        translation_placeholders={"mppt_no": "4"},
     ),
     # device status entities
     FroniusSensorEntityDescription(
@@ -727,7 +767,7 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
         self.response_key = description.response_key or description.key
         self.solar_net_id = solar_net_id
         self._attr_native_value = self._get_entity_value()
-        self._attr_translation_key = description.key
+        self._attr_translation_key = description.translation_key or description.key
 
     def _device_data(self) -> dict[str, Any]:
         """Extract information for SolarNet device from coordinator data."""

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -52,8 +52,8 @@
       "current_dc": {
         "name": "DC current"
       },
-      "current_dc_2": {
-        "name": "DC current 2"
+      "current_dc_mppt_no": {
+        "name": "DC current {mppt_no}"
       },
       "power_ac": {
         "name": "AC power"
@@ -64,8 +64,8 @@
       "voltage_dc": {
         "name": "DC voltage"
       },
-      "voltage_dc_2": {
-        "name": "DC voltage 2"
+      "voltage_dc_mppt_no": {
+        "name": "DC voltage {mppt_no}"
       },
       "inverter_state": {
         "name": "Inverter state"

--- a/tests/components/fronius/snapshots/test_sensor.ambr
+++ b/tests/components/fronius/snapshots/test_sensor.ambr
@@ -238,7 +238,7 @@
     'platform': 'fronius',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'current_dc_2',
+    'translation_key': 'current_dc_mppt_no',
     'unique_id': '12345678-current_dc_2',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
@@ -342,7 +342,7 @@
     'platform': 'fronius',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'voltage_dc_2',
+    'translation_key': 'voltage_dc_mppt_no',
     'unique_id': '12345678-voltage_dc_2',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
@@ -3798,7 +3798,7 @@
     'platform': 'fronius',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'current_dc_2',
+    'translation_key': 'current_dc_mppt_no',
     'unique_id': '12345678-current_dc_2',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
@@ -3902,7 +3902,7 @@
     'platform': 'fronius',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'voltage_dc_2',
+    'translation_key': 'voltage_dc_mppt_no',
     'unique_id': '12345678-voltage_dc_2',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support current and voltage of up to 4 MPP trackers

Support for this in the `pyfronius` lib was added here https://github.com/nielstron/pyfronius/commit/d48d16808d531b4bb555d04e1b0091daf1d6cec2 I'm not aware on an inverter having more than 4 MPP trackers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #139746
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
