### PR TITLE
Reolink fix playback headers

### DIFF
--- a/homeassistant/components/reolink/views.py
+++ b/homeassistant/components/reolink/views.py
@@ -88,7 +88,11 @@ class PlaybackProxyView(HomeAssistantView):
         headers.pop("Referer", None)
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug("Requested Playback Proxy Method %s, Headers: %s", request.method, headers)
+            _LOGGER.debug(
+                "Requested Playback Proxy Method %s, Headers: %s",
+                request.method,
+                headers,
+            )
             _LOGGER.debug(
                 "Opening VOD stream from %s: %s",
                 host.api.camera_name(ch),
@@ -123,17 +127,19 @@ class PlaybackProxyView(HomeAssistantView):
             "apolication/octet-stream",
         ]:
             err_str = f"Reolink playback expected video/mp4 but got {reolink_response.content_type}"
-            if reolink_response.content_type == "text/html":
-                try:
-                    text = await reolink_response.text()
-                    err_str = f"{err_str}:\n{text}"
-                except BaseException:
-                    pass
             _LOGGER.error(err_str)
+            if reolink_response.content_type == "text/html":
+                text = await reolink_response.text()
+                _LOGGER.debug(text)
             return web.Response(body=err_str, status=HTTPStatus.BAD_REQUEST)
 
         response_headers = dict(reolink_response.headers)
-        _LOGGER.debug("Response Playback Proxy Status %s:%s, Headers: %s", reolink_response.status, reolink_response.reason, response_headers)
+        _LOGGER.debug(
+            "Response Playback Proxy Status %s:%s, Headers: %s",
+            reolink_response.status,
+            reolink_response.reason,
+            response_headers,
+        )
         response_headers["Content-Type"] = "video/mp4"
 
         response = web.StreamResponse(

--- a/tests/components/reolink/test_views.py
+++ b/tests/components/reolink/test_views.py
@@ -46,8 +46,12 @@ def get_mock_session(
 
     mock_response = Mock()
     mock_response.content_length = content_length
+    mock_response.headers = {}
+    mock_response.status = 200
+    mock_response.reason = "OK"
     mock_response.content_type = content_type
     mock_response.content.iter_chunked = Mock(return_value=content)
+    mock_response.text = AsyncMock(return_value="test")
 
     mock_session = Mock()
     mock_session.get = AsyncMock(return_value=mock_response)
@@ -178,16 +182,18 @@ async def test_playback_proxy_timeout(
     assert response.status == 200
 
 
+@pytest.mark.parametrize(("content_type"), [("video/x-flv"), ("text/html")])
 async def test_playback_wrong_content(
     hass: HomeAssistant,
     reolink_connect: MagicMock,
     config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
+    content_type: str,
 ) -> None:
     """Test playback proxy URL with a wrong content type in the response."""
     reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
 
-    mock_session = get_mock_session(content_type="video/x-flv")
+    mock_session = get_mock_session(content_type=content_type)
 
     with patch(
         "homeassistant.components.reolink.views.async_get_clientsession",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Pass allong the headers during playback of recorded files through the HomeAssistant proxy.
This allows "HTTP range requests" to properly be handeled (tested and confirmed to now be working).
Apperently Safari and iOS require the server to support byte-range requests, otherwise it wont play the mp4.
information sources for future refrence:
- https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/CreatingVideoforSafarioniPhone/CreatingVideoforSafarioniPhone.html#//apple_ref/doc/uid/TP40006514-SW6
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/137167
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
