### PR TITLE
Add a GetHomeState tool to return the current state of the home

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -901,7 +901,7 @@ class GetHomeStateTool(Tool):
     """
 
     name = "get_home_state"
-    description = "Get the current state of devices in the home. "
+    description = "Get the current state of all devices in the home. "
 
     async def async_call(
         self,

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -66,6 +66,11 @@ Answer questions about the world truthfully.
 Answer in plain text. Keep it simple and to the point.
 """
 
+NO_ENTITIES_PROMPT = (
+    "Only if the user wants to control a device, tell them to expose entities "
+    "to their voice assistant in Home Assistant."
+)
+
 
 @callback
 def async_render_no_api_prompt(hass: HomeAssistant) -> str:
@@ -329,10 +334,7 @@ class AssistAPI(API):
         self, llm_context: LLMContext, exposed_entities: dict | None
     ) -> str:
         if not exposed_entities or not exposed_entities["entities"]:
-            return (
-                "Only if the user wants to control a device, tell them to expose entities "
-                "to their voice assistant in Home Assistant."
-            )
+            return NO_ENTITIES_PROMPT
         return "\n".join(
             [
                 *self._async_get_preable(llm_context),
@@ -453,6 +455,7 @@ class AssistAPI(API):
                 ScriptTool(self.hass, script_entity_id)
                 for script_entity_id in exposed_entities[SCRIPT_DOMAIN]
             )
+            tools.append(GetHomeStateTool())
 
         return tools
 
@@ -885,3 +888,39 @@ class CalendarGetEventsTool(Tool):
         ]
 
         return {"success": True, "result": events}
+
+
+class GetHomeStateTool(Tool):
+    """Tool for getting the current state of exposed entities.
+
+    This returns state for all entities that have been exposed to
+    the assistant. This is different than the GetState intent, which
+    returns state for entities based on intent parameters.
+    """
+
+    name = "get_home_state"
+    description = "Get the current state of devices in the home. "
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: ToolInput,
+        llm_context: LLMContext,
+    ) -> JsonObjectType:
+        """Get the current state of exposed entities."""
+        if llm_context.assistant is None:
+            # Note this doesn't happen in practice since this tool won't be
+            # exposed if no assistant is configured.
+            return {"success": False, "error": "No assistant configured"}
+
+        exposed_entities = _get_exposed_entities(hass, llm_context.assistant)
+        if not exposed_entities["entities"]:
+            return {"success": False, "error": NO_ENTITIES_PROMPT}
+        prompt = [
+            "An overview of the areas and the devices in this smart home:",
+            yaml_util.dump(list(exposed_entities["entities"].values())),
+        ]
+        return {
+            "success": True,
+            "result": "\n".join(prompt),
+        }

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -455,6 +455,8 @@ class AssistAPI(API):
                 ScriptTool(self.hass, script_entity_id)
                 for script_entity_id in exposed_entities[SCRIPT_DOMAIN]
             )
+
+        if exposed_domains:
             tools.append(GetHomeStateTool())
 
         return tools

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -181,19 +181,19 @@ async def test_assist_api(
 
     assert len(llm.async_get_apis(hass)) == 1
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert len(api.tools) == 0
+    assert [tool.name for tool in api.tools] == ["get_home_state"]
 
     # Match all
     intent_handler.platforms = None
 
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert len(api.tools) == 1
+    assert [tool.name for tool in api.tools] == ["test_intent", "get_home_state"]
 
     # Match specific domain
     intent_handler.platforms = {"light"}
 
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert len(api.tools) == 1
+    assert len(api.tools) == 2
     tool = api.tools[0]
     assert tool.name == "test_intent"
     assert tool.description == "Execute Home Assistant test_intent intent"
@@ -642,6 +642,15 @@ async def test_assist_api_prompt(
 {no_timer_prompt}
 {exposed_entities_prompt}"""
     )
+
+    # Verify that the get_home_state tool returns the same results as the exposed_entities_prompt
+    result = await api.async_call_tool(
+        llm.ToolInput(tool_name="get_home_state", tool_args={})
+    )
+    assert result == {
+        "success": True,
+        "result": exposed_entities_prompt,
+    }
 
     # Fake that request is made from a specific device ID with an area
     llm_context.device_id = device.id
@@ -1266,4 +1275,27 @@ async def test_calendar_get_events_tool(hass: HomeAssistant) -> None:
         "entity_id": ["calendar.test_calendar"],
         "start_date_time": now,
         "end_date_time": dt_util.start_of_local_day() + timedelta(days=7),
+    }
+
+
+async def test_get_home_state_no_entities(hass: HomeAssistant) -> None:
+    """Test the get home state tool when no entities are exposed."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    context = Context()
+    llm_context = llm.LLMContext(
+        platform="test_platform",
+        context=context,
+        user_prompt="test_text",
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+    api = await llm.async_get_api(hass, "assist", llm_context)
+
+    result = await api.async_call_tool(
+        llm.ToolInput(tool_name="get_home_state", tool_args={})
+    )
+    assert result == {
+        "success": False,
+        "error": "Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.",
     }

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1278,8 +1278,8 @@ async def test_calendar_get_events_tool(hass: HomeAssistant) -> None:
     }
 
 
-async def test_get_home_state_no_entities(hass: HomeAssistant) -> None:
-    """Test the get home state tool when no entities are exposed."""
+async def test_no_tools_exposed(hass: HomeAssistant) -> None:
+    """Test that tools are not exposed when no entities are exposed."""
     assert await async_setup_component(hass, "homeassistant", {})
     context = Context()
     llm_context = llm.LLMContext(
@@ -1291,11 +1291,4 @@ async def test_get_home_state_no_entities(hass: HomeAssistant) -> None:
         device_id=None,
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
-
-    result = await api.async_call_tool(
-        llm.ToolInput(tool_name="get_home_state", tool_args={})
-    )
-    assert result == {
-        "success": False,
-        "error": "Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.",
-    }
+    assert api.tools == []


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a GetHomeState tool to return the current state of the home. This is intended to (1) support MCP where users need to take action to attach a prompt and (2) in a follow up, replace the state in the prompt which will reduce token count and potentially improve token caching. 

The main insight is that most tool calls don't care about the current state, so no round trips are added typically. The only round trips that add state are things that query current state or need to chain actions together based on state.

Eval results show no significant change (models tested: claude-3-haiku, gemini-1.5-flash, gemini-2.0-flash, gpt-4o-mini, qwen2.5) and all models are within confidence interval.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
