### PR TITLE
Remove redundant after dependencies in search

### DIFF
--- a/homeassistant/components/search/manifest.json
+++ b/homeassistant/components/search/manifest.json
@@ -1,7 +1,6 @@
 {
   "domain": "search",
   "name": "Search",
-  "after_dependencies": ["scene", "group", "automation", "script"],
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/search",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove redundant after dependencies in search.

Search is loaded early in bootstrap. After dependencies are not used at that stage. So those after dependencies are not doing anything right now.

Furthermore all the uses of functionality from these components is guarded against using it too early, so we don't need to load them at that stage.

Scene:
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/homeassistant/scene.py#L141-L142
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/homeassistant/scene.py#L157-L158

Group:
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/group/__init__.py#L129-L130
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/helpers/group.py#L53-L54

Automation:
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/automation/__init__.py#L140-L141
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/automation/__init__.py#L154-L155
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/automation/__init__.py#L226-L227
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/automation/__init__.py#L239-L240

Script:
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/script/__init__.py#L100-L101
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/script/__init__.py#L114-L115
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/script/__init__.py#L188-L189
https://github.com/home-assistant/core/blob/25d6974137b7b8d3f0afe58bc5ec8a55b79d0f8d/homeassistant/components/script/__init__.py#L203-L204

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
