### PR TITLE
Add strict typing of post to Mastodon

### DIFF
--- a/homeassistant/components/mastodon/notify.py
+++ b/homeassistant/components/mastodon/notify.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from mastodon import Mastodon
-from mastodon.Mastodon import MastodonAPIError
+from mastodon.Mastodon import MastodonAPIError, MediaAttachment
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -114,7 +114,7 @@ class MastodonNotificationService(BaseNotificationService):
                     message,
                     visibility=target,
                     spoiler_text=content_warning,
-                    media_ids=mediadata["id"],
+                    media_ids=mediadata.id,
                     sensitive=sensitive,
                 )
             except MastodonAPIError as err:
@@ -134,12 +134,14 @@ class MastodonNotificationService(BaseNotificationService):
                     translation_key="unable_to_send_message",
                 ) from err
 
-    def _upload_media(self, media_path: Any = None) -> Any:
+    def _upload_media(self, media_path: Any = None) -> MediaAttachment:
         """Upload media."""
         with open(media_path, "rb"):
             media_type = get_media_type(media_path)
         try:
-            mediadata = self.client.media_post(media_path, mime_type=media_type)
+            mediadata: MediaAttachment = self.client.media_post(
+                media_path, mime_type=media_type
+            )
         except MastodonAPIError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/mastodon/quality_scale.yaml
+++ b/homeassistant/components/mastodon/quality_scale.yaml
@@ -93,7 +93,4 @@ rules:
   # Platinum
   async-dependency: todo
   inject-websession: todo
-  strict-typing:
-    status: todo
-    comment: |
-      Requirement 'Mastodon.py==1.8.1' appears untyped
+  strict-typing: done

--- a/homeassistant/components/mastodon/services.py
+++ b/homeassistant/components/mastodon/services.py
@@ -5,7 +5,7 @@ from functools import partial
 from typing import Any, cast
 
 from mastodon import Mastodon
-from mastodon.Mastodon import MastodonAPIError
+from mastodon.Mastodon import MastodonAPIError, MediaAttachment
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntryState
@@ -104,7 +104,7 @@ def setup_services(hass: HomeAssistant) -> None:
     def _post(client: Mastodon, **kwargs: Any) -> None:
         """Post to Mastodon."""
 
-        media_data: dict[str, Any] | None = None
+        media_data: MediaAttachment | None = None
 
         media_path = kwargs.get("media_path")
         if media_path:
@@ -137,7 +137,7 @@ def setup_services(hass: HomeAssistant) -> None:
         try:
             media_ids: str | None = None
             if media_data:
-                media_ids = media_data["id"]
+                media_ids = media_data.id
             client.status_post(media_ids=media_ids, **kwargs)
         except MastodonAPIError as err:
             raise HomeAssistantError(

--- a/tests/components/mastodon/test_services.py
+++ b/tests/components/mastodon/test_services.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, Mock, patch
 
-from mastodon.Mastodon import MastodonAPIError
+from mastodon.Mastodon import MastodonAPIError, MediaAttachment
 import pytest
 
 from homeassistant.components.mastodon.const import (
@@ -106,7 +106,9 @@ async def test_service_post(
 
     with (
         patch.object(hass.config, "is_allowed_path", return_value=True),
-        patch.object(mock_mastodon_client, "media_post", return_value={"id": "1"}),
+        patch.object(
+            mock_mastodon_client, "media_post", return_value=MediaAttachment(id="1")
+        ),
     ):
         await hass.services.async_call(
             DOMAIN,
@@ -163,7 +165,7 @@ async def test_post_service_failed(
     await hass.async_block_till_done()
 
     hass.config.is_allowed_path = Mock(return_value=True)
-    mock_mastodon_client.media_post.return_value = {"id": "1"}
+    mock_mastodon_client.media_post.return_value = MediaAttachment(id="1")
 
     mock_mastodon_client.status_post.side_effect = MastodonAPIError
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With v2 of Mastodon.py everything is optionally fully typed, this PR changes post to be fully typed.
This completes the outstanding strict typing so updated quality scale.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
