### PR TITLE
Add lawn mower support to HomeKit

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -15,6 +15,7 @@ from pyhap.service import Service
 from pyhap.util import callback as pyhap_callback
 
 from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
+from homeassistant.components.lawn_mower import LawnMowerEntityFeature
 from homeassistant.components.media_player import MediaPlayerDeviceClass
 from homeassistant.components.remote import RemoteEntityFeature
 from homeassistant.components.sensor import SensorDeviceClass
@@ -249,6 +250,13 @@ def get_accessory(  # noqa: C901
 
     elif state.domain == "vacuum":
         a_type = "Vacuum"
+
+    elif (
+        state.domain == "lawn_mower"
+        and features & LawnMowerEntityFeature.DOCK
+        and features & LawnMowerEntityFeature.START_MOWING
+    ):
+        a_type = "LawnMower"
 
     elif state.domain == "remote" and features & RemoteEntityFeature.ACTIVITY:
         a_type = "ActivityRemote"

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -106,6 +106,7 @@ SUPPORTED_DOMAINS = [
     "sensor",
     "switch",
     "vacuum",
+    "lawn_mower",
     "water_heater",
     VALVE_DOMAIN,
 ]
@@ -123,6 +124,7 @@ DEFAULT_DOMAINS = [
     REMOTE_DOMAIN,
     "switch",
     "vacuum",
+    "lawn_mower",
     "water_heater",
 ]
 

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -12,12 +12,20 @@ from homeassistant.components.homekit.const import (
     TYPE_VALVE,
 )
 from homeassistant.components.homekit.type_switches import (
+    LawnMower,
     Outlet,
     SelectSwitch,
     Switch,
     Vacuum,
     Valve,
     ValveSwitch,
+)
+from homeassistant.components.lawn_mower import (
+    DOMAIN as LAWN_MOWER_DOMAIN,
+    SERVICE_DOCK,
+    SERVICE_START_MOWING,
+    LawnMowerActivity,
+    LawnMowerEntityFeature,
 )
 from homeassistant.components.select import ATTR_OPTIONS
 from homeassistant.components.vacuum import (
@@ -365,6 +373,73 @@ async def test_vacuum_set_state_without_returnhome_and_start_support(
     # Set from HomeKit
     call_turn_on = async_mock_service(hass, VACUUM_DOMAIN, SERVICE_TURN_ON)
     call_turn_off = async_mock_service(hass, VACUUM_DOMAIN, SERVICE_TURN_OFF)
+
+    acc.char_on.client_update_value(1)
+    await hass.async_block_till_done()
+    assert acc.char_on.value == 1
+    assert call_turn_on
+    assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
+    assert len(events) == 1
+    assert events[-1].data[ATTR_VALUE] is None
+
+    acc.char_on.client_update_value(0)
+    await hass.async_block_till_done()
+    assert acc.char_on.value == 0
+    assert call_turn_off
+    assert call_turn_off[0].data[ATTR_ENTITY_ID] == entity_id
+    assert len(events) == 2
+    assert events[-1].data[ATTR_VALUE] is None
+
+
+async def test_lawn_mower_set_state(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
+    """Test if Lawn mower accessory and HA are updated accordingly."""
+    entity_id = "lawn_mower.mower"
+
+    hass.states.async_set(
+        entity_id,
+        None,
+        {
+            ATTR_SUPPORTED_FEATURES: LawnMowerEntityFeature.DOCK
+            | LawnMowerEntityFeature.START_MOWING
+        },
+    )
+    await hass.async_block_till_done()
+
+    acc = LawnMower(hass, hk_driver, "LawnMower", entity_id, 2, None)
+    acc.run()
+    await hass.async_block_till_done()
+    assert acc.aid == 2
+    assert acc.category == 8  # Switch
+
+    assert acc.char_on.value == 0
+
+    hass.states.async_set(
+        entity_id,
+        LawnMowerActivity.MOWING,
+        {
+            ATTR_SUPPORTED_FEATURES: LawnMowerEntityFeature.DOCK
+            | LawnMowerEntityFeature.START_MOWING
+        },
+    )
+    await hass.async_block_till_done()
+    assert acc.char_on.value == 1
+
+    hass.states.async_set(
+        entity_id,
+        LawnMowerActivity.DOCKED,
+        {
+            ATTR_SUPPORTED_FEATURES: LawnMowerEntityFeature.DOCK
+            | LawnMowerEntityFeature.START_MOWING
+        },
+    )
+    await hass.async_block_till_done()
+    assert acc.char_on.value == 0
+
+    # Set from HomeKit
+    call_turn_on = async_mock_service(hass, LAWN_MOWER_DOMAIN, SERVICE_START_MOWING)
+    call_turn_off = async_mock_service(hass, LAWN_MOWER_DOMAIN, SERVICE_DOCK)
 
     acc.char_on.client_update_value(1)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change

Expose lawn mower to homekit using the same logic as vacuum domain.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37932
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
