### PR TITLE
Fix Shelly diagnostics for devices without WebSocket Outbound support

### DIFF
--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -74,12 +74,14 @@ async def async_get_config_entry_diagnostics(
             device_settings = {
                 k: v for k, v in rpc_coordinator.device.config.items() if k in ["cloud"]
             }
-            ws_config = rpc_coordinator.device.config["ws"]
-            device_settings["ws_outbound_enabled"] = ws_config["enable"]
-            if ws_config["enable"]:
-                device_settings["ws_outbound_server_valid"] = bool(
-                    ws_config["server"] == get_rpc_ws_url(hass)
-                )
+            if not (ws_config := rpc_coordinator.device.config.get("ws", {})):
+                device_settings["ws_outbound"] = "not supported"
+            if (ws_outbound_enabled := ws_config.get("enable")) is not None:
+                device_settings["ws_outbound_enabled"] = ws_outbound_enabled
+                if ws_outbound_enabled:
+                    device_settings["ws_outbound_server_valid"] = bool(
+                        ws_config["server"] == get_rpc_ws_url(hass)
+                    )
             device_status = {
                 k: v
                 for k, v in rpc_coordinator.device.status.items()

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -194,3 +194,21 @@ async def test_rpc_config_entry_diagnostics_ws_outbound(
         result["device_settings"]["ws_outbound_server_valid"]
         == ws_outbound_server_valid
     )
+
+
+async def test_rpc_config_entry_diagnostics_no_ws(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test config entry diagnostics for rpc device which doesn't support ws outbound."""
+    config = deepcopy(mock_rpc_device.config)
+    config.pop("ws")
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    entry = await init_integration(hass, 2, sleep_period=60)
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+
+    assert result["device_settings"]["ws_outbound"] == "not supported"

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -207,7 +207,7 @@ async def test_rpc_config_entry_diagnostics_no_ws(
     config.pop("ws")
     monkeypatch.setattr(mock_rpc_device, "config", config)
 
-    entry = await init_integration(hass, 2, sleep_period=60)
+    entry = await init_integration(hass, 3)
 
     result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes Shelly diagnostics for devices without WebSocket Outbound support.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140471
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
