### PR TITLE
Upgrade WSDOT's quality

### DIFF
--- a/homeassistant/components/wsdot/__init__.py
+++ b/homeassistant/components/wsdot/__init__.py
@@ -4,6 +4,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up wsdot as config entry."""
     await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])

--- a/homeassistant/components/wsdot/__init__.py
+++ b/homeassistant/components/wsdot/__init__.py
@@ -1,7 +1,7 @@
 """The wsdot component."""
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_NAME, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/wsdot/__init__.py
+++ b/homeassistant/components/wsdot/__init__.py
@@ -1,1 +1,10 @@
 """The wsdot component."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_KEY, CONF_NAME, Platform
+from homeassistant.core import HomeAssistant
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up wsdot as config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
+    return True

--- a/homeassistant/components/wsdot/config_flow.py
+++ b/homeassistant/components/wsdot/config_flow.py
@@ -12,10 +12,17 @@ from homeassistant import config_entries
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-DOMAIN = "wsdot"
-CONF_NAME = "Name"
-CONF_API_KEY = "API Key"
-
+from .const import (
+    ATTR_TRAVEL_TIME_ID,
+    ATTR_TRAVEL_TIME_NAME,
+    CONF_API_KEY,
+    CONF_TRAVEL_TIMES,
+    CONF_TRAVEL_TIMES_ID,
+    CONF_TRAVEL_TIMES_NAME,
+    DIALOG_API_KEY,
+    DIALOG_NAME,
+    DOMAIN,
+)
 
 class WSDOTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for WSDOT"""
@@ -27,11 +34,11 @@ class WSDOTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                travel_time_routes = await self.get_travel_times(user_input[CONF_API_KEY])
+                travel_time_routes = await self.get_travel_times(user_input[DIALOG_API_KEY])
             except (ClientConnectorError, TimeoutError, ClientError):
                 errors["base"] = "cannot_connect"
             #except InvalidApiKeyError:
-                #errors[CONF_API_KEY] = "invalid_api_key"
+                #errors[DIALOG_API_KEY] = "invalid_api_key"
             else:
                 await self.async_set_unique_id(
                     "+".join(travel_time_routes.keys()),
@@ -40,18 +47,18 @@ class WSDOTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(
-                    title=user_input[CONF_NAME],
+                    title=user_input[DIALOG_NAME],
                     data={
-                        "api_key": user_input[CONF_API_KEY],
-                        "travel_time": [{"id":i, "name":n} for i, n in travel_time_routes.items()],
+                        CONF_API_KEY: user_input[DIALOG_API_KEY],
+                        CONF_TRAVEL_TIMES: [{CONF_TRAVEL_TIMES_ID:i, CONF_TRAVEL_TIMES_NAME:n} for i, n in travel_time_routes.items()],
                     },
                 )
 
         return self.async_show_form(
             step_id=SOURCE_USER,
             data_schema=vol.Schema({
-                vol.Required(CONF_API_KEY): str,
-                vol.Optional(CONF_NAME, default=DOMAIN): str,
+                vol.Required(DIALOG_API_KEY): str,
+                vol.Optional(DIALOG_NAME, default=DOMAIN): str,
             }),
             errors=errors,
         )
@@ -72,4 +79,4 @@ class WSDOTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def get_travel_times(self, api_key: str) -> dict[str, str]:
         travel_times_blobs = await self.fetch_wsdot(api_key)
-        return {str(tt["TravelTimeID"]): tt["Name"] for tt in travel_times_blobs}
+        return {str(tt[ATTR_TRAVEL_TIME_ID]): tt[ATTR_TRAVEL_TIME_NAME] for tt in travel_times_blobs}

--- a/homeassistant/components/wsdot/config_flow.py
+++ b/homeassistant/components/wsdot/config_flow.py
@@ -40,12 +40,6 @@ class WSDOTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             #except InvalidApiKeyError:
                 #errors[DIALOG_API_KEY] = "invalid_api_key"
             else:
-                await self.async_set_unique_id(
-                    "+".join(travel_time_routes.keys()),
-                    raise_on_progress=False
-                )
-                self._abort_if_unique_id_configured()
-
                 return self.async_create_entry(
                     title=user_input[DIALOG_NAME],
                     data={

--- a/homeassistant/components/wsdot/config_flow.py
+++ b/homeassistant/components/wsdot/config_flow.py
@@ -1,0 +1,75 @@
+"""Adds config flow for wsdot."""
+
+from asyncio import timeout
+from typing import Any
+from urllib.parse import urlencode, urlunsplit
+
+from aiohttp import ClientError
+from aiohttp.client_exceptions import ClientConnectorError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+DOMAIN = "wsdot"
+CONF_NAME = "Name"
+CONF_API_KEY = "API Key"
+
+
+class WSDOTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Config flow for WSDOT"""
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        errors = {}
+
+        if user_input is not None:
+            try:
+                travel_time_routes = await self.get_travel_times(user_input[CONF_API_KEY])
+            except (ClientConnectorError, TimeoutError, ClientError):
+                errors["base"] = "cannot_connect"
+            #except InvalidApiKeyError:
+                #errors[CONF_API_KEY] = "invalid_api_key"
+            else:
+                await self.async_set_unique_id(
+                    "+".join(travel_time_routes.keys()),
+                    raise_on_progress=False
+                )
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME],
+                    data={
+                        "api_key": user_input[CONF_API_KEY],
+                        "travel_time": [{"id":i, "name":n} for i, n in travel_time_routes.items()],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id=SOURCE_USER,
+            data_schema=vol.Schema({
+                vol.Required(CONF_API_KEY): str,
+                vol.Optional(CONF_NAME, default=DOMAIN): str,
+            }),
+            errors=errors,
+        )
+
+    async def fetch_wsdot(self, api_key: str) -> dict[str, Any]:
+        url = urlunsplit((
+            'https',
+            'wsdot.com',
+            '/Traffic/api/TravelTimes/TravelTimesREST.svc/GetTravelTimesAsJson',
+            urlencode({"AccessCode": api_key}),
+            ''
+        ))
+        session = async_get_clientsession(self.hass)
+
+        async with timeout(15):
+            async with session.get(url) as response:
+                return await response.json()
+
+    async def get_travel_times(self, api_key: str) -> dict[str, str]:
+        travel_times_blobs = await self.fetch_wsdot(api_key)
+        return {str(tt["TravelTimeID"]): tt["Name"] for tt in travel_times_blobs}

--- a/homeassistant/components/wsdot/const.py
+++ b/homeassistant/components/wsdot/const.py
@@ -1,0 +1,38 @@
+from datetime import timedelta
+from typing import Final
+
+from homeassistant.const import (
+    ATTR_NAME as ATTR_NAME,
+    CONF_API_KEY as CONF_API_KEY,
+    CONF_ID as CONF_ID,
+    CONF_NAME as CONF_NAME,
+    UnitOfTime as UnitOfTime,
+)
+
+ATTRIBUTION: Final[str] = "Data provided by WSDOT"
+
+ATTR_ACCESS_CODE: Final[str] = "AccessCode"
+ATTR_AVG_TIME: Final[str] = "AverageTime"
+ATTR_CURRENT_TIME: Final[str] = "CurrentTime"
+ATTR_DESCRIPTION: Final[str] = "Description"
+ATTR_TIME_UPDATED: Final[str] = "TimeUpdated"
+ATTR_TRAVEL_TIME_ID: Final[str] = "TravelTimeID"
+ATTR_TRAVEL_TIME_NAME: Final[str] = "Name"
+
+CONF_TRAVEL_TIMES: Final[str] = "travel_time"
+CONF_TRAVEL_TIMES_ID: Final[str] = "id"
+CONF_TRAVEL_TIMES_NAME: Final[str] = "name"
+
+DIALOG_API_KEY: Final[str] = "API Key"
+DIALOG_NAME: Final[str] = "Name"
+
+DOMAIN: Final[str] = "wsdot"
+
+ICON: Final[str] = "mdi:car"
+
+RESOURCE: Final[str] = (
+    "http://www.wsdot.wa.gov/Traffic/api/TravelTimes/"
+    "TravelTimesREST.svc/GetTravelTimeAsJson"
+)
+
+SCAN_INTERVAL: Final = timedelta(minutes=3)

--- a/homeassistant/components/wsdot/const.py
+++ b/homeassistant/components/wsdot/const.py
@@ -1,13 +1,8 @@
-from datetime import timedelta
+"""Constants for wsdot integration."""
+
 from typing import Final
 
-from homeassistant.const import (
-    ATTR_NAME as ATTR_NAME,
-    CONF_API_KEY as CONF_API_KEY,
-    CONF_ID as CONF_ID,
-    CONF_NAME as CONF_NAME,
-    UnitOfTime as UnitOfTime,
-)
+from homeassistant import const
 
 ATTRIBUTION: Final[str] = "Data provided by WSDOT"
 
@@ -15,10 +10,14 @@ ATTR_ACCESS_CODE: Final[str] = "AccessCode"
 ATTR_AVG_TIME: Final[str] = "AverageTime"
 ATTR_CURRENT_TIME: Final[str] = "CurrentTime"
 ATTR_DESCRIPTION: Final[str] = "Description"
+ATTR_NAME = const.ATTR_NAME
 ATTR_TIME_UPDATED: Final[str] = "TimeUpdated"
 ATTR_TRAVEL_TIME_ID: Final[str] = "TravelTimeID"
 ATTR_TRAVEL_TIME_NAME: Final[str] = "Name"
 
+CONF_API_KEY = const.CONF_API_KEY
+CONF_ID = const.CONF_ID
+CONF_NAME = const.CONF_NAME
 CONF_TRAVEL_TIMES: Final[str] = "travel_time"
 CONF_TRAVEL_TIMES_ID: Final[str] = "id"
 CONF_TRAVEL_TIMES_NAME: Final[str] = "name"
@@ -35,4 +34,4 @@ RESOURCE: Final[str] = (
     "TravelTimesREST.svc/GetTravelTimeAsJson"
 )
 
-SCAN_INTERVAL: Final = timedelta(minutes=3)
+UnitOfTime = const.UnitOfTime

--- a/homeassistant/components/wsdot/manifest.json
+++ b/homeassistant/components/wsdot/manifest.json
@@ -4,7 +4,7 @@
   "codeowners": ["@ucodery"],
   "dependencies": [],
   "documentation": "https://www.home-assistant.io/integrations/wsdot",
-  "integration_type": "service",
+  "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["wsdot"],
   "quality_scale": "silver",

--- a/homeassistant/components/wsdot/manifest.json
+++ b/homeassistant/components/wsdot/manifest.json
@@ -1,9 +1,14 @@
 {
   "domain": "wsdot",
   "name": "Washington State Department of Transportation (WSDOT)",
-  "codeowners": [],
+  "codeowners": ["@ucodery"],
+  "dependencies": [],
   "documentation": "https://www.home-assistant.io/integrations/wsdot",
+  "integration_type": "service",
   "iot_class": "cloud_polling",
-  "quality_scale": "legacy",
-  "config_flow": true
+  "loggers": ["wsdot"],
+  "quality_scale": "silver",
+  "requirements": [],
+  "config_flow": true,
+  "single_config_entry": true
 }

--- a/homeassistant/components/wsdot/manifest.json
+++ b/homeassistant/components/wsdot/manifest.json
@@ -4,5 +4,6 @@
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/wsdot",
   "iot_class": "cloud_polling",
-  "quality_scale": "legacy"
+  "quality_scale": "legacy",
+  "config_flow": true
 }

--- a/homeassistant/components/wsdot/sensor.py
+++ b/homeassistant/components/wsdot/sensor.py
@@ -11,37 +11,34 @@ from typing import Any
 import requests
 import voluptuous as vol
 
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
     SensorEntity,
 )
-from homeassistant.const import ATTR_NAME, CONF_API_KEY, CONF_ID, CONF_NAME, UnitOfTime
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-_LOGGER = logging.getLogger(__name__)
-
-ATTR_ACCESS_CODE = "AccessCode"
-ATTR_AVG_TIME = "AverageTime"
-ATTR_CURRENT_TIME = "CurrentTime"
-ATTR_DESCRIPTION = "Description"
-ATTR_TIME_UPDATED = "TimeUpdated"
-ATTR_TRAVEL_TIME_ID = "TravelTimeID"
-
-ATTRIBUTION = "Data provided by WSDOT"
-
-CONF_TRAVEL_TIMES = "travel_time"
-
-ICON = "mdi:car"
-
-RESOURCE = (
-    "http://www.wsdot.wa.gov/Traffic/api/TravelTimes/"
-    "TravelTimesREST.svc/GetTravelTimeAsJson"
+from .const import (
+    CONF_API_KEY,
+    CONF_ID,
+    CONF_NAME,
+    CONF_TRAVEL_TIMES,
+    ATTR_ACCESS_CODE,
+    ATTR_AVG_TIME,
+    ATTR_CURRENT_TIME,
+    ATTR_DESCRIPTION,
+    ATTR_NAME,
+    ATTR_TIME_UPDATED,
+    ATTR_TRAVEL_TIME_ID,
+    ATTRIBUTION,
+    ICON,
+    RESOURCE,
+    UnitOfTime,
 )
 
-SCAN_INTERVAL = timedelta(minutes=3)
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
     {
@@ -53,12 +50,10 @@ PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
 )
 
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the WSDOT sensor."""
     sensors = []
@@ -70,26 +65,7 @@ async def async_setup_entry(
             )
         )
 
-    async_add_entities(sensors)
-
-
-def setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the WSDOT sensor."""
-    sensors = []
-    for travel_time in config[CONF_TRAVEL_TIMES]:
-        name = travel_time.get(CONF_NAME) or travel_time.get(CONF_ID)
-        sensors.append(
-            WashingtonStateTravelTimeSensor(
-                name, config.get(CONF_API_KEY), travel_time.get(CONF_ID)
-            )
-        )
-
-    add_entities(sensors, True)
+    add_entities(sensors)
 
 
 class WashingtonStateTransportSensor(SensorEntity):

--- a/homeassistant/components/wsdot/sensor.py
+++ b/homeassistant/components/wsdot/sensor.py
@@ -6,12 +6,11 @@ from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 import logging
 import re
-from typing import Any
+from typing import Any, Final
 
 import requests
 import voluptuous as vol
 
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
     SensorEntity,
@@ -19,12 +18,9 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
-    CONF_API_KEY,
-    CONF_ID,
-    CONF_NAME,
-    CONF_TRAVEL_TIMES,
     ATTR_ACCESS_CODE,
     ATTR_AVG_TIME,
     ATTR_CURRENT_TIME,
@@ -33,12 +29,19 @@ from .const import (
     ATTR_TIME_UPDATED,
     ATTR_TRAVEL_TIME_ID,
     ATTRIBUTION,
+    CONF_API_KEY,
+    CONF_ID,
+    CONF_NAME,
+    CONF_TRAVEL_TIMES,
     ICON,
     RESOURCE,
     UnitOfTime,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL: Final = timedelta(minutes=3)
+
 
 PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
     {
@@ -78,7 +81,7 @@ class WashingtonStateTransportSensor(SensorEntity):
 
     _attr_icon = ICON
 
-    def __init__(self, name, access_code):
+    def __init__(self, name, access_code) -> None:
         """Initialize the sensor."""
         self._data = {}
         self._access_code = access_code
@@ -86,12 +89,12 @@ class WashingtonStateTransportSensor(SensorEntity):
         self._state = None
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
-    def native_value(self):
+    def native_value(self) -> str | None:
         """Return the state of the sensor."""
         return self._state
 
@@ -102,7 +105,7 @@ class WashingtonStateTravelTimeSensor(WashingtonStateTransportSensor):
     _attr_attribution = ATTRIBUTION
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
 
-    def __init__(self, name, access_code, travel_time_id):
+    def __init__(self, name, access_code, travel_time_id) -> None:
         """Construct a travel time sensor."""
         self._travel_time_id = travel_time_id
         WashingtonStateTransportSensor.__init__(self, name, access_code)

--- a/homeassistant/components/wsdot/sensor.py
+++ b/homeassistant/components/wsdot/sensor.py
@@ -53,6 +53,26 @@ PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
 )
 
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the WSDOT sensor."""
+    sensors = []
+    for travel_time in entry.data[CONF_TRAVEL_TIMES]:
+        name = travel_time.get(CONF_NAME) or travel_time.get(CONF_ID)
+        sensors.append(
+            WashingtonStateTravelTimeSensor(
+                name, entry.data.get(CONF_API_KEY), travel_time.get(CONF_ID)
+            )
+        )
+
+    async_add_entities(sensors)
+
+
 def setup_platform(
     hass: HomeAssistant,
     config: ConfigType,

--- a/homeassistant/components/wsdot/strings.json
+++ b/homeassistant/components/wsdot/strings.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -7244,8 +7244,9 @@
     "wsdot": {
       "name": "Washington State Department of Transportation (WSDOT)",
       "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "cloud_polling"
+      "config_flow": true,
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "wyoming": {
       "name": "Wyoming Protocol",

--- a/tests/components/wsdot/conftest.py
+++ b/tests/components/wsdot/conftest.py
@@ -1,12 +1,35 @@
 """Common fixtures for the wsdot tests."""
 
 from collections.abc import Generator
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components.wsdot.config_flow import DOMAIN
-from tests.common import load_json_object_fixture
+from homeassistant.components.wsdot.const import (
+    CONF_API_KEY,
+    CONF_TRAVEL_TIMES,
+    CONF_TRAVEL_TIMES_ID,
+    CONF_TRAVEL_TIMES_NAME,
+    DOMAIN,
+)
+from tests.common import MockConfigEntry, load_json_object_fixture
+
+@pytest.fixture
+def mock_config_data() -> dict[str, Any]:
+    return {
+        CONF_API_KEY: "foo",
+        CONF_TRAVEL_TIMES: [{CONF_TRAVEL_TIMES_ID: 96, CONF_TRAVEL_TIMES_NAME: "I90 EB"}],
+    }
+
+
+@pytest.fixture
+def mock_config_entry(mock_config_data) -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="96",
+        data=mock_config_data,
+    )
 
 @pytest.fixture
 def mock_wsdot_client() -> Generator[AsyncMock]:
@@ -15,7 +38,7 @@ def mock_wsdot_client() -> Generator[AsyncMock]:
     # TODO - more accurate API response
     tt_routes = [tt_routes]
 
-    with  patch(
+    with patch(
             "homeassistant.components.wsdot.config_flow.WSDOTConfigFlow.fetch_wsdot",
         ) as wsdot_api:
         wsdot_api.return_value = tt_routes

--- a/tests/components/wsdot/conftest.py
+++ b/tests/components/wsdot/conftest.py
@@ -13,10 +13,13 @@ from homeassistant.components.wsdot.const import (
     CONF_TRAVEL_TIMES_NAME,
     DOMAIN,
 )
+
 from tests.common import MockConfigEntry, load_json_object_fixture
+
 
 @pytest.fixture
 def mock_config_data() -> dict[str, Any]:
+    """Return valid test config data."""
     return {
         CONF_API_KEY: "foo",
         CONF_TRAVEL_TIMES: [{CONF_TRAVEL_TIMES_ID: 96, CONF_TRAVEL_TIMES_NAME: "I90 EB"}],
@@ -25,21 +28,19 @@ def mock_config_data() -> dict[str, Any]:
 
 @pytest.fixture
 def mock_config_entry(mock_config_data) -> MockConfigEntry:
+    """Mock a wsdot config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        unique_id="96",
         data=mock_config_data,
     )
 
 @pytest.fixture
 def mock_wsdot_client() -> Generator[AsyncMock]:
     """Mock a wsdot client."""
-    tt_routes = load_json_object_fixture("wsdot.json", DOMAIN)
-    # TODO - more accurate API response
-    tt_routes = [tt_routes]
+    tt_routes = [load_json_object_fixture("wsdot.json", DOMAIN)]
 
     with patch(
-            "homeassistant.components.wsdot.config_flow.WSDOTConfigFlow.fetch_wsdot",
+            "homeassistant.components.wsdot.config_flow.WSDOTConfigFlow._fetch_wsdot",
         ) as wsdot_api:
         wsdot_api.return_value = tt_routes
 

--- a/tests/components/wsdot/conftest.py
+++ b/tests/components/wsdot/conftest.py
@@ -1,0 +1,23 @@
+"""Common fixtures for the wsdot tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.wsdot.config_flow import DOMAIN
+from tests.common import load_json_object_fixture
+
+@pytest.fixture
+def mock_wsdot_client() -> Generator[AsyncMock]:
+    """Mock a wsdot client."""
+    tt_routes = load_json_object_fixture("wsdot.json", DOMAIN)
+    # TODO - more accurate API response
+    tt_routes = [tt_routes]
+
+    with  patch(
+            "homeassistant.components.wsdot.config_flow.WSDOTConfigFlow.fetch_wsdot",
+        ) as wsdot_api:
+        wsdot_api.return_value = tt_routes
+
+        yield wsdot_api

--- a/tests/components/wsdot/test_config_flow.py
+++ b/tests/components/wsdot/test_config_flow.py
@@ -71,4 +71,4 @@ async def test_integration_already_exists(
     )
 
     assert result[CONF_TYPE] is FlowResultType.ABORT
-    assert result[CONF_REASON] == "already_configured"
+    assert result[CONF_REASON] == "single_instance_allowed"

--- a/tests/components/wsdot/test_config_flow.py
+++ b/tests/components/wsdot/test_config_flow.py
@@ -2,63 +2,73 @@
 
 from unittest.mock import AsyncMock
 
-from homeassistant.components.wsdot.config_flow import CONF_NAME, CONF_API_KEY, DOMAIN
+from homeassistant.components.wsdot.const import (
+    CONF_API_KEY,
+    CONF_NAME,
+    CONF_TRAVEL_TIMES,
+    CONF_TRAVEL_TIMES_ID,
+    CONF_TRAVEL_TIMES_NAME,
+    DIALOG_API_KEY,
+    DIALOG_NAME,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import (
+    CONF_SOURCE,
+    CONF_TYPE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
-VALID_CONFIG = {
-    CONF_NAME: "wsdot",
-    CONF_API_KEY: "abcd-1234",
+CONF_TITLE = "title"
+CONF_STEP_ID = "step_id"
+CONF_DATA = "data"
+CONF_REASON = "reason"
+
+VALID_USER_CONFIG = {
+    DIALOG_NAME: "wsdot",
+    DIALOG_API_KEY: "abcd-1234",
 }
 
 async def test_show_form(hass: HomeAssistant) -> None:
     """Test that the form is served with no input."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result[CONF_TYPE] is FlowResultType.FORM
+    assert result[CONF_STEP_ID] == SOURCE_USER
 
 
 async def test_create_entry(
     hass: HomeAssistant, mock_wsdot_client: AsyncMock
 ) -> None:
+    """Test that the user step works."""
     result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": SOURCE_USER},
-            data=VALID_CONFIG,
+            context={CONF_SOURCE: SOURCE_USER},
+            data=VALID_USER_CONFIG,
     )
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "wsdot"
-    assert result["data"]["api_key"] == "abcd-1234"
-    assert result["data"]["travel_time"] == [{"id": "96", "name": "Seattle-Bellevue via I-90 (EB AM)"}]
+    assert result[CONF_TYPE] is FlowResultType.CREATE_ENTRY
+    assert result[CONF_TITLE] == "wsdot"
+    assert result[CONF_DATA][CONF_API_KEY] == "abcd-1234"
+    assert result[CONF_DATA][CONF_TRAVEL_TIMES] == [{CONF_TRAVEL_TIMES_ID: "96", CONF_TRAVEL_TIMES_NAME: "Seattle-Bellevue via I-90 (EB AM)"}]
 
 
 async def test_integration_already_exists(
-    hass: HomeAssistant, mock_wsdot_client: AsyncMock
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_wsdot_client: AsyncMock
 ) -> None:
     """Test we only allow a single config flow."""
-    MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="96",
-        data= {
-            "api_key": "efgh-5678",
-            "travel_time": [
-                {"id": "96", "name": "Seattle-Bellevue via I-90 (EB AM)"},
-            ],
-        },
-    ).add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": SOURCE_USER},
-        data=VALID_CONFIG,
+        context={CONF_SOURCE: SOURCE_USER},
+        data=VALID_USER_CONFIG,
     )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result[CONF_TYPE] is FlowResultType.ABORT
+    assert result[CONF_REASON] == "already_configured"

--- a/tests/components/wsdot/test_config_flow.py
+++ b/tests/components/wsdot/test_config_flow.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock
 
 from homeassistant.components.wsdot.const import (
     CONF_API_KEY,
-    CONF_NAME,
     CONF_TRAVEL_TIMES,
     CONF_TRAVEL_TIMES_ID,
     CONF_TRAVEL_TIMES_NAME,
@@ -13,10 +12,7 @@ from homeassistant.components.wsdot.const import (
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import (
-    CONF_SOURCE,
-    CONF_TYPE,
-)
+from homeassistant.const import CONF_SOURCE, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 

--- a/tests/components/wsdot/test_config_flow.py
+++ b/tests/components/wsdot/test_config_flow.py
@@ -1,0 +1,64 @@
+"""Define tests for the wsdot config flow."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.components.wsdot.config_flow import CONF_NAME, CONF_API_KEY, DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+VALID_CONFIG = {
+    CONF_NAME: "wsdot",
+    CONF_API_KEY: "abcd-1234",
+}
+
+async def test_show_form(hass: HomeAssistant) -> None:
+    """Test that the form is served with no input."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+async def test_create_entry(
+    hass: HomeAssistant, mock_wsdot_client: AsyncMock
+) -> None:
+    result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=VALID_CONFIG,
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "wsdot"
+    assert result["data"]["api_key"] == "abcd-1234"
+    assert result["data"]["travel_time"] == [{"id": "96", "name": "Seattle-Bellevue via I-90 (EB AM)"}]
+
+
+async def test_integration_already_exists(
+    hass: HomeAssistant, mock_wsdot_client: AsyncMock
+) -> None:
+    """Test we only allow a single config flow."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="96",
+        data= {
+            "api_key": "efgh-5678",
+            "travel_time": [
+                {"id": "96", "name": "Seattle-Bellevue via I-90 (EB AM)"},
+            ],
+        },
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data=VALID_CONFIG,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/wsdot/test_sensor.py
+++ b/tests/components/wsdot/test_sensor.py
@@ -9,12 +9,7 @@ from homeassistant.components.wsdot import sensor as wsdot_sensor
 from homeassistant.components.wsdot.const import (
     ATTR_DESCRIPTION,
     ATTR_TIME_UPDATED,
-    CONF_API_KEY,
-    CONF_ID,
-    CONF_NAME,
-    CONF_TRAVEL_TIMES,
     RESOURCE,
-    SCAN_INTERVAL,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is targeted at raising the WSDOT component's quality scale from "legacy" to "silver".

There are improvements to this component that I would like to make in the future, expanding the scope of Washington DoT's API that is usable by Home Assistant. But when I began looking at the source of this component, it seemed like the best way to expand its abilities was to first modernize the component. I have tried to minimize the amount of changes that a user would experience from this upgrade.

The two main differences the user will experience:
1) a config flow rather than manually editing config.yaml + restart
2) all travel time routed are automatically retrieved and set up. This can lead to a large number of entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38040
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
