### PR TITLE
Convert inline constants to const/Finally

### DIFF
--- a/homeassistant/components/purpleair/__init__.py
+++ b/homeassistant/components/purpleair/__init__.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Final
+
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import PLATFORMS
 from .coordinator import PurpleAirConfigEntry, PurpleAirDataUpdateCoordinator
+
+PLATFORMS: Final[list[str]] = [Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PurpleAirConfigEntry) -> bool:

--- a/homeassistant/components/purpleair/const.py
+++ b/homeassistant/components/purpleair/const.py
@@ -3,11 +3,33 @@
 import logging
 from typing import Final
 
-from homeassistant.const import Platform
-
 LOGGER: Final = logging.getLogger(__package__)
-PLATFORMS: Final = [Platform.SENSOR]
-
 DOMAIN: Final[str] = "purpleair"
 
 CONF_SENSOR_INDICES: Final[str] = "sensor_indices"
+
+SENSOR_FIELDS_TO_RETRIEVE: Final[list[str]] = [
+    "0.3_um_count",
+    "0.5_um_count",
+    "1.0_um_count",
+    "10.0_um_count",
+    "2.5_um_count",
+    "5.0_um_count",
+    "altitude",
+    "firmware_version",
+    "hardware",
+    "humidity",
+    "latitude",
+    "location_type",
+    "longitude",
+    "model",
+    "name",
+    "pm1.0",
+    "pm10.0",
+    "pm2.5",
+    "pressure",
+    "rssi",
+    "temperature",
+    "uptime",
+    "voc",
+]

--- a/homeassistant/components/purpleair/coordinator.py
+++ b/homeassistant/components/purpleair/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Final
 
 from aiopurpleair import API
 from aiopurpleair.errors import InvalidApiKeyError, PurpleAirError
@@ -15,35 +16,9 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_SENSOR_INDICES, LOGGER
+from .const import CONF_SENSOR_INDICES, LOGGER, SENSOR_FIELDS_TO_RETRIEVE
 
-SENSOR_FIELDS_TO_RETRIEVE = [
-    "0.3_um_count",
-    "0.5_um_count",
-    "1.0_um_count",
-    "10.0_um_count",
-    "2.5_um_count",
-    "5.0_um_count",
-    "altitude",
-    "firmware_version",
-    "hardware",
-    "humidity",
-    "latitude",
-    "location_type",
-    "longitude",
-    "model",
-    "name",
-    "pm1.0",
-    "pm10.0",
-    "pm2.5",
-    "pressure",
-    "rssi",
-    "temperature",
-    "uptime",
-    "voc",
-]
-
-UPDATE_INTERVAL = timedelta(minutes=2)
+UPDATE_INTERVAL: Final[timedelta] = timedelta(minutes=2)
 
 
 type PurpleAirConfigEntry = ConfigEntry[PurpleAirDataUpdateCoordinator]

--- a/homeassistant/components/purpleair/diagnostics.py
+++ b/homeassistant/components/purpleair/diagnostics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import (
@@ -15,7 +15,9 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import PurpleAirConfigEntry
 
-CONF_TITLE = "title"
+CONF_DATA: Final[str] = "data"
+CONF_ENTRY: Final[str] = "entry"
+CONF_TITLE: Final[str] = "title"
 
 TO_REDACT = {
     CONF_API_KEY,
@@ -33,8 +35,8 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     return async_redact_data(
         {
-            "entry": entry.as_dict(),
-            "data": entry.runtime_data.data.model_dump(),
+            CONF_ENTRY: entry.as_dict(),
+            CONF_DATA: entry.runtime_data.data.model_dump(),
         },
         TO_REDACT,
     )

--- a/homeassistant/components/purpleair/entity.py
+++ b/homeassistant/components/purpleair/entity.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Final
 
 from aiopurpleair.models.sensors import SensorModel
 
@@ -13,6 +13,11 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import PurpleAirConfigEntry, PurpleAirDataUpdateCoordinator
+
+MANUFACTURER: Final[str] = "PurpleAir, Inc."
+
+CONF_LATI: Final[str] = "lati"
+CONF_LONG: Final[str] = "long"
 
 
 class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
@@ -34,7 +39,7 @@ class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
             configuration_url=self.coordinator.async_get_map_url(sensor_index),
             hw_version=self.sensor_data.hardware,
             identifiers={(DOMAIN, str(sensor_index))},
-            manufacturer="PurpleAir, Inc.",
+            manufacturer=MANUFACTURER,
             model=self.sensor_data.model,
             name=self.sensor_data.name,
             sw_version=self.sensor_data.firmware_version,
@@ -54,8 +59,8 @@ class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
             attrs[ATTR_LATITUDE] = self.sensor_data.latitude
             attrs[ATTR_LONGITUDE] = self.sensor_data.longitude
         else:
-            attrs["lati"] = self.sensor_data.latitude
-            attrs["long"] = self.sensor_data.longitude
+            attrs[CONF_LATI] = self.sensor_data.latitude
+            attrs[CONF_LONG] = self.sensor_data.longitude
         return attrs
 
     @property

--- a/homeassistant/components/purpleair/sensor.py
+++ b/homeassistant/components/purpleair/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Final
 
 from aiopurpleair.models.sensors import SensorModel
 
@@ -30,7 +31,9 @@ from .const import CONF_SENSOR_INDICES
 from .coordinator import PurpleAirConfigEntry
 from .entity import PurpleAirEntity
 
-CONCENTRATION_PARTICLES_PER_100_MILLILITERS = f"particles/100{UnitOfVolume.MILLILITERS}"
+CONCENTRATION_PARTICLES_PER_100_MILLILITERS: Final[str] = (
+    f"particles/100{UnitOfVolume.MILLILITERS}"
+)
 
 
 @dataclass(frozen=True, kw_only=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Converting inline literal strings and inline constants to scoped contants using `Final[type]`.  
Scoping is determined as file local if only used in that file, or in `.const` if used across files.  
Note that in some cases it may seem silly to convert single use literals in a file to consts, but future changes that break out functionality across files will move some of these local scoped consts to shared scope.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
