### PR TITLE
Add onvif parser support for reolink package and hikvision alarm

### DIFF
--- a/homeassistant/components/onvif/parsers.py
+++ b/homeassistant/components/onvif/parsers.py
@@ -49,6 +49,7 @@ def local_datetime_or_none(value: str) -> datetime.datetime | None:
 
 
 @PARSERS.register("tns1:VideoSource/MotionAlarm")
+@PARSERS.register("tns1:Device/Trigger/tnshik:AlarmIn")
 async def async_parse_motion_alarm(uid: str, msg) -> Event | None:
     """Handle parsing event message.
 
@@ -468,6 +469,28 @@ async def async_parse_visitor_detector(uid: str, msg) -> Event | None:
     return Event(
         f"{uid}_{topic}_{video_source}",
         "Visitor Detection",
+        "binary_sensor",
+        "occupancy",
+        None,
+        payload.Data.SimpleItem[0].Value == "true",
+    )
+
+
+@PARSERS.register("tns1:RuleEngine/MyRuleDetector/Package")
+async def async_parse_package_detector(uid: str, msg) -> Event | None:
+    """Handle parsing event message.
+
+    Topic: tns1:RuleEngine/MyRuleDetector/Package
+    """
+    video_source = ""
+    topic, payload = extract_message(msg)
+    for source in payload.Source.SimpleItem:
+        if source.Name == "Source":
+            video_source = _normalize_video_source(source.Value)
+
+    return Event(
+        f"{uid}_{topic}_{video_source}",
+        "Package Detection",
         "binary_sensor",
         "occupancy",
         None,

--- a/tests/components/onvif/test_parsers.py
+++ b/tests/components/onvif/test_parsers.py
@@ -789,3 +789,93 @@ async def test_tapo_unknown_type(hass: HomeAssistant) -> None:
     )
 
     assert event is None
+
+
+async def test_reolink_package(hass: HomeAssistant) -> None:
+    """Tests reolink package event."""
+    event = await get_event(
+        {
+            "SubscriptionReference": None,
+            "Topic": {
+                "_value_1": "tns1:RuleEngine/MyRuleDetector/Package",
+                "Dialect": "http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet",
+                "_attr_1": {},
+            },
+            "ProducerReference": None,
+            "Message": {
+                "_value_1": {
+                    "Source": {
+                        "SimpleItem": [{"Name": "Source", "Value": "000"}],
+                        "ElementItem": [],
+                        "Extension": None,
+                        "_attr_1": None,
+                    },
+                    "Key": None,
+                    "Data": {
+                        "SimpleItem": [{"Name": "State", "Value": "true"}],
+                        "ElementItem": [],
+                        "Extension": None,
+                        "_attr_1": None,
+                    },
+                    "Extension": None,
+                    "UtcTime": datetime.datetime(
+                        2025, 3, 12, 9, 54, 27, tzinfo=datetime.UTC
+                    ),
+                    "PropertyOperation": "Initialized",
+                    "_attr_1": {},
+                }
+            },
+        }
+    )
+
+    assert event is not None
+    assert event.name == "Package Detection"
+    assert event.platform == "binary_sensor"
+    assert event.device_class == "occupancy"
+    assert event.value
+    assert event.uid == (f"{TEST_UID}_tns1:RuleEngine/MyRuleDetector/Package_000")
+
+
+async def test_hikvision_alarm(hass: HomeAssistant) -> None:
+    """Tests hikvision camera alarm event."""
+    event = await get_event(
+        {
+            "SubscriptionReference": None,
+            "Topic": {
+                "_value_1": "tns1:Device/Trigger/tnshik:AlarmIn",
+                "Dialect": "http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet",
+                "_attr_1": {},
+            },
+            "ProducerReference": None,
+            "Message": {
+                "_value_1": {
+                    "Source": {
+                        "SimpleItem": [{"Name": "AlarmInToken", "Value": "AlarmIn_1"}],
+                        "ElementItem": [],
+                        "Extension": None,
+                        "_attr_1": None,
+                    },
+                    "Key": None,
+                    "Data": {
+                        "SimpleItem": [{"Name": "State", "Value": "true"}],
+                        "ElementItem": [],
+                        "Extension": None,
+                        "_attr_1": None,
+                    },
+                    "Extension": None,
+                    "UtcTime": datetime.datetime(
+                        2025, 3, 13, 22, 57, 26, tzinfo=datetime.UTC
+                    ),
+                    "PropertyOperation": "Initialized",
+                    "_attr_1": {},
+                }
+            },
+        }
+    )
+
+    assert event is not None
+    assert event.name == "Motion Alarm"
+    assert event.platform == "binary_sensor"
+    assert event.device_class == "motion"
+    assert event.value
+    assert event.uid == (f"{TEST_UID}_tns1:Device/Trigger/tnshik:AlarmIn_AlarmIn_1")


### PR DESCRIPTION
## Proposed change

Add onvif parser support for reolink package and hikvision alarm

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #140585
- This PR is related to issue: #140491 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
