### PR TITLE
Jellyfin: display album primary art instead of artist backdrop

### DIFF
--- a/homeassistant/components/jellyfin/client_wrapper.py
+++ b/homeassistant/components/jellyfin/client_wrapper.py
@@ -97,16 +97,30 @@ def get_artwork_url(
     client: JellyfinClient, item: dict[str, Any], max_width: int = 600
 ) -> str | None:
     """Find a suitable thumbnail for an item."""
-    artwork_id: str = item["Id"]
-    artwork_type = "Primary"
+    artwork_id: str | None = None
+    artwork_type: str | None = None
     parent_backdrop_id: str | None = item.get("ParentBackdropItemId")
 
-    if "Backdrop" in item[ITEM_KEY_IMAGE_TAGS]:
+    # The first two cases here for Primary and AlbumPrimaryImageTag
+    # mirror the behavior of the official jellyfin media player
+    # https://github.com/jellyfin/jellyfin-media-player/blob/68ddf01ecef766620d4e564cada0a1125840547f/src/taskbar/TaskbarComponentWin.cpp#L351-L377
+    if "Primary" in item[ITEM_KEY_IMAGE_TAGS]:
+        artwork_type = "Primary"
+        artwork_id = item["Id"]
+    elif "AlbumPrimaryImageTag" in item:
+        # jellyfin_apiclient_python doesn't support passing a specific tag to `.artwork`,
+        # so we don't use the actual value of AlbumPrimaryImageTag.
+        # However, its mere presence tells us that the album does have primary artwork,
+        # and the resulting URL will pull the primary album art even if the tag is not specified.
+        artwork_type = "Primary"
+        artwork_id = item["AlbumId"]
+    elif "Backdrop" in item[ITEM_KEY_IMAGE_TAGS]:
         artwork_type = "Backdrop"
+        artwork_id = item["Id"]
     elif parent_backdrop_id:
         artwork_type = "Backdrop"
         artwork_id = parent_backdrop_id
-    elif "Primary" not in item[ITEM_KEY_IMAGE_TAGS]:
+    else:
         return None
 
     return str(client.jellyfin.artwork(artwork_id, artwork_type, max_width))

--- a/homeassistant/components/jellyfin/client_wrapper.py
+++ b/homeassistant/components/jellyfin/client_wrapper.py
@@ -101,13 +101,7 @@ def get_artwork_url(
     artwork_type: str | None = None
     parent_backdrop_id: str | None = item.get("ParentBackdropItemId")
 
-    # The first two cases here for Primary and AlbumPrimaryImageTag
-    # mirror the behavior of the official jellyfin media player
-    # https://github.com/jellyfin/jellyfin-media-player/blob/68ddf01ecef766620d4e564cada0a1125840547f/src/taskbar/TaskbarComponentWin.cpp#L351-L377
-    if "Primary" in item[ITEM_KEY_IMAGE_TAGS]:
-        artwork_type = "Primary"
-        artwork_id = item["Id"]
-    elif "AlbumPrimaryImageTag" in item:
+    if "AlbumPrimaryImageTag" in item:
         # jellyfin_apiclient_python doesn't support passing a specific tag to `.artwork`,
         # so we don't use the actual value of AlbumPrimaryImageTag.
         # However, its mere presence tells us that the album does have primary artwork,
@@ -120,6 +114,9 @@ def get_artwork_url(
     elif parent_backdrop_id:
         artwork_type = "Backdrop"
         artwork_id = parent_backdrop_id
+    elif "Primary" in item[ITEM_KEY_IMAGE_TAGS]:
+        artwork_type = "Primary"
+        artwork_id = item["Id"]
     else:
         return None
 

--- a/tests/components/jellyfin/fixtures/get-media-folders.json
+++ b/tests/components/jellyfin/fixtures/get-media-folders.json
@@ -302,8 +302,6 @@
       "Album": "string",
       "CollectionType": "tvshows",
       "DisplayOrder": "string",
-      "AlbumId": "21af9851-8e39-43a9-9c47-513d3b9e99fc",
-      "AlbumPrimaryImageTag": "string",
       "SeriesPrimaryImageTag": "string",
       "AlbumArtist": "string",
       "AlbumArtists": [

--- a/tests/components/jellyfin/fixtures/sessions.json
+++ b/tests/components/jellyfin/fixtures/sessions.json
@@ -4346,6 +4346,7 @@
       ],
       "Album": "ALBUM",
       "AlbumId": "ALBUM-UUID",
+      "AlbumPrimaryImageTag": "ALBUM-PRIMARY-IMAGE-TAG",
       "AlbumArtist": "Album Artist",
       "AlbumArtists": [
         { "Name": "Album Artist", "Id": "9a65b2c222ddb34e51f5cae360fad3a1" }

--- a/tests/components/jellyfin/fixtures/user-items-parent-id.json
+++ b/tests/components/jellyfin/fixtures/user-items-parent-id.json
@@ -302,8 +302,6 @@
       "Album": "string",
       "CollectionType": "string",
       "DisplayOrder": "string",
-      "AlbumId": "21af9851-8e39-43a9-9c47-513d3b9e99fc",
-      "AlbumPrimaryImageTag": "string",
       "SeriesPrimaryImageTag": "string",
       "AlbumArtist": "string",
       "AlbumArtists": [

--- a/tests/components/jellyfin/snapshots/test_diagnostics.ambr
+++ b/tests/components/jellyfin/snapshots/test_diagnostics.ambr
@@ -1707,6 +1707,7 @@
             }),
           ]),
           'AlbumId': 'ALBUM-UUID',
+          'AlbumPrimaryImageTag': 'ALBUM-PRIMARY-IMAGE-TAG',
           'ArtistItems': list([
             dict({
               'Id': '1d864900526d9a9513b489f1cc28f8ca',

--- a/tests/components/jellyfin/test_media_player.py
+++ b/tests/components/jellyfin/test_media_player.py
@@ -27,6 +27,7 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
+    ATTR_ENTITY_PICTURE,
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
 )
@@ -124,6 +125,10 @@ async def test_media_player_music(
     assert state.attributes.get(ATTR_MEDIA_SERIES_TITLE) is None
     assert state.attributes.get(ATTR_MEDIA_SEASON) is None
     assert state.attributes.get(ATTR_MEDIA_EPISODE) is None
+    assert (
+        state.attributes.get(ATTR_ENTITY_PICTURE)
+        == "http://localhost/Items/ALBUM-UUID/Images/Primary.jpg"
+    )
 
     entry = entity_registry.async_get(state.entity_id)
     assert entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix player to display album art when playing music, instead of displaying the backdrop image for the album artist.

This was broken because it seems that the primary album art is (no longer?) represented in the ImageTags collection provided from jellyfin. The correct logic for determining the URL for the primary album art was taken from the [official media player](https://github.com/jellyfin/jellyfin-media-player/blob/68ddf01ecef766620d4e564cada0a1125840547f/src/taskbar/TaskbarComponentWin.cpp#L351-L377). 

Before:
![image](https://github.com/user-attachments/assets/fe891f46-dbae-4e04-9c8a-36d10401d617)

After:
![image](https://github.com/user-attachments/assets/13272dab-e7c5-4bbb-8654-1be1f31310c8)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
