### PR TITLE
Add start mowing and dock intents for lawn mower

### DIFF
--- a/homeassistant/components/lawn_mower/intent.py
+++ b/homeassistant/components/lawn_mower/intent.py
@@ -1,0 +1,35 @@
+"""Intents for the lawn mower integration."""
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from . import DOMAIN, SERVICE_DOCK, SERVICE_START_MOWING
+
+INTENT_LANW_MOWER_START_MOWING = "HassLawnMowerStartMowing"
+INTENT_LANW_MOWER_DOCK = "HassLawnMowerDock"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the lawn mower intents."""
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_LANW_MOWER_START_MOWING,
+            DOMAIN,
+            SERVICE_START_MOWING,
+            description="Starts a lawn mower",
+            required_domains={DOMAIN},
+            platforms={DOMAIN},
+        ),
+    )
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_LANW_MOWER_DOCK,
+            DOMAIN,
+            SERVICE_DOCK,
+            description="Sends a lawn mower to dock",
+            required_domains={DOMAIN},
+            platforms={DOMAIN},
+        ),
+    )

--- a/tests/components/lawn_mower/test_intent.py
+++ b/tests/components/lawn_mower/test_intent.py
@@ -1,0 +1,103 @@
+"""The tests for the lawn mower platform."""
+
+from homeassistant.components.lawn_mower import (
+    DOMAIN,
+    SERVICE_DOCK,
+    SERVICE_START_MOWING,
+    LawnMowerActivity,
+    intent as lawn_mower_intent,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from tests.common import async_mock_service
+
+
+async def test_start_lawn_mower_intent(hass: HomeAssistant) -> None:
+    """Test HassLawnMowerStartMowing intent for lawn mowers."""
+    await lawn_mower_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_lawn_mower"
+    hass.states.async_set(entity_id, LawnMowerActivity.DOCKED)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_START_MOWING)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        lawn_mower_intent.INTENT_LANW_MOWER_START_MOWING,
+        {"name": {"value": "test lawn mower"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_START_MOWING
+    assert call.data == {"entity_id": entity_id}
+
+
+async def test_start_lawn_mower_without_name(hass: HomeAssistant) -> None:
+    """Test starting a lawn mower without specifying the name."""
+    await lawn_mower_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_lawn_mower"
+    hass.states.async_set(entity_id, LawnMowerActivity.DOCKED)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_START_MOWING)
+
+    response = await intent.async_handle(
+        hass, "test", lawn_mower_intent.INTENT_LANW_MOWER_START_MOWING, {}
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_START_MOWING
+    assert call.data == {"entity_id": entity_id}
+
+
+async def test_stop_lawn_mower_intent(hass: HomeAssistant) -> None:
+    """Test HassLawnMowerDock intent for lawn mowers."""
+    await lawn_mower_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_lawn_mower"
+    hass.states.async_set(entity_id, LawnMowerActivity.MOWING)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_DOCK)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        lawn_mower_intent.INTENT_LANW_MOWER_DOCK,
+        {"name": {"value": "test lawn mower"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_DOCK
+    assert call.data == {"entity_id": entity_id}
+
+
+async def test_stop_lawn_mower_without_name(hass: HomeAssistant) -> None:
+    """Test stopping a lawn mower without specifying the name."""
+    await lawn_mower_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_lawn_mower"
+    hass.states.async_set(entity_id, LawnMowerActivity.MOWING)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_DOCK)
+
+    response = await intent.async_handle(
+        hass, "test", lawn_mower_intent.INTENT_LANW_MOWER_DOCK, {}
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_DOCK
+    assert call.data == {"entity_id": entity_id}


### PR DESCRIPTION
## Proposed change

Add start and docker intents for lawn mower. Supported feature are the same as the vacuum domain.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
