### PR TITLE
Use google-maps-routing in google_travel_time

### DIFF
--- a/homeassistant/components/google_travel_time/__init__.py
+++ b/homeassistant/components/google_travel_time/__init__.py
@@ -1,10 +1,17 @@
 """The google_travel_time component."""
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .const import CONF_TIME
 
 PLATFORMS = [Platform.SENSOR]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -16,3 +23,37 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate an old config entry."""
+
+    if config_entry.version == 1:
+        _LOGGER.debug(
+            "Migrating from version %s.%s",
+            config_entry.version,
+            config_entry.minor_version,
+        )
+        options = dict(config_entry.options)
+        if options.get(CONF_TIME) == "now":
+            options[CONF_TIME] = None
+        elif options.get(CONF_TIME) is not None:
+            if dt_util.parse_time(options[CONF_TIME]) is None:
+                try:
+                    from_timestamp = dt_util.utc_from_timestamp(int(options[CONF_TIME]))
+                    options[CONF_TIME] = (
+                        f"{from_timestamp.time().hour:02}:{from_timestamp.time().minute:02}"
+                    )
+                except ValueError:
+                    _LOGGER.error(
+                        "Invalid time format found while migrating: %s. The old config never worked. Reset to default (empty)",
+                        options[CONF_TIME],
+                    )
+                    options[CONF_TIME] = None
+        hass.config_entries.async_update_entry(config_entry, options=options, version=2)
+        _LOGGER.debug(
+            "Migration to version %s.%s successful",
+            config_entry.version,
+            config_entry.minor_version,
+        )
+    return True

--- a/homeassistant/components/google_travel_time/config_flow.py
+++ b/homeassistant/components/google_travel_time/config_flow.py
@@ -19,6 +19,9 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
 )
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
@@ -106,7 +109,11 @@ OPTIONS_SCHEMA = vol.Schema(
                 translation_key=CONF_TIME_TYPE,
             )
         ),
-        vol.Optional(CONF_TIME, default=""): cv.string,
+        vol.Optional(CONF_TIME): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.TIME,
+            )
+        ),
         vol.Optional(CONF_TRAFFIC_MODEL): SelectSelector(
             SelectSelectorConfig(
                 options=TRAFFIC_MODELS,
@@ -181,8 +188,7 @@ async def validate_input(
 ) -> dict[str, str] | None:
     """Validate the user input allows us to connect."""
     try:
-        await hass.async_add_executor_job(
-            validate_config_entry,
+        await validate_config_entry(
             hass,
             user_input[CONF_API_KEY],
             user_input[CONF_ORIGIN],
@@ -201,7 +207,7 @@ async def validate_input(
 class GoogleTravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Google Maps Travel Time."""
 
-    VERSION = 1
+    VERSION = 2
 
     @staticmethod
     @callback

--- a/homeassistant/components/google_travel_time/config_flow.py
+++ b/homeassistant/components/google_travel_time/config_flow.py
@@ -19,9 +19,7 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
-    TextSelector,
-    TextSelectorConfig,
-    TextSelectorType,
+    TimeSelector,
 )
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
@@ -109,11 +107,7 @@ OPTIONS_SCHEMA = vol.Schema(
                 translation_key=CONF_TIME_TYPE,
             )
         ),
-        vol.Optional(CONF_TIME): TextSelector(
-            TextSelectorConfig(
-                type=TextSelectorType.TIME,
-            )
-        ),
+        vol.Optional(CONF_TIME): TimeSelector(),
         vol.Optional(CONF_TRAFFIC_MODEL): SelectSelector(
             SelectSelectorConfig(
                 options=TRAFFIC_MODELS,

--- a/homeassistant/components/google_travel_time/const.py
+++ b/homeassistant/components/google_travel_time/const.py
@@ -1,5 +1,12 @@
 """Constants for Google Travel Time."""
 
+from google.maps.routing_v2 import (
+    RouteTravelMode,
+    TrafficModel,
+    TransitPreferences,
+    Units,
+)
+
 DOMAIN = "google_travel_time"
 
 ATTRIBUTION = "Powered by Google"
@@ -7,7 +14,6 @@ ATTRIBUTION = "Powered by Google"
 CONF_DESTINATION = "destination"
 CONF_OPTIONS = "options"
 CONF_ORIGIN = "origin"
-CONF_TRAVEL_MODE = "travel_mode"
 CONF_AVOID = "avoid"
 CONF_UNITS = "units"
 CONF_ARRIVAL_TIME = "arrival_time"
@@ -79,11 +85,37 @@ ALL_LANGUAGES = [
 
 AVOID_OPTIONS = ["tolls", "highways", "ferries", "indoor"]
 TRANSIT_PREFS = ["less_walking", "fewer_transfers"]
+TRANSIT_PREFS_TO_GOOGLE_SDK_ENUM = {
+    "less_walking": TransitPreferences.TransitRoutingPreference.LESS_WALKING,
+    "fewer_transfers": TransitPreferences.TransitRoutingPreference.FEWER_TRANSFERS,
+}
 TRANSPORT_TYPES = ["bus", "subway", "train", "tram", "rail"]
+TRANSPORT_TYPES_TO_GOOGLE_SDK_ENUM = {
+    "bus": TransitPreferences.TransitTravelMode.BUS,
+    "subway": TransitPreferences.TransitTravelMode.SUBWAY,
+    "train": TransitPreferences.TransitTravelMode.TRAIN,
+    "tram": TransitPreferences.TransitTravelMode.LIGHT_RAIL,
+    "rail": TransitPreferences.TransitTravelMode.RAIL,
+}
 TRAVEL_MODES = ["driving", "walking", "bicycling", "transit"]
+TRAVEL_MODES_TO_GOOGLE_SDK_ENUM = {
+    "driving": RouteTravelMode.DRIVE,
+    "walking": RouteTravelMode.WALK,
+    "bicycling": RouteTravelMode.BICYCLE,
+    "transit": RouteTravelMode.TRANSIT,
+}
 TRAFFIC_MODELS = ["best_guess", "pessimistic", "optimistic"]
+TRAFFIC_MODELS_TO_GOOGLE_SDK_ENUM = {
+    "best_guess": TrafficModel.BEST_GUESS,
+    "pessimistic": TrafficModel.PESSIMISTIC,
+    "optimistic": TrafficModel.OPTIMISTIC,
+}
 
 # googlemaps library uses "metric" or "imperial" terminology in distance_matrix
 UNITS_METRIC = "metric"
 UNITS_IMPERIAL = "imperial"
 UNITS = [UNITS_METRIC, UNITS_IMPERIAL]
+UNITS_TO_GOOGLE_SDK_ENUM = {
+    UNITS_METRIC: Units.METRIC,
+    UNITS_IMPERIAL: Units.IMPERIAL,
+}

--- a/homeassistant/components/google_travel_time/helpers.py
+++ b/homeassistant/components/google_travel_time/helpers.py
@@ -2,41 +2,80 @@
 
 import logging
 
-from googlemaps import Client
-from googlemaps.distance_matrix import distance_matrix
-from googlemaps.exceptions import ApiError, Timeout, TransportError
+from google.api_core.client_options import ClientOptions
+from google.api_core.exceptions import (
+    Forbidden,
+    GatewayTimeout,
+    GoogleAPIError,
+    Unauthorized,
+)
+from google.maps.routing_v2 import (
+    ComputeRoutesRequest,
+    Location,
+    RoutesAsyncClient,
+    RouteTravelMode,
+    Waypoint,
+)
+from google.type import latlng_pb2
+import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.location import find_coordinates
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def validate_config_entry(
+def convert_to_waypoint(hass: HomeAssistant, location: str) -> Waypoint | None:
+    """Convert a location to a Waypoint.
+
+    Will either use coordinates or if none are found, use the location as an address.
+    """
+    coordinates = find_coordinates(hass, location)
+    if coordinates is None:
+        return None
+    try:
+        formatted_coordinates = coordinates.split(",")
+        vol.Schema(cv.gps(formatted_coordinates))
+    except (AttributeError, vol.ExactSequenceInvalid):
+        return Waypoint(address=location)
+    return Waypoint(
+        location=Location(
+            lat_lng=latlng_pb2.LatLng(
+                latitude=float(formatted_coordinates[0]),
+                longitude=float(formatted_coordinates[1]),
+            )
+        )
+    )
+
+
+async def validate_config_entry(
     hass: HomeAssistant, api_key: str, origin: str, destination: str
 ) -> None:
     """Return whether the config entry data is valid."""
-    resolved_origin = find_coordinates(hass, origin)
-    resolved_destination = find_coordinates(hass, destination)
+    resolved_origin = convert_to_waypoint(hass, origin)
+    resolved_destination = convert_to_waypoint(hass, destination)
+    client_options = ClientOptions(api_key=api_key)
+    client = RoutesAsyncClient(client_options=client_options)
     try:
-        client = Client(api_key, timeout=10)
-    except ValueError as value_error:
-        _LOGGER.error("Malformed API key")
-        raise InvalidApiKeyException from value_error
-    try:
-        distance_matrix(client, resolved_origin, resolved_destination, mode="driving")
-    except ApiError as api_error:
-        if api_error.status == "REQUEST_DENIED":
-            _LOGGER.error("Request denied: %s", api_error.message)
-            raise InvalidApiKeyException from api_error
-        _LOGGER.error("Unknown error: %s", api_error.message)
-        raise UnknownException from api_error
-    except TransportError as transport_error:
-        _LOGGER.error("Unknown error: %s", transport_error)
-        raise UnknownException from transport_error
-    except Timeout as timeout_error:
+        request = ComputeRoutesRequest(
+            origin=resolved_origin,
+            destination=resolved_destination,
+            travel_mode=RouteTravelMode.DRIVE,
+        )
+        field_mask = "routes.duration"
+        await client.compute_routes(
+            request, metadata=[("x-goog-fieldmask", field_mask)]
+        )
+    except (Unauthorized, Forbidden) as unauthorized_error:
+        _LOGGER.error("Request denied: %s", unauthorized_error.message)
+        raise InvalidApiKeyException from unauthorized_error
+    except GatewayTimeout as timeout_error:
         _LOGGER.error("Timeout error")
         raise TimeoutError from timeout_error
+    except GoogleAPIError as unknown_error:
+        _LOGGER.error("Unknown error: %s", unknown_error)
+        raise UnknownException from unknown_error
 
 
 class InvalidApiKeyException(Exception):

--- a/homeassistant/components/google_travel_time/helpers.py
+++ b/homeassistant/components/google_travel_time/helpers.py
@@ -57,13 +57,13 @@ async def validate_config_entry(
     resolved_destination = convert_to_waypoint(hass, destination)
     client_options = ClientOptions(api_key=api_key)
     client = RoutesAsyncClient(client_options=client_options)
+    field_mask = "routes.duration"
+    request = ComputeRoutesRequest(
+        origin=resolved_origin,
+        destination=resolved_destination,
+        travel_mode=RouteTravelMode.DRIVE,
+    )
     try:
-        request = ComputeRoutesRequest(
-            origin=resolved_origin,
-            destination=resolved_destination,
-            travel_mode=RouteTravelMode.DRIVE,
-        )
-        field_mask = "routes.duration"
         await client.compute_routes(
             request, metadata=[("x-goog-fieldmask", field_mask)]
         )

--- a/homeassistant/components/google_travel_time/manifest.json
+++ b/homeassistant/components/google_travel_time/manifest.json
@@ -5,6 +5,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/google_travel_time",
   "iot_class": "cloud_polling",
-  "loggers": ["googlemaps", "homeassistant.helpers.location"],
-  "requirements": ["googlemaps==2.5.1"]
+  "loggers": ["google", "homeassistant.helpers.location"],
+  "requirements": ["google-maps-routing==0.6.14"]
 }

--- a/homeassistant/components/google_travel_time/sensor.py
+++ b/homeassistant/components/google_travel_time/sensor.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+import datetime
 import logging
+from typing import TYPE_CHECKING, Any
 
-from googlemaps import Client
-from googlemaps.distance_matrix import distance_matrix
-from googlemaps.exceptions import ApiError, Timeout, TransportError
+from google.api_core.client_options import ClientOptions
+from google.api_core.exceptions import GoogleAPIError
+from google.maps.routing_v2 import (
+    ComputeRoutesRequest,
+    Route,
+    RouteModifiers,
+    RoutesAsyncClient,
+    RouteTravelMode,
+    RoutingPreference,
+    TransitPreferences,
+)
+from google.protobuf import timestamp_pb2
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -17,6 +27,8 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_API_KEY,
+    CONF_LANGUAGE,
+    CONF_MODE,
     CONF_NAME,
     EVENT_HOMEASSISTANT_STARTED,
     UnitOfTime,
@@ -30,26 +42,49 @@ from homeassistant.util import dt as dt_util
 from .const import (
     ATTRIBUTION,
     CONF_ARRIVAL_TIME,
+    CONF_AVOID,
     CONF_DEPARTURE_TIME,
     CONF_DESTINATION,
     CONF_ORIGIN,
+    CONF_TRAFFIC_MODEL,
+    CONF_TRANSIT_MODE,
+    CONF_TRANSIT_ROUTING_PREFERENCE,
+    CONF_UNITS,
     DEFAULT_NAME,
     DOMAIN,
+    TRAFFIC_MODELS_TO_GOOGLE_SDK_ENUM,
+    TRANSIT_PREFS_TO_GOOGLE_SDK_ENUM,
+    TRANSPORT_TYPES_TO_GOOGLE_SDK_ENUM,
+    TRAVEL_MODES_TO_GOOGLE_SDK_ENUM,
+    UNITS_TO_GOOGLE_SDK_ENUM,
 )
+from .helpers import convert_to_waypoint
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(minutes=5)
+SCAN_INTERVAL = datetime.timedelta(minutes=5)
+FIELD_MASK = "routes.duration,routes.localized_values"
 
 
-def convert_time_to_utc(timestr):
-    """Take a string like 08:00:00 and convert it to a unix timestamp."""
-    combined = datetime.combine(
-        dt_util.start_of_local_day(), dt_util.parse_time(timestr)
+def convert_time(time_str: str) -> timestamp_pb2.Timestamp | None:
+    """Convert a string like '08:00' to a google pb2 Timestamp.
+
+    If the time is in the past, it will be shifted to the next day.
+    """
+    parsed_time = dt_util.parse_time(time_str)
+    if TYPE_CHECKING:
+        assert parsed_time is not None
+    start_of_day = dt_util.start_of_local_day()
+    combined = datetime.datetime.combine(
+        start_of_day,
+        parsed_time,
+        start_of_day.tzinfo,
     )
-    if combined < datetime.now():
-        combined = combined + timedelta(days=1)
-    return dt_util.as_timestamp(combined)
+    if combined < dt_util.now():
+        combined = combined + datetime.timedelta(days=1)
+    timestamp = timestamp_pb2.Timestamp()
+    timestamp.FromDatetime(dt=combined)
+    return timestamp
 
 
 async def async_setup_entry(
@@ -63,7 +98,8 @@ async def async_setup_entry(
     destination = config_entry.data[CONF_DESTINATION]
     name = config_entry.data.get(CONF_NAME, DEFAULT_NAME)
 
-    client = Client(api_key, timeout=10)
+    client_options = ClientOptions(api_key=api_key)
+    client = RoutesAsyncClient(client_options=client_options)
 
     sensor = GoogleTravelTimeSensor(
         config_entry, name, api_key, origin, destination, client
@@ -80,7 +116,15 @@ class GoogleTravelTimeSensor(SensorEntity):
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, config_entry, name, api_key, origin, destination, client):
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        name: str,
+        api_key: str,
+        origin: str,
+        destination: str,
+        client: RoutesAsyncClient,
+    ) -> None:
         """Initialize the sensor."""
         self._attr_name = name
         self._attr_unique_id = config_entry.entry_id
@@ -91,13 +135,12 @@ class GoogleTravelTimeSensor(SensorEntity):
         )
 
         self._config_entry = config_entry
-        self._matrix = None
-        self._api_key = api_key
+        self._route: Route | None = None
         self._client = client
         self._origin = origin
         self._destination = destination
-        self._resolved_origin = None
-        self._resolved_destination = None
+        self._resolved_origin: str | None = None
+        self._resolved_destination: str | None = None
 
     async def async_added_to_hass(self) -> None:
         """Handle when entity is added."""
@@ -109,77 +152,127 @@ class GoogleTravelTimeSensor(SensorEntity):
             await self.first_update()
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        if self._matrix is None:
+        if self._route is None:
             return None
 
-        _data = self._matrix["rows"][0]["elements"][0]
-        if "duration_in_traffic" in _data:
-            return round(_data["duration_in_traffic"]["value"] / 60)
-        if "duration" in _data:
-            return round(_data["duration"]["value"] / 60)
-        return None
+        return round(self._route.duration.seconds / 60)
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
-        if self._matrix is None:
+        if self._route is None:
             return None
 
-        res = self._matrix.copy()
-        options = self._config_entry.options.copy()
-        res.update(options)
-        del res["rows"]
-        _data = self._matrix["rows"][0]["elements"][0]
-        if "duration_in_traffic" in _data:
-            res["duration_in_traffic"] = _data["duration_in_traffic"]["text"]
-        if "duration" in _data:
-            res["duration"] = _data["duration"]["text"]
-        if "distance" in _data:
-            res["distance"] = _data["distance"]["text"]
-        res["origin"] = self._resolved_origin
-        res["destination"] = self._resolved_destination
-        return res
+        result = self._config_entry.options.copy()
+        result["duration_in_traffic"] = self._route.localized_values.duration.text
+        result["duration"] = self._route.localized_values.static_duration.text
+        result["distance"] = self._route.localized_values.distance.text
 
-    async def first_update(self, _=None):
+        result["origin"] = self._resolved_origin
+        result["destination"] = self._resolved_destination
+        return result
+
+    async def first_update(self, _=None) -> None:
         """Run the first update and write the state."""
-        await self.hass.async_add_executor_job(self.update)
+        await self.async_update()
         self.async_write_ha_state()
 
-    def update(self) -> None:
+    async def async_update(self) -> None:
         """Get the latest data from Google."""
-        options_copy = self._config_entry.options.copy()
-        dtime = options_copy.get(CONF_DEPARTURE_TIME)
-        atime = options_copy.get(CONF_ARRIVAL_TIME)
-        if dtime is not None and ":" in dtime:
-            options_copy[CONF_DEPARTURE_TIME] = convert_time_to_utc(dtime)
-        elif dtime is not None:
-            options_copy[CONF_DEPARTURE_TIME] = dtime
-        elif atime is None:
-            options_copy[CONF_DEPARTURE_TIME] = "now"
+        travel_mode = TRAVEL_MODES_TO_GOOGLE_SDK_ENUM[
+            self._config_entry.options[CONF_MODE]
+        ]
 
-        if atime is not None and ":" in atime:
-            options_copy[CONF_ARRIVAL_TIME] = convert_time_to_utc(atime)
-        elif atime is not None:
-            options_copy[CONF_ARRIVAL_TIME] = atime
+        if (
+            departure_time := self._config_entry.options.get(CONF_DEPARTURE_TIME)
+        ) is not None:
+            departure_time = convert_time(departure_time)
+
+        if (
+            arrival_time := self._config_entry.options.get(CONF_ARRIVAL_TIME)
+        ) is not None:
+            arrival_time = convert_time(arrival_time)
+        if travel_mode != RouteTravelMode.TRANSIT:
+            arrival_time = None
+
+        traffic_model = None
+        routing_preference = None
+        route_modifiers = None
+        if travel_mode == RouteTravelMode.DRIVE:
+            if (
+                options_traffic_model := self._config_entry.options.get(
+                    CONF_TRAFFIC_MODEL
+                )
+            ) is not None:
+                traffic_model = TRAFFIC_MODELS_TO_GOOGLE_SDK_ENUM[options_traffic_model]
+            routing_preference = RoutingPreference.TRAFFIC_AWARE_OPTIMAL
+            route_modifiers = RouteModifiers(
+                avoid_tolls=self._config_entry.options.get(CONF_AVOID) == "tolls",
+                avoid_ferries=self._config_entry.options.get(CONF_AVOID) == "ferries",
+                avoid_highways=self._config_entry.options.get(CONF_AVOID) == "highways",
+                avoid_indoor=self._config_entry.options.get(CONF_AVOID) == "indoor",
+            )
+
+        transit_preferences = None
+        if travel_mode == RouteTravelMode.TRANSIT:
+            transit_routing_preference = None
+            transit_travel_mode = (
+                TransitPreferences.TransitTravelMode.TRANSIT_TRAVEL_MODE_UNSPECIFIED
+            )
+            if (
+                option_transit_preferences := self._config_entry.options.get(
+                    CONF_TRANSIT_ROUTING_PREFERENCE
+                )
+            ) is not None:
+                transit_routing_preference = TRANSIT_PREFS_TO_GOOGLE_SDK_ENUM[
+                    option_transit_preferences
+                ]
+            if (
+                option_transit_mode := self._config_entry.options.get(CONF_TRANSIT_MODE)
+            ) is not None:
+                transit_travel_mode = TRANSPORT_TYPES_TO_GOOGLE_SDK_ENUM[
+                    option_transit_mode
+                ]
+            transit_preferences = TransitPreferences(
+                routing_preference=transit_routing_preference,
+                allowed_travel_modes=[transit_travel_mode],
+            )
+
+        language = None
+        if (
+            options_language := self._config_entry.options.get(CONF_LANGUAGE)
+        ) is not None:
+            language = options_language
 
         self._resolved_origin = find_coordinates(self.hass, self._origin)
         self._resolved_destination = find_coordinates(self.hass, self._destination)
-
         _LOGGER.debug(
             "Getting update for origin: %s destination: %s",
             self._resolved_origin,
             self._resolved_destination,
         )
         if self._resolved_destination is not None and self._resolved_origin is not None:
+            request = ComputeRoutesRequest(
+                origin=convert_to_waypoint(self.hass, self._resolved_origin),
+                destination=convert_to_waypoint(self.hass, self._resolved_destination),
+                travel_mode=travel_mode,
+                routing_preference=routing_preference,
+                departure_time=departure_time,
+                arrival_time=arrival_time,
+                route_modifiers=route_modifiers,
+                language_code=language,
+                units=UNITS_TO_GOOGLE_SDK_ENUM[self._config_entry.options[CONF_UNITS]],
+                traffic_model=traffic_model,
+                transit_preferences=transit_preferences,
+            )
             try:
-                self._matrix = distance_matrix(
-                    self._client,
-                    self._resolved_origin,
-                    self._resolved_destination,
-                    **options_copy,
+                response = await self._client.compute_routes(
+                    request, metadata=[("x-goog-fieldmask", FIELD_MASK)]
                 )
-            except (ApiError, TransportError, Timeout) as ex:
+                if response is not None and len(response.routes) > 0:
+                    self._route = response.routes[0]
+            except GoogleAPIError as ex:
                 _LOGGER.error("Error getting travel time: %s", ex)
-                self._matrix = None
+                self._route = None

--- a/homeassistant/components/google_travel_time/sensor.py
+++ b/homeassistant/components/google_travel_time/sensor.py
@@ -62,7 +62,7 @@ from .helpers import convert_to_waypoint
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = datetime.timedelta(minutes=5)
+SCAN_INTERVAL = datetime.timedelta(minutes=10)
 FIELD_MASK = "routes.duration,routes.localized_values"
 
 

--- a/homeassistant/components/google_travel_time/strings.json
+++ b/homeassistant/components/google_travel_time/strings.json
@@ -1,9 +1,10 @@
 {
   "title": "Google Maps Travel Time",
+
   "config": {
     "step": {
       "user": {
-        "description": "You can specify the origin and destination in the form of an address, latitude/longitude coordinates, or a Google place ID. When specifying the location using a Google place ID, the ID must be prefixed with `place_id:`.",
+        "description": "You can specify the origin and destination in the form of an address, latitude/longitude coordinates or an entity ID that provides this information in its state, an entity ID with latitude and longitude attributes, or zone friendly name (case sensitive)",
         "data": {
           "name": "[%key:common::config_flow::data::name%]",
           "api_key": "[%key:common::config_flow::data::api_key%]",
@@ -33,7 +34,7 @@
   "options": {
     "step": {
       "init": {
-        "description": "You can optionally specify either a Departure Time or Arrival Time. If specifying a departure time, you can enter `now`, a Unix timestamp, or a 24 hour time string like `08:00:00`. If specifying an arrival time, you can use a Unix timestamp or a 24 hour time string like `08:00:00`",
+        "description": "You can optionally specify either a Departure Time or Arrival Time in the form of a 24 hour time string like `08:00:00`",
         "data": {
           "mode": "Travel Mode",
           "language": "[%key:common::config_flow::data::language%]",

--- a/homeassistant/components/google_travel_time/strings.json
+++ b/homeassistant/components/google_travel_time/strings.json
@@ -1,6 +1,5 @@
 {
   "title": "Google Maps Travel Time",
-
   "config": {
     "step": {
       "user": {
@@ -34,16 +33,16 @@
   "options": {
     "step": {
       "init": {
-        "description": "You can optionally specify either a Departure Time or Arrival Time in the form of a 24 hour time string like `08:00:00`",
+        "description": "You can optionally specify either a departure time or arrival time in the form of a 24 hour time string like `08:00:00`",
         "data": {
-          "mode": "Travel Mode",
+          "mode": "Travel mode",
           "language": "[%key:common::config_flow::data::language%]",
-          "time_type": "Time Type",
+          "time_type": "Time type",
           "time": "Time",
           "avoid": "Avoid",
-          "traffic_model": "Traffic Model",
-          "transit_mode": "Transit Mode",
-          "transit_routing_preference": "Transit Routing Preference",
+          "traffic_model": "Traffic model",
+          "transit_mode": "Transit mode",
+          "transit_routing_preference": "Transit routing preference",
           "units": "Units"
         }
       }
@@ -69,19 +68,19 @@
     },
     "units": {
       "options": {
-        "metric": "Metric System",
-        "imperial": "Imperial System"
+        "metric": "Metric system",
+        "imperial": "Imperial system"
       }
     },
     "time_type": {
       "options": {
-        "arrival_time": "Arrival Time",
-        "departure_time": "Departure Time"
+        "arrival_time": "Arrival time",
+        "departure_time": "Departure time"
       }
     },
     "traffic_model": {
       "options": {
-        "best_guess": "Best Guess",
+        "best_guess": "Best guess",
         "pessimistic": "Pessimistic",
         "optimistic": "Optimistic"
       }
@@ -97,8 +96,8 @@
     },
     "transit_routing_preference": {
       "options": {
-        "less_walking": "Less Walking",
-        "fewer_transfers": "Fewer Transfers"
+        "less_walking": "Less walking",
+        "fewer_transfers": "Fewer transfers"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1043,14 +1043,14 @@ google-cloud-texttospeech==2.25.1
 # homeassistant.components.google_generative_ai_conversation
 google-genai==1.7.0
 
+# homeassistant.components.google_travel_time
+google-maps-routing==0.6.14
+
 # homeassistant.components.nest
 google-nest-sdm==7.1.4
 
 # homeassistant.components.google_photos
 google-photos-library-api==0.12.1
-
-# homeassistant.components.google_travel_time
-googlemaps==2.5.1
 
 # homeassistant.components.slide
 # homeassistant.components.slide_local

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -894,14 +894,14 @@ google-cloud-texttospeech==2.25.1
 # homeassistant.components.google_generative_ai_conversation
 google-genai==1.7.0
 
+# homeassistant.components.google_travel_time
+google-maps-routing==0.6.14
+
 # homeassistant.components.nest
 google-nest-sdm==7.1.4
 
 # homeassistant.components.google_photos
 google-photos-library-api==0.12.1
-
-# homeassistant.components.google_travel_time
-googlemaps==2.5.1
 
 # homeassistant.components.slide
 # homeassistant.components.slide_local

--- a/tests/components/google_travel_time/conftest.py
+++ b/tests/components/google_travel_time/conftest.py
@@ -4,7 +4,6 @@ from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
-from google.api_core.exceptions import GatewayTimeout, GoogleAPIError, Unauthorized
 from google.maps.routing_v2 import ComputeRoutesResponse, Route
 from google.protobuf import duration_pb2
 from google.type import localized_text_pb2
@@ -33,8 +32,8 @@ async def mock_config_fixture(
     return config_entry
 
 
-@pytest.fixture(name="bypass_setup")
-def bypass_setup_fixture() -> Generator[None]:
+@pytest.fixture
+def mock_setup_entry() -> Generator[None]:
     """Bypass entry setup."""
     with patch(
         "homeassistant.components.google_travel_time.async_setup_entry",
@@ -43,70 +42,42 @@ def bypass_setup_fixture() -> Generator[None]:
         yield
 
 
-@pytest.fixture(name="bypass_platform_setup")
-def bypass_platform_setup_fixture() -> Generator[None]:
-    """Bypass platform setup."""
-    with patch(
-        "homeassistant.components.google_travel_time.sensor.async_setup_entry",
-        return_value=True,
-    ):
-        yield
-
-
-@pytest.fixture(name="valid_return")
-def valid_return_fixture() -> Generator[AsyncMock]:
+@pytest.fixture
+def routes_mock() -> Generator[AsyncMock]:
     """Return valid API result."""
-    client_mock = AsyncMock()
-    client_mock.compute_routes.return_value = ComputeRoutesResponse(
-        mapping={
-            "routes": [
-                Route(
-                    mapping={
-                        "localized_values": Route.RouteLocalizedValues(
-                            mapping={
-                                "distance": localized_text_pb2.LocalizedText(
-                                    text="21.3 km"
-                                ),
-                                "duration": localized_text_pb2.LocalizedText(
-                                    text="27 mins"
-                                ),
-                                "static_duration": localized_text_pb2.LocalizedText(
-                                    text="26 mins"
-                                ),
-                            }
-                        ),
-                        "duration": duration_pb2.Duration(seconds=1620),
-                    }
-                )
-            ]
-        }
-    )
     with (
         patch(
             "homeassistant.components.google_travel_time.helpers.RoutesAsyncClient",
-            return_value=client_mock,
-        ),
+            autospec=True,
+        ) as mock_client,
         patch(
             "homeassistant.components.google_travel_time.sensor.RoutesAsyncClient",
-            return_value=client_mock,
+            new=mock_client,
         ),
     ):
-        yield client_mock.compute_routes
-
-
-@pytest.fixture(name="invalidate_config_entry")
-def invalidate_config_entry_fixture(valid_return: AsyncMock) -> None:
-    """Return invalid config entry."""
-    valid_return.side_effect = GoogleAPIError("test")
-
-
-@pytest.fixture(name="invalid_api_key")
-def invalid_api_key_fixture(valid_return: AsyncMock) -> None:
-    """Throw an Unauthorized exception."""
-    valid_return.side_effect = Unauthorized("Invalid API key.")
-
-
-@pytest.fixture(name="timeout")
-def timeout_fixture(valid_return: AsyncMock) -> None:
-    """Throw a Timeout exception."""
-    valid_return.side_effect = GatewayTimeout("Timeout error.")
+        client_mock = mock_client.return_value
+        client_mock.compute_routes.return_value = ComputeRoutesResponse(
+            mapping={
+                "routes": [
+                    Route(
+                        mapping={
+                            "localized_values": Route.RouteLocalizedValues(
+                                mapping={
+                                    "distance": localized_text_pb2.LocalizedText(
+                                        text="21.3 km"
+                                    ),
+                                    "duration": localized_text_pb2.LocalizedText(
+                                        text="27 mins"
+                                    ),
+                                    "static_duration": localized_text_pb2.LocalizedText(
+                                        text="26 mins"
+                                    ),
+                                }
+                            ),
+                            "duration": duration_pb2.Duration(seconds=1620),
+                        }
+                    )
+                ]
+            }
+        )
+        yield client_mock

--- a/tests/components/google_travel_time/conftest.py
+++ b/tests/components/google_travel_time/conftest.py
@@ -5,6 +5,9 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from google.api_core.exceptions import GatewayTimeout, GoogleAPIError, Unauthorized
+from google.maps.routing_v2 import ComputeRoutesResponse, Route
+from google.protobuf import duration_pb2
+from google.type import localized_text_pb2
 import pytest
 
 from homeassistant.components.google_travel_time.const import DOMAIN
@@ -50,10 +53,34 @@ def bypass_platform_setup_fixture() -> Generator[None]:
         yield
 
 
-@pytest.fixture(name="validate_config_entry")
-def validate_config_entry_fixture() -> Generator[AsyncMock]:
-    """Return valid config entry."""
+@pytest.fixture(name="valid_return")
+def valid_return_fixture() -> Generator[AsyncMock]:
+    """Return valid API result."""
     client_mock = AsyncMock()
+    client_mock.compute_routes.return_value = ComputeRoutesResponse(
+        mapping={
+            "routes": [
+                Route(
+                    mapping={
+                        "localized_values": Route.RouteLocalizedValues(
+                            mapping={
+                                "distance": localized_text_pb2.LocalizedText(
+                                    text="21.3 km"
+                                ),
+                                "duration": localized_text_pb2.LocalizedText(
+                                    text="27 mins"
+                                ),
+                                "static_duration": localized_text_pb2.LocalizedText(
+                                    text="26 mins"
+                                ),
+                            }
+                        ),
+                        "duration": duration_pb2.Duration(seconds=1620),
+                    }
+                )
+            ]
+        }
+    )
     with (
         patch(
             "homeassistant.components.google_travel_time.helpers.RoutesAsyncClient",
@@ -64,23 +91,22 @@ def validate_config_entry_fixture() -> Generator[AsyncMock]:
             return_value=client_mock,
         ),
     ):
-        client_mock.compute_routes.return_value = None
         yield client_mock.compute_routes
 
 
 @pytest.fixture(name="invalidate_config_entry")
-def invalidate_config_entry_fixture(validate_config_entry: AsyncMock) -> None:
+def invalidate_config_entry_fixture(valid_return: AsyncMock) -> None:
     """Return invalid config entry."""
-    validate_config_entry.side_effect = GoogleAPIError("test")
+    valid_return.side_effect = GoogleAPIError("test")
 
 
 @pytest.fixture(name="invalid_api_key")
-def invalid_api_key_fixture(validate_config_entry: AsyncMock) -> None:
+def invalid_api_key_fixture(valid_return: AsyncMock) -> None:
     """Throw an Unauthorized exception."""
-    validate_config_entry.side_effect = Unauthorized("Invalid API key.")
+    valid_return.side_effect = Unauthorized("Invalid API key.")
 
 
 @pytest.fixture(name="timeout")
-def timeout_fixture(validate_config_entry: AsyncMock) -> None:
+def timeout_fixture(valid_return: AsyncMock) -> None:
     """Throw a Timeout exception."""
-    validate_config_entry.side_effect = GatewayTimeout("Timeout error.")
+    valid_return.side_effect = GatewayTimeout("Timeout error.")

--- a/tests/components/google_travel_time/const.py
+++ b/tests/components/google_travel_time/const.py
@@ -3,13 +3,15 @@
 from homeassistant.components.google_travel_time.const import (
     CONF_DESTINATION,
     CONF_ORIGIN,
+    CONF_UNITS,
+    UNITS_METRIC,
 )
-from homeassistant.const import CONF_API_KEY
+from homeassistant.const import CONF_API_KEY, CONF_MODE
 
 MOCK_CONFIG = {
     CONF_API_KEY: "api_key",
     CONF_ORIGIN: "location1",
-    CONF_DESTINATION: "location2",
+    CONF_DESTINATION: "49.983862755708444,8.223882827079068",
 }
 
 RECONFIGURE_CONFIG = {
@@ -17,3 +19,5 @@ RECONFIGURE_CONFIG = {
     CONF_ORIGIN: "location3",
     CONF_DESTINATION: "location4",
 }
+
+DEFAULT_OPTIONS = {CONF_MODE: "driving", CONF_UNITS: UNITS_METRIC}

--- a/tests/components/google_travel_time/test_config_flow.py
+++ b/tests/components/google_travel_time/test_config_flow.py
@@ -93,7 +93,7 @@ async def assert_common_create_steps(
         }
 
 
-@pytest.mark.usefixtures("validate_config_entry", "bypass_setup")
+@pytest.mark.usefixtures("valid_return", "bypass_setup")
 async def test_minimum_fields(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -163,7 +163,7 @@ async def test_timeout(hass: HomeAssistant) -> None:
     ("data", "options"),
     [(MOCK_CONFIG, DEFAULT_OPTIONS)],
 )
-@pytest.mark.usefixtures("validate_config_entry", "bypass_setup")
+@pytest.mark.usefixtures("valid_return", "bypass_setup")
 async def test_reconfigure(hass: HomeAssistant, mock_config: MockConfigEntry) -> None:
     """Test reconfigure flow."""
     reconfigure_result = await mock_config.start_reconfigure_flow(hass)
@@ -244,7 +244,7 @@ async def test_reconfigure_timeout(
     ("data", "options"),
     [(MOCK_CONFIG, DEFAULT_OPTIONS)],
 )
-@pytest.mark.usefixtures("validate_config_entry")
+@pytest.mark.usefixtures("valid_return")
 async def test_options_flow(hass: HomeAssistant, mock_config: MockConfigEntry) -> None:
     """Test options flow."""
     result = await hass.config_entries.options.async_init(
@@ -297,7 +297,7 @@ async def test_options_flow(hass: HomeAssistant, mock_config: MockConfigEntry) -
     ("data", "options"),
     [(MOCK_CONFIG, DEFAULT_OPTIONS)],
 )
-@pytest.mark.usefixtures("validate_config_entry")
+@pytest.mark.usefixtures("valid_return")
 async def test_options_flow_departure_time(
     hass: HomeAssistant, mock_config: MockConfigEntry
 ) -> None:
@@ -369,7 +369,7 @@ async def test_options_flow_departure_time(
         ),
     ],
 )
-@pytest.mark.usefixtures("validate_config_entry")
+@pytest.mark.usefixtures("valid_return")
 async def test_reset_departure_time(
     hass: HomeAssistant, mock_config: MockConfigEntry
 ) -> None:
@@ -417,7 +417,7 @@ async def test_reset_departure_time(
         ),
     ],
 )
-@pytest.mark.usefixtures("validate_config_entry")
+@pytest.mark.usefixtures("valid_return")
 async def test_reset_arrival_time(
     hass: HomeAssistant, mock_config: MockConfigEntry
 ) -> None:
@@ -463,7 +463,7 @@ async def test_reset_arrival_time(
         )
     ],
 )
-@pytest.mark.usefixtures("validate_config_entry")
+@pytest.mark.usefixtures("valid_return")
 async def test_reset_options_flow_fields(
     hass: HomeAssistant, mock_config: MockConfigEntry
 ) -> None:
@@ -492,7 +492,7 @@ async def test_reset_options_flow_fields(
     }
 
 
-@pytest.mark.usefixtures("validate_config_entry", "bypass_setup")
+@pytest.mark.usefixtures("valid_return", "bypass_setup")
 async def test_dupe(hass: HomeAssistant) -> None:
     """Test setting up the same entry data twice is OK."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/google_travel_time/test_init.py
+++ b/tests/components/google_travel_time/test_init.py
@@ -26,7 +26,7 @@ from tests.common import MockConfigEntry
         (None, None),
     ],
 )
-@pytest.mark.usefixtures("valid_return")
+@pytest.mark.usefixtures("routes_mock", "mock_setup_entry")
 async def test_migrate_entry_v1_v2(
     hass: HomeAssistant,
     v1: str,
@@ -54,7 +54,7 @@ async def test_migrate_entry_v1_v2(
     assert updated_entry.options[CONF_TIME] == v2
 
 
-@pytest.mark.usefixtures("valid_return")
+@pytest.mark.usefixtures("routes_mock", "mock_setup_entry")
 async def test_migrate_entry_v1_v2_invalid_time(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,

--- a/tests/components/google_travel_time/test_init.py
+++ b/tests/components/google_travel_time/test_init.py
@@ -26,7 +26,7 @@ from tests.common import MockConfigEntry
         (None, None),
     ],
 )
-@pytest.mark.usefixtures("validate_config_entry")
+@pytest.mark.usefixtures("valid_return")
 async def test_migrate_entry_v1_v2(
     hass: HomeAssistant,
     v1: str,
@@ -54,7 +54,7 @@ async def test_migrate_entry_v1_v2(
     assert updated_entry.options[CONF_TIME] == v2
 
 
-@pytest.mark.usefixtures("validate_config_entry")
+@pytest.mark.usefixtures("valid_return")
 async def test_migrate_entry_v1_v2_invalid_time(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,

--- a/tests/components/google_travel_time/test_init.py
+++ b/tests/components/google_travel_time/test_init.py
@@ -1,0 +1,59 @@
+"""Tests for Google Maps Travel Time init."""
+
+import pytest
+
+from homeassistant.components.google_travel_time.const import (
+    ARRIVAL_TIME,
+    CONF_TIME,
+    CONF_TIME_TYPE,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from .const import DEFAULT_OPTIONS, MOCK_CONFIG
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("v1", "v2", "caplog_message"),
+    [
+        ("08:00", "08:00", None),
+        ("08:00:00", "08:00:00", None),
+        ("1742144400", "17:00", None),
+        ("now", None, None),
+        (None, None, None),
+        ("invalid", None, "Invalid time format found while migrating"),
+    ],
+)
+@pytest.mark.usefixtures("validate_config_entry")
+async def test_migrate_entry_v1_v2(
+    hass: HomeAssistant,
+    v1: str,
+    v2: str | None,
+    caplog_message: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test successful migration of entry data."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data=MOCK_CONFIG,
+        options={
+            **DEFAULT_OPTIONS,
+            CONF_TIME_TYPE: ARRIVAL_TIME,
+            CONF_TIME: v1,
+        },
+    )
+    mock_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    updated_entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
+
+    assert updated_entry.state is ConfigEntryState.LOADED
+    assert updated_entry.version == 2
+    assert updated_entry.options[CONF_TIME] == v2
+    if caplog_message:
+        assert caplog_message in caplog.text

--- a/tests/components/google_travel_time/test_sensor.py
+++ b/tests/components/google_travel_time/test_sensor.py
@@ -184,7 +184,7 @@ async def test_sensor_unit_system(
     config_entry.add_to_hass(hass)
     with (
         patch(
-            "google.maps.routing_v2.RoutesAsyncClient.compute_routes"
+            "homeassistant.components.google_travel_time.sensor.RoutesAsyncClient.compute_routes",
         ) as compute_routes_mock,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Google has deprecated the Distance Matrix API. The new Routes API does not provide the state attributes `Destination addresses` and `Origin addresses` anymore. The amount of free requests got halved. The sensor now refreshes every 10 minutes instead of every 5 minutes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces the deprecated distance matrix api with the new Routing API.

Sources for the sdk can be found in [googleapis/google-cloud-python](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-maps-routing)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #132894
- This PR is related to issue: https://github.com/home-assistant/home-assistant.io/issues/37977
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38018
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
