### PR TITLE
Make sun `solar_rising` a binary_sensor

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -16,7 +16,10 @@ from homeassistant.helpers.typing import ConfigType
 # as we will always load it and we do not want to have
 # to wait for the import executor when its busy later
 # in the startup process.
-from . import sensor as sensor_pre_import  # noqa: F401
+from . import (
+    binary_sensor as binary_sensor_pre_import,  # noqa: F401
+    sensor as sensor_pre_import,  # noqa: F401
+)
 from .const import (  # noqa: F401  # noqa: F401
     DOMAIN,
     STATE_ABOVE_HORIZON,
@@ -52,14 +55,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: SunConfigEntry) -> bool:
     await component.async_add_entities([sun])
     entry.runtime_data = sun
     entry.async_on_unload(sun.remove_listeners)
-    await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
+    await hass.config_entries.async_forward_entry_setups(
+        entry, [Platform.SENSOR, Platform.BINARY_SENSOR]
+    )
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: SunConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(
-        entry, [Platform.SENSOR]
+        entry, [Platform.SENSOR, Platform.BINARY_SENSOR]
     ):
         await entry.runtime_data.async_remove()
     return unload_ok

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
@@ -21,11 +22,12 @@ from . import (
 )
 from .const import (  # noqa: F401  # noqa: F401
     DOMAIN,
-    PLATFORMS,
     STATE_ABOVE_HORIZON,
     STATE_BELOW_HORIZON,
 )
 from .entity import Sun, SunConfigEntry
+
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
@@ -22,6 +21,7 @@ from . import (
 )
 from .const import (  # noqa: F401  # noqa: F401
     DOMAIN,
+    PLATFORMS,
     STATE_ABOVE_HORIZON,
     STATE_BELOW_HORIZON,
 )
@@ -55,16 +55,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: SunConfigEntry) -> bool:
     await component.async_add_entities([sun])
     entry.runtime_data = sun
     entry.async_on_unload(sun.remove_listeners)
-    await hass.config_entries.async_forward_entry_setups(
-        entry, [Platform.SENSOR, Platform.BINARY_SENSOR]
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: SunConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(
-        entry, [Platform.SENSOR, Platform.BINARY_SENSOR]
-    ):
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         await entry.runtime_data.async_remove()
     return unload_ok

--- a/homeassistant/components/sun/binary_sensor.py
+++ b/homeassistant/components/sun/binary_sensor.py
@@ -1,0 +1,100 @@
+"""Sensor platform for Sun integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_DOMAIN,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN, SIGNAL_EVENTS_CHANGED
+from .entity import Sun, SunConfigEntry
+
+ENTITY_ID_BINARY_SENSOR_FORMAT = BINARY_SENSOR_DOMAIN + ".sun_{}"
+
+
+@dataclass(kw_only=True, frozen=True)
+class SunBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes a Sun sensor entity."""
+
+    value_fn: Callable[[Sun], bool | None]
+    signal: str
+
+
+BINARY_SENSOR_TYPES: tuple[SunBinarySensorEntityDescription, ...] = (
+    SunBinarySensorEntityDescription(
+        key="solar_rising",
+        translation_key="solar_rising",
+        value_fn=lambda data: data.rising,
+        entity_registry_enabled_default=False,
+        signal=SIGNAL_EVENTS_CHANGED,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SunConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Sun binary sensor platform."""
+
+    sun = entry.runtime_data
+
+    async_add_entities(
+        [
+            SunBinarySensor(sun, description, entry.entry_id)
+            for description in BINARY_SENSOR_TYPES
+        ]
+    )
+
+
+class SunBinarySensor(BinarySensorEntity):
+    """Representation of a Sun Sensor."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    entity_description: SunBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        sun: Sun,
+        entity_description: SunBinarySensorEntityDescription,
+        entry_id: str,
+    ) -> None:
+        """Initiate Sun Binary Sensor."""
+        self.entity_description = entity_description
+        self.entity_id = ENTITY_ID_BINARY_SENSOR_FORMAT.format(entity_description.key)
+        self._attr_unique_id = f"{entry_id}-binary-{entity_description.key}"
+        self.sun = sun
+        self._attr_device_info = DeviceInfo(
+            name="Sun",
+            identifiers={(DOMAIN, entry_id)},
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return value of binary sensor."""
+        return self.entity_description.value_fn(self.sun)
+
+    async def async_added_to_hass(self) -> None:
+        """Register signal listener when added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.entity_description.signal,
+                self.async_write_ha_state,
+            )
+        )

--- a/homeassistant/components/sun/binary_sensor.py
+++ b/homeassistant/components/sun/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for Sun integration."""
+"""Binary Sensor platform for Sun integration."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ ENTITY_ID_BINARY_SENSOR_FORMAT = BINARY_SENSOR_DOMAIN + ".sun_{}"
 
 @dataclass(kw_only=True, frozen=True)
 class SunBinarySensorEntityDescription(BinarySensorEntityDescription):
-    """Describes a Sun sensor entity."""
+    """Describes a Sun binary sensor entity."""
 
     value_fn: Callable[[Sun], bool | None]
     signal: str
@@ -59,7 +59,7 @@ async def async_setup_entry(
 
 
 class SunBinarySensor(BinarySensorEntity):
-    """Representation of a Sun Sensor."""
+    """Representation of a Sun binary sensor."""
 
     _attr_has_entity_name = True
     _attr_should_poll = False
@@ -75,7 +75,7 @@ class SunBinarySensor(BinarySensorEntity):
         """Initiate Sun Binary Sensor."""
         self.entity_description = entity_description
         self.entity_id = ENTITY_ID_BINARY_SENSOR_FORMAT.format(entity_description.key)
-        self._attr_unique_id = f"{entry_id}-binary-{entity_description.key}"
+        self._attr_unique_id = f"{entry_id}-{entity_description.key}"
         self.sun = sun
         self._attr_device_info = DeviceInfo(
             name="Sun",

--- a/homeassistant/components/sun/const.py
+++ b/homeassistant/components/sun/const.py
@@ -2,11 +2,7 @@
 
 from typing import Final
 
-from homeassistant.const import Platform
-
 DOMAIN: Final = "sun"
-
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 DEFAULT_NAME: Final = "Sun"
 

--- a/homeassistant/components/sun/const.py
+++ b/homeassistant/components/sun/const.py
@@ -2,7 +2,11 @@
 
 from typing import Final
 
+from homeassistant.const import Platform
+
 DOMAIN: Final = "sun"
+
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 DEFAULT_NAME: Final = "Sun"
 

--- a/homeassistant/components/sun/icons.json
+++ b/homeassistant/components/sun/icons.json
@@ -28,6 +28,15 @@
       "solar_rising": {
         "default": "mdi:sun-clock"
       }
+    },
+    "binary_sensor": {
+      "solar_rising": {
+        "default": "mdi:weather-sunny-off",
+        "state": {
+          "on": "mdi:weather-sunset-up",
+          "off": "mdi:weather-sunset-down"
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -29,7 +29,13 @@
       "solar_rising": { "name": "Solar rising" }
     },
     "binary_sensor": {
-      "solar_rising": { "name": "Solar rising" }
+      "solar_rising": {
+        "name": "Solar rising",
+        "state": {
+          "on": "Rising",
+          "off": "Falling"
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -27,6 +27,9 @@
       "solar_azimuth": { "name": "Solar azimuth" },
       "solar_elevation": { "name": "Solar elevation" },
       "solar_rising": { "name": "Solar rising" }
+    },
+    "binary_sensor": {
+      "solar_rising": { "name": "Solar rising" }
     }
   }
 }

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -33,7 +33,7 @@
         "name": "Solar rising",
         "state": {
           "on": "Rising",
-          "off": "Falling"
+          "off": "Setting"
         }
       }
     }

--- a/tests/components/sun/test_binary_sensor.py
+++ b/tests/components/sun/test_binary_sensor.py
@@ -1,0 +1,44 @@
+"""The tests for the Sun binary_sensor platform."""
+
+from datetime import datetime, timedelta
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.components import sun
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_setting_rising(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test retrieving sun setting and rising."""
+    utc_now = datetime(2016, 11, 1, 8, 0, 0, tzinfo=dt_util.UTC)
+    freezer.move_to(utc_now)
+    await async_setup_component(hass, sun.DOMAIN, {sun.DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.sun_solar_rising").state == "on"
+
+    entry_ids = hass.config_entries.async_entries("sun")
+
+    freezer.tick(timedelta(hours=12))
+    # Block once for Sun to update
+    await hass.async_block_till_done()
+    # Block another time for the sensors to update
+    await hass.async_block_till_done()
+
+    # Make sure all the signals work
+    assert hass.states.get("binary_sensor.sun_solar_rising").state == "off"
+
+    entity = entity_registry.async_get("binary_sensor.sun_solar_rising")
+    assert entity
+    assert entity.entity_category is EntityCategory.DIAGNOSTIC
+    assert entity.unique_id == f"{entry_ids[0].entry_id}-binary-solar_rising"

--- a/tests/components/sun/test_binary_sensor.py
+++ b/tests/components/sun/test_binary_sensor.py
@@ -41,4 +41,4 @@ async def test_setting_rising(
     entity = entity_registry.async_get("binary_sensor.sun_solar_rising")
     assert entity
     assert entity.entity_category is EntityCategory.DIAGNOSTIC
-    assert entity.unique_id == f"{entry_ids[0].entry_id}-binary-solar_rising"
+    assert entity.unique_id == f"{entry_ids[0].entry_id}-solar_rising"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A sun sensor for `solar_rising` has been previously added, but it seems like this maybe should have been a binary sensor instead.

Its only state values are `"True"` or `"False"`. It is just a mirroring of a boolean attribute.

It has no hints in automation editor for what values are valid. Testing `"on"`, `"true"`, `"On"`, `True` etc will all give the wrong result for state comparison and may be confusing to users. 

This PR adds a binary_sensor that mimics the existing sensor. I'm not sure what should be done with the existing sensor, if we should announce a plan to deprecate it, or just let both coexist, or yank it out with a breaking change. 

Both old and new sensor are disabled by default.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39273
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
