### PR TITLE
Add sync-github-labels ci job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,6 +235,43 @@ jobs:
           echo "skip_coverage: ${skip_coverage}"
           echo "skip_coverage=${skip_coverage}" >> $GITHUB_OUTPUT
 
+  sync-github-labels:
+    name: Sync GitHub integration labels
+    runs-on: ubuntu-24.04
+    if: github.ref == 'refs/heads/dev'
+    needs:
+      - info
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.2.2
+      - name: Sync integration labels
+        run: |
+          gh_labels=$(gh api /repos/${OWNER}/${REPO}/labels \
+            --paginate \
+            --jq '.[] | select(.name | startswith("integration: ")) | "\(.name)|\(.description);"')
+
+          for integration_manifest in homeassistant/components/*/manifest.json; do
+            IFS='|' read -ra manifest <<< "$(jq -r '"integration: \(.domain)|\(.name)"' $integration_manifest)"
+            label_name="${manifest[0]}"
+            label_desc="${manifest[1]}"
+            if [[ $gh_labels == *"$label_name|$label_desc;"* ]] ; then
+              # label found and description is correct
+              continue
+            elif [[ $gh_labels == *"$label_name|"* ]] ; then
+              # label found but description is not correct
+              gh api --method PATCH --silent "/repos/${OWNER}/${REPO}/labels/$label_name" -f "description=$label_desc"
+              echo "label '$label_name' updated"
+            else
+              # label not found
+              gh api --silent /repos/${OWNER}/${REPO}/labels -f "name=$label_name" -f "description=$label_desc" -f "color=ededed"
+              echo "label '$label_name' created"
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+
   pre-commit:
     name: Prepare pre-commit base
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,43 +235,6 @@ jobs:
           echo "skip_coverage: ${skip_coverage}"
           echo "skip_coverage=${skip_coverage}" >> $GITHUB_OUTPUT
 
-  sync-github-labels:
-    name: Sync GitHub integration labels
-    runs-on: ubuntu-24.04
-    if: github.ref == 'refs/heads/dev'
-    needs:
-      - info
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.2.2
-      - name: Sync integration labels
-        run: |
-          gh_labels=$(gh api /repos/${OWNER}/${REPO}/labels \
-            --paginate \
-            --jq '.[] | select(.name | startswith("integration: ")) | "\(.name)|\(.description);"')
-
-          for integration_manifest in homeassistant/components/*/manifest.json; do
-            IFS='|' read -ra manifest <<< "$(jq -r '"integration: \(.domain)|\(.name)"' $integration_manifest)"
-            label_name="${manifest[0]}"
-            label_desc="${manifest[1]}"
-            if [[ $gh_labels == *"$label_name|$label_desc;"* ]] ; then
-              # label found and description is correct
-              continue
-            elif [[ $gh_labels == *"$label_name|"* ]] ; then
-              # label found but description is not correct
-              gh api --method PATCH --silent "/repos/${OWNER}/${REPO}/labels/$label_name" -f "description=$label_desc"
-              echo "label '$label_name' updated"
-            else
-              # label not found
-              gh api --silent /repos/${OWNER}/${REPO}/labels -f "name=$label_name" -f "description=$label_desc" -f "color=ededed"
-              echo "label '$label_name' created"
-            fi
-          done
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
-
   pre-commit:
     name: Prepare pre-commit base
     runs-on: ubuntu-24.04

--- a/.github/workflows/sync_gh_labels.yml
+++ b/.github/workflows/sync_gh_labels.yml
@@ -1,0 +1,42 @@
+name: Sync GitHub integration labels
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Sync GitHub integration labels: {0}', github.ref_name) || '' }}"
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches: ["dev"]
+    paths: ["homeassistant/components/*/manifest.json"]
+jobs:
+  sync-github-labels:
+    name: Sync GitHub integration labels
+    runs-on: ubuntu-24.04
+    if: github.repository_owner == 'home-assistant'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.2.2
+      - name: Sync integration labels
+        run: |
+          gh_labels=$(gh api /repos/${OWNER}/${REPO}/labels \
+            --paginate \
+            --jq '.[] | select(.name | startswith("integration: ")) | "\(.name)|\(.description);"')
+          for integration_manifest in homeassistant/components/*/manifest.json; do
+            IFS='|' read -ra manifest <<< "$(jq -r '"integration: \(.domain)|\(.name)"' $integration_manifest)"
+            label_name="${manifest[0]}"
+            label_desc="${manifest[1]}"
+            if [[ $gh_labels == *"$label_name|$label_desc;"* ]] ; then
+              # label found and description is correct
+              continue
+            elif [[ $gh_labels == *"$label_name|"* ]] ; then
+              # label found but description is not correct
+              gh api --method PATCH --silent "/repos/${OWNER}/${REPO}/labels/$label_name" -f "description=$label_desc"
+              echo "label '$label_name' updated"
+            else
+              # label not found
+              gh api --silent /repos/${OWNER}/${REPO}/labels -f "name=$label_name" -f "description=$label_desc" -f "color=ededed"
+              echo "label '$label_name' created"
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/sync_gh_labels.yml
+++ b/.github/workflows/sync_gh_labels.yml
@@ -14,12 +14,19 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.2.2
+      - name: Filter for integration changes
+        uses: dorny/paths-filter@v3.0.2
+        id: filter
+        with:
+          filters: |
+            manifest: ['homeassistant/components/*/manifest.json']
+          list-files: shell
       - name: Sync integration labels
         run: |
           gh_labels=$(gh api /repos/${OWNER}/${REPO}/labels \
             --paginate \
             --jq '.[] | select(.name | startswith("integration: ")) | "\(.name)|\(.description);"')
-          for integration_manifest in homeassistant/components/*/manifest.json; do
+          for integration_manifest in ${{ steps.filter.outputs.manifest_files }}; do
             IFS='|' read -ra manifest <<< "$(jq -r '"integration: \(.domain)|\(.name)"' $integration_manifest)"
             label_name="${manifest[0]}"
             label_desc="${manifest[1]}"

--- a/.github/workflows/sync_gh_labels.yml
+++ b/.github/workflows/sync_gh_labels.yml
@@ -27,6 +27,13 @@ jobs:
             --paginate \
             --jq '.[] | select(.name | startswith("integration: ")) | "\(.name)|\(.description);"')
           for integration_manifest in ${{ steps.filter.outputs.manifest_files }}; do
+            domain=$(echo $integration_manifest | cut -d'/' -f 3)
+            if [[ ! -f $integration_manifest ]] && [[ $gh_labels == *"integration: $domain|"* ]]; then
+              # integration deleted, remove label description
+              gh api --method PATCH --silent "/repos/${OWNER}/${REPO}/labels/integration: $domain" -f "description=''"
+              echo "label '$label_name' updated"
+              continue
+            fi
             IFS='|' read -ra manifest <<< "$(jq -r '"integration: \(.domain)|\(.name)"' $integration_manifest)"
             label_name="${manifest[0]}"
             label_desc="${manifest[1]}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a job to the CI which runs on merge to `dev` and syncs the `integrations: <domain>` labels on GitHub with the integrations manifest. The labels will be named as usual `integration: <domain>` but additional get the integration name as description.
It might hit the api rate limit in case of to many changes at once (_may occur during very first run, since the descriptions are missing to almost all labels, yet_). This task can just be re-run and doesn't block the CI at all if it fails.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
