### PR TITLE
Add cover support to PG LAB integration

### DIFF
--- a/homeassistant/components/pglab/cover.py
+++ b/homeassistant/components/pglab/cover.py
@@ -93,11 +93,15 @@ class PGLabCover(PGLabEntity, CoverEntity):
         return self._shutter.state == PyPGLabShutter.STATE_CLOSED
 
     @property
-    def is_closing(self) -> bool:
+    def is_closing(self) -> bool | None:
         """Return if the cover is closing."""
+        if not self._shutter.state:
+            return None
         return self._shutter.state == PyPGLabShutter.STATE_CLOSING
 
     @property
-    def is_opening(self) -> bool:
+    def is_opening(self) -> bool | None:
         """Return if the cover is opening."""
+        if not self._shutter.state:
+            return None
         return self._shutter.state == PyPGLabShutter.STATE_OPENING

--- a/homeassistant/components/pglab/cover.py
+++ b/homeassistant/components/pglab/cover.py
@@ -1,0 +1,103 @@
+"""PG LAB Electronics Cover."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pypglab.device import Device as PyPGLabDevice
+from pypglab.shutter import Shutter as PyPGLabShutter
+
+from homeassistant.components.cover import (
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .discovery import PGLabDiscovery
+from .entity import PGLabEntity
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up switches for device."""
+
+    @callback
+    def async_discover(
+        pglab_device: PyPGLabDevice, pglab_shutter: PyPGLabShutter
+    ) -> None:
+        """Discover and add a PG LAB Cover."""
+        pglab_discovery = config_entry.runtime_data
+        pglab_cover = PGLabCover(pglab_discovery, pglab_device, pglab_shutter)
+        async_add_entities([pglab_cover])
+
+    # Register the callback to create the cover entity when discovered.
+    pglab_discovery = config_entry.runtime_data
+    await pglab_discovery.register_platform(hass, Platform.COVER, async_discover)
+
+
+class PGLabCover(PGLabEntity, CoverEntity):
+    """A PGLab Cover."""
+
+    _attr_translation_key = "shutter"
+
+    def __init__(
+        self,
+        pglab_discovery: PGLabDiscovery,
+        pglab_device: PyPGLabDevice,
+        pglab_shutter: PyPGLabShutter,
+    ) -> None:
+        """Initialize the Cover class."""
+
+        super().__init__(
+            pglab_discovery,
+            pglab_device,
+            pglab_shutter,
+        )
+
+        self._attr_unique_id = f"{pglab_device.id}_shutter{pglab_shutter.id}"
+        self._attr_translation_placeholders = {"shutter_id": pglab_shutter.id}
+
+        self._shutter = pglab_shutter
+
+        self._attr_device_class = CoverDeviceClass.SHUTTER
+        self._attr_supported_features = (
+            CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+        )
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover."""
+        await self._shutter.open()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close cover."""
+        await self._shutter.close()
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover."""
+        await self._shutter.stop()
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return if cover is closed."""
+        if not self._shutter.state:
+            return None
+        return self._shutter.state == PyPGLabShutter.STATE_CLOSED
+
+    @property
+    def is_closing(self) -> bool:
+        """Return if the cover is closing."""
+        return self._shutter.state == PyPGLabShutter.STATE_CLOSING
+
+    @property
+    def is_opening(self) -> bool:
+        """Return if the cover is opening."""
+        return self._shutter.state == PyPGLabShutter.STATE_OPENING

--- a/homeassistant/components/pglab/discovery.py
+++ b/homeassistant/components/pglab/discovery.py
@@ -34,12 +34,14 @@ if TYPE_CHECKING:
 
 # Supported platforms.
 PLATFORMS = [
+    Platform.COVER,
     Platform.SENSOR,
     Platform.SWITCH,
 ]
 
 # Used to create a new component entity.
 CREATE_NEW_ENTITY = {
+    Platform.COVER: "pglab_create_new_entity_cover",
     Platform.SENSOR: "pglab_create_new_entity_sensor",
     Platform.SWITCH: "pglab_create_new_entity_switch",
 }
@@ -249,6 +251,13 @@ class PGLabDiscovery:
                 hass, config_entry, pglab_device
             )
             self._discovered[pglab_device.id] = discovery_info
+
+            # Create all new cover entities.
+            for s in pglab_device.shutters:
+                # the HA entity is not yet created, send a message to create it
+                async_dispatcher_send(
+                    hass, CREATE_NEW_ENTITY[Platform.COVER], pglab_device, s
+                )
 
             # Create all new relay entities.
             for r in pglab_device.relays:

--- a/homeassistant/components/pglab/strings.json
+++ b/homeassistant/components/pglab/strings.json
@@ -15,6 +15,11 @@
     }
   },
   "entity": {
+    "cover": {
+      "shutter": {
+        "name": "Shutter {shutter_id}"
+      }
+    },
     "switch": {
       "relay": {
         "name": "Relay {relay_id}"

--- a/tests/components/pglab/test_cover.py
+++ b/tests/components/pglab/test_cover.py
@@ -65,17 +65,10 @@ async def test_cover_features(
 
     assert len(hass.states.async_all("cover")) == 4
 
-    cover = hass.states.get("cover.test_shutter_0")
-    assert cover.attributes["supported_features"] == COVER_FEATURES
-
-    cover = hass.states.get("cover.test_shutter_1")
-    assert cover.attributes["supported_features"] == COVER_FEATURES
-
-    cover = hass.states.get("cover.test_shutter_2")
-    assert cover.attributes["supported_features"] == COVER_FEATURES
-
-    cover = hass.states.get("cover.test_shutter_3")
-    assert cover.attributes["supported_features"] == COVER_FEATURES
+    for i in range(4):
+        cover = hass.states.get(f"cover.test_shutter_{i}")
+        assert cover
+        assert cover.attributes["supported_features"] == COVER_FEATURES
 
 
 async def test_cover_availability(

--- a/tests/components/pglab/test_cover.py
+++ b/tests/components/pglab/test_cover.py
@@ -1,0 +1,217 @@
+"""The tests for the PG LAB Electronics cover."""
+
+import json
+
+from homeassistant.components import cover
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_STOP_COVER,
+)
+from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import async_fire_mqtt_message
+from tests.typing import MqttMockHAClient
+
+COVER_FEATURES = (
+    cover.CoverEntityFeature.OPEN
+    | cover.CoverEntityFeature.CLOSE
+    | cover.CoverEntityFeature.STOP
+)
+
+
+async def call_service(hass: HomeAssistant, entity_id, service, **kwargs):
+    """Call a service."""
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        service,
+        {"entity_id": entity_id, **kwargs},
+        blocking=True,
+    )
+
+
+async def test_cover_features(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
+) -> None:
+    """Test cover features."""
+    topic = "pglab/discovery/E-Board-DD53AC85/config"
+    payload = {
+        "ip": "192.168.1.16",
+        "mac": "80:34:28:1B:18:5A",
+        "name": "test",
+        "hw": "1.0.7",
+        "fw": "1.0.0",
+        "type": "E-Board",
+        "id": "E-Board-DD53AC85",
+        "manufacturer": "PG LAB Electronics",
+        "params": {"shutters": 4, "boards": "10000000"},
+    }
+
+    async_fire_mqtt_message(
+        hass,
+        topic,
+        json.dumps(payload),
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all("cover")) == 4
+
+    cover = hass.states.get("cover.test_shutter_0")
+    assert cover.attributes["supported_features"] == COVER_FEATURES
+
+    cover = hass.states.get("cover.test_shutter_1")
+    assert cover.attributes["supported_features"] == COVER_FEATURES
+
+    cover = hass.states.get("cover.test_shutter_2")
+    assert cover.attributes["supported_features"] == COVER_FEATURES
+
+    cover = hass.states.get("cover.test_shutter_3")
+    assert cover.attributes["supported_features"] == COVER_FEATURES
+
+
+async def test_cover_availability(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
+) -> None:
+    """Check if covers are properly created."""
+    topic = "pglab/discovery/E-Board-DD53AC85/config"
+    payload = {
+        "ip": "192.168.1.16",
+        "mac": "80:34:28:1B:18:5A",
+        "name": "test",
+        "hw": "1.0.7",
+        "fw": "1.0.0",
+        "type": "E-Board",
+        "id": "E-Board-DD53AC85",
+        "manufacturer": "PG LAB Electronics",
+        "params": {"shutters": 6, "boards": "11000000"},
+    }
+
+    async_fire_mqtt_message(
+        hass,
+        topic,
+        json.dumps(payload),
+    )
+    await hass.async_block_till_done()
+
+    # We are creating 6 covers using two E-RELAY devices connected to E-BOARD.
+    # Now we are going to check if all covers are created and their state is unknown.
+    for i in range(5):
+        cover = hass.states.get(f"cover.test_shutter_{i}")
+        assert cover.state == STATE_UNKNOWN
+        assert not cover.attributes.get(ATTR_ASSUMED_STATE)
+
+    # The cover with id 7 should not be created.
+    cover = hass.states.get("cover.test_shutter_7")
+    assert not cover
+
+
+async def test_cover_change_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
+) -> None:
+    """Test state update via MQTT."""
+    topic = "pglab/discovery/E-Board-DD53AC85/config"
+    payload = {
+        "ip": "192.168.1.16",
+        "mac": "80:34:28:1B:18:5A",
+        "name": "test",
+        "hw": "1.0.7",
+        "fw": "1.0.0",
+        "type": "E-Board",
+        "id": "E-Board-DD53AC85",
+        "manufacturer": "PG LAB Electronics",
+        "params": {"shutters": 2, "boards": "10000000"},
+    }
+
+    async_fire_mqtt_message(
+        hass,
+        topic,
+        json.dumps(payload),
+    )
+    await hass.async_block_till_done()
+
+    # Check initial state is unknown
+    cover = hass.states.get("cover.test_shutter_0")
+    assert cover.state == STATE_UNKNOWN
+    assert not cover.attributes.get(ATTR_ASSUMED_STATE)
+
+    # Simulate the device responds sending mqtt messages and check if the cover state
+    # change appropriately.
+
+    async_fire_mqtt_message(hass, "pglab/test/shutter/0/state", "OPEN")
+    await hass.async_block_till_done()
+    cover = hass.states.get("cover.test_shutter_0")
+    assert not cover.attributes.get(ATTR_ASSUMED_STATE)
+    assert cover.state == STATE_OPEN
+
+    async_fire_mqtt_message(hass, "pglab/test/shutter/0/state", "OPENING")
+    await hass.async_block_till_done()
+    cover = hass.states.get("cover.test_shutter_0")
+    assert cover.state == STATE_OPENING
+
+    async_fire_mqtt_message(hass, "pglab/test/shutter/0/state", "CLOSING")
+    await hass.async_block_till_done()
+    cover = hass.states.get("cover.test_shutter_0")
+    assert cover.state == STATE_CLOSING
+
+    async_fire_mqtt_message(hass, "pglab/test/shutter/0/state", "CLOSED")
+    await hass.async_block_till_done()
+    cover = hass.states.get("cover.test_shutter_0")
+    assert cover.state == STATE_CLOSED
+
+
+async def test_cover_mqtt_state_by_calling_service(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
+) -> None:
+    """Calling service to OPEN/CLOSE cover and check mqtt state."""
+    topic = "pglab/discovery/E-Board-DD53AC85/config"
+    payload = {
+        "ip": "192.168.1.16",
+        "mac": "80:34:28:1B:18:5A",
+        "name": "test",
+        "hw": "1.0.7",
+        "fw": "1.0.0",
+        "type": "E-Board",
+        "id": "E-Board-DD53AC85",
+        "manufacturer": "PG LAB Electronics",
+        "params": {"shutters": 2, "boards": "10000000"},
+    }
+
+    async_fire_mqtt_message(
+        hass,
+        topic,
+        json.dumps(payload),
+    )
+    await hass.async_block_till_done()
+
+    cover = hass.states.get("cover.test_shutter_0")
+    assert cover.state == STATE_UNKNOWN
+    assert not cover.attributes.get(ATTR_ASSUMED_STATE)
+
+    # Call HA covers services and verify that the MQTT messages are sent correctly
+
+    await call_service(hass, "cover.test_shutter_0", SERVICE_OPEN_COVER)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "pglab/test/shutter/0/set", "OPEN", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    await call_service(hass, "cover.test_shutter_0", SERVICE_STOP_COVER)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "pglab/test/shutter/0/set", "STOP", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    await call_service(hass, "cover.test_shutter_0", SERVICE_CLOSE_COVER)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "pglab/test/shutter/0/set", "CLOSE", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add cover support to PG LAB Electronics integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37903
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
