### PR TITLE
Log nexia responses when enabled for debug

### DIFF
--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -39,6 +39,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
         state_file=state_file,
         brand=brand,
     )
+    # start out logging responses if we are initially enabled for debug logging
+    nexia_home.log_response = _LOGGER.isEnabledFor(logging.DEBUG)
 
     try:
         await nexia_home.login()
@@ -68,6 +70,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> bool:
     """Unload a config entry."""
+    coordinator = entry.runtime_data
+    coordinator.async_cleanup()
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/homeassistant/components/nexia/coordinator.py
+++ b/homeassistant/components/nexia/coordinator.py
@@ -9,7 +9,8 @@ from typing import Any
 from nexia.home import NexiaHome
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_LOGGING_CHANGED
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,7 +29,10 @@ class NexiaDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         config_entry: ConfigEntry,
         nexia_home: NexiaHome,
     ) -> None:
-        """Initialize DataUpdateCoordinator for the nexia home."""
+        """Initialize DataUpdateCoordinator for the nexia home.
+
+        This method must be run in the event loop.
+        """
         self.nexia_home = nexia_home
         super().__init__(
             hass,
@@ -38,7 +42,27 @@ class NexiaDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=timedelta(seconds=DEFAULT_UPDATE_RATE),
             always_update=False,
         )
+        self.cleanup_callbacks: list[CALLBACK_TYPE] = [
+            hass.bus.async_listen(EVENT_LOGGING_CHANGED, self._async_handle_logging_changed)
+        ]
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint."""
         return await self.nexia_home.update()
+
+    @callback
+    def async_cleanup(self) -> None:
+        """Cleanup this instance.
+
+        This method must be run in the event loop.
+        """
+        for cleanup_callback in self.cleanup_callbacks:
+            cleanup_callback()
+
+    @callback
+    def _async_handle_logging_changed(self, _event: Event) -> None:
+        """Handle when the logging level changes.
+
+        Log responses if and only if enabled for debug logging.
+        """
+        self.nexia_home.log_response = _LOGGER.isEnabledFor(logging.DEBUG)

--- a/tests/components/nexia/test_coordinator.py
+++ b/tests/components/nexia/test_coordinator.py
@@ -1,0 +1,35 @@
+"""Test nexia coordinator."""
+
+from homeassistant.components import logger
+from homeassistant.components.nexia import NexiaDataUpdateCoordinator
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .util import async_init_integration
+
+
+async def test_log_control(hass: HomeAssistant) -> None:
+    """Test changing log response."""
+    assert await async_setup_component(hass, logger.const.DOMAIN, {"logger": {}}) is True
+    config_entry = await async_init_integration(hass)
+    coordinator: NexiaDataUpdateCoordinator = config_entry.runtime_data
+    assert isinstance(coordinator, NexiaDataUpdateCoordinator) is True
+    nexia_home = coordinator.nexia_home
+
+    assert nexia_home.log_response is False
+
+    await hass.services.async_call(
+        logger.const.DOMAIN,
+        logger.const.SERVICE_SET_LEVEL,
+        {"homeassistant.components.nexia": logger.const.LOGSEVERITY_DEBUG},
+        blocking=True,
+    )
+    assert nexia_home.log_response is True
+
+    await hass.services.async_call(
+        logger.const.DOMAIN,
+        logger.const.SERVICE_SET_LEVEL,
+        {"homeassistant.components.nexia": logger.const.LOGSEVERITY_WARNING},
+        blocking=True,
+    )
+    assert nexia_home.log_response is False


### PR DESCRIPTION
Log nexia responses when enabled for debug by hooking into the logging changed event.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the nexia library's ability to log http response payloads when the nexia integration has debug logging enabled. This is accomplished by looking up the debug logging state during setup (in case HA restarted while logging was enabled) and by hooking into the logging changed event. This is intended to improve problem diagnosis.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
