### PR TITLE
Handle incomplete power consumption reports in SmartThings

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -228,28 +228,6 @@ KEEP_CAPABILITY_QUIRK: dict[
     Capability.DEMAND_RESPONSE_LOAD_CONTROL: lambda _: True,
 }
 
-POWER_CONSUMPTION_FIELDS = {
-    "energy",
-    "power",
-    "deltaEnergy",
-    "powerEnergy",
-    "energySaved",
-}
-
-CAPABILITY_VALIDATION: dict[
-    Capability | str, Callable[[dict[Attribute | str, Status]], bool]
-] = {
-    Capability.POWER_CONSUMPTION_REPORT: (
-        lambda status: (
-            (power_consumption := status[Attribute.POWER_CONSUMPTION].value) is not None
-            and all(
-                field in cast(dict, power_consumption)
-                for field in POWER_CONSUMPTION_FIELDS
-            )
-        )
-    )
-}
-
 
 def process_status(
     status: dict[str, dict[Capability | str, dict[Attribute | str, Status]]],
@@ -273,8 +251,4 @@ def process_status(
                     or not KEEP_CAPABILITY_QUIRK[capability](main_component[capability])
                 ):
                     del main_component[capability]
-    for capability in list(main_component):
-        if capability in CAPABILITY_VALIDATION:
-            if not CAPABILITY_VALIDATION[capability](main_component[capability]):
-                del main_component[capability]
     return status

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
-from pysmartthings import Attribute, Capability, SmartThings
+from pysmartthings import Attribute, Capability, SmartThings, Status
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -131,6 +131,7 @@ class SmartThingsSensorEntityDescription(SensorEntityDescription):
     unique_id_separator: str = "."
     capability_ignore_list: list[set[Capability]] | None = None
     options_attribute: Attribute | None = None
+    exists_fn: Callable[[Status], bool] | None = None
 
 
 CAPABILITY_TO_SENSORS: dict[
@@ -583,6 +584,10 @@ CAPABILITY_TO_SENSORS: dict[
                 native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                 value_fn=lambda value: value["energy"] / 1000,
                 suggested_display_precision=2,
+                exists_fn=lambda status: (
+                    (value := cast(dict | None, status.value)) is not None
+                    and "energy" in value
+                ),
             ),
             SmartThingsSensorEntityDescription(
                 key="power_meter",
@@ -592,6 +597,10 @@ CAPABILITY_TO_SENSORS: dict[
                 value_fn=lambda value: value["power"],
                 extra_state_attributes_fn=power_attributes,
                 suggested_display_precision=2,
+                exists_fn=lambda status: (
+                    (value := cast(dict | None, status.value)) is not None
+                    and "power" in value
+                ),
             ),
             SmartThingsSensorEntityDescription(
                 key="deltaEnergy_meter",
@@ -601,6 +610,10 @@ CAPABILITY_TO_SENSORS: dict[
                 native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                 value_fn=lambda value: value["deltaEnergy"] / 1000,
                 suggested_display_precision=2,
+                exists_fn=lambda status: (
+                    (value := cast(dict | None, status.value)) is not None
+                    and "deltaEnergy" in value
+                ),
             ),
             SmartThingsSensorEntityDescription(
                 key="powerEnergy_meter",
@@ -610,6 +623,10 @@ CAPABILITY_TO_SENSORS: dict[
                 native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                 value_fn=lambda value: value["powerEnergy"] / 1000,
                 suggested_display_precision=2,
+                exists_fn=lambda status: (
+                    (value := cast(dict | None, status.value)) is not None
+                    and "powerEnergy" in value
+                ),
             ),
             SmartThingsSensorEntityDescription(
                 key="energySaved_meter",
@@ -619,6 +636,10 @@ CAPABILITY_TO_SENSORS: dict[
                 native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                 value_fn=lambda value: value["energySaved"] / 1000,
                 suggested_display_precision=2,
+                exists_fn=lambda status: (
+                    (value := cast(dict | None, status.value)) is not None
+                    and "energySaved" in value
+                ),
             ),
         ]
     },
@@ -979,6 +1000,10 @@ async def async_setup_entry(
                 all(capability in device.status[MAIN] for capability in capability_list)
                 for capability_list in description.capability_ignore_list
             )
+        )
+        and (
+            not description.exists_fn
+            or description.exists_fn(device.status[MAIN][capability][attribute])
         )
     )
 

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -126,6 +126,7 @@ def mock_smartthings() -> Generator[AsyncMock]:
         "generic_ef00_v1",
         "bosch_radiator_thermostat_ii",
         "im_speaker_ai_0001",
+        "tplink_p110",
     ]
 )
 def device_fixture(

--- a/tests/components/smartthings/fixtures/device_status/tplink_p110.json
+++ b/tests/components/smartthings/fixtures/device_status/tplink_p110.json
@@ -1,0 +1,46 @@
+{
+  "components": {
+    "main": {
+      "powerConsumptionReport": {
+        "powerConsumption": {
+          "value": {
+            "start": "2025-03-10T14:43:42.500Z",
+            "end": "2025-03-10T14:59:42.500Z",
+            "energy": 15720,
+            "deltaEnergy": 0
+          },
+          "timestamp": "2025-03-10T14:59:50.010Z"
+        }
+      },
+      "healthCheck": {
+        "checkInterval": {
+          "value": 60,
+          "unit": "s",
+          "data": {
+            "deviceScheme": "UNTRACKED",
+            "protocol": "cloud"
+          },
+          "timestamp": "2024-03-07T21:14:59.839Z"
+        },
+        "healthStatus": {
+          "value": null
+        },
+        "DeviceWatch-Enroll": {
+          "value": null
+        },
+        "DeviceWatch-DeviceStatus": {
+          "value": "online",
+          "data": {},
+          "timestamp": "2025-03-10T14:14:37.232Z"
+        }
+      },
+      "refresh": {},
+      "switch": {
+        "switch": {
+          "value": "on",
+          "timestamp": "2025-03-10T14:14:37.232Z"
+        }
+      }
+    }
+  }
+}

--- a/tests/components/smartthings/fixtures/devices/tplink_p110.json
+++ b/tests/components/smartthings/fixtures/devices/tplink_p110.json
@@ -1,0 +1,73 @@
+{
+  "items": [
+    {
+      "deviceId": "6602696a-1e48-49e4-919f-69406f5b5da1",
+      "name": "plug-energy-usage-report",
+      "label": "Sp\u00fclmaschine",
+      "manufacturerName": "0AI2",
+      "presentationId": "ST_8f2be0ec-1113-46e0-ad56-3e92eb27410f",
+      "deviceManufacturerCode": "TP-Link",
+      "locationId": "70da36b0-bd25-410c-beed-7f0dbf658448",
+      "ownerId": "be5d4173-dd49-1eee-56f5-f98306ee872c",
+      "roomId": "bd13616d-b7e2-44ff-914c-eb38ea18c4b4",
+      "components": [
+        {
+          "id": "main",
+          "label": "main",
+          "capabilities": [
+            {
+              "id": "healthCheck",
+              "version": 1
+            },
+            {
+              "id": "refresh",
+              "version": 1
+            },
+            {
+              "id": "switch",
+              "version": 1
+            },
+            {
+              "id": "powerConsumptionReport",
+              "version": 1
+            }
+          ],
+          "categories": [
+            {
+              "name": "SmartPlug",
+              "categoryType": "manufacturer"
+            },
+            {
+              "name": "SmartPlug",
+              "categoryType": "user"
+            }
+          ]
+        }
+      ],
+      "createTime": "2024-03-07T21:14:59.762Z",
+      "profile": {
+        "id": "a25b207e-cbb9-40ae-8a88-906637c22ab6"
+      },
+      "viper": {
+        "uniqueIdentifier": "8022F7F6FE0A6EACA52B5D89C0D667352136D8C6",
+        "manufacturerName": "TP-Link",
+        "modelName": "P110",
+        "swVersion": "1.3.1 Build 240621 Rel.162048",
+        "hwVersion": "1.0",
+        "endpointAppId": "viper_7ea6bb80-b876-11eb-be42-952f31ab3f7b"
+      },
+      "type": "VIPER",
+      "restrictionTier": 0,
+      "allowed": null,
+      "indoorMap": {
+        "coordinates": [0.0, 0.0, 0.0],
+        "rotation": [0.0, 180.0, 0.0],
+        "visible": false,
+        "data": null
+      },
+      "executionContext": "CLOUD",
+      "relationships": []
+    }
+  ],
+  "_links": {}
+}

--- a/tests/components/smartthings/snapshots/test_init.ambr
+++ b/tests/components/smartthings/snapshots/test_init.ambr
@@ -1091,6 +1091,39 @@
     'via_device_id': None,
   })
 # ---
+# name: test_devices[tplink_p110]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': 'https://account.smartthings.com',
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '1.0',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'smartthings',
+        '6602696a-1e48-49e4-919f-69406f5b5da1',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'TP-Link',
+    'model': 'P110',
+    'model_id': None,
+    'name': 'Spülmaschine',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '1.3.1 Build 240621 Rel.162048',
+    'via_device_id': None,
+  })
+# ---
 # name: test_devices[vd_network_audio_002s]
   DeviceRegistryEntrySnapshot({
     'area_id': 'theater',

--- a/tests/components/smartthings/snapshots/test_sensor.ambr
+++ b/tests/components/smartthings/snapshots/test_sensor.ambr
@@ -6109,6 +6109,116 @@
     'state': '15',
   })
 # ---
+# name: test_all_entities[tplink_p110][sensor.spulmaschine_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.spulmaschine_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Energy',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6602696a-1e48-49e4-919f-69406f5b5da1.energy_meter',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_all_entities[tplink_p110][sensor.spulmaschine_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Spülmaschine Energy',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.spulmaschine_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '15.72',
+  })
+# ---
+# name: test_all_entities[tplink_p110][sensor.spulmaschine_energy_difference-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.spulmaschine_energy_difference',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Energy difference',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_difference',
+    'unique_id': '6602696a-1e48-49e4-919f-69406f5b5da1.deltaEnergy_meter',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_all_entities[tplink_p110][sensor.spulmaschine_energy_difference-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Spülmaschine Energy difference',
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.spulmaschine_energy_difference',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_all_entities[vd_network_audio_002s][sensor.soundbar_living_media_playback_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/smartthings/snapshots/test_switch.ambr
+++ b/tests/components/smartthings/snapshots/test_switch.ambr
@@ -516,6 +516,53 @@
     'state': 'on',
   })
 # ---
+# name: test_all_entities[tplink_p110][switch.spulmaschine-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.spulmaschine',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6602696a-1e48-49e4-919f-69406f5b5da1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[tplink_p110][switch.spulmaschine-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Spülmaschine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.spulmaschine',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_all_entities[vd_network_audio_002s][switch.soundbar_living-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
So originally I found that there are power consumption reports that only have end and start date, and nothing else. So I made the logic to only use reports that are complete. Apparently, there are devices that still report incomplete data. This PR now moves that validation to the platform where we consume the entities. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140287
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
