### PR TITLE
Handle wrong WebDAV URL more gracefully in config flow

### DIFF
--- a/homeassistant/components/webdav/config_flow.py
+++ b/homeassistant/components/webdav/config_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from aiowebdav2.exceptions import UnauthorizedError
+from aiowebdav2.exceptions import MethodNotSupportedError, UnauthorizedError
 import voluptuous as vol
 import yarl
 
@@ -65,6 +65,8 @@ class WebDavConfigFlow(ConfigFlow, domain=DOMAIN):
                 result = await client.check()
             except UnauthorizedError:
                 errors["base"] = "invalid_auth"
+            except MethodNotSupportedError:
+                errors["base"] = "invalid_method"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected error")
                 errors["base"] = "unknown"

--- a/homeassistant/components/webdav/strings.json
+++ b/homeassistant/components/webdav/strings.json
@@ -21,6 +21,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_method": "The server does not support the required methods. Please check whether you have the correct URL. Check with your provider for the correct URL.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/tests/components/webdav/test_config_flow.py
+++ b/tests/components/webdav/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from aiowebdav2.exceptions import UnauthorizedError
+from aiowebdav2.exceptions import MethodNotSupportedError, UnauthorizedError
 import pytest
 
 from homeassistant import config_entries
@@ -86,6 +86,7 @@ async def test_form_fail(hass: HomeAssistant, webdav_client: AsyncMock) -> None:
     ("exception", "expected_error"),
     [
         (UnauthorizedError("https://webdav.demo"), "invalid_auth"),
+        (MethodNotSupportedError("check", "https://webdav.demo"), "invalid_method"),
         (Exception("Unexpected error"), "unknown"),
     ],
 )


### PR DESCRIPTION
## Proposed change
Handle an incorrect WebDAV URL in the config flow more gracefully. Instead of a generic “Unexpected error” message, a message is displayed explaining to the user that their URL may be incorrect.

`check` tries to list files and checks the response code, if the server returns a 405, the package throws a `MethodNotSupportedError`. So if even listing files is not supported, the URL is most likely wrong or something bigger is wrong. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #140955
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
