### PR TITLE
Improve http component to ban IP addresses by subnet

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -414,14 +414,7 @@ class HomeAssistantHTTP:
         self.app[KEY_HASS] = self.hass
         self.app["hass"] = self.hass  # For backwards compatibility
 
-        # Order matters, security filters middleware needs to go first,
-        # forwarded middleware needs to go second.
-        setup_security_filter(self.app)
-
-        async_setup_forwarded(self.app, use_x_forwarded_for, self.trusted_proxies)
-
-        setup_request_context(self.app, current_request)
-
+        # Set up bans first before we look into what's being requested
         if is_ban_enabled:
             setup_bans(
                 self.hass,
@@ -431,6 +424,14 @@ class HomeAssistantHTTP:
                 log_banned_networks,
                 notify_banned_networks,
             )
+
+        # Order matters, security filters middleware needs to go first,
+        # forwarded middleware needs to go second.
+        setup_security_filter(self.app)
+
+        async_setup_forwarded(self.app, use_x_forwarded_for, self.trusted_proxies)
+
+        setup_request_context(self.app, current_request)
 
         await async_setup_auth(self.hass, self.app)
 

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -64,12 +64,6 @@ ATTR_LOG: Final = "log"
 SCHEMA_IP_BAN_ENTRY: Final = vol.Schema(
     {vol.Optional(ATTR_BANNED_AT): vol.Any(None, cv.datetime)}
 )
-SCHEMA_OPTIONS: Final = vol.Schema(
-    {
-        vol.Optional(ATTR_NOTIFY, default=False): cv.boolean,
-        vol.Optional(ATTR_LOG, default=True): cv.boolean,
-    }
-)
 
 
 @callback

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -52,7 +52,6 @@ NOTIFICATION_ID_BAN: Final = "ip-ban"
 NOTIFICATION_ID_LOGIN: Final = "http-login"
 
 IP_BANS_FILE: Final = "ip_bans.yaml"
-NETWORK_BANS_FILE: Final = "network_bans.yaml"
 
 ATTR_BANNED_AT: Final = "banned_at"
 KEY_BANNED_NETWORKS: Final = "networks"
@@ -260,7 +259,6 @@ class IpBanManager:
         """Init the ban manager."""
         self.hass = hass
         self.path = hass.config.path(IP_BANS_FILE)
-        self.banned_networks_path = hass.config.path(NETWORK_BANS_FILE)
         self.ip_bans_lookup: dict[IPv4Address | IPv6Address, IpBan] = {}
         self.banned_networks: list[ip_network] = []
         self.notify_bans: bool = True
@@ -291,10 +289,9 @@ class IpBanManager:
                     self.banned_networks.append(network_ip_network)
             except (AddressValueError, NetmaskValueError, ValueError) as err:
                 _LOGGER.error(
-                    "Error in banned network %s: %s. Check %s",
+                    "Error in banned network %s: %s. Check configuration",
                     network,
                     str(err),
-                    self.banned_networks_path,
                 )
         _LOGGER.info(
             "Banned networks: %s, log %s, notify %s",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Not a breaking change. All extra functionality is optional
## Proposed change
Security enhancement.
To add the option to block incoming requests by IP subnet not just IP address.
Any valid subnet range can be used like 1.2.3.0/24 (small range) or 1.2.0.0/16 (large range)
The existing http component only allows for individual IP addresses.

Change the order of security filtering to check for banned IP addresses (individual or range) before checking for anomalous strings in the requested path.
This is on the logic that if an IP has been flagged as suspicious there's no point checking for details in the requested path.

Added the source path to security notifications and log entries (so the user can see the origin IP address and potentially block it or its subnet)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Every incoming request is checked against a list of banned IP subnets and if the IP address is in any of the banned subnets a forbidden response is generated.
If the IP is not in any of the banned subnets, normal checking for security issues carries on as before.

`__init.py__` has been changed to load the new configuration options which are a list of banned subnets and whether or not the user wants to log and/or be notified of breaches.

The banned subnets are defined in configuration.yaml in the format:
```
http:
  ...
  ip_ban_enabled: true # existing
  login_attempts_threshold: 5 # existing
  banned_networks: # new/optional block
    - 111.7.0.0/16 # any IPv4Network
    - 45.0.0.0/8
    - 179.43.0.0/16
    - 123.160.0.0/14
    - 137.220.0.0/16
    - 195.178.0.0/16
    - 88.214.0.0/16
    - 216.10.0.0/16
  log_banned_networks: True # new/optional, defaults True
  notify_banned_networks: True #new/optional, defaults True

```
- This PR fixes or closes issue: fixes #
- This PR is related to issue: [Ban by subnet in http component (with working code)](https://community.home-assistant.io/t/ban-by-subnet-in-http-component-with-working-code/861008) and [[Security] Improvement of IPBan [HTTP Integration]](https://community.home-assistant.io/t/security-improvement-of-ipban-http-integration/863149)
- Link to documentation pull request: [Documentation update for HA PR #140661 (http banned networks) #38012](https://github.com/home-assistant/home-assistant.io/pull/38012) 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass** I need help with this
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr] I don't understand git well enough
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. I need help with this

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools: Does not communicate

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
