### PR TITLE
Add waiting_state for climate.set_temperature

### DIFF
--- a/homeassistant/components/lg_thinq/climate.py
+++ b/homeassistant/components/lg_thinq/climate.py
@@ -340,27 +340,19 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
                     )
                 )
 
-        if (temperature_low := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None:
+        if (temperature_low := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None and (
+            temperature_high := kwargs.get(ATTR_TARGET_TEMP_HIGH)
+        ) is not None:
             if self.data.step >= 1:
                 temperature_low = int(temperature_low)
-            if temperature_low != self.target_temperature_low:
-                await self.async_call_api(
-                    self.coordinator.api.async_set_target_temperature_low(
-                        self.property_id,
-                        temperature_low,
-                    )
-                )
-
-        if (temperature_high := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None:
-            if self.data.step >= 1:
                 temperature_high = int(temperature_high)
-            if temperature_high != self.target_temperature_high:
-                await self.async_call_api(
-                    self.coordinator.api.async_set_target_temperature_high(
-                        self.property_id,
-                        temperature_high,
-                    )
+            await self.async_call_api(
+                self.coordinator.api.async_set_target_temperature_low_high(
+                    self.property_id,
+                    temperature_low,
+                    temperature_high,
                 )
+            )
 
     async def async_added_to_hass(self) -> None:
         """Handle added to Hass."""

--- a/homeassistant/components/lg_thinq/climate.py
+++ b/homeassistant/components/lg_thinq/climate.py
@@ -280,7 +280,8 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
         if hvac_mode == HVACMode.OFF:
             await self.async_turn_off()
             return
-
+        if hvac_mode == HVACMode.HEAT_COOL:
+            hvac_mode = HVACMode.AUTO
         # If device is off, turn on first.
         if not self.data.is_on:
             await self.async_turn_on()
@@ -305,7 +306,8 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
             if hvac_mode == HVACMode.OFF:
                 await self.async_turn_off()
                 return
-
+            if hvac_mode == HVACMode.HEAT_COOL:
+                hvac_mode = HVACMode.AUTO
             # If device is off, turn on first.
             if not self.data.is_on:
                 await self.async_turn_on()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- LG Air conditioner can only control one thing at a time. If the control command is not appropriate for the situation, it will return an error.
- For some AC devices, a single control command may take several seconds or more.
- We want to use 'async_track_state_change_event' so that we can sequentially execute turn_on, set_hvac_mode, set_temperature for climate's actions(set_hvac_mode and set_temperature).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #139124, #131252, #140783
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
