### PR TITLE
Add attachment and connection status for IOmeter

### DIFF
--- a/homeassistant/components/iometer/__init__.py
+++ b/homeassistant/components/iometer/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .coordinator import IOmeterConfigEntry, IOMeterCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: IOmeterConfigEntry) -> bool:

--- a/homeassistant/components/iometer/binary_sensor.py
+++ b/homeassistant/components/iometer/binary_sensor.py
@@ -1,0 +1,87 @@
+"""IOmeter binary sensor."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import IOMeterCoordinator, IOmeterData
+from .entity import IOmeterEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class IOmeterBinarySensorDescription(BinarySensorEntityDescription):
+    """Describes Iometer binary sensor entity."""
+
+    value_fn: Callable[[IOmeterData], str | None]
+
+
+SENSOR_TYPES: list[IOmeterBinarySensorDescription] = [
+    IOmeterBinarySensorDescription(
+        key="connection_status",
+        translation_key="connection_status",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.status.device.core.connection_status,
+    ),
+    IOmeterBinarySensorDescription(
+        key="attachment_status",
+        translation_key="attachment_status",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.status.device.core.attachment_status,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Sensors."""
+    coordinator: IOMeterCoordinator = config_entry.runtime_data
+
+    async_add_entities(
+        IOmeterBinarySensor(
+            coordinator=coordinator,
+            description=description,
+        )
+        for description in SENSOR_TYPES
+    )
+
+
+class IOmeterBinarySensor(IOmeterEntity, BinarySensorEntity):
+    """Defines a IOmeter binary sensor."""
+
+    entity_description: IOmeterBinarySensorDescription
+
+    def __init__(
+        self,
+        coordinator: IOMeterCoordinator,
+        description: IOmeterBinarySensorDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.identifier}_{description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the binary sensor state."""
+        value = self.entity_description.value_fn(self.coordinator.data)
+
+        if value is None:
+            return None
+
+        if self.entity_description.key == "connection_status":
+            return value == "connected"
+
+        return value == "attached"

--- a/homeassistant/components/iometer/strings.json
+++ b/homeassistant/components/iometer/strings.json
@@ -60,6 +60,14 @@
       "wifi_rssi": {
         "name": "Signal strength Wi-Fi"
       }
+    },
+    "binary_sensor": {
+      "connection_status": {
+        "name": "Core/Bridge connection status"
+      },
+      "attachment_status": {
+        "name": "Core attachment status"
+      }
     }
   }
 }

--- a/tests/components/iometer/__init__.py
+++ b/tests/components/iometer/__init__.py
@@ -1,13 +1,19 @@
 """Tests for the IOmeter integration."""
 
+from unittest.mock import patch
+
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
-    """Fixture for setting up the component."""
+async def setup_platform(
+    hass: HomeAssistant, config_entry: MockConfigEntry, platforms: list[Platform]
+) -> MockConfigEntry:
+    """Fixture for setting up the IOmeter platform."""
     config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with patch("homeassistant.components.iometer.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/components/iometer/conftest.py
+++ b/tests/components/iometer/conftest.py
@@ -54,4 +54,5 @@ def mock_config_entry() -> MockConfigEntry:
         title="IOmeter-1ISK0000000000",
         data={CONF_HOST: "10.0.0.2"},
         unique_id="658c2b34-2017-45f2-a12b-731235f8bb97",
+        entry_id="01JQ6G5395176MAAWKAAPEZHV6",
     )

--- a/tests/components/iometer/snapshots/test_binary_sensor.ambr
+++ b/tests/components/iometer/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,97 @@
+# serializer version: 1
+# name: test_binary_sensors[binary_sensor.iometer_1isk0000000000_core_attachment_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.iometer_1isk0000000000_core_attachment_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Core attachment status',
+    'platform': 'iometer',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'attachment_status',
+    'unique_id': '01JQ6G5395176MAAWKAAPEZHV6_attachment_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.iometer_1isk0000000000_core_attachment_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'IOmeter-1ISK0000000000 Core attachment status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.iometer_1isk0000000000_core_attachment_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.iometer_1isk0000000000_core_bridge_connection_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.iometer_1isk0000000000_core_bridge_connection_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Core/Bridge connection status',
+    'platform': 'iometer',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'connection_status',
+    'unique_id': '01JQ6G5395176MAAWKAAPEZHV6_connection_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.iometer_1isk0000000000_core_bridge_connection_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'IOmeter-1ISK0000000000 Core/Bridge connection status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.iometer_1isk0000000000_core_bridge_connection_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/iometer/test_binary_sensor.py
+++ b/tests/components/iometer/test_binary_sensor.py
@@ -1,0 +1,75 @@
+"""Test the IOmeter binary sensors."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import setup_platform
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_binary_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_iometer_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensors."""
+    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
+
+    assert (
+        hass.states.get(
+            "binary_sensor.iometer_1isk0000000000_core_bridge_connection_status"
+        ).state
+        == STATE_ON
+    )
+
+    assert (
+        hass.states.get(
+            "binary_sensor.iometer_1isk0000000000_core_attachment_status"
+        ).state
+        == STATE_ON
+    )
+
+    mock_iometer_client.get_current_status.return_value.device.core.attachment_status = "detached"
+
+    freezer.tick(delta=timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(
+            "binary_sensor.iometer_1isk0000000000_core_attachment_status"
+        ).state
+        == STATE_OFF
+    )
+
+    mock_iometer_client.get_current_status.return_value.device.core.connection_status = "disconnected"
+    mock_iometer_client.get_current_status.return_value.device.core.attachment_status = None
+
+    freezer.tick(delta=timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(
+            "binary_sensor.iometer_1isk0000000000_core_bridge_connection_status"
+        ).state
+        == STATE_OFF
+    )
+    assert (
+        hass.states.get(
+            "binary_sensor.iometer_1isk0000000000_core_attachment_status"
+        ).state
+        == STATE_UNKNOWN
+    )

--- a/tests/components/iometer/test_binary_sensor.py
+++ b/tests/components/iometer/test_binary_sensor.py
@@ -5,26 +5,39 @@ from unittest.mock import AsyncMock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 
 from . import setup_platform
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_binary_sensors(
     hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
     mock_iometer_client: AsyncMock,
-    device_registry: dr.DeviceRegistry,
-    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test binary sensors."""
+    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_connection_status_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_iometer_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test connection status sensor."""
     await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
 
     assert (
@@ -34,12 +47,44 @@ async def test_binary_sensors(
         == STATE_ON
     )
 
+    freezer.tick(delta=timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    mock_iometer_client.get_current_status.return_value.device.core.connection_status = "disconnected"
+
+    freezer.tick(delta=timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(
+            "binary_sensor.iometer_1isk0000000000_core_bridge_connection_status"
+        ).state
+        == STATE_OFF
+    )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_attachment_status_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_iometer_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test connection status sensor."""
+    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
+
     assert (
         hass.states.get(
             "binary_sensor.iometer_1isk0000000000_core_attachment_status"
         ).state
         == STATE_ON
     )
+
+    freezer.tick(delta=timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     mock_iometer_client.get_current_status.return_value.device.core.attachment_status = "detached"
 
@@ -54,19 +99,34 @@ async def test_binary_sensors(
         == STATE_OFF
     )
 
-    mock_iometer_client.get_current_status.return_value.device.core.connection_status = "disconnected"
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_attachment_status_sensors_unkown(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_iometer_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test connection status sensor."""
+    await setup_platform(hass, mock_config_entry, [Platform.BINARY_SENSOR])
+
+    assert (
+        hass.states.get(
+            "binary_sensor.iometer_1isk0000000000_core_attachment_status"
+        ).state
+        == STATE_ON
+    )
+
+    freezer.tick(delta=timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
     mock_iometer_client.get_current_status.return_value.device.core.attachment_status = None
 
     freezer.tick(delta=timedelta(minutes=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get(
-            "binary_sensor.iometer_1isk0000000000_core_bridge_connection_status"
-        ).state
-        == STATE_OFF
-    )
     assert (
         hass.states.get(
             "binary_sensor.iometer_1isk0000000000_core_attachment_status"

--- a/tests/components/iometer/test_init.py
+++ b/tests/components/iometer/test_init.py
@@ -6,10 +6,11 @@ from unittest.mock import AsyncMock
 from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.components.iometer.const import DOMAIN
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from . import setup_integration
+from . import setup_platform
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -22,7 +23,8 @@ async def test_new_firmware_version(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test device registry integration."""
-    await setup_integration(hass, mock_config_entry)
+    # await setup_integration(hass, mock_config_entry)
+    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
     device_entry = device_registry.async_get_device(
         identifiers={(DOMAIN, mock_config_entry.unique_id)}
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds two binary sensors. Connection status and Attachment status. The data for both is already collected by the coordinator. Both entities were removed from the initial PR because they should be binary sensors.

Connection status can be "connected" (on) and "disconnected" (off)
Attachment status can be "attached" (on), "detached" (off) and None (unknown) in a case were the core is not connected to the bridge. If so, we cant make a judgement about that status and it is set to unknown.

Test are also added for the binary sensor. While doing so I updated the the function `setup_integration` to `setup_platform` to be more flexible when testing.

I have chosen to disable both sensors by default, as the information is not needed at all times but I can imagine that users might build alerts or other things in cases where for example the device is not attached to the electricity meter anymore. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38098
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
