### PR TITLE
Fix Slack channel and user ID resolution for file uploads

### DIFF
--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -85,27 +85,16 @@ class AuthDictT(TypedDict, total=False):
     auth: BasicAuth
 
 
-class FormDataT(TypedDict, total=False):
-    """Type for form data, file upload."""
-
-    channels: str
-    filename: str
-    initial_comment: str
-    title: str
-    token: str
-    thread_ts: str
-
-
 class MessageT(TypedDict, total=False):
     """Type for message data."""
 
     link_names: bool
     text: str
-    username: str
-    icon_url: str
-    icon_emoji: str
-    blocks: list[Any]
-    thread_ts: str
+    username: str  # Optional key
+    icon_url: str  # Optional key
+    icon_emoji: str  # Optional key
+    blocks: list[Any]  # Optional key
+    thread_ts: str  # Optional key
 
 
 async def async_get_service(

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -138,13 +138,12 @@ def _async_process_target(
     if not target:
         return "channel_name", target
 
-    if isinstance(target, str):
-        target = target.lstrip("#")
+    target = target.lstrip("#")
 
-        if SLACK_USERID_PATTERN.match(target):
-            return "user_id", target
-        if SLACK_CHANNELID_PATTERN.match(target):
-            return "channel_id", target
+    if SLACK_USERID_PATTERN.match(target):
+        return "user_id", target
+    if SLACK_CHANNELID_PATTERN.match(target):
+        return "channel_id", target
 
     return "channel_name", target
 

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -46,7 +46,10 @@ from .utils import upload_file_to_slack
 _LOGGER = logging.getLogger(__name__)
 
 # Regex patterns for different Slack identifiers
+# Based on Slack API documentation: https://api.slack.com/types
+# User IDs: Start with U (regular users) or W (workspace users), followed by 8+ alphanumeric chars
 SLACK_USERID_PATTERN = re.compile(r"^[UW][A-Z0-9]{8,}$")
+# Channel IDs: Start with C (channels), G (groups), or D (DMs), followed by 8+ alphanumeric chars
 SLACK_CHANNELID_PATTERN = re.compile(r"^[CGD][A-Z0-9]{8,}$")
 
 FILE_PATH_SCHEMA = vol.Schema({vol.Required(CONF_PATH): cv.isfile})

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -197,8 +197,8 @@ class SlackNotificationService(BaseNotificationService):
         if channel_id := self._channel_id_cache.get(channel_name):
             return channel_id
 
+        channels = []
         try:
-            channels = []
             for channel_type in ("public_channel", "private_channel"):
                 response = await self._client.conversations_list(types=channel_type)
                 if not response["ok"]:

--- a/homeassistant/components/slack/strings.json
+++ b/homeassistant/components/slack/strings.json
@@ -32,5 +32,19 @@
         "name": "Do not disturb until"
       }
     }
+  },
+  "exceptions": {
+    "error_opening_dm": {
+      "message": "Error opening DM with user {user_id}: {error}"
+    },
+    "error_getting_channel": {
+      "message": "Error getting channel ID {channel_name}: {error}"
+    },
+    "error_channel_not_found": {
+      "message": "Channel {channel_name} not found"
+    },
+    "error_targets_not_found": {
+      "message": "No targets resolved for: {targets}"
+    }
   }
 }

--- a/homeassistant/components/slack/utils.py
+++ b/homeassistant/components/slack/utils.py
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def upload_file_to_slack(
     client: AsyncWebClient,
-    channel_ids: list[str | None],
+    channel_ids: list[str],
     file_content: bytes | str | None,
     filename: str,
     title: str | None,
@@ -23,7 +23,7 @@ async def upload_file_to_slack(
 
     Args:
         client (AsyncWebClient): The Slack WebClient instance.
-        channel_ids (list[str | None]): List of channel IDs to upload the file to.
+        channel_ids (list[str]): List of channel IDs to upload the file to.
         file_content (Union[bytes, str, None]): Content of the file (local or remote). If None, file_path is used.
         filename (str): The file's name.
         title (str | None): Title of the file in Slack.

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
+
+from aiohttp.client_exceptions import ClientError
+import pytest
+from slack.errors import SlackApiError
 
 from homeassistant.components import notify
-from homeassistant.components.slack import DOMAIN
+from homeassistant.components.slack import DATA_CLIENT, DOMAIN, SLACK_DATA
 from homeassistant.components.slack.notify import (
-    ATTR_THREAD_TS,
     CONF_DEFAULT_CHANNEL,
     SlackNotificationService,
+    _async_process_target,
+    async_get_service,
 )
 from homeassistant.const import ATTR_ICON, CONF_API_KEY, CONF_NAME, CONF_PLATFORM
+from homeassistant.core import HomeAssistant
 
 from . import CONF_DATA
 
@@ -29,16 +35,42 @@ DEFAULT_CONFIG = {
 }
 
 
-async def test_message_includes_default_emoji() -> None:
+@pytest.fixture
+def mock_client():
+    """Create a mock Slack client."""
+    client = Mock()
+    client.chat_postMessage = AsyncMock(return_value={"ok": True})
+    client.conversations_list = AsyncMock(
+        return_value={
+            "ok": True,
+            "channels": [
+                {"name": "general", "id": "C111"},
+                {"name": "random", "id": "C222"},
+            ],
+        }
+    )
+    client.conversations_open = AsyncMock(
+        return_value={"ok": True, "channel": {"id": "D111"}}
+    )
+    client.files_upload_v2 = AsyncMock(return_value={"ok": True})
+    return client
+
+
+@pytest.fixture
+def hass_mock(hass: HomeAssistant):
+    """Mock hass for allowing external URLs."""
+    hass.config.is_allowed_external_url = Mock(return_value=True)
+    return hass
+
+
+async def test_message_includes_default_emoji(mock_client) -> None:
     """Tests that default icon is used when no message icon is given."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
     expected_icon = ":robot_face:"
     service = SlackNotificationService(
         None, mock_client, CONF_DATA | {ATTR_ICON: expected_icon}
     )
 
-    await service.async_send_message("test")
+    await service.async_send_message("test", target="C123456789")
 
     mock_fn = mock_client.chat_postMessage
     mock_fn.assert_called_once()
@@ -46,67 +78,327 @@ async def test_message_includes_default_emoji() -> None:
     assert kwargs["icon_emoji"] == expected_icon
 
 
-async def test_message_emoji_overrides_default() -> None:
-    """Tests that overriding the default icon emoji when sending a message works."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
-    service = SlackNotificationService(
-        None, mock_client, CONF_DATA | {ATTR_ICON: "default_icon"}
-    )
-
-    expected_icon = ":new:"
-    await service.async_send_message("test", data={"icon": expected_icon})
-
-    mock_fn = mock_client.chat_postMessage
-    mock_fn.assert_called_once()
-    _, kwargs = mock_fn.call_args
-    assert kwargs["icon_emoji"] == expected_icon
-
-
-async def test_message_includes_default_icon_url() -> None:
-    """Tests that overriding the default icon url when sending a message works."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
-    expected_icon = "https://example.com/hass.png"
-    service = SlackNotificationService(
-        None, mock_client, CONF_DATA | {ATTR_ICON: expected_icon}
-    )
-
-    await service.async_send_message("test")
-
-    mock_fn = mock_client.chat_postMessage
-    mock_fn.assert_called_once()
-    _, kwargs = mock_fn.call_args
-    assert kwargs["icon_url"] == expected_icon
-
-
-async def test_message_icon_url_overrides_default() -> None:
-    """Tests that overriding the default icon url when sending a message works."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
-    service = SlackNotificationService(
-        None, mock_client, CONF_DATA | {ATTR_ICON: "default_icon"}
-    )
-
-    expected_icon = "https://example.com/hass.png"
-    await service.async_send_message("test", data={ATTR_ICON: expected_icon})
-
-    mock_fn = mock_client.chat_postMessage
-    mock_fn.assert_called_once()
-    _, kwargs = mock_fn.call_args
-    assert kwargs["icon_url"] == expected_icon
-
-
-async def test_message_as_reply() -> None:
-    """Tests that a message pointer will be passed to Slack if specified."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
+async def test_targets_channel_name(mock_client) -> None:
+    """Test sending message to channel by name."""
     service = SlackNotificationService(None, mock_client, CONF_DATA)
 
-    expected_ts = "1624146685.064129"
-    await service.async_send_message("test", data={ATTR_THREAD_TS: expected_ts})
+    await service.async_send_message("test", target="#general")
 
-    mock_fn = mock_client.chat_postMessage
-    mock_fn.assert_called_once()
-    _, kwargs = mock_fn.call_args
-    assert kwargs["thread_ts"] == expected_ts
+    # Should only call conversations_list for public and private channels once each
+    assert mock_client.conversations_list.call_count == 2
+    mock_client.chat_postMessage.assert_called_once_with(
+        link_names=True, text="test", channel="C111"
+    )
+
+
+async def test_targets_channel_id(mock_client) -> None:
+    """Test sending message to channel by ID."""
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+    channel_id = "C123456789"
+
+    await service.async_send_message("test", target=channel_id)
+
+    # Should not need to resolve channel ID
+    mock_client.conversations_list.assert_not_called()
+    mock_client.chat_postMessage.assert_called_once_with(
+        link_names=True, text="test", channel=channel_id
+    )
+
+
+async def test_targets_user_id(mock_client) -> None:
+    """Test sending message to user by ID."""
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+    user_id = "U123456789"
+
+    await service.async_send_message("test", target=user_id)
+
+    # Should get DM channel ID via conversations_open
+    mock_client.conversations_open.assert_called_once_with(users=[user_id])
+    mock_client.chat_postMessage.assert_called_once_with(
+        link_names=True, text="test", channel="D111"
+    )
+
+
+async def test_targets_multiple(mock_client) -> None:
+    """Test sending message to multiple targets."""
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+
+    await service.async_send_message(
+        "test", target=["#general", "C123456789", "U123456789"]
+    )
+
+    # Should resolve channel name and user ID, but not channel ID
+    assert mock_client.conversations_list.call_count == 2  # public and private
+    assert mock_client.conversations_open.call_count == 1
+    assert mock_client.chat_postMessage.call_count == 3
+
+
+async def test_target_resolution_failure(mock_client) -> None:
+    """Test handling of target resolution failures."""
+    mock_client.conversations_list.return_value = {"ok": False, "error": "error"}
+    mock_client.conversations_open.return_value = {"ok": False, "error": "error"}
+
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+
+    # Should not raise an exception
+    await service.async_send_message(
+        "test", target=["#nonexistent", "INVALID", "U123456789"]
+    )
+
+    # No successful message sends due to resolution failures
+    assert mock_client.chat_postMessage.call_count == 0
+
+
+async def test_file_upload_targets(mock_client, hass_mock) -> None:
+    """Test file upload with different target types."""
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = AsyncMock()
+    mock_response.read = AsyncMock(return_value=b"file content")
+
+    with patch(
+        "homeassistant.components.slack.notify.aiohttp_client.async_get_clientsession"
+    ) as mock_session:
+        mock_session.return_value.get.return_value.__aenter__.return_value = (
+            mock_response
+        )
+
+        service = SlackNotificationService(hass_mock, mock_client, CONF_DATA)
+
+        await service.async_send_message(
+            "test",
+            target=["#general", "U123456789"],
+            data={"file": {"url": "http://example.com/image.jpg"}},
+        )
+
+        # Should resolve targets and call files_upload_v2 once with all resolved channel IDs
+        assert mock_client.conversations_list.call_count == 2
+        assert mock_client.conversations_open.call_count == 1
+        assert mock_client.files_upload_v2.call_count == 2
+
+
+async def test_remote_file_not_allowed(hass_mock, mock_client) -> None:
+    """Test uploading a remote file from a non-allowed URL."""
+    hass_mock.config.is_allowed_external_url = Mock(return_value=False)
+    service = SlackNotificationService(hass_mock, mock_client, CONF_DATA)
+
+    await service.async_send_message(
+        "test", data={"file": {"url": "http://example.com/not-allowed.jpg"}}
+    )
+
+    mock_client.files_upload_v2.assert_not_called()
+
+
+async def test_remote_file_download_error(mock_client, hass_mock) -> None:
+    """Test handling of remote file download errors."""
+    with patch(
+        "homeassistant.components.slack.notify.aiohttp_client.async_get_clientsession"
+    ) as mock_session:
+        mock_session.return_value.get.side_effect = ClientError()
+
+        service = SlackNotificationService(hass_mock, mock_client, CONF_DATA)
+
+        await service.async_send_message(
+            "test", data={"file": {"url": "http://example.com/error.jpg"}}
+        )
+
+        mock_client.files_upload_v2.assert_not_called()
+
+
+async def test_slack_api_errors(mock_client) -> None:
+    """Test handling of Slack API errors."""
+    mock_client.chat_postMessage.side_effect = SlackApiError("error", {"ok": False})
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+
+    # Should not raise an exception
+    await service.async_send_message("test", target="C123456789")
+
+
+async def test_conversation_list_error(mock_client) -> None:
+    """Test handling of conversation list errors."""
+    mock_client.conversations_list.side_effect = SlackApiError("error", {"ok": False})
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+
+    await service.async_send_message("test", target="#some-channel")
+    mock_client.chat_postMessage.assert_not_called()
+
+
+async def test_channel_not_found(mock_client) -> None:
+    """Test handling of non-existent channel."""
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+
+    await service.async_send_message("test", target="#nonexistent")
+    mock_client.chat_postMessage.assert_not_called()
+
+
+async def test_file_upload_with_auth(mock_client, hass_mock) -> None:
+    """Test file upload with basic auth credentials."""
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = AsyncMock()
+    mock_response.read = AsyncMock(return_value=b"file content")
+
+    with patch(
+        "homeassistant.components.slack.notify.aiohttp_client.async_get_clientsession"
+    ) as mock_session:
+        mock_session.return_value.get.return_value.__aenter__.return_value = (
+            mock_response
+        )
+
+        service = SlackNotificationService(hass_mock, mock_client, CONF_DATA)
+
+        await service.async_send_message(
+            "test",
+            target="#general",  # Added explicit target
+            data={
+                "file": {
+                    "url": "http://example.com/image.jpg",
+                    "username": "user",
+                    "password": "pass",
+                }
+            },
+        )
+
+        # Verify auth was used
+        mock_session.return_value.get.assert_called_once()
+        kwargs = mock_session.return_value.get.call_args.kwargs
+        assert "auth" in kwargs
+
+        # Verify file upload
+        assert (
+            mock_client.files_upload_v2.call_count == 1
+        )  # Changed to handle one upload per channel
+
+
+async def test_get_service_discovery_info(hass: HomeAssistant) -> None:
+    """Test async_get_service with discovery info."""
+    mock_client = AsyncMock()
+    discovery_info = {SLACK_DATA: {DATA_CLIENT: mock_client}}
+
+    service = await async_get_service(hass, {}, discovery_info)
+
+    assert service is not None
+    assert isinstance(service, SlackNotificationService)
+    assert service._client == mock_client
+    assert service._hass == hass
+    assert service._config == discovery_info
+
+
+async def test_get_service_no_discovery_info(hass: HomeAssistant) -> None:
+    """Test async_get_service without discovery info."""
+    service = await async_get_service(hass, {}, None)
+    assert service is None
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        # Empty/None handling
+        ("", ("channel_name", "")),
+        # User IDs
+        ("U123ABC456", ("user_id", "U123ABC456")),
+        ("W123ABC456", ("user_id", "W123ABC456")),
+        ("UABCDEF123", ("user_id", "UABCDEF123")),
+        # Channel IDs
+        ("C123ABC456", ("channel_id", "C123ABC456")),
+        ("G123ABC456", ("channel_id", "G123ABC456")),
+        ("D123ABC456", ("channel_id", "D123ABC456")),
+        # Channel names
+        ("general", ("channel_name", "general")),
+        ("#general", ("channel_name", "general")),
+        ("my-channel", ("channel_name", "my-channel")),
+        ("#my-channel", ("channel_name", "my-channel")),
+        # Invalid/Edge cases
+        ("U12345", ("channel_name", "U12345")),  # Too short for user ID
+        ("C12345", ("channel_name", "C12345")),  # Too short for channel ID
+        ("X123ABC456", ("channel_name", "X123ABC456")),  # Invalid prefix
+        ("U123ABC456DEF", ("user_id", "U123ABC456DEF")),  # Extra long but valid
+        ("not-an-id", ("channel_name", "not-an-id")),
+    ],
+)
+def test_process_target(target: str, expected: tuple[str, str]) -> None:
+    """Test target processing for various input formats."""
+    assert _async_process_target(target) == expected
+
+
+def test_process_target_not_string() -> None:
+    """Test handling of non-string input (shouldn't happen in practice but good to test)."""
+    # Type ignore because we're intentionally testing with wrong type
+    result = _async_process_target(123)  # type: ignore[arg-type]
+    assert result == ("channel_name", 123)  # type: ignore[comparison-overlap]
+
+
+def test_process_target_strip_multiple_hashes() -> None:
+    """Test that multiple # characters are all stripped."""
+    assert _async_process_target("###general") == ("channel_name", "general")
+
+
+async def test_dm_channel_api_error(mock_client) -> None:
+    """Test handling of Slack API error when opening DM channel."""
+    mock_client.conversations_open.side_effect = SlackApiError("error", {"ok": False})
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+
+    await service.async_send_message("test", target="U123456789")
+    mock_client.chat_postMessage.assert_not_called()
+
+
+async def test_channel_id_cache(mock_client) -> None:
+    """Test channel ID is cached and reused."""
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+
+    # First call should use API
+    await service.async_send_message("test", target="#general")
+    assert mock_client.conversations_list.call_count == 2
+
+    # Second call should use cached value
+    await service.async_send_message("test", target="#general")
+    assert mock_client.conversations_list.call_count == 2  # Count shouldn't increase
+
+
+async def test_local_file_upload(mock_client, hass_mock) -> None:
+    """Test successful local file upload."""
+    hass_mock.config.is_allowed_path = Mock(return_value=True)
+    service = SlackNotificationService(hass_mock, mock_client, CONF_DATA)
+
+    with (
+        patch("homeassistant.components.slack.notify.DATA_SCHEMA") as mock_schema,
+        patch(
+            "aiofiles.open",
+            return_value=AsyncMock(
+                __aenter__=AsyncMock(
+                    return_value=AsyncMock(read=AsyncMock(return_value=b"file content"))
+                ),
+                __aexit__=AsyncMock(),
+            ),
+        ),
+    ):
+        mock_schema.side_effect = lambda x: x
+
+        data = {"file": {"path": "/allowed/path/image.jpg"}}
+
+        await service.async_send_message("test", target="#general", data=data)
+
+        mock_client.files_upload_v2.assert_called_once_with(
+            channel="C111",
+            file=b"file content",
+            filename="image.jpg",
+            title="image.jpg",
+            initial_comment="test",
+            thread_ts="",
+        )
+
+
+async def test_local_file_not_allowed(hass_mock, mock_client) -> None:
+    """Test uploading a local file that's not in an allowed path."""
+    hass_mock.config.is_allowed_path = Mock(return_value=False)
+    service = SlackNotificationService(hass_mock, mock_client, CONF_DATA)
+
+    with patch("homeassistant.components.slack.notify.DATA_SCHEMA") as mock_schema:
+        mock_schema.side_effect = lambda x: x
+
+        await service.async_send_message(
+            "test", target="#general", data={"file": {"path": "/not/allowed/path.jpg"}}
+        )
+
+        hass_mock.config.is_allowed_path.assert_called_once_with(
+            "/not/allowed/path.jpg"
+        )
+        mock_client.files_upload_v2.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes issues reported in #137555 and #137567 where file uploads to Slack no longer work when using channel IDs or user IDs as targets. When I implemented support for the new Slack API `files_upload_v2` (in PR #135818), I inadvertently broke support for sending files to channel IDs and direct messages.
The changes improve target resolution to properly handle different types of Slack identifiers (channel names, channel IDs, and user IDs) and implement simple caching to reduce API calls. This allows users to continue using any supported target format when sending files via Slack.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes issues: 
  - #137555 
  - #137567
- This PR is related to previous PR: #135818

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
