### PR TITLE
2025.3.3

### DIFF
--- a/homeassistant/components/bluesound/config_flow.py
+++ b/homeassistant/components/bluesound/config_flow.py
@@ -75,6 +75,9 @@ class BluesoundConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle a flow initialized by zeroconf discovery."""
+        # the player can have an ipv6 address, but the api is only available on ipv4
+        if discovery_info.ip_address.version != 4:
+            return self.async_abort(reason="no_ipv4_address")
         if discovery_info.port is not None:
             self._port = discovery_info.port
 

--- a/homeassistant/components/bluesound/strings.json
+++ b/homeassistant/components/bluesound/strings.json
@@ -19,7 +19,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "no_ipv4_address": "No IPv4 address found."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -11,7 +11,7 @@
   "loggers": ["xknx", "xknxproject"],
   "requirements": [
     "xknx==3.6.0",
-    "xknxproject==3.8.1",
+    "xknxproject==3.8.2",
     "knx-frontend==2025.1.30.194235"
   ],
   "single_config_entry": true

--- a/homeassistant/components/number/const.py
+++ b/homeassistant/components/number/const.py
@@ -486,6 +486,7 @@ DEVICE_CLASS_UNITS: dict[NumberDeviceClass, set[type[StrEnum] | str | None]] = {
     NumberDeviceClass.PM25: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
     NumberDeviceClass.POWER_FACTOR: {PERCENTAGE, None},
     NumberDeviceClass.POWER: {
+        UnitOfPower.MILLIWATT,
         UnitOfPower.WATT,
         UnitOfPower.KILO_WATT,
         UnitOfPower.MEGA_WATT,

--- a/homeassistant/components/number/services.yaml
+++ b/homeassistant/components/number/services.yaml
@@ -7,5 +7,6 @@ set_value:
   fields:
     value:
       example: 42
+      required: true
       selector:
         text:

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -112,19 +112,6 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         """Return if this map is the currently selected map."""
         return self.map_flag == self.coordinator.current_map
 
-    def is_map_valid(self) -> bool:
-        """Update the map if it is valid.
-
-        Update this map if it is the currently active map, and the
-        vacuum is cleaning, or if it has never been set at all.
-        """
-        return self.cached_map == b"" or (
-            self.is_selected
-            and self.image_last_updated is not None
-            and self.coordinator.roborock_device_info.props.status is not None
-            and bool(self.coordinator.roborock_device_info.props.status.in_cleaning)
-        )
-
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass load any previously cached maps from disk."""
         await super().async_added_to_hass()
@@ -137,15 +124,22 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         # Bump last updated every third time the coordinator runs, so that async_image
         # will be called and we will evaluate on the new coordinator data if we should
         # update the cache.
-        if (
-            dt_util.utcnow() - self.image_last_updated
-        ).total_seconds() > IMAGE_CACHE_INTERVAL and self.is_map_valid():
+        if self.is_selected and (
+            (
+                (dt_util.utcnow() - self.image_last_updated).total_seconds()
+                > IMAGE_CACHE_INTERVAL
+                and self.coordinator.roborock_device_info.props.status is not None
+                and bool(self.coordinator.roborock_device_info.props.status.in_cleaning)
+            )
+            or self.cached_map == b""
+        ):
+            # This will tell async_image it should update.
             self._attr_image_last_updated = dt_util.utcnow()
         super()._handle_coordinator_update()
 
     async def async_image(self) -> bytes | None:
         """Update the image if it is not cached."""
-        if self.is_map_valid():
+        if self.is_selected:
             response = await asyncio.gather(
                 *(
                     self.cloud_api.get_map_v1(),

--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -582,6 +582,7 @@ DEVICE_CLASS_UNITS: dict[SensorDeviceClass, set[type[StrEnum] | str | None]] = {
     SensorDeviceClass.PM25: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
     SensorDeviceClass.POWER_FACTOR: {PERCENTAGE, None},
     SensorDeviceClass.POWER: {
+        UnitOfPower.MILLIWATT,
         UnitOfPower.WATT,
         UnitOfPower.KILO_WATT,
         UnitOfPower.MEGA_WATT,

--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -74,12 +74,14 @@ async def async_get_config_entry_diagnostics(
             device_settings = {
                 k: v for k, v in rpc_coordinator.device.config.items() if k in ["cloud"]
             }
-            ws_config = rpc_coordinator.device.config["ws"]
-            device_settings["ws_outbound_enabled"] = ws_config["enable"]
-            if ws_config["enable"]:
-                device_settings["ws_outbound_server_valid"] = bool(
-                    ws_config["server"] == get_rpc_ws_url(hass)
-                )
+            if not (ws_config := rpc_coordinator.device.config.get("ws", {})):
+                device_settings["ws_outbound"] = "not supported"
+            if (ws_outbound_enabled := ws_config.get("enable")) is not None:
+                device_settings["ws_outbound_enabled"] = ws_outbound_enabled
+                if ws_outbound_enabled:
+                    device_settings["ws_outbound_server_valid"] = bool(
+                        ws_config["server"] == get_rpc_ws_url(hass)
+                    )
             device_status = {
                 k: v
                 for k, v in rpc_coordinator.device.status.items()

--- a/homeassistant/components/smartthings/cover.py
+++ b/homeassistant/components/smartthings/cover.py
@@ -118,6 +118,10 @@ class SmartThingsCover(SmartThingsEntity, CoverEntity):
             self._attr_current_cover_position = self.get_attribute_value(
                 Capability.SWITCH_LEVEL, Attribute.LEVEL
             )
+        elif self.supports_capability(Capability.WINDOW_SHADE_LEVEL):
+            self._attr_current_cover_position = self.get_attribute_value(
+                Capability.WINDOW_SHADE_LEVEL, Attribute.SHADE_LEVEL
+            )
 
         self._attr_extra_state_attributes = {}
         if self.supports_capability(Capability.BATTERY):

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -572,6 +572,9 @@ CAPABILITY_TO_SENSORS: dict[
             SmartThingsSensorEntityDescription(
                 key=Attribute.OVEN_SETPOINT,
                 translation_key="oven_setpoint",
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+                value_fn=lambda value: value if value != 0 else None,
             )
         ]
     },

--- a/homeassistant/components/suez_water/coordinator.py
+++ b/homeassistant/components/suez_water/coordinator.py
@@ -20,8 +20,8 @@ class SuezWaterAggregatedAttributes:
 
     this_month_consumption: dict[str, float]
     previous_month_consumption: dict[str, float]
-    last_year_overall: dict[str, float]
-    this_year_overall: dict[str, float]
+    last_year_overall: int
+    this_year_overall: int
     history: dict[str, float]
     highest_monthly_consumption: float
 

--- a/homeassistant/components/suez_water/manifest.json
+++ b/homeassistant/components/suez_water/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["pysuez", "regex"],
   "quality_scale": "bronze",
-  "requirements": ["pysuezV2==2.0.3"]
+  "requirements": ["pysuezV2==2.0.4"]
 }

--- a/homeassistant/components/tesla_fleet/manifest.json
+++ b/homeassistant/components/tesla_fleet/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tesla_fleet",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==0.9.12"]
+  "requirements": ["tesla-fleet-api==0.9.13"]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/teslemetry",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==0.9.12", "teslemetry-stream==0.6.12"]
+  "requirements": ["tesla-fleet-api==0.9.13", "teslemetry-stream==0.6.12"]
 }

--- a/homeassistant/components/tessie/manifest.json
+++ b/homeassistant/components/tessie/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tessie",
   "iot_class": "cloud_polling",
   "loggers": ["tessie", "tesla-fleet-api"],
-  "requirements": ["tessie-api==0.1.1", "tesla-fleet-api==0.9.12"]
+  "requirements": ["tessie-api==0.1.1", "tesla-fleet-api==0.9.13"]
 }

--- a/homeassistant/components/upb/manifest.json
+++ b/homeassistant/components/upb/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/upb",
   "iot_class": "local_push",
   "loggers": ["upb_lib"],
-  "requirements": ["upb-lib==0.6.0"]
+  "requirements": ["upb-lib==0.6.1"]
 }

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -14,7 +14,7 @@
     "velbus-protocol"
   ],
   "quality_scale": "bronze",
-  "requirements": ["velbus-aio==2025.3.0"],
+  "requirements": ["velbus-aio==2025.3.1"],
   "usb": [
     {
       "vid": "10CF",

--- a/homeassistant/components/webdav/helpers.py
+++ b/homeassistant/components/webdav/helpers.py
@@ -49,7 +49,8 @@ async def async_ensure_path_exists(client: Client, path: str) -> bool:
 async def async_migrate_wrong_folder_path(client: Client, path: str) -> None:
     """Migrate the wrong encoded folder path to the correct one."""
     wrong_path = path.replace(" ", "%20")
-    if await client.check(wrong_path):
+    # migrate folder when the old folder exists
+    if wrong_path != path and await client.check(wrong_path):
         try:
             await client.move(wrong_path, path)
         except WebDavError as err:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2025
 MINOR_VERSION: Final = 3
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2025.3.2"
+version     = "2025.3.3"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2872,7 +2872,7 @@ temperusb==1.6.1
 # homeassistant.components.tesla_fleet
 # homeassistant.components.teslemetry
 # homeassistant.components.tessie
-tesla-fleet-api==0.9.12
+tesla-fleet-api==0.9.13
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2346,7 +2346,7 @@ pysqueezebox==0.12.0
 pystiebeleltron==0.0.1.dev2
 
 # homeassistant.components.suez_water
-pysuezV2==2.0.3
+pysuezV2==2.0.4
 
 # homeassistant.components.switchbee
 pyswitchbee==1.8.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3000,7 +3000,7 @@ vallox-websocket-api==5.3.0
 vehicle==2.2.2
 
 # homeassistant.components.velbus
-velbus-aio==2025.3.0
+velbus-aio==2025.3.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.19

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3091,7 +3091,7 @@ xiaomi-ble==0.33.0
 xknx==3.6.0
 
 # homeassistant.components.knx
-xknxproject==3.8.1
+xknxproject==3.8.2
 
 # homeassistant.components.fritz
 # homeassistant.components.rest

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2977,7 +2977,7 @@ unifiled==0.11
 universal-silabs-flasher==0.0.29
 
 # homeassistant.components.upb
-upb-lib==0.6.0
+upb-lib==0.6.1
 
 # homeassistant.components.upcloud
 upcloud-api==2.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2312,7 +2312,7 @@ temperusb==1.6.1
 # homeassistant.components.tesla_fleet
 # homeassistant.components.teslemetry
 # homeassistant.components.tessie
-tesla-fleet-api==0.9.12
+tesla-fleet-api==0.9.13
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1915,7 +1915,7 @@ pyspeex-noise==1.0.2
 pysqueezebox==0.12.0
 
 # homeassistant.components.suez_water
-pysuezV2==2.0.3
+pysuezV2==2.0.4
 
 # homeassistant.components.switchbee
 pyswitchbee==1.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2393,7 +2393,7 @@ ultraheat-api==0.5.7
 unifi-discovery==1.2.0
 
 # homeassistant.components.upb
-upb-lib==0.6.0
+upb-lib==0.6.1
 
 # homeassistant.components.upcloud
 upcloud-api==2.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2492,7 +2492,7 @@ xiaomi-ble==0.33.0
 xknx==3.6.0
 
 # homeassistant.components.knx
-xknxproject==3.8.1
+xknxproject==3.8.2
 
 # homeassistant.components.fritz
 # homeassistant.components.rest

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2416,7 +2416,7 @@ vallox-websocket-api==5.3.0
 vehicle==2.2.2
 
 # homeassistant.components.velbus
-velbus-aio==2025.3.0
+velbus-aio==2025.3.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.19

--- a/tests/components/bluesound/test_config_flow.py
+++ b/tests/components/bluesound/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Bluesound config flow."""
 
+from ipaddress import IPv4Address, IPv6Address
 from unittest.mock import AsyncMock
 
 from pyblu.errors import PlayerUnreachableError
@@ -121,8 +122,8 @@ async def test_zeroconf_flow_success(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=ZeroconfServiceInfo(
-            ip_address="1.1.1.1",
-            ip_addresses=["1.1.1.1"],
+            ip_address=IPv4Address("1.1.1.1"),
+            ip_addresses=[IPv4Address("1.1.1.1")],
             port=11000,
             hostname="player-name1111",
             type="_musc._tcp.local.",
@@ -160,8 +161,8 @@ async def test_zeroconf_flow_cannot_connect(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=ZeroconfServiceInfo(
-            ip_address="1.1.1.1",
-            ip_addresses=["1.1.1.1"],
+            ip_address=IPv4Address("1.1.1.1"),
+            ip_addresses=[IPv4Address("1.1.1.1")],
             port=11000,
             hostname="player-name1111",
             type="_musc._tcp.local.",
@@ -187,8 +188,8 @@ async def test_zeroconf_flow_already_configured(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=ZeroconfServiceInfo(
-            ip_address="1.1.1.2",
-            ip_addresses=["1.1.1.2"],
+            ip_address=IPv4Address("1.1.1.2"),
+            ip_addresses=[IPv4Address("1.1.1.2")],
             port=11000,
             hostname="player-name1112",
             type="_musc._tcp.local.",
@@ -203,3 +204,23 @@ async def test_zeroconf_flow_already_configured(
     assert config_entry.data[CONF_HOST] == "1.1.1.2"
 
     player_mocks.player_data_for_already_configured.player.sync_status.assert_called_once()
+
+
+async def test_zeroconf_flow_no_ipv4_address(hass: HomeAssistant) -> None:
+    """Test abort flow when no ipv4 address is found in zeroconf data."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZeroconfServiceInfo(
+            ip_address=IPv6Address("2001:db8::1"),
+            ip_addresses=[IPv6Address("2001:db8::1")],
+            port=11000,
+            hostname="player-name1112",
+            type="_musc._tcp.local.",
+            name="player-name._musc._tcp.local.",
+            properties={},
+        ),
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_ipv4_address"

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -194,3 +194,21 @@ async def test_rpc_config_entry_diagnostics_ws_outbound(
         result["device_settings"]["ws_outbound_server_valid"]
         == ws_outbound_server_valid
     )
+
+
+async def test_rpc_config_entry_diagnostics_no_ws(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test config entry diagnostics for rpc device which doesn't support ws outbound."""
+    config = deepcopy(mock_rpc_device.config)
+    config.pop("ws")
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    entry = await init_integration(hass, 3)
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+
+    assert result["device_settings"]["ws_outbound"] == "not supported"

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -109,6 +109,7 @@ def mock_smartthings() -> Generator[AsyncMock]:
         "da_wm_wm_000001_1",
         "da_rvc_normal_000001",
         "da_ks_microwave_0101x",
+        "da_ks_range_0101x",
         "hue_color_temperature_bulb",
         "hue_rgbw_color_bulb",
         "c2c_shade",

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -129,6 +129,7 @@ def mock_smartthings() -> Generator[AsyncMock]:
         "im_speaker_ai_0001",
         "abl_light_b_001",
         "tplink_p110",
+        "ikea_kadrilj",
     ]
 )
 def device_fixture(

--- a/tests/components/smartthings/fixtures/device_status/da_ks_range_0101x.json
+++ b/tests/components/smartthings/fixtures/device_status/da_ks_range_0101x.json
@@ -1,0 +1,688 @@
+{
+  "components": {
+    "cavity-01": {
+      "ovenSetpoint": {
+        "ovenSetpointRange": {
+          "value": null
+        },
+        "ovenSetpoint": {
+          "value": 0,
+          "timestamp": "2022-02-21T22:37:06.976Z"
+        }
+      },
+      "custom.disabledCapabilities": {
+        "disabledCapabilities": {
+          "value": [],
+          "timestamp": "2022-09-07T22:35:34.197Z"
+        }
+      },
+      "temperatureMeasurement": {
+        "temperatureRange": {
+          "value": null
+        },
+        "temperature": {
+          "value": 175,
+          "unit": "F",
+          "timestamp": "2022-02-21T22:37:06.976Z"
+        }
+      },
+      "samsungce.ovenOperatingState": {
+        "completionTime": {
+          "value": "2024-05-14T19:00:04.579Z",
+          "timestamp": "2024-05-14T19:00:04.584Z"
+        },
+        "operatingState": {
+          "value": "ready",
+          "timestamp": "2022-02-21T22:37:05.415Z"
+        },
+        "progress": {
+          "value": 1,
+          "timestamp": "2022-02-21T22:37:05.415Z"
+        },
+        "ovenJobState": {
+          "value": "ready",
+          "timestamp": "2022-02-21T22:37:05.415Z"
+        },
+        "operationTime": {
+          "value": "00:00:00",
+          "timestamp": "2022-02-21T22:37:05.415Z"
+        }
+      },
+      "samsungce.kitchenDeviceDefaults": {
+        "defaultOperationTime": {
+          "value": null
+        },
+        "defaultOvenMode": {
+          "value": "ConvectionBake",
+          "timestamp": "2022-02-21T22:37:06.983Z"
+        },
+        "defaultOvenSetpoint": {
+          "value": 350,
+          "timestamp": "2022-02-21T22:37:06.976Z"
+        }
+      },
+      "custom.ovenCavityStatus": {
+        "ovenCavityStatus": {
+          "value": "off",
+          "timestamp": "2025-03-12T20:38:01.259Z"
+        }
+      },
+      "ovenMode": {
+        "supportedOvenModes": {
+          "value": ["Others"],
+          "timestamp": "2022-02-21T22:37:08.409Z"
+        },
+        "ovenMode": {
+          "value": "Others",
+          "timestamp": "2022-02-21T22:37:06.983Z"
+        }
+      },
+      "ovenOperatingState": {
+        "completionTime": {
+          "value": "2024-05-14T19:00:04.579Z",
+          "timestamp": "2024-05-14T19:00:04.584Z"
+        },
+        "machineState": {
+          "value": "ready",
+          "timestamp": "2022-02-21T22:37:05.415Z"
+        },
+        "progress": {
+          "value": 1,
+          "unit": "%",
+          "timestamp": "2022-02-21T22:37:05.415Z"
+        },
+        "supportedMachineStates": {
+          "value": null
+        },
+        "ovenJobState": {
+          "value": "ready",
+          "timestamp": "2022-02-21T22:37:05.415Z"
+        },
+        "operationTime": {
+          "value": 0,
+          "timestamp": "2022-02-21T22:37:05.415Z"
+        }
+      },
+      "samsungce.ovenMode": {
+        "supportedOvenModes": {
+          "value": ["SelfClean", "SteamClean", "NoOperation"],
+          "timestamp": "2022-02-21T22:37:08.409Z"
+        },
+        "ovenMode": {
+          "value": "NoOperation",
+          "timestamp": "2022-02-21T22:37:06.983Z"
+        }
+      }
+    },
+    "main": {
+      "ovenSetpoint": {
+        "ovenSetpointRange": {
+          "value": null
+        },
+        "ovenSetpoint": {
+          "value": 425,
+          "timestamp": "2025-03-13T21:42:23.492Z"
+        }
+      },
+      "samsungce.meatProbe": {
+        "temperatureSetpoint": {
+          "value": 0,
+          "unit": "F",
+          "timestamp": "2022-02-21T22:37:02.619Z"
+        },
+        "temperature": {
+          "value": 0,
+          "unit": "F",
+          "timestamp": "2022-02-21T22:37:02.619Z"
+        },
+        "status": {
+          "value": "disconnected",
+          "timestamp": "2022-02-21T22:37:02.679Z"
+        }
+      },
+      "refresh": {},
+      "samsungce.doorState": {
+        "doorState": {
+          "value": "closed",
+          "timestamp": "2025-03-12T20:38:01.255Z"
+        }
+      },
+      "samsungce.kitchenDeviceDefaults": {
+        "defaultOperationTime": {
+          "value": 3600,
+          "timestamp": "2025-03-13T21:23:24.771Z"
+        },
+        "defaultOvenMode": {
+          "value": "ConvectionBake",
+          "timestamp": "2025-03-13T21:23:27.659Z"
+        },
+        "defaultOvenSetpoint": {
+          "value": 350,
+          "timestamp": "2025-03-13T21:23:27.596Z"
+        }
+      },
+      "execute": {
+        "data": {
+          "value": {
+            "payload": {
+              "rt": ["x.com.samsung.da.information"],
+              "if": ["oic.if.baseline", "oic.if.a"],
+              "x.com.samsung.da.modelNum": "TP1X_DA-KS-RANGE-0101X|40445041|5001011E03151101020000000000000",
+              "x.com.samsung.da.description": "TP1X_DA-KS-OVEN-01011",
+              "x.com.samsung.da.serialNum": "0J4D7DARB03393K",
+              "x.com.samsung.da.otnDUID": "ZPCNQWBWXI47Q",
+              "x.com.samsung.da.items": [
+                {
+                  "x.com.samsung.da.id": "0",
+                  "x.com.samsung.da.description": "Version",
+                  "x.com.samsung.da.type": "Software",
+                  "x.com.samsung.da.number": "02144A221005",
+                  "x.com.samsung.da.newVersionAvailable": "0"
+                },
+                {
+                  "x.com.samsung.da.id": "1",
+                  "x.com.samsung.da.description": "Version",
+                  "x.com.samsung.da.type": "Firmware",
+                  "x.com.samsung.da.number": "20121600,FFFFFFFF",
+                  "x.com.samsung.da.newVersionAvailable": "0"
+                }
+              ]
+            }
+          },
+          "data": {
+            "href": "/information/vs/0"
+          },
+          "timestamp": "2023-11-28T22:49:09.333Z"
+        }
+      },
+      "samsungce.deviceIdentification": {
+        "micomAssayCode": {
+          "value": null
+        },
+        "modelName": {
+          "value": null
+        },
+        "serialNumber": {
+          "value": null
+        },
+        "serialNumberExtra": {
+          "value": null
+        },
+        "modelClassificationCode": {
+          "value": null
+        },
+        "description": {
+          "value": null
+        },
+        "releaseYear": {
+          "value": null
+        },
+        "binaryId": {
+          "value": "TP1X_DA-KS-RANGE-0101X",
+          "timestamp": "2025-03-12T20:40:29.034Z"
+        }
+      },
+      "ocf": {
+        "st": {
+          "value": null
+        },
+        "mndt": {
+          "value": null
+        },
+        "mnfv": {
+          "value": "AKS-WW-TP1-20-OVEN-3-CR_40240205",
+          "timestamp": "2024-05-14T19:00:26.132Z"
+        },
+        "mnhw": {
+          "value": "Realtek",
+          "timestamp": "2024-05-14T19:00:26.132Z"
+        },
+        "di": {
+          "value": "2c3cbaa0-1899-5ddc-7b58-9d657bd48f18",
+          "timestamp": "2022-02-21T22:37:02.282Z"
+        },
+        "mnsl": {
+          "value": "http://www.samsung.com",
+          "timestamp": "2022-02-21T22:37:02.282Z"
+        },
+        "dmv": {
+          "value": "1.2.1",
+          "timestamp": "2022-12-19T22:33:09.710Z"
+        },
+        "n": {
+          "value": "Samsung Range",
+          "timestamp": "2024-05-14T19:00:26.132Z"
+        },
+        "mnmo": {
+          "value": "TP1X_DA-KS-RANGE-0101X|40445041|5001011E031511010200000000000000",
+          "timestamp": "2024-05-14T19:00:26.132Z"
+        },
+        "vid": {
+          "value": "DA-KS-RANGE-0101X",
+          "timestamp": "2022-02-21T22:37:02.282Z"
+        },
+        "mnmn": {
+          "value": "Samsung Electronics",
+          "timestamp": "2022-02-21T22:37:02.282Z"
+        },
+        "mnml": {
+          "value": "http://www.samsung.com",
+          "timestamp": "2022-02-21T22:37:02.282Z"
+        },
+        "mnpv": {
+          "value": "DAWIT 3.0",
+          "timestamp": "2024-05-14T19:00:26.132Z"
+        },
+        "mnos": {
+          "value": "TizenRT 3.1",
+          "timestamp": "2024-05-14T19:00:26.132Z"
+        },
+        "pi": {
+          "value": "2c3cbaa0-1899-5ddc-7b58-9d657bd48f18",
+          "timestamp": "2022-02-21T22:37:02.282Z"
+        },
+        "icv": {
+          "value": "core.1.1.0",
+          "timestamp": "2022-02-21T22:37:02.282Z"
+        }
+      },
+      "remoteControlStatus": {
+        "remoteControlEnabled": {
+          "value": "true",
+          "timestamp": "2025-03-13T21:42:23.615Z"
+        }
+      },
+      "samsungce.customRecipe": {},
+      "samsungce.kitchenDeviceIdentification": {
+        "regionCode": {
+          "value": "US",
+          "timestamp": "2025-03-13T21:23:27.659Z"
+        },
+        "modelCode": {
+          "value": "NE6516A-/AA0",
+          "timestamp": "2025-03-13T21:23:27.659Z"
+        },
+        "fuel": {
+          "value": null
+        },
+        "type": {
+          "value": "range",
+          "timestamp": "2022-02-21T22:37:02.487Z"
+        },
+        "representativeComponent": {
+          "value": null
+        }
+      },
+      "samsungce.kitchenModeSpecification": {
+        "specification": {
+          "value": {
+            "single": [
+              {
+                "mode": "Bake",
+                "supportedOperations": ["start", "set"],
+                "supportedOptions": {
+                  "temperature": {
+                    "C": {
+                      "min": 80,
+                      "max": 285,
+                      "default": 175,
+                      "resolution": 0
+                    },
+                    "F": {
+                      "min": 175,
+                      "max": 550,
+                      "default": 350,
+                      "resolution": 0
+                    }
+                  },
+                  "operationTime": {
+                    "min": "00:01:00",
+                    "max": "09:59:00",
+                    "default": "01:00:00",
+                    "resolution": "00:01:00"
+                  }
+                }
+              },
+              {
+                "mode": "Broil",
+                "supportedOperations": ["set"],
+                "supportedOptions": {
+                  "temperature": {
+                    "C": {
+                      "min": 61441,
+                      "max": 61442,
+                      "default": 61441,
+                      "supportedValues": [61441, 61442]
+                    },
+                    "F": {
+                      "min": 61441,
+                      "max": 61442,
+                      "default": 61441,
+                      "supportedValues": [61441, 61442]
+                    }
+                  }
+                }
+              },
+              {
+                "mode": "ConvectionBake",
+                "supportedOperations": ["start", "set"],
+                "supportedOptions": {
+                  "temperature": {
+                    "C": {
+                      "min": 80,
+                      "max": 285,
+                      "default": 160,
+                      "resolution": 0
+                    },
+                    "F": {
+                      "min": 175,
+                      "max": 550,
+                      "default": 325,
+                      "resolution": 0
+                    }
+                  },
+                  "operationTime": {
+                    "min": "00:01:00",
+                    "max": "09:59:00",
+                    "default": "01:00:00",
+                    "resolution": "00:01:00"
+                  }
+                }
+              },
+              {
+                "mode": "ConvectionRoast",
+                "supportedOperations": ["start", "set"],
+                "supportedOptions": {
+                  "temperature": {
+                    "C": {
+                      "min": 80,
+                      "max": 285,
+                      "default": 160,
+                      "resolution": 0
+                    },
+                    "F": {
+                      "min": 175,
+                      "max": 550,
+                      "default": 325,
+                      "resolution": 0
+                    }
+                  },
+                  "operationTime": {
+                    "min": "00:01:00",
+                    "max": "09:59:00",
+                    "default": "01:00:00",
+                    "resolution": "00:01:00"
+                  }
+                }
+              },
+              {
+                "mode": "KeepWarm",
+                "supportedOperations": ["set"],
+                "supportedOptions": {
+                  "temperature": {
+                    "C": {
+                      "min": 80,
+                      "max": 80,
+                      "default": 80,
+                      "supportedValues": [80]
+                    },
+                    "F": {
+                      "min": 175,
+                      "max": 175,
+                      "default": 175,
+                      "supportedValues": [175]
+                    }
+                  }
+                }
+              },
+              {
+                "mode": "BreadProof",
+                "supportedOperations": ["set"],
+                "supportedOptions": {
+                  "temperature": {
+                    "C": {
+                      "min": 35,
+                      "max": 35,
+                      "default": 35,
+                      "supportedValues": [35]
+                    },
+                    "F": {
+                      "min": 95,
+                      "max": 95,
+                      "default": 95,
+                      "supportedValues": [95]
+                    }
+                  }
+                }
+              },
+              {
+                "mode": "AirFryer",
+                "supportedOperations": ["start", "set"],
+                "supportedOptions": {
+                  "temperature": {
+                    "C": {
+                      "min": 175,
+                      "max": 260,
+                      "default": 220,
+                      "resolution": 0
+                    },
+                    "F": {
+                      "min": 350,
+                      "max": 500,
+                      "default": 425,
+                      "resolution": 0
+                    }
+                  },
+                  "operationTime": {
+                    "min": "00:01:00",
+                    "max": "09:59:00",
+                    "default": "01:00:00",
+                    "resolution": "00:01:00"
+                  }
+                }
+              },
+              {
+                "mode": "Dehydrate",
+                "supportedOperations": ["start", "set"],
+                "supportedOptions": {
+                  "temperature": {
+                    "C": {
+                      "min": 40,
+                      "max": 105,
+                      "default": 65,
+                      "resolution": 0
+                    },
+                    "F": {
+                      "min": 100,
+                      "max": 225,
+                      "default": 150,
+                      "resolution": 0
+                    }
+                  },
+                  "operationTime": {
+                    "min": "00:01:00",
+                    "max": "09:59:00",
+                    "default": "01:00:00",
+                    "resolution": "00:01:00"
+                  }
+                }
+              },
+              {
+                "mode": "SelfClean",
+                "supportedOperations": [],
+                "supportedOptions": {}
+              },
+              {
+                "mode": "SteamClean",
+                "supportedOperations": [],
+                "supportedOptions": {}
+              }
+            ]
+          },
+          "timestamp": "2024-05-14T19:00:30.062Z"
+        }
+      },
+      "custom.cooktopOperatingState": {
+        "supportedCooktopOperatingState": {
+          "value": ["run", "ready"],
+          "timestamp": "2022-02-21T22:37:05.293Z"
+        },
+        "cooktopOperatingState": {
+          "value": "ready",
+          "timestamp": "2025-03-12T20:38:01.402Z"
+        }
+      },
+      "custom.disabledCapabilities": {
+        "disabledCapabilities": {
+          "value": [],
+          "timestamp": "2025-03-13T21:23:27.659Z"
+        }
+      },
+      "samsungce.driverVersion": {
+        "versionNumber": {
+          "value": 22100101,
+          "timestamp": "2022-11-01T21:37:51.304Z"
+        }
+      },
+      "samsungce.softwareUpdate": {
+        "targetModule": {
+          "value": null
+        },
+        "otnDUID": {
+          "value": "ZPCNQWBWXI47Q",
+          "timestamp": "2025-03-12T20:38:01.262Z"
+        },
+        "lastUpdatedDate": {
+          "value": null
+        },
+        "availableModules": {
+          "value": [],
+          "timestamp": "2025-03-12T20:38:01.262Z"
+        },
+        "newVersionAvailable": {
+          "value": false,
+          "timestamp": "2025-03-12T20:38:01.262Z"
+        },
+        "operatingState": {
+          "value": null
+        },
+        "progress": {
+          "value": null
+        }
+      },
+      "temperatureMeasurement": {
+        "temperatureRange": {
+          "value": null
+        },
+        "temperature": {
+          "value": 425,
+          "unit": "F",
+          "timestamp": "2025-03-13T21:46:35.545Z"
+        }
+      },
+      "samsungce.ovenOperatingState": {
+        "completionTime": {
+          "value": "2025-03-14T03:23:28.048Z",
+          "timestamp": "2025-03-13T22:09:29.052Z"
+        },
+        "operatingState": {
+          "value": "running",
+          "timestamp": "2025-03-13T21:23:24.771Z"
+        },
+        "progress": {
+          "value": 13,
+          "timestamp": "2025-03-13T22:06:35.591Z"
+        },
+        "ovenJobState": {
+          "value": "cooking",
+          "timestamp": "2025-03-13T21:46:34.327Z"
+        },
+        "operationTime": {
+          "value": "06:00:00",
+          "timestamp": "2025-03-13T21:23:24.771Z"
+        }
+      },
+      "ovenMode": {
+        "supportedOvenModes": {
+          "value": [
+            "Bake",
+            "Broil",
+            "ConvectionBake",
+            "ConvectionRoast",
+            "warming",
+            "Others",
+            "Dehydrate"
+          ],
+          "timestamp": "2025-03-12T20:38:01.259Z"
+        },
+        "ovenMode": {
+          "value": "Bake",
+          "timestamp": "2025-03-13T21:23:27.659Z"
+        }
+      },
+      "ovenOperatingState": {
+        "completionTime": {
+          "value": "2025-03-14T03:23:28.048Z",
+          "timestamp": "2025-03-13T22:09:29.052Z"
+        },
+        "machineState": {
+          "value": "running",
+          "timestamp": "2025-03-13T21:23:24.771Z"
+        },
+        "progress": {
+          "value": 13,
+          "unit": "%",
+          "timestamp": "2025-03-13T22:06:35.591Z"
+        },
+        "supportedMachineStates": {
+          "value": null
+        },
+        "ovenJobState": {
+          "value": "cooking",
+          "timestamp": "2025-03-13T21:46:34.327Z"
+        },
+        "operationTime": {
+          "value": 21600,
+          "timestamp": "2025-03-13T21:23:24.771Z"
+        }
+      },
+      "samsungce.ovenMode": {
+        "supportedOvenModes": {
+          "value": [
+            "Bake",
+            "Broil",
+            "ConvectionBake",
+            "ConvectionRoast",
+            "KeepWarm",
+            "BreadProof",
+            "AirFryer",
+            "Dehydrate",
+            "SelfClean",
+            "SteamClean"
+          ],
+          "timestamp": "2025-03-12T20:38:01.259Z"
+        },
+        "ovenMode": {
+          "value": "Bake",
+          "timestamp": "2025-03-13T21:23:27.659Z"
+        }
+      },
+      "samsungce.lamp": {
+        "brightnessLevel": {
+          "value": "off",
+          "timestamp": "2025-03-13T21:23:27.659Z"
+        },
+        "supportedBrightnessLevel": {
+          "value": ["off", "high"],
+          "timestamp": "2025-03-13T21:23:27.659Z"
+        }
+      },
+      "samsungce.kidsLock": {
+        "lockState": {
+          "value": "unlocked",
+          "timestamp": "2025-03-12T20:38:01.400Z"
+        }
+      }
+    }
+  }
+}

--- a/tests/components/smartthings/fixtures/device_status/ikea_kadrilj.json
+++ b/tests/components/smartthings/fixtures/device_status/ikea_kadrilj.json
@@ -1,0 +1,68 @@
+{
+  "components": {
+    "main": {
+      "windowShadeLevel": {
+        "shadeLevel": {
+          "value": 32,
+          "unit": "%",
+          "timestamp": "2025-03-13T10:40:25.613Z"
+        }
+      },
+      "refresh": {},
+      "windowShadePreset": {},
+      "battery": {
+        "quantity": {
+          "value": null
+        },
+        "battery": {
+          "value": 37,
+          "unit": "%",
+          "timestamp": "2025-03-13T07:09:05.149Z"
+        },
+        "type": {
+          "value": null
+        }
+      },
+      "firmwareUpdate": {
+        "lastUpdateStatusReason": {
+          "value": null
+        },
+        "availableVersion": {
+          "value": "22007631",
+          "timestamp": "2025-03-12T20:35:04.576Z"
+        },
+        "lastUpdateStatus": {
+          "value": null
+        },
+        "supportedCommands": {
+          "value": null
+        },
+        "state": {
+          "value": "updateRequested",
+          "timestamp": "2025-03-12T20:35:03.879Z"
+        },
+        "updateAvailable": {
+          "value": false,
+          "timestamp": "2025-03-12T20:35:04.577Z"
+        },
+        "currentVersion": {
+          "value": "22007631",
+          "timestamp": "2025-03-12T20:35:04.508Z"
+        },
+        "lastUpdateTime": {
+          "value": null
+        }
+      },
+      "windowShade": {
+        "supportedWindowShadeCommands": {
+          "value": ["open", "close", "pause"],
+          "timestamp": "2025-03-13T10:33:48.402Z"
+        },
+        "windowShade": {
+          "value": "partially open",
+          "timestamp": "2025-03-13T10:55:58.205Z"
+        }
+      }
+    }
+  }
+}

--- a/tests/components/smartthings/fixtures/devices/da_ks_range_0101x.json
+++ b/tests/components/smartthings/fixtures/devices/da_ks_range_0101x.json
@@ -1,0 +1,197 @@
+{
+  "items": [
+    {
+      "deviceId": "2c3cbaa0-1899-5ddc-7b58-9d657bd48f18",
+      "name": "Samsung Range",
+      "label": "Vulcan",
+      "manufacturerName": "Samsung Electronics",
+      "presentationId": "DA-KS-RANGE-0101X",
+      "deviceManufacturerCode": "Samsung Electronics",
+      "locationId": "597a4912-13c9-47ab-9956-7ebc38b61abd",
+      "ownerId": "c4478c70-9014-e5c9-993c-f62707fa1e61",
+      "roomId": "fc407cd9-3b32-4fc0-bf23-e0d4995101e9",
+      "deviceTypeName": "Samsung OCF Range",
+      "components": [
+        {
+          "id": "main",
+          "label": "main",
+          "capabilities": [
+            {
+              "id": "ocf",
+              "version": 1
+            },
+            {
+              "id": "execute",
+              "version": 1
+            },
+            {
+              "id": "refresh",
+              "version": 1
+            },
+            {
+              "id": "remoteControlStatus",
+              "version": 1
+            },
+            {
+              "id": "ovenSetpoint",
+              "version": 1
+            },
+            {
+              "id": "ovenMode",
+              "version": 1
+            },
+            {
+              "id": "ovenOperatingState",
+              "version": 1
+            },
+            {
+              "id": "temperatureMeasurement",
+              "version": 1
+            },
+            {
+              "id": "samsungce.deviceIdentification",
+              "version": 1
+            },
+            {
+              "id": "samsungce.driverVersion",
+              "version": 1
+            },
+            {
+              "id": "samsungce.kitchenDeviceIdentification",
+              "version": 1
+            },
+            {
+              "id": "samsungce.kitchenDeviceDefaults",
+              "version": 1
+            },
+            {
+              "id": "samsungce.doorState",
+              "version": 1
+            },
+            {
+              "id": "samsungce.customRecipe",
+              "version": 1
+            },
+            {
+              "id": "samsungce.ovenMode",
+              "version": 1
+            },
+            {
+              "id": "samsungce.ovenOperatingState",
+              "version": 1
+            },
+            {
+              "id": "samsungce.meatProbe",
+              "version": 1
+            },
+            {
+              "id": "samsungce.lamp",
+              "version": 1
+            },
+            {
+              "id": "samsungce.kitchenModeSpecification",
+              "version": 1
+            },
+            {
+              "id": "samsungce.kidsLock",
+              "version": 1
+            },
+            {
+              "id": "samsungce.softwareUpdate",
+              "version": 1
+            },
+            {
+              "id": "custom.cooktopOperatingState",
+              "version": 1
+            },
+            {
+              "id": "custom.disabledCapabilities",
+              "version": 1
+            }
+          ],
+          "categories": [
+            {
+              "name": "Range",
+              "categoryType": "manufacturer"
+            }
+          ]
+        },
+        {
+          "id": "cavity-01",
+          "label": "cavity-01",
+          "capabilities": [
+            {
+              "id": "ovenSetpoint",
+              "version": 1
+            },
+            {
+              "id": "ovenMode",
+              "version": 1
+            },
+            {
+              "id": "ovenOperatingState",
+              "version": 1
+            },
+            {
+              "id": "temperatureMeasurement",
+              "version": 1
+            },
+            {
+              "id": "samsungce.ovenMode",
+              "version": 1
+            },
+            {
+              "id": "samsungce.ovenOperatingState",
+              "version": 1
+            },
+            {
+              "id": "samsungce.kitchenDeviceDefaults",
+              "version": 1
+            },
+            {
+              "id": "custom.ovenCavityStatus",
+              "version": 1
+            },
+            {
+              "id": "custom.disabledCapabilities",
+              "version": 1
+            }
+          ],
+          "categories": [
+            {
+              "name": "Other",
+              "categoryType": "manufacturer"
+            }
+          ]
+        }
+      ],
+      "createTime": "2022-02-21T22:37:01.648Z",
+      "profile": {
+        "id": "8e479dd0-9719-337a-9fbe-2c4572f95c71"
+      },
+      "ocf": {
+        "ocfDeviceType": "oic.d.range",
+        "name": "Samsung Range",
+        "specVersion": "core.1.1.0",
+        "verticalDomainSpecVersion": "1.2.1",
+        "manufacturerName": "Samsung Electronics",
+        "modelNumber": "TP1X_DA-KS-RANGE-0101X|40445041|5001011E031511010200000000000000",
+        "platformVersion": "DAWIT 3.0",
+        "platformOS": "TizenRT 3.1",
+        "hwVersion": "Realtek",
+        "firmwareVersion": "AKS-WW-TP1-20-OVEN-3-CR_40240205",
+        "vendorId": "DA-KS-RANGE-0101X",
+        "vendorResourceClientServerVersion": "Realtek Release 3.1.220727",
+        "lastSignupTime": "2023-11-28T22:49:01.876575Z",
+        "transferCandidate": false,
+        "additionalAuthCodeRequired": false
+      },
+      "type": "OCF",
+      "restrictionTier": 0,
+      "allowed": null,
+      "executionContext": "CLOUD",
+      "relationships": []
+    }
+  ],
+  "_links": {}
+}

--- a/tests/components/smartthings/fixtures/devices/ikea_kadrilj.json
+++ b/tests/components/smartthings/fixtures/devices/ikea_kadrilj.json
@@ -1,0 +1,78 @@
+{
+  "items": [
+    {
+      "deviceId": "71afed1c-006d-4e48-b16e-e7f88f9fd638",
+      "name": "window-treatment-battery",
+      "label": "Kitchen IKEA KADRILJ Window blind",
+      "manufacturerName": "SmartThingsCommunity",
+      "presentationId": "fa41d7d3-4c03-327f-b0ce-2edc829f0e34",
+      "deviceManufacturerCode": "IKEA of Sweden",
+      "locationId": "5b5f96b5-0286-4f4a-86ef-d5d5c1a78cb8",
+      "ownerId": "f43fd9e5-2ecd-4aae-aeac-73a8e5cb04da",
+      "roomId": "89f675a1-1f16-451c-8ab1-a7fdacc5852d",
+      "components": [
+        {
+          "id": "main",
+          "label": "main",
+          "capabilities": [
+            {
+              "id": "windowShade",
+              "version": 1
+            },
+            {
+              "id": "windowShadePreset",
+              "version": 1
+            },
+            {
+              "id": "windowShadeLevel",
+              "version": 1
+            },
+            {
+              "id": "battery",
+              "version": 1
+            },
+            {
+              "id": "firmwareUpdate",
+              "version": 1
+            },
+            {
+              "id": "refresh",
+              "version": 1
+            }
+          ],
+          "categories": [
+            {
+              "name": "Blind",
+              "categoryType": "manufacturer"
+            }
+          ]
+        }
+      ],
+      "createTime": "2023-04-26T18:19:06.792Z",
+      "parentDeviceId": "3ffe04c4-a12c-41f5-b83d-c1b28eca2b5f",
+      "profile": {
+        "id": "6d9804bc-9e56-3823-95be-4b315669c481"
+      },
+      "zigbee": {
+        "eui": "000D6FFFFE2AD0E7",
+        "networkId": "3009",
+        "driverId": "46b8bada-1a55-4f84-8915-47ce2cad3621",
+        "executingLocally": true,
+        "hubId": "3ffe04c4-a12c-41f5-b83d-c1b28eca2b5f",
+        "provisioningState": "NONFUNCTIONAL"
+      },
+      "type": "ZIGBEE",
+      "restrictionTier": 0,
+      "allowed": null,
+      "indoorMap": {
+        "coordinates": [10.0, 36.0, 98.0],
+        "rotation": [270.0, 0.0, 0.0],
+        "visible": true,
+        "data": null
+      },
+      "executionContext": "LOCAL",
+      "relationships": []
+    }
+  ],
+  "_links": {}
+}

--- a/tests/components/smartthings/snapshots/test_cover.ambr
+++ b/tests/components/smartthings/snapshots/test_cover.ambr
@@ -49,3 +49,54 @@
     'state': 'open',
   })
 # ---
+# name: test_all_entities[ikea_kadrilj][cover.kitchen_ikea_kadrilj_window_blind-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.kitchen_ikea_kadrilj_window_blind',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.SHADE: 'shade'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 7>,
+    'translation_key': None,
+    'unique_id': '71afed1c-006d-4e48-b16e-e7f88f9fd638',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[ikea_kadrilj][cover.kitchen_ikea_kadrilj_window_blind-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'battery_level': 37,
+      'current_position': 32,
+      'device_class': 'shade',
+      'friendly_name': 'Kitchen IKEA KADRILJ Window blind',
+      'supported_features': <CoverEntityFeature: 7>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.kitchen_ikea_kadrilj_window_blind',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---

--- a/tests/components/smartthings/snapshots/test_init.ambr
+++ b/tests/components/smartthings/snapshots/test_init.ambr
@@ -398,6 +398,39 @@
     'via_device_id': None,
   })
 # ---
+# name: test_devices[da_ks_range_0101x]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': 'https://account.smartthings.com',
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': 'Realtek',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'smartthings',
+        '2c3cbaa0-1899-5ddc-7b58-9d657bd48f18',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Samsung Electronics',
+    'model': 'TP1X_DA-KS-RANGE-0101X',
+    'model_id': None,
+    'name': 'Vulcan',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': 'AKS-WW-TP1-20-OVEN-3-CR_40240205',
+    'via_device_id': None,
+  })
+# ---
 # name: test_devices[da_ref_normal_000001]
   DeviceRegistryEntrySnapshot({
     'area_id': None,

--- a/tests/components/smartthings/snapshots/test_init.ambr
+++ b/tests/components/smartthings/snapshots/test_init.ambr
@@ -959,6 +959,39 @@
     'via_device_id': None,
   })
 # ---
+# name: test_devices[ikea_kadrilj]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': 'https://account.smartthings.com',
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'smartthings',
+        '71afed1c-006d-4e48-b16e-e7f88f9fd638',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': None,
+    'model': None,
+    'model_id': None,
+    'name': 'Kitchen IKEA KADRILJ Window blind',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_devices[im_speaker_ai_0001]
   DeviceRegistryEntrySnapshot({
     'area_id': None,

--- a/tests/components/smartthings/snapshots/test_sensor.ambr
+++ b/tests/components/smartthings/snapshots/test_sensor.ambr
@@ -5506,6 +5506,55 @@
     'state': '19.0',
   })
 # ---
+# name: test_all_entities[ikea_kadrilj][sensor.kitchen_ikea_kadrilj_window_blind_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_ikea_kadrilj_window_blind_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '71afed1c-006d-4e48-b16e-e7f88f9fd638.battery',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_entities[ikea_kadrilj][sensor.kitchen_ikea_kadrilj_window_blind_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Kitchen IKEA KADRILJ Window blind Battery',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_ikea_kadrilj_window_blind_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '37',
+  })
+# ---
 # name: test_all_entities[im_speaker_ai_0001][sensor.galaxy_home_mini_media_input_source-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/smartthings/snapshots/test_sensor.ambr
+++ b/tests/components/smartthings/snapshots/test_sensor.ambr
@@ -2007,7 +2007,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
     'original_icon': None,
     'original_name': 'Set point',
     'platform': 'smartthings',
@@ -2015,20 +2015,22 @@
     'supported_features': 0,
     'translation_key': 'oven_setpoint',
     'unique_id': '2bad3237-4886-e699-1b90-4a51a3d55c8a.ovenSetpoint',
-    'unit_of_measurement': None,
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
 # name: test_all_entities[da_ks_microwave_0101x][sensor.microwave_set_point-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
       'friendly_name': 'Microwave Set point',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.microwave_set_point',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': 'unknown',
   })
 # ---
 # name: test_all_entities[da_ks_microwave_0101x][sensor.microwave_temperature-entry]
@@ -2081,6 +2083,404 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-17',
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.vulcan_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Completion time',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'completion_time',
+    'unique_id': '2c3cbaa0-1899-5ddc-7b58-9d657bd48f18.completionTime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Vulcan Completion time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vulcan_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-03-14T03:23:28+00:00',
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_job_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'cleaning',
+        'cooking',
+        'cooling',
+        'draining',
+        'preheat',
+        'ready',
+        'rinsing',
+        'finished',
+        'scheduled_start',
+        'warming',
+        'defrosting',
+        'sensing',
+        'searing',
+        'fast_preheat',
+        'scheduled_end',
+        'stone_heating',
+        'time_hold_preheat',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.vulcan_job_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Job state',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_job_state',
+    'unique_id': '2c3cbaa0-1899-5ddc-7b58-9d657bd48f18.ovenJobState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_job_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Vulcan Job state',
+      'options': list([
+        'cleaning',
+        'cooking',
+        'cooling',
+        'draining',
+        'preheat',
+        'ready',
+        'rinsing',
+        'finished',
+        'scheduled_start',
+        'warming',
+        'defrosting',
+        'sensing',
+        'searing',
+        'fast_preheat',
+        'scheduled_end',
+        'stone_heating',
+        'time_hold_preheat',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vulcan_job_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cooking',
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_machine_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'ready',
+        'running',
+        'paused',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.vulcan_machine_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Machine state',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_machine_state',
+    'unique_id': '2c3cbaa0-1899-5ddc-7b58-9d657bd48f18.machineState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_machine_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Vulcan Machine state',
+      'options': list([
+        'ready',
+        'running',
+        'paused',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vulcan_machine_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'running',
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_oven_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'conventional',
+        'bake',
+        'bottom_heat',
+        'convection_bake',
+        'convection_roast',
+        'broil',
+        'convection_broil',
+        'steam_cook',
+        'steam_bake',
+        'steam_roast',
+        'steam_bottom_heat_plus_convection',
+        'microwave',
+        'microwave_plus_grill',
+        'microwave_plus_convection',
+        'microwave_plus_hot_blast',
+        'microwave_plus_hot_blast_2',
+        'slim_middle',
+        'slim_strong',
+        'slow_cook',
+        'proof',
+        'dehydrate',
+        'others',
+        'strong_steam',
+        'descale',
+        'rinse',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.vulcan_oven_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Oven mode',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_mode',
+    'unique_id': '2c3cbaa0-1899-5ddc-7b58-9d657bd48f18.ovenMode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_oven_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Vulcan Oven mode',
+      'options': list([
+        'conventional',
+        'bake',
+        'bottom_heat',
+        'convection_bake',
+        'convection_roast',
+        'broil',
+        'convection_broil',
+        'steam_cook',
+        'steam_bake',
+        'steam_roast',
+        'steam_bottom_heat_plus_convection',
+        'microwave',
+        'microwave_plus_grill',
+        'microwave_plus_convection',
+        'microwave_plus_hot_blast',
+        'microwave_plus_hot_blast_2',
+        'slim_middle',
+        'slim_strong',
+        'slow_cook',
+        'proof',
+        'dehydrate',
+        'others',
+        'strong_steam',
+        'descale',
+        'rinse',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vulcan_oven_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'bake',
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_set_point-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.vulcan_set_point',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Set point',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_setpoint',
+    'unique_id': '2c3cbaa0-1899-5ddc-7b58-9d657bd48f18.ovenSetpoint',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_set_point-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Vulcan Set point',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vulcan_set_point',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '218',
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.vulcan_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '2c3cbaa0-1899-5ddc-7b58-9d657bd48f18.temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][sensor.vulcan_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Vulcan Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vulcan_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '218',
   })
 # ---
 # name: test_all_entities[da_ref_normal_000001][sensor.refrigerator_energy-entry]


### PR DESCRIPTION
- Fix bug with all Roborock maps being set to the wrong map when empty ([@Lash-L] - [#138493]) ([roborock docs])
- Bump pysuezV2 to 2.0.4 ([@jb101010-2] - [#139824]) ([suez_water docs]) (dependency)
- Bump upb-lib to 0.6.1 ([@gwww] - [#140212]) ([upb docs]) (dependency)
- Use only IPv4 for zeroconf in bluesound integration ([@LouisChrist] - [#140226]) ([bluesound docs])
- Only do WebDAV path migration when path differs ([@jpbede] - [#140402]) ([webdav docs])
- Bump velbusaio to 2025.3.1 ([@cereal2nd] - [#140443]) ([velbus docs]) (dependency)
- Mark value in number.set_value action as required ([@joostlek] - [#140445]) ([number docs])
- Bump Tesla Fleet API to 0.9.13 ([@Bre77] - [#140485]) ([tessie docs]) ([teslemetry docs]) ([tesla_fleet docs])
- Update xknxproject to 3.8.2 ([@farmio] - [#140499]) ([knx docs]) (dependency)
- Fix Shelly diagnostics for devices without WebSocket Outbound support ([@bieniu] - [#140501]) ([shelly docs])
- Fix windowShadeLevel capability in SmartThings ([@joostlek] - [#140552]) ([smartthings docs])
- Set unit of measurement for SmartThings oven setpoint ([@joostlek] - [#140560]) ([smartthings docs])
- Fix missing UnitOfPower.MILLIWATT in sensor and number allowed units ([@ashionky] - [#140567]) ([sensor docs])

[#138493]: https://github.com/home-assistant/core/pull/138493
[#139824]: https://github.com/home-assistant/core/pull/139824
[#139859]: https://github.com/home-assistant/core/pull/139859
[#140061]: https://github.com/home-assistant/core/pull/140061
[#140212]: https://github.com/home-assistant/core/pull/140212
[#140226]: https://github.com/home-assistant/core/pull/140226
[#140392]: https://github.com/home-assistant/core/pull/140392
[#140402]: https://github.com/home-assistant/core/pull/140402
[#140443]: https://github.com/home-assistant/core/pull/140443
[#140445]: https://github.com/home-assistant/core/pull/140445
[#140485]: https://github.com/home-assistant/core/pull/140485
[#140499]: https://github.com/home-assistant/core/pull/140499
[#140501]: https://github.com/home-assistant/core/pull/140501
[#140552]: https://github.com/home-assistant/core/pull/140552
[#140560]: https://github.com/home-assistant/core/pull/140560
[#140567]: https://github.com/home-assistant/core/pull/140567
[@Bre77]: https://github.com/Bre77
[@Lash-L]: https://github.com/Lash-L
[@LouisChrist]: https://github.com/LouisChrist
[@ashionky]: https://github.com/ashionky
[@bieniu]: https://github.com/bieniu
[@cereal2nd]: https://github.com/cereal2nd
[@farmio]: https://github.com/farmio
[@frenck]: https://github.com/frenck
[@gwww]: https://github.com/gwww
[@jb101010-2]: https://github.com/jb101010-2
[@joostlek]: https://github.com/joostlek
[@jpbede]: https://github.com/jpbede
[abode docs]: https://www.home-assistant.io/integrations/abode/
[acaia docs]: https://www.home-assistant.io/integrations/acaia/
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/
[bluesound docs]: https://www.home-assistant.io/integrations/bluesound/
[knx docs]: https://www.home-assistant.io/integrations/knx/
[number docs]: https://www.home-assistant.io/integrations/number/
[roborock docs]: https://www.home-assistant.io/integrations/roborock/
[sensor docs]: https://www.home-assistant.io/integrations/sensor/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[smartthings docs]: https://www.home-assistant.io/integrations/smartthings/
[suez_water docs]: https://www.home-assistant.io/integrations/suez_water/
[tesla_fleet docs]: https://www.home-assistant.io/integrations/tesla_fleet/
[teslemetry docs]: https://www.home-assistant.io/integrations/teslemetry/
[tessie docs]: https://www.home-assistant.io/integrations/tessie/
[upb docs]: https://www.home-assistant.io/integrations/upb/
[velbus docs]: https://www.home-assistant.io/integrations/velbus/
[webdav docs]: https://www.home-assistant.io/integrations/webdav/

Release notes: https://github.com/home-assistant/home-assistant.io/pull/37972