### PR TITLE
Remove Home Connect service error string constants

### DIFF
--- a/homeassistant/components/home_connect/__init__.py
+++ b/homeassistant/components/home_connect/__init__.py
@@ -60,9 +60,6 @@ from .const import (
     SERVICE_SET_PROGRAM_AND_OPTIONS,
     SERVICE_SETTING,
     SERVICE_START_PROGRAM,
-    SVE_TRANSLATION_PLACEHOLDER_KEY,
-    SVE_TRANSLATION_PLACEHOLDER_PROGRAM,
-    SVE_TRANSLATION_PLACEHOLDER_VALUE,
     TRANSLATION_KEYS_PROGRAMS_MAP,
 )
 from .coordinator import HomeConnectConfigEntry, HomeConnectCoordinator
@@ -336,7 +333,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                 translation_key="start_program" if start else "select_program",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_PROGRAM: program,
+                    "program": program,
                 },
             ) from err
 
@@ -410,8 +407,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                 else "set_options_selected_program",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_KEY: option_key,
-                    SVE_TRANSLATION_PLACEHOLDER_VALUE: str(value),
+                    "key": option_key,
+                    "value": str(value),
                 },
             ) from err
 
@@ -466,8 +463,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                 translation_key="set_setting",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_KEY: key,
-                    SVE_TRANSLATION_PLACEHOLDER_VALUE: str(value),
+                    "key": key,
+                    "value": str(value),
                 },
             ) from err
 
@@ -545,11 +542,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                 translation_key=exception_translation_key,
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    **(
-                        {SVE_TRANSLATION_PLACEHOLDER_PROGRAM: program}
-                        if program
-                        else {}
-                    ),
+                    **({"program": program} if program else {}),
                 },
             ) from err
 

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -79,13 +79,6 @@ ATTR_VALUE = "value"
 AFFECTS_TO_ACTIVE_PROGRAM = "active_program"
 AFFECTS_TO_SELECTED_PROGRAM = "selected_program"
 
-SVE_TRANSLATION_KEY_SET_SETTING = "set_setting_entity"
-SVE_TRANSLATION_PLACEHOLDER_APPLIANCE_NAME = "appliance_name"
-SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID = "entity_id"
-SVE_TRANSLATION_PLACEHOLDER_PROGRAM = "program"
-SVE_TRANSLATION_PLACEHOLDER_KEY = "key"
-SVE_TRANSLATION_PLACEHOLDER_VALUE = "value"
-
 
 TRANSLATION_KEYS_PROGRAMS_MAP = {
     bsh_key_to_translation_key(program.value): cast(ProgramKey, program)

--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -21,11 +21,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import color as color_util
 
 from .common import setup_home_connect_entry
-from .const import (
-    BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR,
-    DOMAIN,
-    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID,
-)
+from .const import BSH_AMBIENT_LIGHT_COLOR_CUSTOM_COLOR, DOMAIN
 from .coordinator import (
     HomeConnectApplianceData,
     HomeConnectConfigEntry,
@@ -164,7 +160,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 translation_key="turn_on_light",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
+                    "entity_id": self.entity_id,
                 },
             ) from err
         if self._color_key and self._custom_color_key:
@@ -183,7 +179,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                         translation_key="select_light_custom_color",
                         translation_placeholders={
                             **get_dict_from_home_connect_error(err),
-                            SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
+                            "entity_id": self.entity_id,
                         },
                     ) from err
 
@@ -201,7 +197,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                         translation_key="set_light_color",
                         translation_placeholders={
                             **get_dict_from_home_connect_error(err),
-                            SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
+                            "entity_id": self.entity_id,
                         },
                     ) from err
                 return
@@ -231,7 +227,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                         translation_key="set_light_color",
                         translation_placeholders={
                             **get_dict_from_home_connect_error(err),
-                            SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
+                            "entity_id": self.entity_id,
                         },
                     ) from err
                 return
@@ -254,7 +250,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                     translation_key="set_light_brightness",
                     translation_placeholders={
                         **get_dict_from_home_connect_error(err),
-                        SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
+                        "entity_id": self.entity_id,
                     },
                 ) from err
 
@@ -272,7 +268,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 translation_key="turn_off_light",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
+                    "entity_id": self.entity_id,
                 },
             ) from err
 

--- a/homeassistant/components/home_connect/number.py
+++ b/homeassistant/components/home_connect/number.py
@@ -16,14 +16,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .common import setup_home_connect_entry
-from .const import (
-    DOMAIN,
-    SVE_TRANSLATION_KEY_SET_SETTING,
-    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID,
-    SVE_TRANSLATION_PLACEHOLDER_KEY,
-    SVE_TRANSLATION_PLACEHOLDER_VALUE,
-    UNIT_MAP,
-)
+from .const import DOMAIN, UNIT_MAP
 from .coordinator import HomeConnectApplianceData, HomeConnectConfigEntry
 from .entity import HomeConnectEntity, HomeConnectOptionEntity, constraint_fetcher
 from .utils import get_dict_from_home_connect_error
@@ -180,12 +173,12 @@ class HomeConnectNumberEntity(HomeConnectEntity, NumberEntity):
         except HomeConnectError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key=SVE_TRANSLATION_KEY_SET_SETTING,
+                translation_key="set_setting_entity",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
-                    SVE_TRANSLATION_PLACEHOLDER_KEY: self.bsh_key,
-                    SVE_TRANSLATION_PLACEHOLDER_VALUE: str(value),
+                    "entity_id": self.entity_id,
+                    "key": self.bsh_key,
+                    "value": str(value),
                 },
             ) from err
 

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -31,11 +31,6 @@ from .const import (
     INTENSIVE_LEVEL_OPTIONS,
     PROGRAMS_TRANSLATION_KEYS_MAP,
     SPIN_SPEED_OPTIONS,
-    SVE_TRANSLATION_KEY_SET_SETTING,
-    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID,
-    SVE_TRANSLATION_PLACEHOLDER_KEY,
-    SVE_TRANSLATION_PLACEHOLDER_PROGRAM,
-    SVE_TRANSLATION_PLACEHOLDER_VALUE,
     TEMPERATURE_OPTIONS,
     TRANSLATION_KEYS_PROGRAMS_MAP,
     VARIO_PERFECT_OPTIONS,
@@ -406,7 +401,7 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
                 translation_key=self.entity_description.error_translation_key,
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_PROGRAM: program_key.value,
+                    "program": program_key.value,
                 },
             ) from err
 
@@ -443,12 +438,12 @@ class HomeConnectSelectEntity(HomeConnectEntity, SelectEntity):
         except HomeConnectError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key=SVE_TRANSLATION_KEY_SET_SETTING,
+                translation_key="set_setting_entity",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
-                    SVE_TRANSLATION_PLACEHOLDER_KEY: self.bsh_key,
-                    SVE_TRANSLATION_PLACEHOLDER_VALUE: value,
+                    "entity_id": self.entity_id,
+                    "key": self.bsh_key,
+                    "value": value,
                 },
             ) from err
 

--- a/homeassistant/components/home_connect/switch.py
+++ b/homeassistant/components/home_connect/switch.py
@@ -22,16 +22,7 @@ from homeassistant.helpers.issue_registry import (
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from .common import setup_home_connect_entry
-from .const import (
-    BSH_POWER_OFF,
-    BSH_POWER_ON,
-    BSH_POWER_STANDBY,
-    DOMAIN,
-    SVE_TRANSLATION_PLACEHOLDER_APPLIANCE_NAME,
-    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID,
-    SVE_TRANSLATION_PLACEHOLDER_KEY,
-    SVE_TRANSLATION_PLACEHOLDER_VALUE,
-)
+from .const import BSH_POWER_OFF, BSH_POWER_ON, BSH_POWER_STANDBY, DOMAIN
 from .coordinator import (
     HomeConnectApplianceData,
     HomeConnectConfigEntry,
@@ -226,8 +217,8 @@ class HomeConnectSwitch(HomeConnectEntity, SwitchEntity):
                 translation_key="turn_on",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
-                    SVE_TRANSLATION_PLACEHOLDER_KEY: self.bsh_key,
+                    "entity_id": self.entity_id,
+                    "key": self.bsh_key,
                 },
             ) from err
 
@@ -246,8 +237,8 @@ class HomeConnectSwitch(HomeConnectEntity, SwitchEntity):
                 translation_key="turn_off",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
-                    SVE_TRANSLATION_PLACEHOLDER_KEY: self.bsh_key,
+                    "entity_id": self.entity_id,
+                    "key": self.bsh_key,
                 },
             ) from err
 
@@ -385,7 +376,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
                 translation_key="power_on",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_APPLIANCE_NAME: self.appliance.info.name,
+                    "appliance_name": self.appliance.info.name,
                 },
             ) from err
 
@@ -398,7 +389,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
                     translation_domain=DOMAIN,
                     translation_key="unable_to_retrieve_turn_off",
                     translation_placeholders={
-                        SVE_TRANSLATION_PLACEHOLDER_APPLIANCE_NAME: self.appliance.info.name
+                        "appliance_name": self.appliance.info.name
                     },
                 )
 
@@ -406,9 +397,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="turn_off_not_supported",
-                translation_placeholders={
-                    SVE_TRANSLATION_PLACEHOLDER_APPLIANCE_NAME: self.appliance.info.name
-                },
+                translation_placeholders={"appliance_name": self.appliance.info.name},
             )
         try:
             await self.coordinator.client.set_setting(
@@ -423,8 +412,8 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
                 translation_key="power_off",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_APPLIANCE_NAME: self.appliance.info.name,
-                    SVE_TRANSLATION_PLACEHOLDER_VALUE: self.power_off_state,
+                    "appliance_name": self.appliance.info.name,
+                    "value": self.power_off_state,
                 },
             ) from err
 

--- a/homeassistant/components/home_connect/time.py
+++ b/homeassistant/components/home_connect/time.py
@@ -12,13 +12,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .common import setup_home_connect_entry
-from .const import (
-    DOMAIN,
-    SVE_TRANSLATION_KEY_SET_SETTING,
-    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID,
-    SVE_TRANSLATION_PLACEHOLDER_KEY,
-    SVE_TRANSLATION_PLACEHOLDER_VALUE,
-)
+from .const import DOMAIN
 from .coordinator import HomeConnectApplianceData, HomeConnectConfigEntry
 from .entity import HomeConnectEntity
 from .utils import get_dict_from_home_connect_error
@@ -84,12 +78,12 @@ class HomeConnectTimeEntity(HomeConnectEntity, TimeEntity):
         except HomeConnectError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key=SVE_TRANSLATION_KEY_SET_SETTING,
+                translation_key="set_setting_entity",
                 translation_placeholders={
                     **get_dict_from_home_connect_error(err),
-                    SVE_TRANSLATION_PLACEHOLDER_ENTITY_ID: self.entity_id,
-                    SVE_TRANSLATION_PLACEHOLDER_KEY: self.bsh_key,
-                    SVE_TRANSLATION_PLACEHOLDER_VALUE: str(value),
+                    "entity_id": self.entity_id,
+                    "key": self.bsh_key,
+                    "value": str(value),
                 },
             ) from err
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As suggested by @MartinHjelmare, this constants used for the service error placeholders should not be used, raw strings should be used instead

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
