### PR TITLE
Move redundant attribute and key error handling to event parser caller

### DIFF
--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -174,11 +174,20 @@ class EventManager:
                     UNHANDLED_TOPICS.add(topic)
                 continue
 
-            event = await parser(unique_id, msg)
+            try:
+                event = await parser(unique_id, msg)
+                error = None
+            except (AttributeError, KeyError) as e:
+                event = None
+                error = e
 
             if not event:
                 LOGGER.warning(
-                    "%s: Unable to parse event from %s: %s", self.name, unique_id, msg
+                    "%s: Unable to parse event from %s: %s: %s",
+                    self.name,
+                    unique_id,
+                    error,
+                    msg,
                 )
                 return
 

--- a/homeassistant/components/onvif/parsers.py
+++ b/homeassistant/components/onvif/parsers.py
@@ -54,19 +54,16 @@ async def async_parse_motion_alarm(uid: str, msg) -> Event | None:
 
     Topic: tns1:VideoSource/MotionAlarm
     """
-    try:
-        topic, payload = extract_message(msg)
-        source = payload.Source.SimpleItem[0].Value
-        return Event(
-            f"{uid}_{topic}_{source}",
-            "Motion Alarm",
-            "binary_sensor",
-            "motion",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    source = payload.Source.SimpleItem[0].Value
+    return Event(
+        f"{uid}_{topic}_{source}",
+        "Motion Alarm",
+        "binary_sensor",
+        "motion",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:VideoSource/ImageTooBlurry/AnalyticsService")
@@ -77,20 +74,17 @@ async def async_parse_image_too_blurry(uid: str, msg) -> Event | None:
 
     Topic: tns1:VideoSource/ImageTooBlurry/*
     """
-    try:
-        topic, payload = extract_message(msg)
-        source = payload.Source.SimpleItem[0].Value
-        return Event(
-            f"{uid}_{topic}_{source}",
-            "Image Too Blurry",
-            "binary_sensor",
-            "problem",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    source = payload.Source.SimpleItem[0].Value
+    return Event(
+        f"{uid}_{topic}_{source}",
+        "Image Too Blurry",
+        "binary_sensor",
+        "problem",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:VideoSource/ImageTooDark/AnalyticsService")
@@ -101,20 +95,17 @@ async def async_parse_image_too_dark(uid: str, msg) -> Event | None:
 
     Topic: tns1:VideoSource/ImageTooDark/*
     """
-    try:
-        topic, payload = extract_message(msg)
-        source = payload.Source.SimpleItem[0].Value
-        return Event(
-            f"{uid}_{topic}_{source}",
-            "Image Too Dark",
-            "binary_sensor",
-            "problem",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    source = payload.Source.SimpleItem[0].Value
+    return Event(
+        f"{uid}_{topic}_{source}",
+        "Image Too Dark",
+        "binary_sensor",
+        "problem",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:VideoSource/ImageTooBright/AnalyticsService")
@@ -125,20 +116,17 @@ async def async_parse_image_too_bright(uid: str, msg) -> Event | None:
 
     Topic: tns1:VideoSource/ImageTooBright/*
     """
-    try:
-        topic, payload = extract_message(msg)
-        source = payload.Source.SimpleItem[0].Value
-        return Event(
-            f"{uid}_{topic}_{source}",
-            "Image Too Bright",
-            "binary_sensor",
-            "problem",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    source = payload.Source.SimpleItem[0].Value
+    return Event(
+        f"{uid}_{topic}_{source}",
+        "Image Too Bright",
+        "binary_sensor",
+        "problem",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:VideoSource/GlobalSceneChange/AnalyticsService")
@@ -149,19 +137,16 @@ async def async_parse_scene_change(uid: str, msg) -> Event | None:
 
     Topic: tns1:VideoSource/GlobalSceneChange/*
     """
-    try:
-        topic, payload = extract_message(msg)
-        source = payload.Source.SimpleItem[0].Value
-        return Event(
-            f"{uid}_{topic}_{source}",
-            "Global Scene Change",
-            "binary_sensor",
-            "problem",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    source = payload.Source.SimpleItem[0].Value
+    return Event(
+        f"{uid}_{topic}_{source}",
+        "Global Scene Change",
+        "binary_sensor",
+        "problem",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:AudioAnalytics/Audio/DetectedSound")
@@ -170,29 +155,26 @@ async def async_parse_detected_sound(uid: str, msg) -> Event | None:
 
     Topic: tns1:AudioAnalytics/Audio/DetectedSound
     """
-    try:
-        audio_source = ""
-        audio_analytics = ""
-        rule = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "AudioSourceConfigurationToken":
-                audio_source = source.Value
-            if source.Name == "AudioAnalyticsConfigurationToken":
-                audio_analytics = source.Value
-            if source.Name == "Rule":
-                rule = source.Value
+    audio_source = ""
+    audio_analytics = ""
+    rule = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "AudioSourceConfigurationToken":
+            audio_source = source.Value
+        if source.Name == "AudioAnalyticsConfigurationToken":
+            audio_analytics = source.Value
+        if source.Name == "Rule":
+            rule = source.Value
 
-        return Event(
-            f"{uid}_{topic}_{audio_source}_{audio_analytics}_{rule}",
-            "Detected Sound",
-            "binary_sensor",
-            "sound",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{audio_source}_{audio_analytics}_{rule}",
+        "Detected Sound",
+        "binary_sensor",
+        "sound",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/FieldDetector/ObjectsInside")
@@ -201,30 +183,26 @@ async def async_parse_field_detector(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/FieldDetector/ObjectsInside
     """
-    try:
-        video_source = ""
-        video_analytics = ""
-        rule = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "VideoSourceConfigurationToken":
-                video_source = _normalize_video_source(source.Value)
-            if source.Name == "VideoAnalyticsConfigurationToken":
-                video_analytics = source.Value
-            if source.Name == "Rule":
-                rule = source.Value
+    video_source = ""
+    video_analytics = ""
+    rule = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "VideoSourceConfigurationToken":
+            video_source = _normalize_video_source(source.Value)
+        if source.Name == "VideoAnalyticsConfigurationToken":
+            video_analytics = source.Value
+        if source.Name == "Rule":
+            rule = source.Value
 
-        evt = Event(
-            f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
-            "Field Detection",
-            "binary_sensor",
-            "motion",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
-    return evt
+    return Event(
+        f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
+        "Field Detection",
+        "binary_sensor",
+        "motion",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/CellMotionDetector/Motion")
@@ -233,29 +211,26 @@ async def async_parse_cell_motion_detector(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/CellMotionDetector/Motion
     """
-    try:
-        video_source = ""
-        video_analytics = ""
-        rule = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "VideoSourceConfigurationToken":
-                video_source = _normalize_video_source(source.Value)
-            if source.Name == "VideoAnalyticsConfigurationToken":
-                video_analytics = source.Value
-            if source.Name == "Rule":
-                rule = source.Value
+    video_source = ""
+    video_analytics = ""
+    rule = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "VideoSourceConfigurationToken":
+            video_source = _normalize_video_source(source.Value)
+        if source.Name == "VideoAnalyticsConfigurationToken":
+            video_analytics = source.Value
+        if source.Name == "Rule":
+            rule = source.Value
 
-        return Event(
-            f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
-            "Cell Motion Detection",
-            "binary_sensor",
-            "motion",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
+        "Cell Motion Detection",
+        "binary_sensor",
+        "motion",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/MotionRegionDetector/Motion")
@@ -264,29 +239,26 @@ async def async_parse_motion_region_detector(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/MotionRegionDetector/Motion
     """
-    try:
-        video_source = ""
-        video_analytics = ""
-        rule = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "VideoSourceConfigurationToken":
-                video_source = _normalize_video_source(source.Value)
-            if source.Name == "VideoAnalyticsConfigurationToken":
-                video_analytics = source.Value
-            if source.Name == "Rule":
-                rule = source.Value
+    video_source = ""
+    video_analytics = ""
+    rule = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "VideoSourceConfigurationToken":
+            video_source = _normalize_video_source(source.Value)
+        if source.Name == "VideoAnalyticsConfigurationToken":
+            video_analytics = source.Value
+        if source.Name == "Rule":
+            rule = source.Value
 
-        return Event(
-            f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
-            "Motion Region Detection",
-            "binary_sensor",
-            "motion",
-            None,
-            payload.Data.SimpleItem[0].Value in ["1", "true"],
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
+        "Motion Region Detection",
+        "binary_sensor",
+        "motion",
+        None,
+        payload.Data.SimpleItem[0].Value in ["1", "true"],
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/TamperDetector/Tamper")
@@ -295,30 +267,27 @@ async def async_parse_tamper_detector(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/TamperDetector/Tamper
     """
-    try:
-        video_source = ""
-        video_analytics = ""
-        rule = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "VideoSourceConfigurationToken":
-                video_source = _normalize_video_source(source.Value)
-            if source.Name == "VideoAnalyticsConfigurationToken":
-                video_analytics = source.Value
-            if source.Name == "Rule":
-                rule = source.Value
+    video_source = ""
+    video_analytics = ""
+    rule = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "VideoSourceConfigurationToken":
+            video_source = _normalize_video_source(source.Value)
+        if source.Name == "VideoAnalyticsConfigurationToken":
+            video_analytics = source.Value
+        if source.Name == "Rule":
+            rule = source.Value
 
-        return Event(
-            f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
-            "Tamper Detection",
-            "binary_sensor",
-            "problem",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
+        "Tamper Detection",
+        "binary_sensor",
+        "problem",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/MyRuleDetector/DogCatDetect")
@@ -327,23 +296,20 @@ async def async_parse_dog_cat_detector(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/MyRuleDetector/DogCatDetect
     """
-    try:
-        video_source = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "Source":
-                video_source = _normalize_video_source(source.Value)
+    video_source = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "Source":
+            video_source = _normalize_video_source(source.Value)
 
-        return Event(
-            f"{uid}_{topic}_{video_source}",
-            "Pet Detection",
-            "binary_sensor",
-            "motion",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}",
+        "Pet Detection",
+        "binary_sensor",
+        "motion",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/MyRuleDetector/VehicleDetect")
@@ -352,23 +318,20 @@ async def async_parse_vehicle_detector(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/MyRuleDetector/VehicleDetect
     """
-    try:
-        video_source = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "Source":
-                video_source = _normalize_video_source(source.Value)
+    video_source = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "Source":
+            video_source = _normalize_video_source(source.Value)
 
-        return Event(
-            f"{uid}_{topic}_{video_source}",
-            "Vehicle Detection",
-            "binary_sensor",
-            "motion",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}",
+        "Vehicle Detection",
+        "binary_sensor",
+        "motion",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 _TAPO_EVENT_TEMPLATES: dict[str, Event] = {
@@ -420,32 +383,28 @@ async def async_parse_tplink_detector(uid: str, msg) -> Event | None:
     Topic: tns1:RuleEngine/PeopleDetector/People
     Topic: tns1:RuleEngine/TPSmartEventDetector/TPSmartEvent
     """
-    try:
-        video_source = ""
-        video_analytics = ""
-        rule = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "VideoSourceConfigurationToken":
-                video_source = _normalize_video_source(source.Value)
-            if source.Name == "VideoAnalyticsConfigurationToken":
-                video_analytics = source.Value
-            if source.Name == "Rule":
-                rule = source.Value
+    video_source = ""
+    video_analytics = ""
+    rule = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "VideoSourceConfigurationToken":
+            video_source = _normalize_video_source(source.Value)
+        if source.Name == "VideoAnalyticsConfigurationToken":
+            video_analytics = source.Value
+        if source.Name == "Rule":
+            rule = source.Value
 
-        for item in payload.Data.SimpleItem:
-            event_template = _TAPO_EVENT_TEMPLATES.get(item.Name, None)
-            if event_template is None:
-                continue
+    for item in payload.Data.SimpleItem:
+        event_template = _TAPO_EVENT_TEMPLATES.get(item.Name, None)
+        if event_template is None:
+            continue
 
-            return dataclasses.replace(
-                event_template,
-                uid=f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
-                value=item.Value == "true",
-            )
-
-    except (AttributeError, KeyError):
-        return None
+        return dataclasses.replace(
+            event_template,
+            uid=f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
+            value=item.Value == "true",
+        )
 
     return None
 
@@ -456,23 +415,20 @@ async def async_parse_person_detector(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/MyRuleDetector/PeopleDetect
     """
-    try:
-        video_source = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "Source":
-                video_source = _normalize_video_source(source.Value)
+    video_source = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "Source":
+            video_source = _normalize_video_source(source.Value)
 
-        return Event(
-            f"{uid}_{topic}_{video_source}",
-            "Person Detection",
-            "binary_sensor",
-            "motion",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}",
+        "Person Detection",
+        "binary_sensor",
+        "motion",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/MyRuleDetector/FaceDetect")
@@ -481,23 +437,20 @@ async def async_parse_face_detector(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/MyRuleDetector/FaceDetect
     """
-    try:
-        video_source = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "Source":
-                video_source = _normalize_video_source(source.Value)
+    video_source = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "Source":
+            video_source = _normalize_video_source(source.Value)
 
-        return Event(
-            f"{uid}_{topic}_{video_source}",
-            "Face Detection",
-            "binary_sensor",
-            "motion",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}",
+        "Face Detection",
+        "binary_sensor",
+        "motion",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/MyRuleDetector/Visitor")
@@ -506,23 +459,20 @@ async def async_parse_visitor_detector(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/MyRuleDetector/Visitor
     """
-    try:
-        video_source = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "Source":
-                video_source = _normalize_video_source(source.Value)
+    video_source = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "Source":
+            video_source = _normalize_video_source(source.Value)
 
-        return Event(
-            f"{uid}_{topic}_{video_source}",
-            "Visitor Detection",
-            "binary_sensor",
-            "occupancy",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}",
+        "Visitor Detection",
+        "binary_sensor",
+        "occupancy",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:Device/Trigger/DigitalInput")
@@ -531,19 +481,16 @@ async def async_parse_digital_input(uid: str, msg) -> Event | None:
 
     Topic: tns1:Device/Trigger/DigitalInput
     """
-    try:
-        topic, payload = extract_message(msg)
-        source = payload.Source.SimpleItem[0].Value
-        return Event(
-            f"{uid}_{topic}_{source}",
-            "Digital Input",
-            "binary_sensor",
-            None,
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    source = payload.Source.SimpleItem[0].Value
+    return Event(
+        f"{uid}_{topic}_{source}",
+        "Digital Input",
+        "binary_sensor",
+        None,
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
 
 
 @PARSERS.register("tns1:Device/Trigger/Relay")
@@ -552,19 +499,16 @@ async def async_parse_relay(uid: str, msg) -> Event | None:
 
     Topic: tns1:Device/Trigger/Relay
     """
-    try:
-        topic, payload = extract_message(msg)
-        source = payload.Source.SimpleItem[0].Value
-        return Event(
-            f"{uid}_{topic}_{source}",
-            "Relay Triggered",
-            "binary_sensor",
-            None,
-            None,
-            payload.Data.SimpleItem[0].Value == "active",
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    source = payload.Source.SimpleItem[0].Value
+    return Event(
+        f"{uid}_{topic}_{source}",
+        "Relay Triggered",
+        "binary_sensor",
+        None,
+        None,
+        payload.Data.SimpleItem[0].Value == "active",
+    )
 
 
 @PARSERS.register("tns1:Device/HardwareFailure/StorageFailure")
@@ -573,20 +517,17 @@ async def async_parse_storage_failure(uid: str, msg) -> Event | None:
 
     Topic: tns1:Device/HardwareFailure/StorageFailure
     """
-    try:
-        topic, payload = extract_message(msg)
-        source = payload.Source.SimpleItem[0].Value
-        return Event(
-            f"{uid}_{topic}_{source}",
-            "Storage Failure",
-            "binary_sensor",
-            "problem",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    source = payload.Source.SimpleItem[0].Value
+    return Event(
+        f"{uid}_{topic}_{source}",
+        "Storage Failure",
+        "binary_sensor",
+        "problem",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:Monitoring/ProcessorUsage")
@@ -595,23 +536,20 @@ async def async_parse_processor_usage(uid: str, msg) -> Event | None:
 
     Topic: tns1:Monitoring/ProcessorUsage
     """
-    try:
-        topic, payload = extract_message(msg)
-        usage = float(payload.Data.SimpleItem[0].Value)
-        if usage <= 1:
-            usage *= 100
+    topic, payload = extract_message(msg)
+    usage = float(payload.Data.SimpleItem[0].Value)
+    if usage <= 1:
+        usage *= 100
 
-        return Event(
-            f"{uid}_{topic}",
-            "Processor Usage",
-            "sensor",
-            None,
-            "percent",
-            int(usage),
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}",
+        "Processor Usage",
+        "sensor",
+        None,
+        "percent",
+        int(usage),
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:Monitoring/OperatingTime/LastReboot")
@@ -620,20 +558,17 @@ async def async_parse_last_reboot(uid: str, msg) -> Event | None:
 
     Topic: tns1:Monitoring/OperatingTime/LastReboot
     """
-    try:
-        topic, payload = extract_message(msg)
-        date_time = local_datetime_or_none(payload.Data.SimpleItem[0].Value)
-        return Event(
-            f"{uid}_{topic}",
-            "Last Reboot",
-            "sensor",
-            "timestamp",
-            None,
-            date_time,
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    date_time = local_datetime_or_none(payload.Data.SimpleItem[0].Value)
+    return Event(
+        f"{uid}_{topic}",
+        "Last Reboot",
+        "sensor",
+        "timestamp",
+        None,
+        date_time,
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:Monitoring/OperatingTime/LastReset")
@@ -642,21 +577,18 @@ async def async_parse_last_reset(uid: str, msg) -> Event | None:
 
     Topic: tns1:Monitoring/OperatingTime/LastReset
     """
-    try:
-        topic, payload = extract_message(msg)
-        date_time = local_datetime_or_none(payload.Data.SimpleItem[0].Value)
-        return Event(
-            f"{uid}_{topic}",
-            "Last Reset",
-            "sensor",
-            "timestamp",
-            None,
-            date_time,
-            EntityCategory.DIAGNOSTIC,
-            entity_enabled=False,
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    date_time = local_datetime_or_none(payload.Data.SimpleItem[0].Value)
+    return Event(
+        f"{uid}_{topic}",
+        "Last Reset",
+        "sensor",
+        "timestamp",
+        None,
+        date_time,
+        EntityCategory.DIAGNOSTIC,
+        entity_enabled=False,
+    )
 
 
 @PARSERS.register("tns1:Monitoring/Backup/Last")
@@ -665,22 +597,18 @@ async def async_parse_backup_last(uid: str, msg) -> Event | None:
 
     Topic: tns1:Monitoring/Backup/Last
     """
-
-    try:
-        topic, payload = extract_message(msg)
-        date_time = local_datetime_or_none(payload.Data.SimpleItem[0].Value)
-        return Event(
-            f"{uid}_{topic}",
-            "Last Backup",
-            "sensor",
-            "timestamp",
-            None,
-            date_time,
-            EntityCategory.DIAGNOSTIC,
-            entity_enabled=False,
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    date_time = local_datetime_or_none(payload.Data.SimpleItem[0].Value)
+    return Event(
+        f"{uid}_{topic}",
+        "Last Backup",
+        "sensor",
+        "timestamp",
+        None,
+        date_time,
+        EntityCategory.DIAGNOSTIC,
+        entity_enabled=False,
+    )
 
 
 @PARSERS.register("tns1:Monitoring/OperatingTime/LastClockSynchronization")
@@ -689,21 +617,18 @@ async def async_parse_last_clock_sync(uid: str, msg) -> Event | None:
 
     Topic: tns1:Monitoring/OperatingTime/LastClockSynchronization
     """
-    try:
-        topic, payload = extract_message(msg)
-        date_time = local_datetime_or_none(payload.Data.SimpleItem[0].Value)
-        return Event(
-            f"{uid}_{topic}",
-            "Last Clock Synchronization",
-            "sensor",
-            "timestamp",
-            None,
-            date_time,
-            EntityCategory.DIAGNOSTIC,
-            entity_enabled=False,
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    date_time = local_datetime_or_none(payload.Data.SimpleItem[0].Value)
+    return Event(
+        f"{uid}_{topic}",
+        "Last Clock Synchronization",
+        "sensor",
+        "timestamp",
+        None,
+        date_time,
+        EntityCategory.DIAGNOSTIC,
+        entity_enabled=False,
+    )
 
 
 @PARSERS.register("tns1:RecordingConfig/JobState")
@@ -713,20 +638,17 @@ async def async_parse_jobstate(uid: str, msg) -> Event | None:
     Topic: tns1:RecordingConfig/JobState
     """
 
-    try:
-        topic, payload = extract_message(msg)
-        source = payload.Source.SimpleItem[0].Value
-        return Event(
-            f"{uid}_{topic}_{source}",
-            "Recording Job State",
-            "binary_sensor",
-            None,
-            None,
-            payload.Data.SimpleItem[0].Value == "Active",
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    topic, payload = extract_message(msg)
+    source = payload.Source.SimpleItem[0].Value
+    return Event(
+        f"{uid}_{topic}_{source}",
+        "Recording Job State",
+        "binary_sensor",
+        None,
+        None,
+        payload.Data.SimpleItem[0].Value == "Active",
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/LineDetector/Crossed")
@@ -735,30 +657,27 @@ async def async_parse_linedetector_crossed(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/LineDetector/Crossed
     """
-    try:
-        video_source = ""
-        video_analytics = ""
-        rule = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "VideoSourceConfigurationToken":
-                video_source = source.Value
-            if source.Name == "VideoAnalyticsConfigurationToken":
-                video_analytics = source.Value
-            if source.Name == "Rule":
-                rule = source.Value
+    video_source = ""
+    video_analytics = ""
+    rule = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "VideoSourceConfigurationToken":
+            video_source = source.Value
+        if source.Name == "VideoAnalyticsConfigurationToken":
+            video_analytics = source.Value
+        if source.Name == "Rule":
+            rule = source.Value
 
-        return Event(
-            f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
-            "Line Detector Crossed",
-            "sensor",
-            None,
-            None,
-            payload.Data.SimpleItem[0].Value,
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
+        "Line Detector Crossed",
+        "sensor",
+        None,
+        None,
+        payload.Data.SimpleItem[0].Value,
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:RuleEngine/CountAggregation/Counter")
@@ -767,30 +686,27 @@ async def async_parse_count_aggregation_counter(uid: str, msg) -> Event | None:
 
     Topic: tns1:RuleEngine/CountAggregation/Counter
     """
-    try:
-        video_source = ""
-        video_analytics = ""
-        rule = ""
-        topic, payload = extract_message(msg)
-        for source in payload.Source.SimpleItem:
-            if source.Name == "VideoSourceConfigurationToken":
-                video_source = _normalize_video_source(source.Value)
-            if source.Name == "VideoAnalyticsConfigurationToken":
-                video_analytics = source.Value
-            if source.Name == "Rule":
-                rule = source.Value
+    video_source = ""
+    video_analytics = ""
+    rule = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "VideoSourceConfigurationToken":
+            video_source = _normalize_video_source(source.Value)
+        if source.Name == "VideoAnalyticsConfigurationToken":
+            video_analytics = source.Value
+        if source.Name == "Rule":
+            rule = source.Value
 
-        return Event(
-            f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
-            "Count Aggregation Counter",
-            "sensor",
-            None,
-            None,
-            payload.Data.SimpleItem[0].Value,
-            EntityCategory.DIAGNOSTIC,
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}_{video_analytics}_{rule}",
+        "Count Aggregation Counter",
+        "sensor",
+        None,
+        None,
+        payload.Data.SimpleItem[0].Value,
+        EntityCategory.DIAGNOSTIC,
+    )
 
 
 @PARSERS.register("tns1:UserAlarm/IVA/HumanShapeDetect")
@@ -799,21 +715,18 @@ async def async_parse_human_shape_detect(uid: str, msg) -> Event | None:
 
     Topic: tns1:UserAlarm/IVA/HumanShapeDetect
     """
-    try:
-        topic, payload = extract_message(msg)
-        video_source = ""
-        for source in payload.Source.SimpleItem:
-            if source.Name == "VideoSourceConfigurationToken":
-                video_source = _normalize_video_source(source.Value)
-                break
+    topic, payload = extract_message(msg)
+    video_source = ""
+    for source in payload.Source.SimpleItem:
+        if source.Name == "VideoSourceConfigurationToken":
+            video_source = _normalize_video_source(source.Value)
+            break
 
-        return Event(
-            f"{uid}_{topic}_{video_source}",
-            "Human Shape Detect",
-            "binary_sensor",
-            "motion",
-            None,
-            payload.Data.SimpleItem[0].Value == "true",
-        )
-    except (AttributeError, KeyError):
-        return None
+    return Event(
+        f"{uid}_{topic}_{video_source}",
+        "Human Shape Detect",
+        "binary_sensor",
+        "motion",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )

--- a/tests/components/onvif/test_parsers.py
+++ b/tests/components/onvif/test_parsers.py
@@ -5,6 +5,7 @@ import os
 
 import onvif
 import onvif.settings
+import pytest
 from zeep import Client
 from zeep.transports import Transport
 
@@ -732,25 +733,24 @@ async def test_tapo_intrusion(hass: HomeAssistant) -> None:
 
 async def test_tapo_missing_attributes(hass: HomeAssistant) -> None:
     """Tests async_parse_tplink_detector with missing fields."""
-    event = await get_event(
-        {
-            "Message": {
-                "_value_1": {
-                    "Data": {
-                        "ElementItem": [],
-                        "Extension": None,
-                        "SimpleItem": [{"Name": "IsPeople", "Value": "true"}],
-                        "_attr_1": None,
-                    },
-                }
-            },
-            "Topic": {
-                "_value_1": "tns1:RuleEngine/PeopleDetector/People",
-            },
-        }
-    )
-
-    assert event is None
+    with pytest.raises(AttributeError, match="SimpleItem"):
+        await get_event(
+            {
+                "Message": {
+                    "_value_1": {
+                        "Data": {
+                            "ElementItem": [],
+                            "Extension": None,
+                            "SimpleItem": [{"Name": "IsPeople", "Value": "true"}],
+                            "_attr_1": None,
+                        },
+                    }
+                },
+                "Topic": {
+                    "_value_1": "tns1:RuleEngine/PeopleDetector/People",
+                },
+            }
+        )
 
 
 async def test_tapo_unknown_type(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

Move redundant attribute and key error handling to event parser caller

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
