### PR TITLE
Fix double space quoting in WebDAV

### DIFF
--- a/homeassistant/components/webdav/__init__.py
+++ b/homeassistant/components/webdav/__init__.py
@@ -13,7 +13,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
 from .const import CONF_BACKUP_PATH, DATA_BACKUP_AGENT_LISTENERS, DOMAIN
-from .helpers import async_create_client, async_ensure_path_exists
+from .helpers import (
+    async_create_client,
+    async_ensure_path_exists,
+    async_migrate_wrong_folder_path,
+)
 
 type WebDavConfigEntry = ConfigEntry[Client]
 
@@ -46,10 +50,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: WebDavConfigEntry) -> bo
             translation_key="cannot_connect",
         )
 
+    path = entry.data.get(CONF_BACKUP_PATH, "/")
+    await async_migrate_wrong_folder_path(client, path)
+
     # Ensure the backup directory exists
-    if not await async_ensure_path_exists(
-        client, entry.data.get(CONF_BACKUP_PATH, "/")
-    ):
+    if not await async_ensure_path_exists(client, path):
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="cannot_access_or_create_backup_path",

--- a/homeassistant/components/webdav/helpers.py
+++ b/homeassistant/components/webdav/helpers.py
@@ -1,9 +1,17 @@
 """Helper functions for the WebDAV component."""
 
+import logging
+
 from aiowebdav2.client import Client, ClientOptions
+from aiowebdav2.exceptions import WebDavError
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @callback
@@ -36,3 +44,24 @@ async def async_ensure_path_exists(client: Client, path: str) -> bool:
             return False
 
     return True
+
+
+async def async_migrate_wrong_folder_path(client: Client, path: str) -> None:
+    """Migrate the wrong encoded folder path to the correct one."""
+    wrong_path = path.replace(" ", "%20")
+    if await client.check(wrong_path):
+        try:
+            await client.move(wrong_path, path)
+        except WebDavError as err:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="failed_to_migrate_folder",
+                translation_placeholders={
+                    "wrong_path": wrong_path,
+                    "correct_path": path,
+                },
+            ) from err
+
+        _LOGGER.debug(
+            "Migrated wrong encoded folder path from %s to %s", wrong_path, path
+        )

--- a/homeassistant/components/webdav/manifest.json
+++ b/homeassistant/components/webdav/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aiowebdav2"],
   "quality_scale": "bronze",
-  "requirements": ["aiowebdav2==0.4.1"]
+  "requirements": ["aiowebdav2==0.4.2"]
 }

--- a/homeassistant/components/webdav/strings.json
+++ b/homeassistant/components/webdav/strings.json
@@ -36,6 +36,9 @@
     },
     "cannot_access_or_create_backup_path": {
       "message": "Cannot access or create backup path. Please check the path and permissions."
+    },
+    "failed_to_migrate_folder": {
+      "message": "Failed to migrate wrong encoded folder \"{wrong_path}\" to \"{correct_path}\"."
     }
   }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -422,7 +422,7 @@ aiowaqi==3.1.0
 aiowatttime==0.1.1
 
 # homeassistant.components.webdav
-aiowebdav2==0.4.1
+aiowebdav2==0.4.2
 
 # homeassistant.components.webostv
 aiowebostv==0.7.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -404,7 +404,7 @@ aiowaqi==3.1.0
 aiowatttime==0.1.1
 
 # homeassistant.components.webdav
-aiowebdav2==0.4.1
+aiowebdav2==0.4.2
 
 # homeassistant.components.webostv
 aiowebostv==0.7.3

--- a/tests/components/webdav/__init__.py
+++ b/tests/components/webdav/__init__.py
@@ -1,1 +1,14 @@
 """Tests for the WebDAV integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Set up the WebDAV integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/webdav/conftest.py
+++ b/tests/components/webdav/conftest.py
@@ -62,4 +62,5 @@ def mock_webdav_client() -> Generator[AsyncMock]:
         mock.download_iter.side_effect = _download_mock
         mock.upload_iter.return_value = None
         mock.clean.return_value = None
+        mock.move.return_value = None
         yield mock

--- a/tests/components/webdav/test_init.py
+++ b/tests/components/webdav/test_init.py
@@ -1,0 +1,96 @@
+"""Test WebDAV component setup."""
+
+from unittest.mock import AsyncMock
+
+from aiowebdav2.exceptions import WebDavError
+import pytest
+
+from homeassistant.components.webdav.const import CONF_BACKUP_PATH, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_migrate_wrong_path(
+    hass: HomeAssistant, webdav_client: AsyncMock
+) -> None:
+    """Test migration of wrong encoded folder path."""
+    webdav_client.list_with_properties.return_value = [
+        {"/wrong%20path": []},
+    ]
+
+    config_entry = MockConfigEntry(
+        title="user@webdav.demo",
+        domain=DOMAIN,
+        data={
+            CONF_URL: "https://webdav.demo",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "supersecretpassword",
+            CONF_BACKUP_PATH: "/wrong path",
+        },
+        entry_id="01JKXV07ASC62D620DGYNG2R8H",
+    )
+    await setup_integration(hass, config_entry)
+
+    webdav_client.move.assert_called_once_with("/wrong%20path", "/wrong path")
+
+
+async def test_migrate_non_wrong_path(
+    hass: HomeAssistant, webdav_client: AsyncMock
+) -> None:
+    """Test no migration of correct folder path."""
+    webdav_client.list_with_properties.return_value = [
+        {"/correct path": []},
+    ]
+    webdav_client.check.side_effect = lambda path: path == "/correct path"
+
+    config_entry = MockConfigEntry(
+        title="user@webdav.demo",
+        domain=DOMAIN,
+        data={
+            CONF_URL: "https://webdav.demo",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "supersecretpassword",
+            CONF_BACKUP_PATH: "/correct path",
+        },
+        entry_id="01JKXV07ASC62D620DGYNG2R8H",
+    )
+
+    await setup_integration(hass, config_entry)
+
+    webdav_client.move.assert_not_called()
+
+
+async def test_migrate_error(
+    hass: HomeAssistant,
+    webdav_client: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test migration of wrong encoded folder path with error."""
+    webdav_client.list_with_properties.return_value = [
+        {"/wrong%20path": []},
+    ]
+    webdav_client.move.side_effect = WebDavError("Failed to move")
+
+    config_entry = MockConfigEntry(
+        title="user@webdav.demo",
+        domain=DOMAIN,
+        data={
+            CONF_URL: "https://webdav.demo",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "supersecretpassword",
+            CONF_BACKUP_PATH: "/wrong path",
+        },
+        entry_id="01JKXV07ASC62D620DGYNG2R8H",
+    )
+    await setup_integration(hass, config_entry)
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        'Failed to migrate wrong encoded folder "/wrong%20path" to "/wrong path"'
+        in caplog.text
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This fixes the problem of spaces being quoted twice in the backup path. I have added a migration (just replace the space with the quoted one, which will then be quoted a second time by the package, as it was before), so this change will not be a breaking one for existing users.

https://github.com/jpbede/aiowebdav2/releases/tag/v0.4.2
https://github.com/jpbede/aiowebdav2/compare/v0.4.1...v0.4.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140345
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
