### PR TITLE
Bump wolf-comm to 0.0.23

### DIFF
--- a/homeassistant/components/wolflink/manifest.json
+++ b/homeassistant/components/wolflink/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/wolflink",
   "iot_class": "cloud_polling",
   "loggers": ["wolf_comm"],
-  "requirements": ["wolf-comm==0.0.19"]
+  "requirements": ["wolf-comm==0.0.23"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3080,7 +3080,7 @@ wirelesstagpy==0.8.1
 wled==0.21.0
 
 # homeassistant.components.wolflink
-wolf-comm==0.0.19
+wolf-comm==0.0.23
 
 # homeassistant.components.wyoming
 wyoming==1.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2478,7 +2478,7 @@ wiffi==1.1.2
 wled==0.21.0
 
 # homeassistant.components.wolflink
-wolf-comm==0.0.19
+wolf-comm==0.0.23
 
 # homeassistant.components.wyoming
 wyoming==1.5.4

--- a/tests/components/wolflink/conftest.py
+++ b/tests/components/wolflink/conftest.py
@@ -67,22 +67,25 @@ def mock_wolflink() -> Generator[MagicMock]:
         wolflink = wolflink_mock.return_value
 
         wolflink.fetch_parameters.return_value = [
-            EnergyParameter(6002800000, "Energy Parameter", "Heating", 6005200000),
+            EnergyParameter(
+                6002800000, "Energy Parameter", "Heating", 6005200000, 2000
+            ),
             ListItemParameter(
                 8002800000,
                 "List Item Parameter",
                 "Heating",
                 [ListItem("0", "Aus"), ListItem("1", "Ein")],
                 8005200000,
+                3001,
             ),
-            PowerParameter(5002800000, "Power Parameter", "Heating", 5005200000),
-            Pressure(4002800000, "Pressure Parameter", "Heating", 4005200000),
-            Temperature(3002800000, "Temperature Parameter", "Solar", 3005200000),
+            PowerParameter(5002800000, "Power Parameter", "Heating", 5005200000, 1000),
+            Pressure(4002800000, "Pressure Parameter", "Heating", 4005200000, 1000),
+            Temperature(3002800000, "Temperature Parameter", "Solar", 3005200000, 1000),
             PercentageParameter(
-                2002800000, "Percentage Parameter", "Solar", 2005200000
+                2002800000, "Percentage Parameter", "Solar", 2005200000, 1000
             ),
-            HoursParameter(7002800000, "Hours Parameter", "Heating", 7005200000),
-            SimpleParameter(1002800000, "Simple Parameter", "DHW", 1005200000),
+            HoursParameter(7002800000, "Hours Parameter", "Heating", 7005200000, 1000),
+            SimpleParameter(1002800000, "Simple Parameter", "DHW", 1005200000, 1000),
         ]
 
         wolflink.fetch_value.return_value = [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Bump wolf-comm to 0.0.23 to add support for more heatpump parameters
https://github.com/janrothkegel/wolf-comm/compare/0.0.19...0.0.23


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #138646
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
