### PR TITLE
Enable HEOS automatic failover

### DIFF
--- a/homeassistant/components/heos/coordinator.py
+++ b/homeassistant/components/heos/coordinator.py
@@ -43,7 +43,6 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
 
     def __init__(self, hass: HomeAssistant, config_entry: HeosConfigEntry) -> None:
         """Set up the coordinator and set in config_entry."""
-        self.host: str = config_entry.data[CONF_HOST]
         credentials: Credentials | None = None
         if config_entry.options:
             credentials = Credentials(
@@ -53,9 +52,10 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
         # media position update upon start of playback or when media changes
         self.heos = Heos(
             HeosOptions(
-                self.host,
+                config_entry.data[CONF_HOST],
                 all_progress_events=False,
                 auto_reconnect=True,
+                auto_failover=True,
                 credentials=credentials,
             )
         )
@@ -65,6 +65,11 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
         self._favorites: dict[int, MediaItem] = {}
         self._inputs: Sequence[MediaItem] = []
         super().__init__(hass, _LOGGER, config_entry=config_entry, name=DOMAIN)
+
+    @property
+    def host(self) -> str:
+        """Get the host address of the device."""
+        return self.heos.current_host
 
     @property
     def inputs(self) -> Sequence[MediaItem]:
@@ -159,8 +164,15 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
 
     async def _async_on_reconnected(self) -> None:
         """Handle when reconnected so resources are updated and entities marked available."""
+        assert self.config_entry is not None
+        if self.host != self.config_entry.data[CONF_HOST]:
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data={CONF_HOST: self.host}
+            )
+            _LOGGER.warning("Successfully failed over to HEOS host %s", self.host)
+        else:
+            _LOGGER.warning("Successfully reconnected to HEOS host %s", self.host)
         await self._async_update_sources()
-        _LOGGER.warning("Successfully reconnected to HEOS host %s", self.host)
         self.async_update_listeners()
 
     async def _async_on_controller_event(

--- a/tests/components/heos/__init__.py
+++ b/tests/components/heos/__init__.py
@@ -64,3 +64,7 @@ class MockHeos(Heos):
     def mock_set_connection_state(self, connection_state: ConnectionState) -> None:
         """Set the connection state on the mock instance."""
         self._connection._state = connection_state
+
+    def mock_set_current_host(self, host: str) -> None:
+        """Set the current host on the mock instance."""
+        self._connection._host = host

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -297,6 +297,25 @@ async def test_reconnected_new_entities_created(
     assert entity_registry.async_get_entity_id(MEDIA_PLAYER_DOMAIN, DOMAIN, "3")
 
 
+async def test_reconnected_failover_updates_host(
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
+) -> None:
+    """Test the config entry host is updated after failover."""
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
+
+    # Simulate reconnection
+    controller.mock_set_current_host("127.0.0.2")
+    await controller.dispatcher.wait_send(
+        SignalType.HEOS_EVENT, SignalHeosEvent.CONNECTED
+    )
+    await hass.async_block_till_done()
+
+    # Assert config entry host updated
+    assert config_entry.data[CONF_HOST] == "127.0.0.2"
+
+
 async def test_players_changed_new_entities_created(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This enables a HEOS library feature to automatically failover to other hosts in the HEOS System when the connected host goes down, improving resiliency. When a failover occurs, the config entry will be updated so it accurately represents what host the integration is connected to and ensures that it uses the working host after a restart/reload. Test added to verify functionality.

See it in action:
```pycon
DEBUG (MainThread) [pyheos.connection] Command executed 'heos://system/heart_beat': '{"heos": {"command": "system/heart_beat", "result": "success", "message": ""}}

<< I physically unplugged the receiver here >>

DEBUG (MainThread) [pyheos.connection] Command timed out 'heos://system/heart_beat'
DEBUG (MainThread) [pyheos.connection] Disconnected from 172.16.2.8 due to error: IncompleteReadError: 0 bytes read on a total of undefined expected bytes
WARNING (MainThread) [homeassistant.components.heos.coordinator] Connection to HEOS host 172.16.2.8 lost
DEBUG (MainThread) [pyheos.connection] Attempting reconnect #1 to 172.16.2.8
DEBUG (MainThread) [pyheos.connection] Failed to connect to 172.16.2.8: Connection timed out
DEBUG (MainThread) [pyheos.connection] Failing over from 172.16.2.8 to 172.16.0.79
DEBUG (MainThread) [pyheos.connection] Attempting reconnect #1 to 172.16.0.79
DEBUG (MainThread) [pyheos.connection] Connected to 172.16.0.79
WARNING (MainThread) [homeassistant.components.heos.coordinator] Successfully failed over to HEOS host 172.16.0.79
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37916
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
