### PR TITLE
Raise ConfigEntryNotReady mqtt setup fails In LG ThinQ

### DIFF
--- a/homeassistant/components/lg_thinq/__init__.py
+++ b/homeassistant/components/lg_thinq/__init__.py
@@ -137,7 +137,13 @@ async def async_setup_mqtt(
     entry.runtime_data.mqtt_client = mqtt_client
 
     # Try to connect.
-    result = await mqtt_client.async_connect()
+    try:
+        result = await mqtt_client.async_connect()
+    except ThinQAPIException as exc:
+        raise ConfigEntryNotReady(exc.message) from exc
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ConfigEntryNotReady("Failed to connect MQTT") from exc
+
     if not result:
         _LOGGER.error("Failed to set up mqtt connection")
         return

--- a/homeassistant/components/lg_thinq/__init__.py
+++ b/homeassistant/components/lg_thinq/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import CONF_CONNECT_CLIENT_ID, MQTT_SUBSCRIPTION_INTERVAL
+from .const import CONF_CONNECT_CLIENT_ID, DOMAIN, MQTT_SUBSCRIPTION_INTERVAL
 from .coordinator import DeviceDataUpdateCoordinator, async_setup_device_coordinator
 from .mqtt import ThinQMQTT
 
@@ -139,10 +139,12 @@ async def async_setup_mqtt(
     # Try to connect.
     try:
         result = await mqtt_client.async_connect()
-    except ThinQAPIException as exc:
-        raise ConfigEntryNotReady(exc.message) from exc
-    except (AttributeError, TypeError, ValueError) as exc:
-        raise ConfigEntryNotReady("Failed to connect MQTT") from exc
+    except (AttributeError, ThinQAPIException, TypeError, ValueError) as exc:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="failed_to_connect_mqtt",
+            translation_placeholders={"error": str(exc)},
+        ) from exc
 
     if not result:
         _LOGGER.error("Failed to set up mqtt connection")

--- a/homeassistant/components/lg_thinq/mqtt.py
+++ b/homeassistant/components/lg_thinq/mqtt.py
@@ -43,18 +43,15 @@ class ThinQMQTT:
 
     async def async_connect(self) -> bool:
         """Create a mqtt client and then try to connect."""
-        try:
-            self.client = await ThinQMQTTClient(
-                self.thinq_api, self.client_id, self.on_message_received
-            )
-            if self.client is None:
-                return False
 
-            # Connect to server and create certificate.
-            return await self.client.async_prepare_mqtt()
-        except (ThinQAPIException, TypeError, ValueError):
-            _LOGGER.exception("Failed to connect")
+        self.client = await ThinQMQTTClient(
+            self.thinq_api, self.client_id, self.on_message_received
+        )
+        if self.client is None:
             return False
+
+        # Connect to server and create certificate.
+        return await self.client.async_prepare_mqtt()
 
     async def async_disconnect(self, event: Event | None = None) -> None:
         """Unregister client and disconnects handlers."""

--- a/homeassistant/components/lg_thinq/strings.json
+++ b/homeassistant/components/lg_thinq/strings.json
@@ -1023,5 +1023,10 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "failed_to_connect_mqtt": {
+      "message": "Failed to connect MQTT: {error}"
+    }
   }
 }

--- a/tests/components/lg_thinq/conftest.py
+++ b/tests/components/lg_thinq/conftest.py
@@ -68,7 +68,7 @@ def mock_uuid() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_thinq_api(mock_thinq_mqtt_client: AsyncMock) -> Generator[AsyncMock]:
+def mock_thinq_api() -> Generator[AsyncMock]:
     """Mock a thinq api."""
     with (
         patch("homeassistant.components.lg_thinq.ThinQApi", autospec=True) as mock_api,
@@ -91,12 +91,18 @@ def mock_thinq_api(mock_thinq_mqtt_client: AsyncMock) -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_thinq_mqtt_client() -> Generator[AsyncMock]:
+def mock_thinq_mqtt_client(mock_thinq_api: AsyncMock) -> Generator[AsyncMock]:
     """Mock a thinq api."""
-    with patch(
-        "homeassistant.components.lg_thinq.mqtt.ThinQMQTTClient", autospec=True
-    ) as mock_api:
-        yield mock_api
+    with (
+        patch("homeassistant.components.lg_thinq.ThinQMQTT", autospec=True) as mock_api,
+        patch(
+            "homeassistant.components.lg_thinq.ThinQMQTT",
+            new=mock_api,
+        ),
+    ):
+        mqtt_client = mock_api.return_value
+        mqtt_client.async_connect.return_value = True
+        yield mqtt_client
 
 
 @pytest.fixture

--- a/tests/components/lg_thinq/conftest.py
+++ b/tests/components/lg_thinq/conftest.py
@@ -95,10 +95,6 @@ def mock_thinq_mqtt_client(mock_thinq_api: AsyncMock) -> Generator[AsyncMock]:
     """Mock a thinq api."""
     with (
         patch("homeassistant.components.lg_thinq.ThinQMQTT", autospec=True) as mock_api,
-        patch(
-            "homeassistant.components.lg_thinq.ThinQMQTT",
-            new=mock_api,
-        ),
     ):
         mqtt_client = mock_api.return_value
         mqtt_client.async_connect.return_value = True

--- a/tests/components/lg_thinq/test_config_flow.py
+++ b/tests/components/lg_thinq/test_config_flow.py
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry
 
 async def test_config_flow(
     hass: HomeAssistant,
-    mock_thinq_api: AsyncMock,
+    mock_config_thinq_api: AsyncMock,
     mock_uuid: AsyncMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
@@ -37,11 +37,12 @@ async def test_config_flow(
         CONF_CONNECT_CLIENT_ID: MOCK_CONNECT_CLIENT_ID,
     }
 
-    mock_thinq_api.async_get_device_list.assert_called_once()
+    mock_config_thinq_api.async_get_device_list.assert_called_once()
 
 
 async def test_config_flow_invalid_pat(
-    hass: HomeAssistant, mock_invalid_thinq_api: AsyncMock
+    hass: HomeAssistant,
+    mock_invalid_thinq_api: AsyncMock,
 ) -> None:
     """Test that an thinq flow should be aborted with an invalid PAT."""
     result = await hass.config_entries.flow.async_init(
@@ -55,7 +56,9 @@ async def test_config_flow_invalid_pat(
 
 
 async def test_config_flow_already_configured(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_thinq_api: AsyncMock
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_config_thinq_api: AsyncMock,
 ) -> None:
     """Test that thinq flow should be aborted when already configured."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/lg_thinq/test_init.py
+++ b/tests/components/lg_thinq/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the LG ThinQ integration."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -14,11 +14,16 @@ from tests.common import MockConfigEntry
 
 async def test_load_unload_entry(
     hass: HomeAssistant,
+    mock_thinq_api: AsyncMock,
     mock_thinq_mqtt_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test load and unload entry."""
-    await setup_integration(hass, mock_config_entry)
+    with patch(
+        "homeassistant.components.lg_thinq.ThinQMQTT.async_connect",
+        return_value=True,
+    ):
+        await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
@@ -31,12 +36,16 @@ async def test_load_unload_entry(
 @pytest.mark.parametrize("exception", [AttributeError(), TypeError(), ValueError()])
 async def test_config_not_ready(
     hass: HomeAssistant,
+    mock_thinq_api: AsyncMock,
     mock_thinq_mqtt_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     exception: Exception,
 ) -> None:
     """Test for setup failure exception occurred."""
-    mock_thinq_mqtt_client.async_connect = AsyncMock(side_effect=exception)
-    await setup_integration(hass, mock_config_entry)
+    with patch(
+        "homeassistant.components.lg_thinq.ThinQMQTT.async_connect",
+        side_effect=exception,
+    ):
+        await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/lg_thinq/test_init.py
+++ b/tests/components/lg_thinq/test_init.py
@@ -10,7 +10,7 @@ from tests.common import MockConfigEntry
 
 async def test_load_unload_entry(
     hass: HomeAssistant,
-    mock_thinq_api: AsyncMock,
+    mock_thinq_mqtt_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test load and unload entry."""

--- a/tests/components/lg_thinq/test_init.py
+++ b/tests/components/lg_thinq/test_init.py
@@ -2,8 +2,12 @@
 
 from unittest.mock import AsyncMock
 
+import pytest
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+
+from . import setup_integration
 
 from tests.common import MockConfigEntry
 
@@ -14,9 +18,7 @@ async def test_load_unload_entry(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test load and unload entry."""
-    mock_config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
@@ -24,3 +26,17 @@ async def test_load_unload_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize("exception", [AttributeError(), TypeError(), ValueError()])
+async def test_config_not_ready(
+    hass: HomeAssistant,
+    mock_thinq_mqtt_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+) -> None:
+    """Test for setup failure exception occurred."""
+    mock_thinq_mqtt_client.async_connect = AsyncMock(side_effect=exception)
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- MQTT connection failure issue occurs when repeatedly testing enable and disable of Integration.
- Even if an exception occurs when fetching_data, API initialization is required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
