### PR TITLE
Handle non documented options at Home Connect select entities

### DIFF
--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -413,6 +413,7 @@ class HomeConnectSelectEntity(HomeConnectEntity, SelectEntity):
     """Select setting class for Home Connect."""
 
     entity_description: HomeConnectSelectEntityDescription
+    _original_option_keys: set[str | None]
 
     def __init__(
         self,
@@ -421,6 +422,7 @@ class HomeConnectSelectEntity(HomeConnectEntity, SelectEntity):
         desc: HomeConnectSelectEntityDescription,
     ) -> None:
         """Initialize the entity."""
+        self._original_option_keys = set(desc.values_translation_key.keys())
         super().__init__(
             coordinator,
             appliance,
@@ -471,10 +473,13 @@ class HomeConnectSelectEntity(HomeConnectEntity, SelectEntity):
                 )
 
         if setting and setting.constraints and setting.constraints.allowed_values:
+            self._original_option_keys = set(setting.constraints.allowed_values)
             self._attr_options = [
-                self.entity_description.values_translation_key[option]
-                for option in setting.constraints.allowed_values
-                if option in self.entity_description.values_translation_key
+                self.entity_description.values_translation_key.get(
+                    option, bsh_key_to_translation_key(option)
+                )
+                for option in self._original_option_keys
+                if option is not None
             ]
 
 
@@ -521,8 +526,9 @@ class HomeConnectSelectOptionEntity(HomeConnectOptionEntity, SelectEntity):
         ):
             self._original_option_keys = set(option_constraints.allowed_values)
             self._attr_options = [
-                self.entity_description.values_translation_key[option]
+                self.entity_description.values_translation_key.get(
+                    option, bsh_key_to_translation_key(option)
+                )
                 for option in self._original_option_keys
                 if option is not None
             ]
-            self.__dict__.pop("options", None)

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -422,7 +422,7 @@ class HomeConnectSelectEntity(HomeConnectEntity, SelectEntity):
         desc: HomeConnectSelectEntityDescription,
     ) -> None:
         """Initialize the entity."""
-        self._original_option_keys = set(desc.values_translation_key.keys())
+        self._original_option_keys = set(desc.values_translation_key)
         super().__init__(
             coordinator,
             appliance,
@@ -475,11 +475,10 @@ class HomeConnectSelectEntity(HomeConnectEntity, SelectEntity):
         if setting and setting.constraints and setting.constraints.allowed_values:
             self._original_option_keys = set(setting.constraints.allowed_values)
             self._attr_options = [
-                self.entity_description.values_translation_key.get(
-                    option, bsh_key_to_translation_key(option)
-                )
+                self.entity_description.values_translation_key[option]
                 for option in self._original_option_keys
                 if option is not None
+                and option in self.entity_description.values_translation_key
             ]
 
 
@@ -496,7 +495,7 @@ class HomeConnectSelectOptionEntity(HomeConnectOptionEntity, SelectEntity):
         desc: HomeConnectSelectEntityDescription,
     ) -> None:
         """Initialize the entity."""
-        self._original_option_keys = set(desc.values_translation_key.keys())
+        self._original_option_keys = set(desc.values_translation_key)
         super().__init__(
             coordinator,
             appliance,
@@ -526,9 +525,8 @@ class HomeConnectSelectOptionEntity(HomeConnectOptionEntity, SelectEntity):
         ):
             self._original_option_keys = set(option_constraints.allowed_values)
             self._attr_options = [
-                self.entity_description.values_translation_key.get(
-                    option, bsh_key_to_translation_key(option)
-                )
+                self.entity_description.values_translation_key[option]
                 for option in self._original_option_keys
                 if option is not None
+                and option in self.entity_description.values_translation_key
             ]

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -527,8 +527,11 @@ async def test_select_functionality(
         (
             "select.hood_ambient_light_color",
             SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR,
-            ["A.Non.Documented.Option"],
-            {"a_non_documented_option"},
+            [
+                "A.Non.Documented.Option",
+                "BSH.Common.EnumType.AmbientLightColor.Color42",
+            ],
+            {"42"},
         ),
     ],
 )
@@ -693,7 +696,6 @@ async def test_select_entity_error(
                 "LaundryCare.Washer.EnumType.Temperature.UlWarm",
             ],
             {
-                "a_non_documented_option",
                 "laundry_care_washer_enum_type_temperature_ul_warm",
             },
         ),

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -521,8 +521,14 @@ async def test_select_functionality(
         (
             "select.hood_ambient_light_color",
             SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR,
-            [f"BSH.Common.EnumType.AmbientLightColor.Color{i}" for i in range(50)],
+            [f"BSH.Common.EnumType.AmbientLightColor.Color{i}" for i in range(1, 50)],
             {str(i) for i in range(1, 50)},
+        ),
+        (
+            "select.hood_ambient_light_color",
+            SettingKey.BSH_COMMON_AMBIENT_LIGHT_COLOR,
+            ["A.Non.Documented.Option"],
+            {"a_non_documented_option"},
         ),
     ],
 )
@@ -677,6 +683,18 @@ async def test_select_entity_error(
                 "laundry_care_washer_enum_type_temperature_ul_warm",
                 "laundry_care_washer_enum_type_temperature_ul_hot",
                 "laundry_care_washer_enum_type_temperature_ul_extra_hot",
+            },
+        ),
+        (
+            "select.washer_temperature",
+            OptionKey.LAUNDRY_CARE_WASHER_TEMPERATURE,
+            [
+                "A.Non.Documented.Option",
+                "LaundryCare.Washer.EnumType.Temperature.UlWarm",
+            ],
+            {
+                "a_non_documented_option",
+                "laundry_care_washer_enum_type_temperature_ul_warm",
             },
         ),
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Because some times there are options at select entities that are non-documented, and therefore not added to Home Connect integration.
This breaks the integration so I changed the logic so that if a non recognized option is detected, the option will be formatted to the translation key that we use at Home Connect.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #140038, #140550
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
