### PR TITLE
Promote after dependencies in bootstrap

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -859,14 +859,22 @@ async def _async_set_up_integrations(
     integrations, all_integrations = await _async_resolve_domains_and_preload(
         hass, config
     )
-    all_domains = set(all_integrations)
-    domains = set(integrations)
+    # Detect all cycles
+    integrations_after_dependencies = (
+        await loader.resolve_integrations_after_dependencies(
+            hass, all_integrations.values(), set(all_integrations)
+        )
+    )
+    all_domains = set(integrations_after_dependencies)
+    domains = set(integrations) & all_domains
 
     _LOGGER.info(
         "Domains to be set up: %s | %s",
         domains,
         all_domains - domains,
     )
+
+    async_set_domains_to_be_loaded(hass, all_domains)
 
     # Initialize recorder
     if "recorder" in all_domains:
@@ -900,24 +908,12 @@ async def _async_set_up_integrations(
         stage_dep_domains_unfiltered = {
             dep
             for domain in stage_domains
-            for dep in all_integrations[domain].all_dependencies
+            for dep in integrations_after_dependencies[domain]
             if dep not in stage_domains
         }
         stage_dep_domains = stage_dep_domains_unfiltered - hass.config.components
 
         stage_all_domains = stage_domains | stage_dep_domains
-        stage_all_integrations = {
-            domain: all_integrations[domain] for domain in stage_all_domains
-        }
-        # Detect all cycles
-        stage_integrations_after_dependencies = (
-            await loader.resolve_integrations_after_dependencies(
-                hass, stage_all_integrations.values(), stage_all_domains
-            )
-        )
-        stage_all_domains = set(stage_integrations_after_dependencies)
-        stage_domains &= stage_all_domains
-        stage_dep_domains &= stage_all_domains
 
         _LOGGER.info(
             "Setting up stage %s: %s | %s\nDependencies: %s | %s",
@@ -927,8 +923,6 @@ async def _async_set_up_integrations(
             stage_dep_domains,
             stage_dep_domains_unfiltered - stage_dep_domains,
         )
-
-        async_set_domains_to_be_loaded(hass, stage_all_domains)
 
         if timeout is None:
             await _async_setup_multi_components(hass, stage_all_domains, config)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -252,8 +252,8 @@ async def test_setup_after_deps_all_present(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("load_registries", [False])
-async def test_setup_after_deps_in_stage_1_ignored(hass: HomeAssistant) -> None:
-    """Test after_dependencies are ignored in stage 1."""
+async def test_setup_after_deps_in_stage_1(hass: HomeAssistant) -> None:
+    """Test after_dependencies are promoted in stage 1."""
     # This test relies on this
     assert "cloud" in bootstrap.STAGE_1_INTEGRATIONS
     order = []
@@ -295,7 +295,7 @@ async def test_setup_after_deps_in_stage_1_ignored(hass: HomeAssistant) -> None:
 
     assert "normal_integration" in hass.config.components
     assert "cloud" in hass.config.components
-    assert order == ["cloud", "an_after_dep", "normal_integration"]
+    assert order == ["an_after_dep", "normal_integration", "cloud"]
 
 
 @pytest.mark.parametrize("load_registries", [False])
@@ -304,7 +304,7 @@ async def test_setup_after_deps_manifests_are_loaded_even_if_not_setup(
 ) -> None:
     """Ensure we preload manifests for after deps even if they are not setup.
 
-    Its important that we preload the after dep manifests even if they are not setup
+    It's important that we preload the after dep manifests even if they are not setup
     since we will always have to check their requirements since any integration
     that lists an after dep may import it and we have to ensure requirements are
     up to date before the after dep can be imported.
@@ -371,7 +371,7 @@ async def test_setup_after_deps_manifests_are_loaded_even_if_not_setup(
     assert "an_after_dep" not in hass.config.components
     assert "an_after_dep_of_after_dep" not in hass.config.components
     assert "an_after_dep_of_after_dep_of_after_dep" not in hass.config.components
-    assert order == ["cloud", "normal_integration"]
+    assert order == ["normal_integration", "cloud"]
     assert loader.async_get_loaded_integration(hass, "an_after_dep") is not None
     assert (
         loader.async_get_loaded_integration(hass, "an_after_dep_of_after_dep")
@@ -456,9 +456,9 @@ async def test_setup_frontend_before_recorder(hass: HomeAssistant) -> None:
 
     assert order == [
         "http",
+        "an_after_dep",
         "frontend",
         "recorder",
-        "an_after_dep",
         "normal_integration",
     ]
 
@@ -1577,8 +1577,10 @@ async def test_no_base_platforms_loaded_before_recorder(hass: HomeAssistant) -> 
         assert not isinstance(integrations_or_excs, Exception)
         integrations[domain] = integration
 
-    integrations_all_dependencies = await loader.resolve_integrations_dependencies(
-        hass, integrations.values()
+    integrations_all_dependencies = (
+        await loader.resolve_integrations_after_dependencies(
+            hass, integrations.values(), ignore_exceptions=True
+        )
     )
     all_integrations = integrations.copy()
     all_integrations.update(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Promote after dependencies in bootstrap.

Currently after dependencies don't work in early stages of bootstrap. If an integration loads in one of early stages and it has an after dependency, this after dependency will not be setup at that time. We want to instead promote after dependencies in early stages, that is to move them to setup in that early stage where something has an after dependency on them.

This provides uniform experience and reduces surprises. Several people already made the mistake of using after dependencies, when those didn't do anything, all the people mentioned with good understanding of Home Assistant code otherwise. We want to prevent that in the future. 

Furthermore this change will allow us to move some of the dependencies into after dependencies, increasing the overall reliability of Home Assistant, especially in the face of failures, like running in recovery mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
