### PR TITLE
Use only IPv4 for zeroconf in bluesound integration

### DIFF
--- a/homeassistant/components/bluesound/strings.json
+++ b/homeassistant/components/bluesound/strings.json
@@ -19,7 +19,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "no_ipv4_address": "No IPv4 address found."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"

--- a/tests/components/bluesound/test_config_flow.py
+++ b/tests/components/bluesound/test_config_flow.py
@@ -206,13 +206,8 @@ async def test_zeroconf_flow_already_configured(
     player_mocks.player_data_for_already_configured.player.sync_status.assert_called_once()
 
 
-async def test_zeroconf_flow_no_ipv4_address(
-    hass: HomeAssistant,
-    player_mocks: PlayerMocks,
-    config_entry: MockConfigEntry,
-) -> None:
+async def test_zeroconf_flow_no_ipv4_address(hass: HomeAssistant) -> None:
     """Test abort flow when no ipv4 address is found in zeroconf data."""
-    config_entry.add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},

--- a/tests/components/bluesound/test_config_flow.py
+++ b/tests/components/bluesound/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Bluesound config flow."""
 
+from ipaddress import IPv4Address
 from unittest.mock import AsyncMock
 
 from pyblu.errors import PlayerUnreachableError
@@ -121,8 +122,8 @@ async def test_zeroconf_flow_success(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=ZeroconfServiceInfo(
-            ip_address="1.1.1.1",
-            ip_addresses=["1.1.1.1"],
+            ip_address=IPv4Address("1.1.1.1"),
+            ip_addresses=[IPv4Address("1.1.1.1")],
             port=11000,
             hostname="player-name1111",
             type="_musc._tcp.local.",
@@ -160,8 +161,8 @@ async def test_zeroconf_flow_cannot_connect(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=ZeroconfServiceInfo(
-            ip_address="1.1.1.1",
-            ip_addresses=["1.1.1.1"],
+            ip_address=IPv4Address("1.1.1.1"),
+            ip_addresses=[IPv4Address("1.1.1.1")],
             port=11000,
             hostname="player-name1111",
             type="_musc._tcp.local.",
@@ -187,8 +188,8 @@ async def test_zeroconf_flow_already_configured(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=ZeroconfServiceInfo(
-            ip_address="1.1.1.2",
-            ip_addresses=["1.1.1.2"],
+            ip_address=IPv4Address("1.1.1.2"),
+            ip_addresses=[IPv4Address("1.1.1.2")],
             port=11000,
             hostname="player-name1112",
             type="_musc._tcp.local.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ignore IPv6 addresses from zeroconf.

It seems that the devices got partial IPv6 support in a firmware update, but the API is only listening on the IPv4 address.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #140144 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
