### PR TITLE
Fixed issue where the device was already disconnected when setting up the event platform

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -12,6 +12,7 @@ from aioshelly.exceptions import (
     DeviceConnectionError,
     InvalidAuthError,
     MacAddressMismatchError,
+    RpcCallError,
 )
 from aioshelly.rpc_device import RpcDevice, bluetooth_mac_from_primary_mac
 import voluptuous as vol
@@ -275,7 +276,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
             runtime_data.script_events = await get_rpc_scripts_event_types(
                 device, ignore_scripts=[BLE_SCRIPT_NAME]
             )
-        except (DeviceConnectionError, MacAddressMismatchError) as err:
+        except (DeviceConnectionError, MacAddressMismatchError, RpcCallError) as err:
             await device.shutdown()
             raise ConfigEntryNotReady(repr(err)) from err
         except InvalidAuthError as err:

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
+from aioshelly.ble.const import BLE_SCRIPT_NAME
 from aioshelly.block_device import BlockDevice
 from aioshelly.common import ConnectionOptions
 from aioshelly.const import DEFAULT_COAP_PORT, RPC_GENERATIONS
@@ -59,6 +60,7 @@ from .utils import (
     get_coap_context,
     get_device_entry_gen,
     get_http_port,
+    get_rpc_scripts_event_types,
     get_ws_context,
 )
 
@@ -270,6 +272,9 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                 async_create_issue_unsupported_firmware(hass, entry)
                 await device.shutdown()
                 raise ConfigEntryNotReady
+            runtime_data.script_events = await get_rpc_scripts_event_types(
+                device, ignore_scripts=[BLE_SCRIPT_NAME]
+            )
         except (DeviceConnectionError, MacAddressMismatchError) as err:
             await device.shutdown()
             raise ConfigEntryNotReady(repr(err)) from err

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -273,7 +273,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                 async_create_issue_unsupported_firmware(hass, entry)
                 await device.shutdown()
                 raise ConfigEntryNotReady
-            runtime_data.script_events = await get_rpc_scripts_event_types(
+            runtime_data.rpc_script_events = await get_rpc_scripts_event_types(
                 device, ignore_scripts=[BLE_SCRIPT_NAME]
             )
         except (DeviceConnectionError, MacAddressMismatchError, RpcCallError) as err:

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -88,6 +88,7 @@ class ShellyEntryData:
     rest: ShellyRestCoordinator | None = None
     rpc: ShellyRpcCoordinator | None = None
     rpc_poll: ShellyRpcPollingCoordinator | None = None
+    script_events: dict[int, list[str]] | None = None
 
 
 type ShellyConfigEntry = ConfigEntry[ShellyEntryData]

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -88,7 +88,7 @@ class ShellyEntryData:
     rest: ShellyRestCoordinator | None = None
     rpc: ShellyRpcCoordinator | None = None
     rpc_poll: ShellyRpcPollingCoordinator | None = None
-    script_events: dict[int, list[str]] | None = None
+    rpc_script_events: dict[int, list[str]] | None = None
 
 
 type ShellyConfigEntry = ConfigEntry[ShellyEntryData]

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -108,17 +108,15 @@ async def async_setup_entry(
         script_instances = get_rpc_key_instances(
             coordinator.device.status, SCRIPT_EVENT.key
         )
-        script_events = coordinator.config_entry.runtime_data.script_events
+        script_events = config_entry.runtime_data.script_events
         for script in script_instances:
             script_name = get_rpc_entity_name(coordinator.device, script)
             if script_name == BLE_SCRIPT_NAME:
                 continue
 
             script_id = int(script.split(":")[-1])
-            if script_events and script_events[script_id]:
-                entities.append(
-                    ShellyRpcScriptEvent(coordinator, script, script_events[script_id])
-                )
+            if script_events and (event_types := script_events[script_id]):
+                entities.append(ShellyRpcScriptEvent(coordinator, script, event_types))
 
         # If a script is removed, from the device configuration, we need to remove orphaned entities
         async_remove_orphaned_entities(

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -108,7 +108,7 @@ async def async_setup_entry(
         script_instances = get_rpc_key_instances(
             coordinator.device.status, SCRIPT_EVENT.key
         )
-        script_events = config_entry.runtime_data.script_events
+        script_events = config_entry.runtime_data.rpc_script_events
         for script in script_instances:
             script_name = get_rpc_entity_name(coordinator.device, script)
             if script_name == BLE_SCRIPT_NAME:

--- a/homeassistant/components/shelly/event.py
+++ b/homeassistant/components/shelly/event.py
@@ -34,7 +34,6 @@ from .utils import (
     get_device_entry_gen,
     get_rpc_entity_name,
     get_rpc_key_instances,
-    get_rpc_script_event_types,
     is_block_momentary_input,
     is_rpc_momentary_input,
 )
@@ -109,18 +108,17 @@ async def async_setup_entry(
         script_instances = get_rpc_key_instances(
             coordinator.device.status, SCRIPT_EVENT.key
         )
+        script_events = coordinator.config_entry.runtime_data.script_events
         for script in script_instances:
             script_name = get_rpc_entity_name(coordinator.device, script)
             if script_name == BLE_SCRIPT_NAME:
                 continue
 
-            event_types = await get_rpc_script_event_types(
-                coordinator.device, int(script.split(":")[-1])
-            )
-            if not event_types:
-                continue
-
-            entities.append(ShellyRpcScriptEvent(coordinator, script, event_types))
+            script_id = int(script.split(":")[-1])
+            if script_events and script_events[script_id]:
+                entities.append(
+                    ShellyRpcScriptEvent(coordinator, script, script_events[script_id])
+                )
 
         # If a script is removed, from the device configuration, we need to remove orphaned entities
         async_remove_orphaned_entities(

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -664,3 +664,20 @@ def get_shelly_air_lamp_life(lamp_seconds: int) -> float:
     if lamp_hours >= SHAIR_MAX_WORK_HOURS:
         return 0.0
     return 100 * (1 - lamp_hours / SHAIR_MAX_WORK_HOURS)
+
+
+async def get_rpc_scripts_event_types(
+    device: RpcDevice, ignore_scripts: list[str]
+) -> dict[int, list[str]]:
+    """Return a dict of all scripts and their event types."""
+    script_instances = get_rpc_key_instances(device.status, "script")
+    script_events = {}
+    for script in script_instances:
+        script_name = get_rpc_entity_name(device, script)
+        if script_name in ignore_scripts:
+            continue
+
+        script_id = int(script.split(":")[-1])
+        script_events[script_id] = await get_rpc_script_event_types(device, script_id)
+
+    return script_events

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -513,6 +513,9 @@ def _mock_blu_rtv_device(version: str | None = None):
         firmware_version="some fw string",
         initialized=True,
         connected=True,
+        script_getcode=AsyncMock(
+            side_effect=lambda script_id: {"data": MOCK_SCRIPTS[script_id - 1]}
+        ),
         xmod_info={},
     )
     type(device).name = PropertyMock(return_value="Test name")

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -10,6 +10,7 @@ from aioshelly.exceptions import (
     DeviceConnectionError,
     InvalidAuthError,
     MacAddressMismatchError,
+    RpcCallError,
 )
 from aioshelly.rpc_device.utils import bluetooth_mac_from_primary_mac
 import pytest
@@ -555,3 +556,17 @@ async def test_bluetooth_cleanup_on_remove_entry(
     remove_mock.assert_called_once_with(
         hass, format_mac(bluetooth_mac_from_primary_mac(entry.unique_id)).upper()
     )
+
+
+async def test_device_script_getcode_error(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test device script get code error."""
+    monkeypatch.setattr(
+        mock_rpc_device, "script_getcode", AsyncMock(side_effect=RpcCallError(0))
+    )
+
+    entry = await init_integration(hass, 2)
+    assert entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Moved `get_rpc_script_event_types` to `async_setup_entry` inside `__init__.py`, because calling it inside the `event` platform is to late and subject to a rare race condition where the device has already disconnected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140699
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
