### PR TITLE
Add Gemini/OpenAI token stats to the conversation trace

### DIFF
--- a/homeassistant/components/conversation/chat_log.py
+++ b/homeassistant/components/conversation/chat_log.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, field, replace
 import logging
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 import voluptuous as vol
 
@@ -456,10 +456,16 @@ class ChatLog:
         LOGGER.debug("Prompt: %s", self.content)
         LOGGER.debug("Tools: %s", self.llm_api.tools if self.llm_api else None)
 
-        trace.async_conversation_trace_append(
-            trace.ConversationTraceEventType.AGENT_DETAIL,
+        self.async_trace(
             {
                 "messages": self.content,
                 "tools": self.llm_api.tools if self.llm_api else None,
-            },
+            }
+        )
+
+    def async_trace(self, agent_details: dict[str, Any]) -> None:
+        """Append agent specific details to the conversation trace."""
+        trace.async_conversation_trace_append(
+            trace.ConversationTraceEventType.AGENT_DETAIL,
+            agent_details,
         )

--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -403,6 +403,18 @@ class GoogleGenerativeAIConversationEntity(
                 error = f"Sorry, I had a problem talking to Google Generative AI: {err}"
                 raise HomeAssistantError(error) from err
 
+            if (usage_metadata := chat_response.usage_metadata) is not None:
+                chat_log.async_trace(
+                    {
+                        "stats": {
+                            "input_tokens": usage_metadata.prompt_token_count,
+                            "cached_input_tokens": usage_metadata.cached_content_token_count
+                            or 0,
+                            "output_tokens": usage_metadata.candidates_token_count,
+                        }
+                    }
+                )
+
             response_parts = chat_response.candidates[0].content.parts
             if not response_parts:
                 raise HomeAssistantError(

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -140,13 +140,18 @@ async def _transform_stream(
                     )
                 ]
             }
-        elif isinstance(event, ResponseCompletedEvent) and (usage := event.response.usage) is not None:
-            chat_log.async_trace({
-                "stats": {
-                    "input_tokens": usage.input_tokens,
-                    "output_tokens": usage.output_tokens,
+        elif (
+            isinstance(event, ResponseCompletedEvent)
+            and (usage := event.response.usage) is not None
+        ):
+            chat_log.async_trace(
+                {
+                    "stats": {
+                        "input_tokens": usage.input_tokens,
+                        "output_tokens": usage.output_tokens,
+                    }
                 }
-            })
+            )
 
 
 class OpenAIConversationEntity(

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -144,7 +144,6 @@ async def _transform_stream(
             chat_log.async_trace({
                 "stats": {
                     "input_tokens": usage.input_tokens,
-                    "cached_input_tokens": usage.input_tokens_details.cached_tokens,
                     "output_tokens": usage.output_tokens,
                 }
             })

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -9,6 +9,7 @@ from openai._streaming import AsyncStream
 from openai.types.responses import (
     EasyInputMessageParam,
     FunctionToolParam,
+    ResponseCompletedEvent,
     ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent,
     ResponseFunctionToolCall,
@@ -112,6 +113,7 @@ def _convert_content_to_param(
 
 
 async def _transform_stream(
+    chat_log: conversation.ChatLog,
     result: AsyncStream[ResponseStreamEvent],
 ) -> AsyncGenerator[conversation.AssistantContentDeltaDict]:
     """Transform an OpenAI delta stream into HA format."""
@@ -138,6 +140,14 @@ async def _transform_stream(
                     )
                 ]
             }
+        elif isinstance(event, ResponseCompletedEvent) and (usage := event.response.usage) is not None:
+            chat_log.async_trace({
+                "stats": {
+                    "input_tokens": usage.input_tokens,
+                    "cached_input_tokens": usage.input_tokens_details.cached_tokens,
+                    "output_tokens": usage.output_tokens,
+                }
+            })
 
 
 class OpenAIConversationEntity(
@@ -253,7 +263,7 @@ class OpenAIConversationEntity(
                 raise HomeAssistantError("Error talking to OpenAI") from err
 
             async for content in chat_log.async_add_delta_content_stream(
-                user_input.agent_id, _transform_stream(result)
+                user_input.agent_id, _transform_stream(chat_log, result)
             ):
                 messages.extend(_convert_content_to_param(content))
 

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -156,8 +156,10 @@ async def test_function_call(
     trace_events = last_trace.get("events", [])
     assert [event["event_type"] for event in trace_events] == [
         trace.ConversationTraceEventType.ASYNC_PROCESS,
-        trace.ConversationTraceEventType.AGENT_DETAIL,
+        trace.ConversationTraceEventType.AGENT_DETAIL,  # prompt and tools
+        trace.ConversationTraceEventType.AGENT_DETAIL,  # stats for response
         trace.ConversationTraceEventType.TOOL_CALL,
+        trace.ConversationTraceEventType.AGENT_DETAIL,  # stats for response
     ]
     # AGENT_DETAIL event contains the raw prompt passed to the model
     detail_event = trace_events[1]
@@ -165,6 +167,13 @@ async def test_function_call(
     assert [
         p["tool_name"] for p in detail_event["data"]["messages"][2]["tool_calls"]
     ] == ["test_tool"]
+
+    detail_event = trace_events[2]
+    assert set(detail_event["data"]["stats"].keys()) == {
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+    }
 
 
 @patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add gemini token status to the conversation trace. This allows us to measure any changes to the input/output tokens and measure things like cachability.

This is an example event from a tool call:

```yaml
  - event_type: agent_detail
    data:
      stats:
        input_tokens: 1590
        cached_input_tokens: 0
        output_tokens: 8
```
These stats are recorded as a dict which can be retrieved in our evaluation scripts, similar to how tool details are recorded. This is not yet formalized into a rigid structure yet, but we can have other integrations follow the same convention if that is desirable. ([survey of metrics agents apis](https://docs.google.com/document/d/1xJCx5mxZODfEhetAmPzrkS38vRD5g-V6vVDSNgktcyc/edit?tab=t.0))

This is useful for analysis such as the change in https://github.com/home-assistant/core/pull/141034

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
