### PR TITLE
Remove stale devices automatically for Roborock

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -148,6 +148,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
             ):
                 # The home_data api returns ALL devices on the account
                 # even if they are offline, so we can safely delete.
+                _LOGGER.info(
+                    "Removing device: %s because it is no longer exists in your account",
+                    identifier[1],
+                )
                 device_registry.async_update_device(
                     device_id=device.id,
                     remove_config_entry_id=entry.entry_id,

--- a/homeassistant/components/roborock/quality_scale.yaml
+++ b/homeassistant/components/roborock/quality_scale.yaml
@@ -70,11 +70,7 @@ rules:
   repair-issues:
     status: todo
     comment: The Cloud vs Local API warning should probably be a repair issue.
-  stale-devices:
-    status: todo
-    comment: |
-      The integration does not yet handle stale devices. The roborock app does
-      support deleting devices and this is a gap #132590
+  stale-devices: done
   # Platinum
   async-dependency: todo
   inject-websession:

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -11,6 +11,7 @@ import uuid
 import pytest
 from roborock import RoborockCategory, RoomMapping
 from roborock.code_mappings import DyadError, RoborockDyadStateCode, ZeoError, ZeoState
+from roborock.containers import NetworkInfo
 from roborock.roborock_message import RoborockDyadDataProtocol, RoborockZeoProtocol
 from roborock.version_a01_apis import RoborockMqttClientA01
 
@@ -29,6 +30,7 @@ from .mock_data import (
     MAP_DATA,
     MULTI_MAP_LIST,
     NETWORK_INFO,
+    NETWORK_INFO_2,
     PROP,
     SCENES,
     USER_DATA,
@@ -87,6 +89,13 @@ def bypass_api_client_fixture() -> None:
         yield
 
 
+def cycle_network_info() -> Generator[NetworkInfo]:
+    """Return the appropriate network info for the corresponding device."""
+    while True:
+        yield NETWORK_INFO
+        yield NETWORK_INFO_2
+
+
 @pytest.fixture(name="bypass_api_fixture")
 def bypass_api_fixture(bypass_api_client_fixture: Any) -> None:
     """Skip calls to the API."""
@@ -98,7 +107,7 @@ def bypass_api_fixture(bypass_api_client_fixture: Any) -> None:
         ),
         patch(
             "homeassistant.components.roborock.RoborockMqttClientV1.get_networking",
-            return_value=NETWORK_INFO,
+            side_effect=cycle_network_info(),
         ),
         patch(
             "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_prop",

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -1122,6 +1122,9 @@ PROP = DeviceProp(
 NETWORK_INFO = NetworkInfo(
     ip="123.232.12.1", ssid="wifi", mac="ac:cc:cc:cc:cc", bssid="bssid", rssi=90
 )
+NETWORK_INFO_2 = NetworkInfo(
+    ip="123.232.12.2", ssid="wifi", mac="ac:cc:cc:cc:cd", bssid="bssid", rssi=90
+)
 
 MULTI_MAP_LIST = MultiMapsList.from_dict(
     {

--- a/tests/components/roborock/snapshots/test_diagnostics.ambr
+++ b/tests/components/roborock/snapshots/test_diagnostics.ambr
@@ -357,7 +357,7 @@
           }),
           'network_info': dict({
             'bssid': '**REDACTED**',
-            'ip': '123.232.12.1',
+            'ip': '123.232.12.2',
             'mac': '**REDACTED**',
             'rssi': 90,
             'ssid': 'wifi',

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.setup import async_setup_component
 
-from .mock_data import HOME_DATA
+from .mock_data import HOME_DATA, NETWORK_INFO
 
 from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator
@@ -310,7 +310,7 @@ async def test_stale_device(
     existing_devices = device_registry.devices.get_devices_for_config_entry_id(
         mock_roborock_entry.entry_id
     )
-    assert len(existing_devices) == 5  # 2 for each robot, 1 for A01
+    assert len(existing_devices) == 6  # 2 for each robot, 1 for A01, 1 for Zeo
     hd = deepcopy(HOME_DATA)
     hd.devices = [hd.devices[0]]
 
@@ -324,6 +324,32 @@ async def test_stale_device(
         mock_roborock_entry.entry_id
     )
     assert (
-        len(new_devices) == 3
-    )  # 2 for the one remaining robot. 1 for the A01 which is shared and therefore
-    # not deleted.
+        len(new_devices) == 4
+    )  # 2 for the one remaining robot. 1 for both the A01s which are shared and
+    # therefore not deleted.
+
+
+async def test_no_stale_device(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    mock_roborock_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test that we don't remove a device if fails to setup."""
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    assert mock_roborock_entry.state is ConfigEntryState.LOADED
+    existing_devices = device_registry.devices.get_devices_for_config_entry_id(
+        mock_roborock_entry.entry_id
+    )
+    assert len(existing_devices) == 6  # 2 for each robot, 1 for A01, 1 for Zeo
+
+    with patch(
+        "homeassistant.components.roborock.RoborockMqttClientV1.get_networking",
+        side_effect=[NETWORK_INFO, RoborockException],
+    ):
+        await hass.config_entries.async_reload(mock_roborock_entry.entry_id)
+        await hass.async_block_till_done()
+    new_devices = device_registry.devices.get_devices_for_config_entry_id(
+        mock_roborock_entry.entry_id
+    )
+    assert len(new_devices) == 6  # 2 for each robot, 1 for A01, 1 for Zeo


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Roborock home_data_v2 endpoint will give all devices currently on the account. If a user removes a device, it will no longer show up in home_data_v2, and will then be removed from the integration.

This currently can only happen once on config entry load, as we do not get this information on every coordinator update.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #132590
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
