### PR TITLE
Use Debouncer helper in HEOS Coordinator

### DIFF
--- a/homeassistant/components/heos/coordinator.py
+++ b/homeassistant/components/heos/coordinator.py
@@ -6,7 +6,6 @@ entities to update. Entities subscribe to entity-specific updates within the ent
 """
 
 from collections.abc import Callable, Sequence
-from datetime import datetime, timedelta
 import logging
 from typing import Any
 
@@ -25,10 +24,10 @@ from pyheos import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
@@ -60,7 +59,13 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
             )
         )
         self._platform_callbacks: list[Callable[[Sequence[HeosPlayer]], None]] = []
-        self._update_sources_pending: bool = False
+        self._update_sources_debouncer = Debouncer(
+            hass,
+            _LOGGER,
+            immediate=True,
+            cooldown=2.0,
+            function=self._async_update_sources,
+        )
         self._source_list: list[str] = []
         self._favorites: dict[int, MediaItem] = {}
         self._inputs: Sequence[MediaItem] = []
@@ -182,31 +187,9 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
         if event == const.EVENT_PLAYERS_CHANGED:
             assert data is not None
             self._async_handle_player_update_result(data)
-        elif (
-            event in (const.EVENT_SOURCES_CHANGED, const.EVENT_USER_CHANGED)
-            and not self._update_sources_pending
-        ):
-            # Update the sources after a brief delay as we may have received multiple qualifying
-            # events at once and devices cannot handle immediately attempting to refresh sources.
-            self._update_sources_pending = True
-
-            async def update_sources_job(_: datetime | None = None) -> None:
-                await self._async_update_sources()
-                self._update_sources_pending = False
-                self.async_update_listeners()
-
-            assert self.config_entry is not None
-            self.config_entry.async_on_unload(
-                async_call_later(
-                    self.hass,
-                    timedelta(seconds=1),
-                    HassJob(
-                        update_sources_job,
-                        "heos_update_sources",
-                        cancel_on_shutdown=True,
-                    ),
-                )
-            )
+        elif event in (const.EVENT_SOURCES_CHANGED, const.EVENT_USER_CHANGED):
+            # Debounce because we may have received multiple qualifying events in rapid succession.
+            await self._update_sources_debouncer.async_call()
         self.async_update_listeners()
 
     def _async_update_player_ids(self, updated_player_ids: dict[int, int]) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates the HEOS coordinator to use the Debouncer helper (` homeassistant.helpers.debounce.Debouncer`) instead of a custom implementation. The library also now ensures that events are delayed adequately so we can set `immediate=True`. Functionality is covered by tests and did not need to be updated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
