### PR TITLE
Separate Roborock entities to a new dock device

### DIFF
--- a/homeassistant/components/roborock/binary_sensor.py
+++ b/homeassistant/components/roborock/binary_sensor.py
@@ -26,6 +26,8 @@ class RoborockBinarySensorDescription(BinarySensorEntityDescription):
     """A class that describes Roborock binary sensors."""
 
     value_fn: Callable[[DeviceProp], bool | int | None]
+    # If it is a dock entity
+    is_dock_entity: bool = False
 
 
 BINARY_SENSOR_DESCRIPTIONS = [
@@ -35,6 +37,7 @@ BINARY_SENSOR_DESCRIPTIONS = [
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.status.dry_status,
+        is_dock_entity=True,
     ),
     RoborockBinarySensorDescription(
         key="water_box_carriage_status",
@@ -105,6 +108,7 @@ class RoborockBinarySensorEntity(RoborockCoordinatedEntityV1, BinarySensorEntity
         super().__init__(
             f"{description.key}_{coordinator.duid_slug}",
             coordinator,
+            is_dock_entity=description.is_dock_entity,
         )
         self.entity_description = description
 

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -128,10 +128,10 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
         """
         dock_type = self.roborock_device_info.props.status.dock_type
         return DeviceInfo(
-            name=self.roborock_device_info.device.name + " Dock",
-            identifiers={(DOMAIN, self.duid + "_dock")},
+            name=f"{self.roborock_device_info.device.name} Dock",
+            identifiers={(DOMAIN, f"{self.duid}_dock")},
             manufacturer="Roborock",
-            model=self.roborock_device_info.product.model + " Dock",
+            model=f"{self.roborock_device_info.product.model} Dock",
             model_id=str(dock_type.value) if dock_type is not None else "Unknown",
             sw_version=self.roborock_device_info.device.fv,
         )

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -119,6 +119,23 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
         self._user_data = user_data
         self._api_client = api_client
 
+    @cached_property
+    def dock_device_info(self) -> DeviceInfo:
+        """Gets the device info for the dock.
+
+        This must happen after the coordinator does the first update.
+        Which will be the case when this is called.
+        """
+        dock_type = self.roborock_device_info.props.status.dock_type
+        return DeviceInfo(
+            name=self.roborock_device_info.device.name + " Dock",
+            identifiers={(DOMAIN, self.duid + "_dock")},
+            manufacturer="Roborock",
+            model=self.roborock_device_info.product.model + " Dock",
+            model_id=str(dock_type.value) if dock_type is not None else "Unknown",
+            sw_version=self.roborock_device_info.device.fv,
+        )
+
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         # Verify we can communicate locally - if we can't, switch to cloud api

--- a/homeassistant/components/roborock/entity.py
+++ b/homeassistant/components/roborock/entity.py
@@ -121,12 +121,15 @@ class RoborockCoordinatedEntityV1(
         listener_request: list[RoborockDataProtocol]
         | RoborockDataProtocol
         | None = None,
+        is_dock_entity: bool = False,
     ) -> None:
         """Initialize the coordinated Roborock Device."""
         RoborockEntityV1.__init__(
             self,
             unique_id=unique_id,
-            device_info=coordinator.device_info,
+            device_info=coordinator.device_info
+            if not is_dock_entity
+            else coordinator.dock_device_info,
             api=coordinator.api,
         )
         CoordinatorEntity.__init__(self, coordinator=coordinator)

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -32,6 +32,8 @@ class RoborockSelectDescription(SelectEntityDescription):
     parameter_lambda: Callable[[str, DeviceProp], list[int]]
 
     protocol_listener: RoborockDataProtocol | None = None
+    # If it is a dock entity
+    is_dock_entity: bool = False
 
 
 SELECT_DESCRIPTIONS: list[RoborockSelectDescription] = [
@@ -70,6 +72,7 @@ SELECT_DESCRIPTIONS: list[RoborockSelectDescription] = [
         parameter_lambda=lambda key, _: [
             RoborockDockDustCollectionModeCode.as_dict().get(key)
         ],
+        is_dock_entity=True,
     ),
 ]
 
@@ -117,6 +120,7 @@ class RoborockSelectEntity(RoborockCoordinatedEntityV1, SelectEntity):
             f"{entity_description.key}_{coordinator.duid_slug}",
             coordinator,
             entity_description.protocol_listener,
+            is_dock_entity=entity_description.is_dock_entity,
         )
         self._attr_options = options
 

--- a/homeassistant/components/roborock/sensor.py
+++ b/homeassistant/components/roborock/sensor.py
@@ -47,6 +47,9 @@ class RoborockSensorDescription(SensorEntityDescription):
 
     protocol_listener: RoborockDataProtocol | None = None
 
+    # If it is a dock entity
+    is_dock_entity: bool = False
+
 
 @dataclass(frozen=True, kw_only=True)
 class RoborockSensorDescriptionA01(SensorEntityDescription):
@@ -197,6 +200,7 @@ SENSOR_DESCRIPTIONS = [
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.ENUM,
         options=RoborockDockErrorCode.keys(),
+        is_dock_entity=True,
     ),
     RoborockSensorDescription(
         key="mop_clean_remaining",
@@ -205,6 +209,7 @@ SENSOR_DESCRIPTIONS = [
         value_fn=lambda data: data.status.rdt,
         translation_key="mop_drying_remaining_time",
         entity_category=EntityCategory.DIAGNOSTIC,
+        is_dock_entity=True,
     ),
 ]
 
@@ -335,6 +340,7 @@ class RoborockSensorEntity(RoborockCoordinatedEntityV1, SensorEntity):
             f"{description.key}_{coordinator.duid_slug}",
             coordinator,
             description.protocol_listener,
+            is_dock_entity=description.is_dock_entity,
         )
 
     @property

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -35,6 +35,8 @@ class RoborockSwitchDescription(SwitchEntityDescription):
     update_value: Callable[[AttributeCache, bool], Coroutine[Any, Any, None]]
     # Attribute from cache
     attribute: str
+    # If it is a dock entity
+    is_dock_entity: bool = False
 
 
 SWITCH_DESCRIPTIONS: list[RoborockSwitchDescription] = [
@@ -47,6 +49,7 @@ SWITCH_DESCRIPTIONS: list[RoborockSwitchDescription] = [
         key="child_lock",
         translation_key="child_lock",
         entity_category=EntityCategory.CONFIG,
+        is_dock_entity=True,
     ),
     RoborockSwitchDescription(
         cache_key=CacheableAttribute.flow_led_status,
@@ -57,6 +60,7 @@ SWITCH_DESCRIPTIONS: list[RoborockSwitchDescription] = [
         key="status_indicator",
         translation_key="status_indicator",
         entity_category=EntityCategory.CONFIG,
+        is_dock_entity=True,
     ),
     RoborockSwitchDescription(
         cache_key=CacheableAttribute.dnd_timer,
@@ -147,7 +151,13 @@ class RoborockSwitch(RoborockEntityV1, SwitchEntity):
     ) -> None:
         """Initialize the entity."""
         self.entity_description = entity_description
-        super().__init__(unique_id, coordinator.device_info, coordinator.api)
+        super().__init__(
+            unique_id,
+            coordinator.device_info
+            if not entity_description.is_dock_entity
+            else coordinator.dock_device_info,
+            coordinator.api,
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -53,7 +53,7 @@ async def test_sensors(hass: HomeAssistant, setup_entry: MockConfigEntry) -> Non
     assert hass.states.get("sensor.roborock_s7_maxv_cleaning_area").state == "21.0"
     assert hass.states.get("sensor.roborock_s7_maxv_vacuum_error").state == "none"
     assert hass.states.get("sensor.roborock_s7_maxv_battery").state == "100"
-    assert hass.states.get("sensor.roborock_s7_maxv_dock_error").state == "ok"
+    assert hass.states.get("sensor.roborock_s7_maxv_dock_dock_error").state == "ok"
     assert hass.states.get("sensor.roborock_s7_maxv_total_cleaning_count").state == "31"
     assert (
         hass.states.get("sensor.roborock_s7_maxv_last_clean_begin").state

--- a/tests/components/roborock/test_switch.py
+++ b/tests/components/roborock/test_switch.py
@@ -22,8 +22,8 @@ def platforms() -> list[Platform]:
 @pytest.mark.parametrize(
     ("entity_id"),
     [
-        ("switch.roborock_s7_maxv_child_lock"),
-        ("switch.roborock_s7_maxv_status_indicator_light"),
+        ("switch.roborock_s7_maxv_dock_child_lock"),
+        ("switch.roborock_s7_maxv_dock_status_indicator_light"),
         ("switch.roborock_s7_maxv_do_not_disturb"),
     ],
 )
@@ -59,8 +59,8 @@ async def test_update_success(
 @pytest.mark.parametrize(
     ("entity_id", "service"),
     [
-        ("switch.roborock_s7_maxv_status_indicator_light", SERVICE_TURN_ON),
-        ("switch.roborock_s7_maxv_status_indicator_light", SERVICE_TURN_OFF),
+        ("switch.roborock_s7_maxv_dock_status_indicator_light", SERVICE_TURN_ON),
+        ("switch.roborock_s7_maxv_dock_status_indicator_light", SERVICE_TURN_OFF),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
From a offline conversation with Paulus, we realized it would probably be good to separate dock entities from non-dock entities.

So this creates a new device where you can see everything relating to your dock in one place.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
