### PR TITLE
Add service for counting the omer

### DIFF
--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     DEFAULT_LANGUAGE,
 )
 from .entity import JewishCalendarConfigEntry, JewishCalendarData
+from .service import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
@@ -67,6 +68,7 @@ async def async_setup_entry(
     )
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+    async_setup_services(hass, config_entry)
 
     async def update_listener(
         hass: HomeAssistant, config_entry: JewishCalendarConfigEntry

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -27,12 +27,14 @@ from .const import (
     DEFAULT_DIASPORA,
     DEFAULT_HAVDALAH_OFFSET_MINUTES,
     DEFAULT_LANGUAGE,
+    DOMAIN,
 )
 from .entity import JewishCalendarConfigEntry, JewishCalendarData
 from .service import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_CANDLE_LIGHT_MINUTES,
@@ -32,6 +33,13 @@ from .service import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Jewish Calendar service."""
+    async_setup_services(hass)
+
+    return True
 
 
 async def async_setup_entry(
@@ -68,7 +76,6 @@ async def async_setup_entry(
     )
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-    async_setup_services(hass, config_entry)
 
     async def update_listener(
         hass: HomeAssistant, config_entry: JewishCalendarConfigEntry

--- a/homeassistant/components/jewish_calendar/const.py
+++ b/homeassistant/components/jewish_calendar/const.py
@@ -2,6 +2,9 @@
 
 DOMAIN = "jewish_calendar"
 
+ATTR_DATE = "date"
+ATTR_NUSACH = "nusach"
+
 CONF_DIASPORA = "diaspora"
 CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
 CONF_HAVDALAH_OFFSET_MINUTES = "havdalah_minutes_after_sunset"
@@ -11,3 +14,5 @@ DEFAULT_CANDLE_LIGHT = 18
 DEFAULT_DIASPORA = False
 DEFAULT_HAVDALAH_OFFSET_MINUTES = 0
 DEFAULT_LANGUAGE = "english"
+
+SERVICE_COUNT_OMER = "count_omer"

--- a/homeassistant/components/jewish_calendar/icons.json
+++ b/homeassistant/components/jewish_calendar/icons.json
@@ -1,0 +1,7 @@
+{
+  "services": {
+    "count_omer": {
+      "service": "mdi:counter"
+    }
+  }
+}

--- a/homeassistant/components/jewish_calendar/service.py
+++ b/homeassistant/components/jewish_calendar/service.py
@@ -49,7 +49,6 @@ def async_setup_services(hass: HomeAssistant) -> None:
         omer = Omer(date=hebrew_date, nusach=nusach, language=language)
         return {
             "message": str(omer.count_str()),
-            "hebrew_date": str(hebrew_date),
             "weeks": omer.week,
             "days": omer.day,
             "total_days": omer.total_days,

--- a/homeassistant/components/jewish_calendar/service.py
+++ b/homeassistant/components/jewish_calendar/service.py
@@ -46,9 +46,6 @@ def async_setup_services(hass: HomeAssistant) -> None:
         # the full language name
         language = cast(Language, SUPPORTED_LANGUAGES[call.data[CONF_LANGUAGE]])
 
-        # Show the Hebrew Date in the response in the correct language
-        hebrew_date.set_language(language)
-
         omer = Omer(date=hebrew_date, nusach=nusach, language=language)
         return {
             "message": str(omer.count_str()),

--- a/homeassistant/components/jewish_calendar/service.py
+++ b/homeassistant/components/jewish_calendar/service.py
@@ -15,6 +15,7 @@ from homeassistant.core import (
     ServiceResponse,
     SupportsResponse,
 )
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import LanguageSelector, LanguageSelectorConfig
 
 from .const import ATTR_DATE, ATTR_NUSACH, DOMAIN, SERVICE_COUNT_OMER
@@ -22,7 +23,7 @@ from .const import ATTR_DATE, ATTR_NUSACH, DOMAIN, SERVICE_COUNT_OMER
 SUPPORTED_LANGUAGES = {"en": "english", "fr": "french", "he": "hebrew"}
 OMER_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_DATE, default=datetime.date.today): datetime.date,
+        vol.Required(ATTR_DATE, default=datetime.date.today): cv.date,
         vol.Required(ATTR_NUSACH, default="sfarad"): vol.In(
             [nusach.name.lower() for nusach in Nusach]
         ),

--- a/homeassistant/components/jewish_calendar/service.py
+++ b/homeassistant/components/jewish_calendar/service.py
@@ -46,6 +46,9 @@ def async_setup_services(hass: HomeAssistant) -> None:
         # the full language name
         language = cast(Language, SUPPORTED_LANGUAGES[call.data[CONF_LANGUAGE]])
 
+        # Show the Hebrew Date in the response in the correct language
+        hebrew_date.set_language(language)
+
         omer = Omer(date=hebrew_date, nusach=nusach, language=language)
         return {
             "message": str(omer.count_str()),

--- a/homeassistant/components/jewish_calendar/service.py
+++ b/homeassistant/components/jewish_calendar/service.py
@@ -1,0 +1,48 @@
+"""Services for Jewish Calendar."""
+
+import datetime
+
+from hdate import HebrewDate
+from hdate.omer import Nusach, Omer
+import voluptuous as vol
+
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
+
+from . import JewishCalendarConfigEntry
+from .const import DOMAIN
+
+OMER_SCHEMA = vol.Schema(
+    {
+        vol.Required("date", default=datetime.date.today): datetime.date,
+        vol.Required("nusach", default=Nusach.SFARAD): Nusach,
+        vol.Required("language"): str,
+    }
+)
+
+
+def async_setup_services(
+    hass: HomeAssistant, config_entry: JewishCalendarConfigEntry
+) -> None:
+    """Set up the Jewish Calendar services."""
+
+    async def get_omer_blessing(call: ServiceCall) -> ServiceResponse:
+        """Return the Omer blessing for a given date."""
+        value = Omer(
+            date=HebrewDate.from_gdate(call.data["date"]),
+            nusach=call.data["nusach"],
+            language=call.data.get("language", config_entry.runtime_data.language),
+        ).count_str()
+        return {"message": str(value)}
+
+    hass.services.async_register(
+        DOMAIN,
+        "get_omer_blessing",
+        get_omer_blessing,
+        schema=OMER_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )

--- a/homeassistant/components/jewish_calendar/services.yaml
+++ b/homeassistant/components/jewish_calendar/services.yaml
@@ -18,12 +18,12 @@ count_omer:
             - "italian"
     language:
       required: true
-      default: "hebrew"
-      example: "hebrew"
+      default: "he"
+      example: "he"
       selector:
         select:
           translation_key: "language"
           options:
-            - "english"
-            - "hebrew"
-            - "french"
+            - "en"
+            - "he"
+            - "fr"

--- a/homeassistant/components/jewish_calendar/services.yaml
+++ b/homeassistant/components/jewish_calendar/services.yaml
@@ -21,9 +21,8 @@ count_omer:
       default: "he"
       example: "he"
       selector:
-        select:
-          translation_key: "language"
-          options:
+        language:
+          languages:
             - "en"
             - "he"
             - "fr"

--- a/homeassistant/components/jewish_calendar/services.yaml
+++ b/homeassistant/components/jewish_calendar/services.yaml
@@ -1,0 +1,29 @@
+count_omer:
+  fields:
+    date:
+      required: true
+      example: "2025-04-14"
+      selector:
+        date:
+    nusach:
+      example: "sfarad"
+      default: "sfarad"
+      selector:
+        select:
+          translation_key: "nusach"
+          options:
+            - "sfarad"
+            - "ashkenaz"
+            - "adot_mizrah"
+            - "italian"
+    language:
+      required: true
+      default: "hebrew"
+      example: "hebrew"
+      selector:
+        select:
+          translation_key: "language"
+          options:
+            - "english"
+            - "hebrew"
+            - "french"

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -66,7 +66,7 @@
   "services": {
     "count_omer": {
       "name": "Count the Omer",
-      "description": "Return the phrase for counting the Omer on a given date.",
+      "description": "Returns the phrase for counting the Omer on a given date.",
       "fields": {
         "date": {
           "name": "Date",

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -54,13 +54,6 @@
         "adot_mizrah": "Adot Mizrah",
         "italian": "Italian"
       }
-    },
-    "language": {
-      "options": {
-        "he": "Hebrew",
-        "en": "English",
-        "fr": "French"
-      }
     }
   },
   "services": {

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -45,5 +45,42 @@
         }
       }
     }
+  },
+  "selector": {
+    "nusach": {
+      "options": {
+        "sfarad": "Sfarad",
+        "ashkenaz": "Ashkenaz",
+        "adot_mizrah": "Adot Mizrah",
+        "italian": "Italian"
+      }
+    },
+    "language": {
+      "options": {
+        "hebrew": "Hebrew",
+        "english": "English",
+        "french": "French"
+      }
+    }
+  },
+  "services": {
+    "count_omer": {
+      "name": "Count the Omer",
+      "description": "Return the phrase for counting the Omer on a given date.",
+      "fields": {
+        "date": {
+          "name": "Date",
+          "description": "Date to count the Omer for."
+        },
+        "nusach": {
+          "name": "Nusach",
+          "description": "Nusach to count the Omer in."
+        },
+        "language": {
+          "name": "Language",
+          "description": "Language to count the Omer in."
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -57,9 +57,9 @@
     },
     "language": {
       "options": {
-        "hebrew": "Hebrew",
-        "english": "English",
-        "french": "French"
+        "he": "Hebrew",
+        "en": "English",
+        "fr": "French"
       }
     }
   },

--- a/tests/components/jewish_calendar/test_service.py
+++ b/tests/components/jewish_calendar/test_service.py
@@ -14,24 +14,18 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(
     ("test_date", "nusach", "language", "expected"),
     [
-        pytest.param(
-            dt.date(2025, 3, 20),
-            "sfarad",
-            "hebrew",
-            "",
-            id="no_blessing",
-        ),
+        pytest.param(dt.date(2025, 3, 20), "sfarad", "he", "", id="no_blessing"),
         pytest.param(
             dt.date(2025, 5, 20),
             "ashkenaz",
-            "hebrew",
+            "he",
             "היום שבעה ושלושים יום שהם חמישה שבועות ושני ימים בעומר",
             id="ahskenaz-hebrew",
         ),
         pytest.param(
             dt.date(2025, 5, 20),
             "sfarad",
-            "english",
+            "en",
             "Today is the thirty-seventh day, which are five weeks and two days of the Omer",
             id="sefarad-english",
         ),

--- a/tests/components/jewish_calendar/test_service.py
+++ b/tests/components/jewish_calendar/test_service.py
@@ -2,7 +2,6 @@
 
 import datetime as dt
 
-from hdate.omer import Nusach
 from hdate.translator import Language
 import pytest
 
@@ -17,21 +16,21 @@ from tests.common import MockConfigEntry
     [
         pytest.param(
             dt.date(2025, 3, 20),
-            Nusach.SFARAD,
+            "sfarad",
             "hebrew",
             "",
             id="no_blessing",
         ),
         pytest.param(
             dt.date(2025, 5, 20),
-            Nusach.ASHKENAZ,
+            "ashkenaz",
             "hebrew",
             "היום שבעה ושלושים יום שהם חמישה שבועות ושני ימים בעומר",
             id="ahskenaz-hebrew",
         ),
         pytest.param(
             dt.date(2025, 5, 20),
-            Nusach.SFARAD,
+            "sfarad",
             "english",
             "Today is the thirty-seventh day, which are five weeks and two days of the Omer",
             id="sefarad-english",
@@ -42,7 +41,7 @@ async def test_get_omer_blessing(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     test_date: dt.date,
-    nusach: Nusach,
+    nusach: str,
     language: Language,
     expected: str,
 ) -> None:
@@ -53,7 +52,7 @@ async def test_get_omer_blessing(
 
     result = await hass.services.async_call(
         DOMAIN,
-        "get_omer_blessing",
+        "count_omer",
         {"date": test_date, "nusach": nusach, "language": language},
         blocking=True,
         return_response=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During the period between Passover and Shavuot, a blessing is recited each night counting the 50 days up to Shavuot.
This adds the capability to get the blessing in various Nusachim (customs) and languages (currently supporting English, French and Hebrew).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#38100
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
