### PR TITLE
Reset config temperature_unit back to CELSIUS to fix CI

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -54,6 +54,7 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED,
     STATE_OFF,
     STATE_ON,
+    UnitOfTemperature,
 )
 from homeassistant.core import (
     CoreState,
@@ -345,6 +346,8 @@ async def async_test_home_assistant(
     finally:
         # Restore timezone, it is set when creating the hass object
         dt_util.set_default_time_zone(orig_tz)
+        # Restore temperature_unit back to CELSIUS
+        hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
         # Remove loop shutdown indicator to not interfere with additional hass objects
         with suppress(AttributeError):
             delattr(hass.loop, _SHUTDOWN_RUN_CALLBACK_THREADSAFE)

--- a/tests/common.py
+++ b/tests/common.py
@@ -346,7 +346,6 @@ async def async_test_home_assistant(
     finally:
         # Restore timezone, it is set when creating the hass object
         dt_util.set_default_time_zone(orig_tz)
-        # Restore temperature_unit back to CELSIUS
         with suppress(AttributeError):
             delattr(hass.loop, _SHUTDOWN_RUN_CALLBACK_THREADSAFE)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,6 +14,7 @@ from collections.abc import (
     Sequence,
 )
 from contextlib import asynccontextmanager, contextmanager, suppress
+import copy
 from datetime import UTC, datetime, timedelta
 from enum import Enum, StrEnum
 import functools as ft
@@ -54,7 +55,6 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED,
     STATE_OFF,
     STATE_ON,
-    UnitOfTemperature,
 )
 from homeassistant.core import (
     CoreState,
@@ -263,7 +263,7 @@ async def async_test_home_assistant(
     hass.config.longitude = -117.22743
     hass.config.elevation = 0
     await hass.config.async_set_time_zone("US/Pacific")
-    hass.config.units = METRIC_SYSTEM
+    hass.config.units = copy.deepcopy(METRIC_SYSTEM)
     hass.config.media_dirs = {"local": get_test_config_dir("media")}
     hass.config.skip_pip = True
     hass.config.skip_pip_packages = []
@@ -347,8 +347,6 @@ async def async_test_home_assistant(
         # Restore timezone, it is set when creating the hass object
         dt_util.set_default_time_zone(orig_tz)
         # Restore temperature_unit back to CELSIUS
-        hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
-        # Remove loop shutdown indicator to not interfere with additional hass objects
         with suppress(AttributeError):
             delattr(hass.loop, _SHUTDOWN_RUN_CALLBACK_THREADSAFE)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have noticed the same test fails recently:
https://github.com/home-assistant/core/actions/runs/13759982103/job/38476395271?pr=140262#step:10:337
```
FAILED tests/components/temper/test_sensor.py::test_temperature_readback - AssertionError: assert '54.1' == '12.3'
```
The failure hinted that there is some problem with Celsius to Fahrenheit conversation, however when reviewing the test there is nothing wrong with the test, but with another test that changes the config temperature unit from Celsius to Fahrenheit 

**An example:**
The following scenario fails:
```python
pytest tests/components/lg_thinq/test_climate.py tests/components/temper/test_sensor.py 
FAILED tests/components/temper/test_sensor.py::test_temperature_readback - AssertionError: assert '54.1' == '12.3'
```
Reversing the order of the tests fixes the issue so it is important to keep the unit back to Celsius

Based on https://github.com/home-assistant/core/pull/140289#discussion_r1987354004 - reset the temperature unit back to Celsius in the context manager that creates the `hass` object.
assistant/core/blob/688d5bb4c98130358e4cf9ae5ec8d30139cf6f19/tests/common.py#L346-L347

With this change the tests pass:
```python
pytest tests/components/lg_thinq/test_climate.py tests/components/temper/test_sensor.py
 tests/components/lg_thinq/test_climate.py ✓
 tests/components/temper/test_sensor.py ✓
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
