### PR TITLE
Revert "Check if the unit of measurement is valid before creating the entity"

### DIFF
--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -11,7 +11,6 @@ import voluptuous as vol
 from homeassistant.components import sensor
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
-    DEVICE_CLASS_UNITS,
     DEVICE_CLASSES_SCHEMA,
     ENTITY_ID_FORMAT,
     STATE_CLASSES_SCHEMA,
@@ -107,20 +106,6 @@ def validate_sensor_state_and_device_class_config(config: ConfigType) -> ConfigT
                 f"together with device class `{SensorDeviceClass.ENUM}`, "
                 f"got `{CONF_DEVICE_CLASS}` '{device_class}'"
             )
-
-    if (device_class := config.get(CONF_DEVICE_CLASS)) is None or (
-        unit_of_measurement := config.get(CONF_UNIT_OF_MEASUREMENT)
-    ) is None:
-        return config
-
-    if (
-        device_class in DEVICE_CLASS_UNITS
-        and unit_of_measurement not in DEVICE_CLASS_UNITS[device_class]
-    ):
-        raise vol.Invalid(
-            f"The unit of measurement `{unit_of_measurement}` is not valid "
-            f"together with device class `{device_class}`"
-        )
 
     return config
 

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -875,32 +875,6 @@ async def test_invalid_device_class(
     [
         {
             mqtt.DOMAIN: {
-                sensor.DOMAIN: {
-                    "name": "test",
-                    "state_topic": "test-topic",
-                    "device_class": "energy",
-                    "unit_of_measurement": "ppm",
-                }
-            }
-        }
-    ],
-)
-async def test_invalid_unit_of_measurement(
-    mqtt_mock_entry: MqttMockHAClientGenerator, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test device_class with invalid unit of measurement."""
-    assert await mqtt_mock_entry()
-    assert (
-        "The unit of measurement `ppm` is not valid together with device class `energy`"
-        in caplog.text
-    )
-
-
-@pytest.mark.parametrize(
-    "hass_config",
-    [
-        {
-            mqtt.DOMAIN: {
                 sensor.DOMAIN: [
                     {
                         "name": "Test 1",


### PR DESCRIPTION
Reverts home-assistant/core#139932, which was included with 2025.3.1 as a bugfix

Revering because it seemed to be a breaking change. Warnings are logged but sensors should sttill work.

https://github.com/home-assistant/core/blob/e54febdc1e4effe9d609939ba48040cece5e552f/homeassistant/components/sensor/__init__.py#L699-L714