### PR TITLE
Proper handling of unavailable Synology DSM nas during backup

### DIFF
--- a/homeassistant/components/backup/__init__.py
+++ b/homeassistant/components/backup/__init__.py
@@ -14,7 +14,6 @@ from .agent import (
     BackupAgent,
     BackupAgentError,
     BackupAgentPlatformProtocol,
-    BackupAgentUnreachableError,
     LocalBackupAgent,
 )
 from .config import BackupConfig, CreateBackupParametersDict
@@ -50,7 +49,6 @@ __all__ = [
     "BackupAgent",
     "BackupAgentError",
     "BackupAgentPlatformProtocol",
-    "BackupAgentUnreachableError",
     "BackupConfig",
     "BackupManagerError",
     "BackupNotFound",

--- a/homeassistant/components/backup/__init__.py
+++ b/homeassistant/components/backup/__init__.py
@@ -14,6 +14,7 @@ from .agent import (
     BackupAgent,
     BackupAgentError,
     BackupAgentPlatformProtocol,
+    BackupAgentUnreachableError,
     LocalBackupAgent,
 )
 from .config import BackupConfig, CreateBackupParametersDict
@@ -49,6 +50,7 @@ __all__ = [
     "BackupAgent",
     "BackupAgentError",
     "BackupAgentPlatformProtocol",
+    "BackupAgentUnreachableError",
     "BackupConfig",
     "BackupManagerError",
     "BackupNotFound",

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -123,6 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SynologyDSMConfigEntry) 
     entry.runtime_data = SynologyDSMData(
         api=api,
         coordinator_central=coordinator_central,
+        coordinator_central_old_update_success=True,
         coordinator_cameras=coordinator_cameras,
         coordinator_switches=coordinator_switches,
     )
@@ -139,8 +140,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: SynologyDSMConfigEntry) 
             entry.async_on_state_change(async_notify_backup_listeners)
         )
 
+        def async_check_last_update_success() -> None:
+            if (
+                coordinator_central.last_update_success
+                is not entry.runtime_data.coordinator_central_old_update_success
+            ):
+                entry.runtime_data.coordinator_central_old_update_success = (
+                    coordinator_central.last_update_success
+                )
+                async_notify_backup_listeners()
+
         entry.runtime_data.coordinator_central.async_add_listener(
-            async_notify_backup_listeners
+            async_check_last_update_success
         )
 
     return True

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -139,6 +139,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: SynologyDSMConfigEntry) 
             entry.async_on_state_change(async_notify_backup_listeners)
         )
 
+        entry.runtime_data.coordinator_central.async_add_listener(
+            async_notify_backup_listeners
+        )
+
     return True
 
 

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -142,12 +142,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: SynologyDSMConfigEntry) 
 
         def async_check_last_update_success() -> None:
             if (
-                coordinator_central.last_update_success
-                is not entry.runtime_data.coordinator_central_old_update_success
-            ):
-                entry.runtime_data.coordinator_central_old_update_success = (
-                    coordinator_central.last_update_success
-                )
+                last := coordinator_central.last_update_success
+            ) is not entry.runtime_data.coordinator_central_old_update_success:
+                entry.runtime_data.coordinator_central_old_update_success = last
                 async_notify_backup_listeners()
 
         entry.runtime_data.coordinator_central.async_add_listener(

--- a/homeassistant/components/synology_dsm/backup.py
+++ b/homeassistant/components/synology_dsm/backup.py
@@ -58,6 +58,7 @@ async def async_get_backup_agents(
         if entry.unique_id is not None
         and entry.runtime_data.api.file_station
         and entry.options.get(CONF_BACKUP_PATH)
+        and entry.runtime_data.coordinator_central.last_update_success
     ]
 
 

--- a/homeassistant/components/synology_dsm/backup.py
+++ b/homeassistant/components/synology_dsm/backup.py
@@ -8,16 +8,12 @@ from typing import TYPE_CHECKING, Any
 
 from aiohttp import StreamReader
 from synology_dsm.api.file_station import SynoFileStation
-from synology_dsm.exceptions import (
-    SynologyDSMAPIErrorException,
-    SynologyDSMRequestException,
-)
+from synology_dsm.exceptions import SynologyDSMAPIErrorException
 
 from homeassistant.components.backup import (
     AgentBackup,
     BackupAgent,
     BackupAgentError,
-    BackupAgentUnreachableError,
     BackupNotFound,
     suggested_filename,
 )
@@ -242,8 +238,6 @@ class SynologyDSMBackupAgent(BackupAgent):
             files = await self._file_station.get_files(path=self.path)
         except SynologyDSMAPIErrorException as err:
             raise BackupAgentError("Failed to list backups") from err
-        except SynologyDSMRequestException as err:
-            raise BackupAgentUnreachableError from err
 
         if TYPE_CHECKING:
             assert files

--- a/homeassistant/components/synology_dsm/backup.py
+++ b/homeassistant/components/synology_dsm/backup.py
@@ -8,12 +8,16 @@ from typing import TYPE_CHECKING, Any
 
 from aiohttp import StreamReader
 from synology_dsm.api.file_station import SynoFileStation
-from synology_dsm.exceptions import SynologyDSMAPIErrorException
+from synology_dsm.exceptions import (
+    SynologyDSMAPIErrorException,
+    SynologyDSMRequestException,
+)
 
 from homeassistant.components.backup import (
     AgentBackup,
     BackupAgent,
     BackupAgentError,
+    BackupAgentUnreachableError,
     BackupNotFound,
     suggested_filename,
 )
@@ -238,6 +242,8 @@ class SynologyDSMBackupAgent(BackupAgent):
             files = await self._file_station.get_files(path=self.path)
         except SynologyDSMAPIErrorException as err:
             raise BackupAgentError("Failed to list backups") from err
+        except SynologyDSMRequestException as err:
+            raise BackupAgentUnreachableError from err
 
         if TYPE_CHECKING:
             assert files

--- a/homeassistant/components/synology_dsm/backup.py
+++ b/homeassistant/components/synology_dsm/backup.py
@@ -178,6 +178,8 @@ class SynologyDSMBackupAgent(BackupAgent):
             )
         except SynologyDSMAPIErrorException as err:
             raise BackupAgentError("Failed to upload backup") from err
+        except SynologyDSMRequestException as err:
+            raise BackupAgentUnreachableError from err
 
         # upload backup_meta.json file when backup.tar was successful uploaded
         try:
@@ -188,6 +190,8 @@ class SynologyDSMBackupAgent(BackupAgent):
             )
         except SynologyDSMAPIErrorException as err:
             raise BackupAgentError("Failed to upload backup") from err
+        except SynologyDSMRequestException as err:
+            raise BackupAgentUnreachableError from err
 
     async def async_delete_backup(
         self,

--- a/homeassistant/components/synology_dsm/backup.py
+++ b/homeassistant/components/synology_dsm/backup.py
@@ -178,8 +178,6 @@ class SynologyDSMBackupAgent(BackupAgent):
             )
         except SynologyDSMAPIErrorException as err:
             raise BackupAgentError("Failed to upload backup") from err
-        except SynologyDSMRequestException as err:
-            raise BackupAgentUnreachableError from err
 
         # upload backup_meta.json file when backup.tar was successful uploaded
         try:
@@ -190,8 +188,6 @@ class SynologyDSMBackupAgent(BackupAgent):
             )
         except SynologyDSMAPIErrorException as err:
             raise BackupAgentError("Failed to upload backup") from err
-        except SynologyDSMRequestException as err:
-            raise BackupAgentUnreachableError from err
 
     async def async_delete_backup(
         self,

--- a/homeassistant/components/synology_dsm/coordinator.py
+++ b/homeassistant/components/synology_dsm/coordinator.py
@@ -35,6 +35,7 @@ class SynologyDSMData:
 
     api: SynoApi
     coordinator_central: SynologyDSMCentralUpdateCoordinator
+    coordinator_central_old_update_success: bool
     coordinator_cameras: SynologyDSMCameraUpdateCoordinator | None
     coordinator_switches: SynologyDSMSwitchUpdateCoordinator | None
 

--- a/tests/components/synology_dsm/test_backup.py
+++ b/tests/components/synology_dsm/test_backup.py
@@ -4,9 +4,13 @@ from io import StringIO
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from synology_dsm.api.file_station.models import SynoFileFile, SynoFileSharedFolder
-from synology_dsm.exceptions import SynologyDSMAPIErrorException
+from synology_dsm.exceptions import (
+    SynologyDSMAPIErrorException,
+    SynologyDSMRequestException,
+)
 
 from homeassistant.components.backup import (
     DOMAIN as BACKUP_DOMAIN,
@@ -277,6 +281,50 @@ async def test_agents_on_unload(
             {"agent_id": "backup.local", "name": "local"},
         ],
     }
+
+
+async def test_agents_on_changed_update_success(
+    hass: HomeAssistant,
+    setup_dsm_with_filestation: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test backup agent on changed update success of coordintaor."""
+    client = await hass_ws_client(hass)
+
+    # config entry is loaded
+    await client.send_json_auto_id({"type": "backup/agents/info"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert len(response["result"]["agents"]) == 2
+
+    # coordinator update was successful
+    freezer.tick(910)  # 15 min interval + 10s
+    await hass.async_block_till_done(wait_background_tasks=True)
+    await client.send_json_auto_id({"type": "backup/agents/info"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert len(response["result"]["agents"]) == 2
+
+    # coordinator update was un-successful
+    setup_dsm_with_filestation.update.side_effect = SynologyDSMRequestException(
+        OSError()
+    )
+    freezer.tick(910)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    await client.send_json_auto_id({"type": "backup/agents/info"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert len(response["result"]["agents"]) == 1
+
+    # coordinator update was successful again
+    setup_dsm_with_filestation.update.side_effect = None
+    freezer.tick(910)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    await client.send_json_auto_id({"type": "backup/agents/info"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert len(response["result"]["agents"]) == 2
 
 
 async def test_agents_list_backups(

--- a/tests/components/synology_dsm/test_backup.py
+++ b/tests/components/synology_dsm/test_backup.py
@@ -4,14 +4,9 @@ from io import StringIO
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
-from aiohttp import ClientError
 import pytest
 from synology_dsm.api.file_station.models import SynoFileFile, SynoFileSharedFolder
-from synology_dsm.exceptions import (
-    SynologyDSMAPIErrorException,
-    SynologyDSMException,
-    SynologyDSMRequestException,
-)
+from synology_dsm.exceptions import SynologyDSMAPIErrorException
 
 from homeassistant.components.backup import (
     DOMAIN as BACKUP_DOMAIN,
@@ -320,37 +315,26 @@ async def test_agents_list_backups(
     ]
 
 
-@pytest.mark.parametrize(
-    ("error", "expected_aget_errors"),
-    [
-        (
-            SynologyDSMAPIErrorException("api", "500", "error"),
-            {"synology_dsm.mocked_syno_dsm_entry": "Failed to list backups"},
-        ),
-        (
-            SynologyDSMRequestException(ClientError("error")),
-            {"synology_dsm.mocked_syno_dsm_entry": "The backup agent is unreachable."},
-        ),
-    ],
-)
 async def test_agents_list_backups_error(
     hass: HomeAssistant,
     setup_dsm_with_filestation: MagicMock,
     hass_ws_client: WebSocketGenerator,
-    error: SynologyDSMException,
-    expected_aget_errors: dict[str, str],
 ) -> None:
     """Test agent error while list backups."""
     client = await hass_ws_client(hass)
 
-    setup_dsm_with_filestation.file.get_files.side_effect = error
+    setup_dsm_with_filestation.file.get_files.side_effect = (
+        SynologyDSMAPIErrorException("api", "500", "error")
+    )
 
     await client.send_json_auto_id({"type": "backup/info"})
     response = await client.receive_json()
 
     assert response["success"]
     assert response["result"] == {
-        "agent_errors": expected_aget_errors,
+        "agent_errors": {
+            "synology_dsm.mocked_syno_dsm_entry": "Failed to list backups"
+        },
         "backups": [],
         "last_attempted_automatic_backup": None,
         "last_completed_automatic_backup": None,

--- a/tests/components/synology_dsm/test_backup.py
+++ b/tests/components/synology_dsm/test_backup.py
@@ -444,38 +444,27 @@ async def test_agents_get_backup_not_existing(
     assert response["result"] == {"agent_errors": {}, "backup": None}
 
 
-@pytest.mark.parametrize(
-    ("error", "expected_aget_errors"),
-    [
-        (
-            SynologyDSMAPIErrorException("api", "500", "error"),
-            {"synology_dsm.mocked_syno_dsm_entry": "Failed to list backups"},
-        ),
-        (
-            SynologyDSMRequestException(ClientError("error")),
-            {"synology_dsm.mocked_syno_dsm_entry": "The backup agent is unreachable."},
-        ),
-    ],
-)
 async def test_agents_get_backup_error(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     setup_dsm_with_filestation: MagicMock,
-    error: SynologyDSMException,
-    expected_aget_errors: dict[str, str],
 ) -> None:
     """Test agent error while get backup."""
     client = await hass_ws_client(hass)
     backup_id = "ef34ab12"
 
-    setup_dsm_with_filestation.file.get_files.side_effect = error
+    setup_dsm_with_filestation.file.get_files.side_effect = (
+        SynologyDSMAPIErrorException("api", "500", "error")
+    )
 
     await client.send_json_auto_id({"type": "backup/details", "backup_id": backup_id})
     response = await client.receive_json()
 
     assert response["success"]
     assert response["result"] == {
-        "agent_errors": expected_aget_errors,
+        "agent_errors": {
+            "synology_dsm.mocked_syno_dsm_entry": "Failed to list backups"
+        },
         "backup": None,
     }
 
@@ -585,26 +574,11 @@ async def test_agents_upload(
     assert mock.call_args_list[1].kwargs["path"] == "/ha_backup/my_backup_path"
 
 
-@pytest.mark.parametrize(
-    ("error", "expected_error"),
-    [
-        (
-            SynologyDSMAPIErrorException("api", "500", "error"),
-            "Failed to upload backup",
-        ),
-        (
-            SynologyDSMRequestException(ClientError("error")),
-            "The backup agent is unreachable.",
-        ),
-    ],
-)
 async def test_agents_upload_error(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     caplog: pytest.LogCaptureFixture,
     setup_dsm_with_filestation: MagicMock,
-    error: SynologyDSMException,
-    expected_error: str,
 ) -> None:
     """Test agent error while uploading backup."""
     client = await hass_client()
@@ -637,7 +611,9 @@ async def test_agents_upload_error(
     ):
         mocked_open.return_value.read = Mock(side_effect=[b"test", b""])
         fetch_backup.return_value = test_backup
-        setup_dsm_with_filestation.file.upload_file.side_effect = error
+        setup_dsm_with_filestation.file.upload_file.side_effect = (
+            SynologyDSMAPIErrorException("api", "500", "error")
+        )
         resp = await client.post(
             "/api/backup/upload?agent_id=synology_dsm.mocked_syno_dsm_entry",
             data={"file": StringIO("test")},
@@ -645,7 +621,7 @@ async def test_agents_upload_error(
 
     assert resp.status == 201
     assert f"Uploading backup {backup_id}" in caplog.text
-    assert expected_error in caplog.text
+    assert "Failed to upload backup" in caplog.text
     mock: AsyncMock = setup_dsm_with_filestation.file.upload_file
     assert len(mock.mock_calls) == 1
     assert mock.call_args_list[0].kwargs["filename"] == f"{base_filename}.tar"
@@ -676,7 +652,7 @@ async def test_agents_upload_error(
 
     assert resp.status == 201
     assert f"Uploading backup {backup_id}" in caplog.text
-    assert expected_error in caplog.text
+    assert "Failed to upload backup" in caplog.text
     mock: AsyncMock = setup_dsm_with_filestation.file.upload_file
     assert len(mock.mock_calls) == 3
     assert mock.call_args_list[1].kwargs["filename"] == f"{base_filename}.tar"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
~~This will proper raise the `BackupAgentUnreachableError` in case the nas is unavailable.~~
We now register a listener to `coordinator_central` updates to call the backup-agent-listeners on changes and check the `last_update_success` of the `coordinator_central` before adding a backup agent

- [x] needs #141084

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140673
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
