### PR TITLE
Add capability to display updated firmware versions in Home Assistant

### DIFF
--- a/homeassistant/components/iometer/coordinator.py
+++ b/homeassistant/components/iometer/coordinator.py
@@ -8,6 +8,7 @@ from iometer import IOmeterClient, IOmeterConnectionError, Reading, Status
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -31,6 +32,7 @@ class IOMeterCoordinator(DataUpdateCoordinator[IOmeterData]):
 
     config_entry: IOmeterConfigEntry
     client: IOmeterClient
+    _current_fw_version: str
 
     def __init__(
         self,
@@ -50,6 +52,13 @@ class IOMeterCoordinator(DataUpdateCoordinator[IOmeterData]):
         self.client = client
         self.identifier = config_entry.entry_id
 
+    async def _async_setup(self) -> None:
+        """Set up the device sw_version."""
+        status = await self.client.get_current_status()
+        self._current_fw_version = (
+            f"{status.device.core.version}/{status.device.bridge.version}"
+        )
+
     async def _async_update_data(self) -> IOmeterData:
         """Update data async."""
         try:
@@ -57,5 +66,19 @@ class IOMeterCoordinator(DataUpdateCoordinator[IOmeterData]):
             status = await self.client.get_current_status()
         except IOmeterConnectionError as error:
             raise UpdateFailed(f"Error communicating with IOmeter: {error}") from error
+
+        fw_version = f"{status.device.core.version}/{status.device.bridge.version}"
+
+        if fw_version != self._current_fw_version:
+            device_registry = dr.async_get(self.hass)
+            device_entry = device_registry.async_get_device(
+                identifiers={(DOMAIN, status.device.id)}
+            )
+            assert device_entry
+            device_registry.async_update_device(
+                device_entry.id,
+                sw_version=fw_version,
+            )
+            self._current_fw_version = fw_version
 
         return IOmeterData(reading=reading, status=status)

--- a/homeassistant/components/iometer/entity.py
+++ b/homeassistant/components/iometer/entity.py
@@ -20,5 +20,5 @@ class IOmeterEntity(CoordinatorEntity[IOMeterCoordinator]):
             identifiers={(DOMAIN, status.device.id)},
             manufacturer="IOmeter GmbH",
             model="IOmeter",
-            sw_version=f"{status.device.core.version}/{status.device.bridge.version}",
+            sw_version=coordinator.current_fw_version,
         )

--- a/tests/components/iometer/__init__.py
+++ b/tests/components/iometer/__init__.py
@@ -1,1 +1,13 @@
 """Tests for the IOmeter integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/iometer/test_init.py
+++ b/tests/components/iometer/test_init.py
@@ -1,0 +1,42 @@
+"""Tests for the AirGradient integration."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.iometer.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_new_firmware_version(
+    hass: HomeAssistant,
+    mock_iometer_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test device registry integration."""
+    await setup_integration(hass, mock_config_entry)
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    )
+    assert device_entry is not None
+    assert device_entry.sw_version == "build-58/build-65"
+    mock_iometer_client.get_current_status.return_value.device.core.version = "build-62"
+    mock_iometer_client.get_current_status.return_value.device.bridge.version = (
+        "build-69"
+    )
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    )
+    assert device_entry is not None
+    assert device_entry.sw_version == "build-62/build-69"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR improves the IOmeter integration with the capability to display new firmware versions. The firmware of the device is not updated by Home Assistant. This is just the capability to show the new firmware version that is published by the local HTTP endpoint.

This PR is inspired by the implementation of the airgradient integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
