### PR TITLE
Allow integrations to set a remove config subentry callback

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -10,7 +10,7 @@ from aiohttp import web
 import aiohttp.web_exceptions
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries, data_entry_flow, loader
 from homeassistant.auth.permissions.const import CAT_CONFIG_ENTRIES, POLICY_EDIT
 from homeassistant.components import websocket_api
 from homeassistant.components.http import KEY_HASS, HomeAssistantView, require_admin
@@ -709,6 +709,26 @@ async def config_subentry_delete(
     entry = get_entry(hass, connection, msg["entry_id"], msg["id"])
     if entry is None:
         return
+
+    if entry.supports_remove_subentry:
+        try:
+            integration = await loader.async_get_integration(hass, entry.domain)
+            component = await integration.async_get_component()
+        except (ImportError, loader.IntegrationNotFound):
+            connection.send_error(
+                msg["id"],
+                websocket_api.const.ERR_NOT_ALLOWED,
+                "Integration not found",
+            )
+            return
+
+        if not await component.async_remove_subentry(hass, entry, msg["subentry_id"]):
+            connection.send_error(
+                msg["id"],
+                websocket_api.const.ERR_NOT_ALLOWED,
+                "Failed to remove device entry, rejected by integration",
+            )
+            return
 
     try:
         hass.config_entries.async_remove_subentry(entry, msg["subentry_id"])

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -392,6 +392,7 @@ class ConfigEntry[_DataT = Any]:
     disabled_by: ConfigEntryDisabler | None
     supports_unload: bool | None
     supports_remove_device: bool | None
+    supports_remove_subentry: bool | None
     _supports_options: bool | None
     _supports_reconfigure: bool | None
     _supported_subentry_types: dict[str, dict[str, bool]] | None
@@ -499,6 +500,9 @@ class ConfigEntry[_DataT = Any]:
 
         # Supports remove device
         _setter(self, "supports_remove_device", None)
+
+        # Supports remove subentry
+        _setter(self, "supports_remove_subentry", None)
 
         # Supports options
         _setter(self, "_supports_options", None)
@@ -623,6 +627,7 @@ class ConfigEntry[_DataT = Any]:
             "state": self.state.value,
             "supports_options": self.supports_options,
             "supports_remove_device": self.supports_remove_device or False,
+            "supports_remove_subentry": self.supports_remove_subentry or False,
             "supports_unload": self.supports_unload or False,
             "supports_reconfigure": self.supports_reconfigure,
             "supported_subentry_types": self.supported_subentry_types,
@@ -694,6 +699,10 @@ class ConfigEntry[_DataT = Any]:
             self.supports_unload = await support_entry_unload(hass, self.domain)
         if self.supports_remove_device is None:
             self.supports_remove_device = await support_remove_from_device(
+                hass, self.domain
+            )
+        if self.supports_remove_subentry is None:
+            self.supports_remove_subentry = await support_remove_subentry(
                 hass, self.domain
             )
         try:
@@ -3723,6 +3732,13 @@ async def support_remove_from_device(hass: HomeAssistant, domain: str) -> bool:
     integration = await loader.async_get_integration(hass, domain)
     component = await integration.async_get_component()
     return hasattr(component, "async_remove_config_entry_device")
+
+
+async def support_remove_subentry(hass: HomeAssistant, domain: str) -> bool:
+    """Test if a domain supports removing subentries."""
+    integration = await loader.async_get_integration(hass, domain)
+    component = await integration.async_get_component()
+    return hasattr(component, "async_remove_subentry")
 
 
 async def _support_single_config_entry_only(hass: HomeAssistant, domain: str) -> bool:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -393,6 +393,14 @@ class ComponentProtocol(Protocol):
     ) -> bool:
         """Remove a config entry device."""
 
+    async def async_remove_subentry(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        subentry_id: str,
+    ) -> bool:
+        """Remove a config subentry."""
+
     async def async_reset_platform(
         self, hass: HomeAssistant, integration_name: str
     ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Integrations might need to define a delete subentry callback to perform internal device cleanup. For example, an integration that manages a hub can define different types of subconfig entries for different kind of bound devices. When removing the subentry from the UI, the integration needs access to the subentry to delete the device from the hub:

```
async def async_remove_subentry(
    hass: HomeAssistant,
    config_entry: ConfigEntry,
    subentry_id: str,
) -> bool:
    """Remove a config subentry."""
    subentry = config_entry.subentries[subentry_id]
    slave_id = subentry.data[CONF_SLAVE]
    name = subentry.data[CONF_NAME]
    coordinator: AiriosDataUpdateCoordinator = config_entry.runtime_data
    api = coordinator.api
    _LOGGER.info("Unbinding %s", name)
    return await api.unbind(slave_id)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
