### PR TITLE
Reset config temperature_unit back to CELSIUS to fix CI

### DIFF
--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1117,6 +1117,10 @@ async def test_temperature_setting_climate_onoff(hass: HomeAssistant) -> None:
     )
     assert len(calls) == 1
 
+    # Reset config temperature_unit back to CELSIUS, required for
+    # additional tests outside this component.
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+
 
 async def test_temperature_setting_climate_no_modes(hass: HomeAssistant) -> None:
     """Test TemperatureSetting trait support for climate domain not supporting any modes."""
@@ -1261,6 +1265,9 @@ async def test_temperature_setting_climate_range(hass: HomeAssistant) -> None:
         ATTR_ENTITY_ID: "climate.bla",
         climate.ATTR_TEMPERATURE: 75,
     }
+
+    # Reset config temperature_unit back to CELSIUS, required for
+    # additional tests outside this component.
     hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 
 
@@ -1485,6 +1492,10 @@ async def test_temperature_control_water_heater(
         "temperatureAmbientCelsius": current_out,
     }
 
+    # Reset config temperature_unit back to CELSIUS, required for
+    # additional tests outside this component.
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+
 
 @pytest.mark.parametrize(
     ("unit", "temp_init", "temp_in", "temp_out", "current_init"),
@@ -1555,6 +1566,10 @@ async def test_temperature_control_water_heater_set_temperature(
         ATTR_ENTITY_ID: "water_heater.bla",
         ATTR_TEMPERATURE: temp_out,
     }
+
+    # Reset config temperature_unit back to CELSIUS, required for
+    # additional tests outside this component.
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 
 
 async def test_humidity_setting_humidifier_setpoint(hass: HomeAssistant) -> None:
@@ -3668,6 +3683,9 @@ async def test_temperature_control_sensor_data(
         }
     else:
         assert trt.query_attributes() == {}
+
+    # Reset config temperature_unit back to CELSIUS, required for
+    # additional tests outside this component.
     hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 
 

--- a/tests/components/lg_thinq/snapshots/test_climate.ambr
+++ b/tests/components/lg_thinq/snapshots/test_climate.ambr
@@ -15,8 +15,8 @@
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 86,
-      'min_temp': 64,
+      'max_temp': 30,
+      'min_temp': 18,
       'preset_modes': list([
         'air_clean',
       ]),
@@ -28,7 +28,7 @@
         'on',
         'off',
       ]),
-      'target_temp_step': 2,
+      'target_temp_step': 1,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -62,7 +62,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_humidity': 40,
-      'current_temperature': 77,
+      'current_temperature': 25,
       'fan_mode': 'mid',
       'fan_modes': list([
         'low',
@@ -75,8 +75,8 @@
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 86,
-      'min_temp': 64,
+      'max_temp': 30,
+      'min_temp': 18,
       'preset_mode': None,
       'preset_modes': list([
         'air_clean',
@@ -94,8 +94,8 @@
       ]),
       'target_temp_high': None,
       'target_temp_low': None,
-      'target_temp_step': 2,
-      'temperature': 66,
+      'target_temp_step': 1,
+      'temperature': 19,
     }),
     'context': <ANY>,
     'entity_id': 'climate.test_air_conditioner',

--- a/tests/components/lg_thinq/test_climate.py
+++ b/tests/components/lg_thinq/test_climate.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.const import Platform, UnitOfTemperature
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -23,7 +23,6 @@ async def test_all_entities(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test all entities."""
-    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
     with patch("homeassistant.components.lg_thinq.PLATFORMS", [Platform.CLIMATE]):
         await setup_integration(hass, mock_config_entry)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have noticed the same test fails recently:
https://github.com/home-assistant/core/actions/runs/13759982103/job/38476395271?pr=140262#step:10:337
```
FAILED tests/components/temper/test_sensor.py::test_temperature_readback - AssertionError: assert '54.1' == '12.3'
```
The failure hinted that there is some problem with Celsius to Fahrenheit conversation, however when reviewing the test there is nothing wrong with the test, but with another test that changes the config temperature unit from Celsius to Fahrenheit 

**An example:**
The following scenario fails:
```python
pytest tests/components/lg_thinq/test_climate.py tests/components/temper/test_sensor.py 
FAILED tests/components/temper/test_sensor.py::test_temperature_readback - AssertionError: assert '54.1' == '12.3'
```
Reversing the order of the tests fixes the issue so it is important to keep the unit back to Celsius

#### Reviewing all the tests in the codebase I found the following:
- `gree` tests set the unit back to Celsius with a clear note:
```python
    # Reset config temperature_unit back to CELSIUS, required for
    # additional tests outside this component.
    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
```
- `lg_thinq` leaves the temperature unit at Fahrenheit after the test while it can also run using Celsius so I think it is safer to keep it on Celsius 
https://github.com/home-assistant/core/blob/219b441be0d66d5a016ea2d726846f249eb2ed0a/tests/components/lg_thinq/test_climate.py#L26
- `google_assistant` is setting the temperature unit back to Celsius in most cases but some places leave it on Fahrenheit - fixed and added a note

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
