### PR TITLE
Add coordinator context override to Home Connect entity constructor

### DIFF
--- a/homeassistant/components/home_connect/button.py
+++ b/homeassistant/components/home_connect/button.py
@@ -1,6 +1,6 @@
 """Provides button entities for Home Connect."""
 
-from aiohomeconnect.model import CommandKey, EventKey
+from aiohomeconnect.model import CommandKey
 from aiohomeconnect.model.error import HomeConnectError
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
@@ -94,15 +94,9 @@ class HomeConnectButtonEntity(HomeConnectEntity, ButtonEntity):
         super().__init__(
             coordinator,
             appliance,
-            # The entity is subscribed to the appliance connected event,
-            # but it will receive also the disconnected event
-            ButtonEntityDescription(
-                key=EventKey.BSH_COMMON_APPLIANCE_CONNECTED,
-            ),
+            desc,
+            (appliance.info.ha_id,),
         )
-        self.entity_description = desc
-        self.appliance = appliance
-        self._attr_unique_id = f"{appliance.info.ha_id}-{desc.key}"
 
     def update_native_value(self) -> None:
         """Set the value of the entity."""

--- a/homeassistant/components/home_connect/entity.py
+++ b/homeassistant/components/home_connect/entity.py
@@ -40,9 +40,15 @@ class HomeConnectEntity(CoordinatorEntity[HomeConnectCoordinator]):
         coordinator: HomeConnectCoordinator,
         appliance: HomeConnectApplianceData,
         desc: EntityDescription,
+        context_override: Any | None = None,
     ) -> None:
         """Initialize the entity."""
-        super().__init__(coordinator, (appliance.info.ha_id, EventKey(desc.key)))
+        super().__init__(
+            coordinator,
+            (appliance.info.ha_id, EventKey(desc.key))
+            if context_override is None
+            else context_override,
+        )
         self.appliance = appliance
         self.entity_description = desc
         self._attr_unique_id = f"{appliance.info.ha_id}-{desc.key}"

--- a/homeassistant/components/home_connect/entity.py
+++ b/homeassistant/components/home_connect/entity.py
@@ -43,12 +43,10 @@ class HomeConnectEntity(CoordinatorEntity[HomeConnectCoordinator]):
         context_override: Any | None = None,
     ) -> None:
         """Initialize the entity."""
-        super().__init__(
-            coordinator,
-            (appliance.info.ha_id, EventKey(desc.key))
-            if context_override is None
-            else context_override,
-        )
+        context = (appliance.info.ha_id, EventKey(desc.key))
+        if context_override is not None:
+            context = context_override
+        super().__init__(coordinator, context)
         self.appliance = appliance
         self.entity_description = desc
         self._attr_unique_id = f"{appliance.info.ha_id}-{desc.key}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As discussed at #140745, Home Connect button entity constructor needed to be more future proof, as it was doing some bad practices.

The reason to do that bad practices was because Home Connect entity always subscribed to the context related to the description key, which always was (or was able to be transformed into) an `EventKey` (Buttons doesn't have any kind of event key).

To overcome that, I created a parameter in the Home Connect entity constructor that allows overriding the context. that way we can subscribe to another thing, but still use the entity description provided.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
