### PR TITLE
Refresh Home Connect token during config entry setup

### DIFF
--- a/homeassistant/components/home_connect/__init__.py
+++ b/homeassistant/components/home_connect/__init__.py
@@ -16,11 +16,17 @@ from aiohomeconnect.model import (
     SettingKey,
 )
 from aiohomeconnect.model.error import HomeConnectError
+import aiohttp
 import voluptuous as vol
 
 from homeassistant.const import ATTR_DEVICE_ID, Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+    ServiceValidationError,
+)
 from homeassistant.helpers import (
     config_entry_oauth2_flow,
     config_validation as cv,
@@ -611,6 +617,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomeConnectConfigEntry) 
     session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
 
     config_entry_auth = AsyncConfigEntryAuth(hass, session)
+    try:
+        await config_entry_auth.async_get_access_token()
+    except aiohttp.ClientResponseError as err:
+        if 400 <= err.status < 500:
+            raise ConfigEntryAuthFailed from err
+        raise ConfigEntryNotReady from err
+    except aiohttp.ClientError as err:
+        raise ConfigEntryNotReady from err
 
     home_connect_client = HomeConnectClient(config_entry_auth)
 

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -8,9 +8,8 @@ from unittest.mock import MagicMock, patch
 from aiohomeconnect.const import OAUTH2_TOKEN
 from aiohomeconnect.model import OptionKey, ProgramKey, SettingKey, StatusKey
 from aiohomeconnect.model.error import HomeConnectError, UnauthorizedError
+import aiohttp
 import pytest
-import requests_mock
-import respx
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -221,14 +220,12 @@ async def test_exception_handling(
 
 
 @pytest.mark.parametrize("token_expiration_time", [12345])
-@respx.mock
 async def test_token_refresh_success(
     hass: HomeAssistant,
     platforms: list[Platform],
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
-    requests_mock: requests_mock.Mocker,
     setup_credentials: None,
     client: MagicMock,
 ) -> None:
@@ -236,7 +233,6 @@ async def test_token_refresh_success(
 
     assert config_entry.data["token"]["access_token"] == FAKE_ACCESS_TOKEN
 
-    requests_mock.post(OAUTH2_TOKEN, json=SERVER_ACCESS_TOKEN)
     aioclient_mock.post(
         OAUTH2_TOKEN,
         json=SERVER_ACCESS_TOKEN,
@@ -278,6 +274,55 @@ async def test_token_refresh_success(
         config_entry.data["token"]["access_token"]
         == SERVER_ACCESS_TOKEN["access_token"]
     )
+
+
+@pytest.mark.parametrize("token_expiration_time", [12345])
+@pytest.mark.parametrize(
+    ("aioclient_mock_args", "expected_config_entry_state"),
+    [
+        (
+            {
+                "status": 400,
+                "json": {"error": "invalid_grant"},
+            },
+            ConfigEntryState.SETUP_ERROR,
+        ),
+        (
+            {
+                "exc": aiohttp.ClientError,
+            },
+            ConfigEntryState.SETUP_RETRY,
+        ),
+    ],
+)
+async def test_token_refresh_error(
+    aioclient_mock_args: dict[str, Any],
+    expected_config_entry_state: ConfigEntryState,
+    hass: HomeAssistant,
+    platforms: list[Platform],
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+    setup_credentials: None,
+    client: MagicMock,
+) -> None:
+    """Test where token is expired and the refresh attempt fails."""
+
+    config_entry.data["token"]["access_token"] = FAKE_ACCESS_TOKEN
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        **aioclient_mock_args,
+    )
+
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    with patch(
+        "homeassistant.components.home_connect.HomeConnectClient", return_value=client
+    ):
+        assert not await integration_setup(client)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == expected_config_entry_state
 
 
 @pytest.mark.parametrize(

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -289,6 +289,12 @@ async def test_token_refresh_success(
         ),
         (
             {
+                "status": 500,
+            },
+            ConfigEntryState.SETUP_RETRY,
+        ),
+        (
+            {
                 "exc": aiohttp.ClientError,
             },
             ConfigEntryState.SETUP_RETRY,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refresh the token, if needed, during config entry setup, so that we can handle the aiohttp error appropriately and raise `ConfigEntryAuthFailed` to prompt the user to re-authenticate.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140121
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
