### PR TITLE
Make `UnitSystem` a frozen dataclass

### DIFF
--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -131,18 +131,16 @@ class UnitSystem:
         if errors:
             raise ValueError(errors)
 
-        object.__setattr__(self, "_name", name)
-        object.__setattr__(
-            self, "accumulated_precipitation_unit", accumulated_precipitation
-        )
-        object.__setattr__(self, "area_unit", area)
-        object.__setattr__(self, "length_unit", length)
-        object.__setattr__(self, "mass_unit", mass)
-        object.__setattr__(self, "pressure_unit", pressure)
-        object.__setattr__(self, "temperature_unit", temperature)
-        object.__setattr__(self, "volume_unit", volume)
-        object.__setattr__(self, "wind_speed_unit", wind_speed)
-        object.__setattr__(self, "_conversions", conversions)
+        super().__setattr__("_name", name)
+        super().__setattr__("accumulated_precipitation_unit", accumulated_precipitation)
+        super().__setattr__("area_unit", area)
+        super().__setattr__("length_unit", length)
+        super().__setattr__("mass_unit", mass)
+        super().__setattr__("pressure_unit", pressure)
+        super().__setattr__("temperature_unit", temperature)
+        super().__setattr__("volume_unit", volume)
+        super().__setattr__("wind_speed_unit", wind_speed)
+        super().__setattr__("_conversions", conversions)
 
     def temperature(self, temperature: float, from_unit: str) -> float:
         """Convert the given temperature to this unit system."""

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from numbers import Number
 from typing import TYPE_CHECKING, Final
 
@@ -82,8 +83,20 @@ def _is_valid_unit(unit: str, unit_type: str) -> bool:
     return False
 
 
+@dataclass(frozen=True, kw_only=True)
 class UnitSystem:
     """A container for units of measure."""
+
+    _name: str
+    accumulated_precipitation_unit: UnitOfPrecipitationDepth
+    area_unit: UnitOfArea
+    length_unit: UnitOfLength
+    mass_unit: UnitOfMass
+    pressure_unit: UnitOfPressure
+    temperature_unit: UnitOfTemperature
+    volume_unit: UnitOfVolume
+    wind_speed_unit: UnitOfSpeed
+    _conversions: dict[tuple[SensorDeviceClass | str | None, str | None], str]
 
     def __init__(
         self,
@@ -118,16 +131,18 @@ class UnitSystem:
         if errors:
             raise ValueError(errors)
 
-        self._name = name
-        self.accumulated_precipitation_unit = accumulated_precipitation
-        self.area_unit = area
-        self.length_unit = length
-        self.mass_unit = mass
-        self.pressure_unit = pressure
-        self.temperature_unit = temperature
-        self.volume_unit = volume
-        self.wind_speed_unit = wind_speed
-        self._conversions = conversions
+        object.__setattr__(self, "_name", name)
+        object.__setattr__(
+            self, "accumulated_precipitation_unit", accumulated_precipitation
+        )
+        object.__setattr__(self, "area_unit", area)
+        object.__setattr__(self, "length_unit", length)
+        object.__setattr__(self, "mass_unit", mass)
+        object.__setattr__(self, "pressure_unit", pressure)
+        object.__setattr__(self, "temperature_unit", temperature)
+        object.__setattr__(self, "volume_unit", volume)
+        object.__setattr__(self, "wind_speed_unit", wind_speed)
+        object.__setattr__(self, "_conversions", conversions)
 
     def temperature(self, temperature: float, from_unit: str) -> float:
         """Convert the given temperature to this unit system."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
CI was failing since tests were modifying the `UnitSystem` metric constant which affected all tests if it is not set back to the original values after the test is finished, discussion about it suggested to make it a frozen data class.

Background: https://github.com/home-assistant/core/pull/140295, https://github.com/home-assistant/core/pull/140323

CI tests fixed already at: https://github.com/home-assistant/core/pull/140376, https://github.com/home-assistant/core/pull/140372, https://github.com/home-assistant/core/pull/140371, https://github.com/home-assistant/core/pull/140366, https://github.com/home-assistant/core/pull/140365, https://github.com/home-assistant/core/pull/140358, https://github.com/home-assistant/core/pull/140357 which can be seen that CI pass here for all tests.

With a frozen data class if a test modify the `UnitSystem` constant it fails (example of reverting https://github.com/home-assistant/core/pull/140365 locally):
```python
E     dataclasses.FrozenInstanceError: cannot assign to field 'temperature_unit'

<string>:24: FrozenInstanceError

tests/components/lg_thinq/test_climate.py ⨯                                                                                                                         
FAILED tests/components/lg_thinq/test_climate.py::test_all_entities - dataclasses.FrozenInstanceError: cannot assign to field 'temperature_unit'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2618
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
