### PR TITLE
Bump linkplay to v0.2.0

### DIFF
--- a/homeassistant/components/linkplay/manifest.json
+++ b/homeassistant/components/linkplay/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["linkplay"],
-  "requirements": ["python-linkplay==0.1.3"],
+  "requirements": ["python-linkplay==0.2.0"],
   "zeroconf": ["_linkplay._tcp.local."]
 }

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -86,7 +86,7 @@ REPEAT_MAP: dict[LoopMode, RepeatMode] = {
 
 REPEAT_MAP_INV: dict[RepeatMode, LoopMode] = {v: k for k, v in REPEAT_MAP.items()}
 
-EQUALIZER_MAP_INV: dict[str, EqualizerMode] = {v: k for k, v in EqualizerMode.items()}
+EQUALIZER_MAP_INV: dict[str, EqualizerMode] = {mode.value: mode for mode in EqualizerMode}
 
 DEFAULT_FEATURES: MediaPlayerEntityFeature = (
     MediaPlayerEntityFeature.PLAY

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -86,15 +86,7 @@ REPEAT_MAP: dict[LoopMode, RepeatMode] = {
 
 REPEAT_MAP_INV: dict[RepeatMode, LoopMode] = {v: k for k, v in REPEAT_MAP.items()}
 
-EQUALIZER_MAP: dict[EqualizerMode, str] = {
-    EqualizerMode.NONE: "None",
-    EqualizerMode.CLASSIC: "Classic",
-    EqualizerMode.POP: "Pop",
-    EqualizerMode.JAZZ: "Jazz",
-    EqualizerMode.VOCAL: "Vocal",
-}
-
-EQUALIZER_MAP_INV: dict[str, EqualizerMode] = {v: k for k, v in EQUALIZER_MAP.items()}
+EQUALIZER_MAP_INV: dict[str, EqualizerMode] = {v: k for k, v in EqualizerMode.items()}
 
 DEFAULT_FEATURES: MediaPlayerEntityFeature = (
     MediaPlayerEntityFeature.PLAY
@@ -148,7 +140,6 @@ async def async_setup_entry(
 class LinkPlayMediaPlayerEntity(LinkPlayBaseEntity, MediaPlayerEntity):
     """Representation of a LinkPlay media player."""
 
-    _attr_sound_mode_list = list(EQUALIZER_MAP.values())
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
     _attr_media_content_type = MediaType.MUSIC
     _attr_name = None
@@ -162,6 +153,9 @@ class LinkPlayMediaPlayerEntity(LinkPlayBaseEntity, MediaPlayerEntity):
 
         self._attr_source_list = [
             SOURCE_MAP[playing_mode] for playing_mode in bridge.device.playmode_support
+        ]
+        self._attr_sound_mode_list = [
+            mode.value for mode in bridge.player.available_equalizer_modes
         ]
 
     @exception_wrap
@@ -348,7 +342,7 @@ class LinkPlayMediaPlayerEntity(LinkPlayBaseEntity, MediaPlayerEntity):
         self._attr_is_volume_muted = self._bridge.player.muted
         self._attr_repeat = REPEAT_MAP[self._bridge.player.loop_mode]
         self._attr_shuffle = self._bridge.player.loop_mode == LoopMode.RANDOM_PLAYBACK
-        self._attr_sound_mode = EQUALIZER_MAP[self._bridge.player.equalizer_mode]
+        self._attr_sound_mode = self._bridge.player.equalizer_mode.value
         self._attr_supported_features = DEFAULT_FEATURES
 
         if self._bridge.player.status == PlayingStatus.PLAYING:

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -86,7 +86,9 @@ REPEAT_MAP: dict[LoopMode, RepeatMode] = {
 
 REPEAT_MAP_INV: dict[RepeatMode, LoopMode] = {v: k for k, v in REPEAT_MAP.items()}
 
-EQUALIZER_MAP_INV: dict[str, EqualizerMode] = {mode.value: mode for mode in EqualizerMode}
+EQUALIZER_MAP_INV: dict[str, EqualizerMode] = {
+    mode.value: mode for mode in EqualizerMode
+}
 
 DEFAULT_FEATURES: MediaPlayerEntityFeature = (
     MediaPlayerEntityFeature.PLAY

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2425,7 +2425,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.10.2
 
 # homeassistant.components.linkplay
-python-linkplay==0.1.3
+python-linkplay==0.2.0
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1961,7 +1961,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.10.2
 
 # homeassistant.components.linkplay
-python-linkplay==0.1.3
+python-linkplay==0.2.0
 
 # homeassistant.components.matter
 python-matter-server==7.0.0


### PR DESCRIPTION
## Proposed change
Bump the linkplay library to v0.2.0:
https://github.com/Velleman/python-linkplay/releases/tag/v0.2.0
https://github.com/Velleman/python-linkplay/compare/v0.1.3...v0.2.0

WiiM devices don't support the equalizer modes, neither the commands that set it. It made their own commands and their own custom equalizer modes. 
I've seen this more and more on the broad range of devices that support LinkPlay in some way. 
So, in general, this adds the equalizer modes to the enum, and makes a new method available_equalizer_modes in the library to return the equalizer modes a device supports. 

There's an additional thing that moved to the library and a pull request will be opened after this dependency bump. 

Fixes https://github.com/home-assistant/core/issues/140809

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
