### PR TITLE
Migrate google_assistant tests to use unit system

### DIFF
--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -79,6 +79,11 @@ from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, St
 from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import TemperatureConverter
+from homeassistant.util.unit_system import (
+    METRIC_SYSTEM,
+    US_CUSTOMARY_SYSTEM,
+    UnitSystem,
+)
 
 from . import BASIC_CONFIG, MockConfig
 
@@ -1072,7 +1077,7 @@ async def test_temperature_setting_climate_onoff(hass: HomeAssistant) -> None:
     assert helpers.get_google_type(climate.DOMAIN, None) is not None
     assert trait.TemperatureSettingTrait.supported(climate.DOMAIN, 0, None, None)
 
-    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+    hass.config.units = US_CUSTOMARY_SYSTEM
 
     trt = trait.TemperatureSettingTrait(
         hass,
@@ -1123,8 +1128,6 @@ async def test_temperature_setting_climate_no_modes(hass: HomeAssistant) -> None
     assert helpers.get_google_type(climate.DOMAIN, None) is not None
     assert trait.TemperatureSettingTrait.supported(climate.DOMAIN, 0, None, None)
 
-    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
-
     trt = trait.TemperatureSettingTrait(
         hass,
         State(
@@ -1153,7 +1156,7 @@ async def test_temperature_setting_climate_range(hass: HomeAssistant) -> None:
     assert helpers.get_google_type(climate.DOMAIN, None) is not None
     assert trait.TemperatureSettingTrait.supported(climate.DOMAIN, 0, None, None)
 
-    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+    hass.config.units = US_CUSTOMARY_SYSTEM
 
     trt = trait.TemperatureSettingTrait(
         hass,
@@ -1261,15 +1264,12 @@ async def test_temperature_setting_climate_range(hass: HomeAssistant) -> None:
         ATTR_ENTITY_ID: "climate.bla",
         climate.ATTR_TEMPERATURE: 75,
     }
-    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 
 
 async def test_temperature_setting_climate_setpoint(hass: HomeAssistant) -> None:
     """Test TemperatureSetting trait support for climate domain - setpoint."""
     assert helpers.get_google_type(climate.DOMAIN, None) is not None
     assert trait.TemperatureSettingTrait.supported(climate.DOMAIN, 0, None, None)
-
-    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 
     trt = trait.TemperatureSettingTrait(
         hass,
@@ -1356,8 +1356,6 @@ async def test_temperature_setting_climate_setpoint_auto(hass: HomeAssistant) ->
 
     Setpoint in auto mode.
     """
-    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
-
     trt = trait.TemperatureSettingTrait(
         hass,
         State(
@@ -1407,8 +1405,6 @@ async def test_temperature_setting_climate_setpoint_auto(hass: HomeAssistant) ->
 
 async def test_temperature_control(hass: HomeAssistant) -> None:
     """Test TemperatureControl trait support for sensor domain."""
-    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
-
     trt = trait.TemperatureControlTrait(
         hass,
         State("sensor.temp", 18),
@@ -1431,13 +1427,13 @@ async def test_temperature_control(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("unit_in", "unit_out", "temp_in", "temp_out", "current_in", "current_out"),
     [
-        (UnitOfTemperature.CELSIUS, "C", "120", 120, "130", 130),
-        (UnitOfTemperature.FAHRENHEIT, "F", "248", 120, "266", 130),
+        (METRIC_SYSTEM, "C", "120", 120, "130", 130),
+        (US_CUSTOMARY_SYSTEM, "F", "248", 120, "266", 130),
     ],
 )
 async def test_temperature_control_water_heater(
     hass: HomeAssistant,
-    unit_in: UnitOfTemperature,
+    unit_in: UnitSystem,
     unit_out: str,
     temp_in: str,
     temp_out: float,
@@ -1445,17 +1441,17 @@ async def test_temperature_control_water_heater(
     current_out: float,
 ) -> None:
     """Test TemperatureControl trait support for water heater domain."""
-    hass.config.units.temperature_unit = unit_in
+    hass.config.units = unit_in
 
     min_temp = TemperatureConverter.convert(
         water_heater.DEFAULT_MIN_TEMP,
         UnitOfTemperature.CELSIUS,
-        unit_in,
+        unit_in.temperature_unit,
     )
     max_temp = TemperatureConverter.convert(
         water_heater.DEFAULT_MAX_TEMP,
         UnitOfTemperature.CELSIUS,
-        unit_in,
+        unit_in.temperature_unit,
     )
 
     trt = trait.TemperatureControlTrait(
@@ -1489,30 +1485,30 @@ async def test_temperature_control_water_heater(
 @pytest.mark.parametrize(
     ("unit", "temp_init", "temp_in", "temp_out", "current_init"),
     [
-        (UnitOfTemperature.CELSIUS, "180", 220, 220, "180"),
-        (UnitOfTemperature.FAHRENHEIT, "356", 220, 428, "356"),
+        (METRIC_SYSTEM, "180", 220, 220, "180"),
+        (US_CUSTOMARY_SYSTEM, "356", 220, 428, "356"),
     ],
 )
 async def test_temperature_control_water_heater_set_temperature(
     hass: HomeAssistant,
-    unit: UnitOfTemperature,
+    unit: UnitSystem,
     temp_init: str,
     temp_in: float,
     temp_out: float,
     current_init: str,
 ) -> None:
     """Test TemperatureControl trait support for water heater domain - SetTemperature."""
-    hass.config.units.temperature_unit = unit
+    hass.config.units = unit
 
     min_temp = TemperatureConverter.convert(
         40,
         UnitOfTemperature.CELSIUS,
-        unit,
+        unit.temperature_unit,
     )
     max_temp = TemperatureConverter.convert(
         230,
         UnitOfTemperature.CELSIUS,
-        unit,
+        unit.temperature_unit,
     )
 
     trt = trait.TemperatureControlTrait(
@@ -3633,17 +3629,17 @@ async def test_temperature_control_sensor(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("unit_in", "unit_out", "state", "ambient"),
     [
-        (UnitOfTemperature.FAHRENHEIT, "F", "70", 21.1),
-        (UnitOfTemperature.CELSIUS, "C", "21.1", 21.1),
-        (UnitOfTemperature.FAHRENHEIT, "F", "unavailable", None),
-        (UnitOfTemperature.FAHRENHEIT, "F", "unknown", None),
+        (US_CUSTOMARY_SYSTEM, "F", "70", 21.1),
+        (METRIC_SYSTEM, "C", "21.1", 21.1),
+        (US_CUSTOMARY_SYSTEM, "F", "unavailable", None),
+        (US_CUSTOMARY_SYSTEM, "F", "unknown", None),
     ],
 )
 async def test_temperature_control_sensor_data(
-    hass: HomeAssistant, unit_in, unit_out, state, ambient
+    hass: HomeAssistant, unit_in: UnitSystem, unit_out, state, ambient
 ) -> None:
     """Test TemperatureControl trait support for temperature sensor."""
-    hass.config.units.temperature_unit = unit_in
+    hass.config.units = unit_in
 
     trt = trait.TemperatureControlTrait(
         hass,
@@ -3668,7 +3664,6 @@ async def test_temperature_control_sensor_data(
         }
     else:
         assert trt.query_attributes() == {}
-    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 
 
 async def test_humidity_setting_sensor(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
Unit systems are meant to be frozen/read-only

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
