### PR TITLE
Improve default icons for sensors in NUT

### DIFF
--- a/homeassistant/components/nut/icons.json
+++ b/homeassistant/components/nut/icons.json
@@ -84,17 +84,11 @@
       "input_voltage_status": {
         "default": "mdi:information-outline"
       },
-      "outlet_number_current": {
-        "default": "mdi:current-ac"
-      },
       "outlet_number_current_status": {
         "default": "mdi:information-outline"
       },
       "outlet_number_desc": {
         "default": "mdi:information-outline"
-      },
-      "outlet_number_power": {
-        "default": "mdi:gauge"
       },
       "output_l1_power_percent": {
         "default": "mdi:percent-circle-outline"

--- a/homeassistant/components/nut/icons.json
+++ b/homeassistant/components/nut/icons.json
@@ -6,8 +6,14 @@
       }
     },
     "sensor": {
+      "ambient_humidity": {
+        "default": "mdi:water-percent"
+      },
       "ambient_humidity_status": {
         "default": "mdi:information-outline"
+      },
+      "ambient_temperature": {
+        "default": "mdi:thermometer"
       },
       "ambient_temperature_status": {
         "default": "mdi:information-outline"
@@ -17,6 +23,9 @@
       },
       "battery_capacity": {
         "default": "mdi:flash"
+      },
+      "battery_charge": {
+        "default": "mdi:percent-box"
       },
       "battery_charge_low": {
         "default": "mdi:gauge"
@@ -30,6 +39,12 @@
       "battery_charger_status": {
         "default": "mdi:information-outline"
       },
+      "battery_currrent": {
+        "default": "mdi:gauge"
+      },
+      "battery_currrent_total": {
+        "default": "mdi:gauge"
+      },
       "battery_date": {
         "default": "mdi:calendar"
       },
@@ -42,17 +57,125 @@
       "battery_packs_bad": {
         "default": "mdi:information-outline"
       },
+      "battery_runtime": {
+        "default": "mdi:timer-outline"
+      },
+      "battery_runtime_low": {
+        "default": "mdi:timer-alert-outline"
+      },
+      "battery_runtime_restart": {
+        "default": "mdi:timer-alert-outline"
+      },
+      "battery_temperature": {
+        "default": "mdi:thermometer"
+      },
       "battery_type": {
         "default": "mdi:information-outline"
+      },
+      "battery_voltage": {
+        "default": "mdi:current-dc"
+      },
+      "battery_voltage_high": {
+        "default": "mdi:battery-high"
+      },
+      "battery_voltage_low": {
+        "default": "mdi:battery-low"
+      },
+      "battery_voltage_nominal": {
+        "default": "mdi:current-dc"
+      },
+      "input_bypass_current": {
+        "default": "mdi:gauge"
+      },
+      "input_bypass_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "input_bypass_l1_current": {
+        "default": "mdi:gauge"
+      },
+      "input_bypass_l1_n_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "input_bypass_l1_real_power": {
+        "default": "mdi:gauge"
+      },
+      "input_bypass_l2_current": {
+        "default": "mdi:gauge"
+      },
+      "input_bypass_l2_n_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "input_bypass_l2_real_power": {
+        "default": "mdi:gauge"
+      },
+      "input_bypass_l3_current": {
+        "default": "mdi:gauge"
+      },
+      "input_bypass_l3_n_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "input_bypass_l3_real_power": {
+        "default": "mdi:gauge"
       },
       "input_bypass_phases": {
         "default": "mdi:information-outline"
       },
+      "input_bypass_realpower": {
+        "default": "mdi:gauge"
+      },
+      "input_bypass_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "input_current": {
+        "default": "mdi:current-ac"
+      },
       "input_current_status": {
         "default": "mdi:information-outline"
       },
+      "input_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "input_frequency_nominal": {
+        "default": "mdi:sine-wave"
+      },
       "input_frequency_status": {
         "default": "mdi:information-outline"
+      },
+      "input_l1_current": {
+        "default": "mdi:current-ac"
+      },
+      "input_l1_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "input_l1_n_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "input_l1_realpower": {
+        "default": "mdi:gauge"
+      },
+      "input_l2_current": {
+        "default": "mdi:current-ac"
+      },
+      "input_l2_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "input_l2_n_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "input_l2_realpower": {
+        "default": "mdi:gauge"
+      },
+      "input_l3_current": {
+        "default": "mdi:current-ac"
+      },
+      "input_l3_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "input_l3_n_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "input_l3_realpower": {
+        "default": "mdi:gauge"
       },
       "input_load": {
         "default": "mdi:gauge"
@@ -63,11 +186,26 @@
       "input_power": {
         "default": "mdi:gauge"
       },
+      "input_realpower": {
+        "default": "mdi:gauge"
+      },
       "input_sensitivity": {
         "default": "mdi:information-outline"
       },
+      "input_transfer_high": {
+        "default": "mdi:battery-alert-variant-outline"
+      },
+      "input_transfer_low": {
+        "default": "mdi:battery-alert-variant-outline"
+      },
       "input_transfer_reason": {
         "default": "mdi:information-outline"
+      },
+      "input_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "input_voltage_nominal": {
+        "default": "mdi:sine-wave"
       },
       "input_voltage_status": {
         "default": "mdi:information-outline"
@@ -90,17 +228,74 @@
       "outlet_voltage": {
         "default": "mdi:gauge"
       },
+      "output_current": {
+        "default": "mdi:current-ac"
+      },
+      "output_current_nominal": {
+        "default": "mdi:current-ac"
+      },
+      "output_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "output_frequency_nominal": {
+        "default": "mdi:sine-wave"
+      },
+      "output_l1_current": {
+        "default": "mdi:current-ac"
+      },
+      "output_l1_n_voltage": {
+        "default": "mdi:sine-wave"
+      },
       "output_l1_power_percent": {
+        "default": "mdi:percent-box"
+      },
+      "output_l1_realpower": {
         "default": "mdi:gauge"
+      },
+      "output_l2_current": {
+        "default": "mdi:current-ac"
+      },
+      "output_l2_n_voltage": {
+        "default": "mdi:sine-wave"
       },
       "output_l2_power_percent": {
+        "default": "mdi:percent-box"
+      },
+      "output_l2_realpower": {
         "default": "mdi:gauge"
       },
+      "output_l3_current": {
+        "default": "mdi:current-ac"
+      },
+      "output_l3_n_voltage": {
+        "default": "mdi:sine-wave"
+      },
       "output_l3_power_percent": {
+        "default": "mdi:percent-box"
+      },
+      "output_l3_realpower": {
         "default": "mdi:gauge"
       },
       "output_phases": {
         "default": "mdi:information-outline"
+      },
+      "output_power": {
+        "default": "mdi:gauge"
+      },
+      "output_power_nominal": {
+        "default": "mdi:gauge"
+      },
+      "output_realpower": {
+        "default": "mdi:gauge"
+      },
+      "output_realpower_nominal": {
+        "default": "mdi:gauge"
+      },
+      "output_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "output_voltage_nominal": {
+        "default": "mdi:sine-wave"
       },
       "ups_alarm": {
         "default": "mdi:alarm"
@@ -110,6 +305,15 @@
       },
       "ups_contacts": {
         "default": "mdi:information-outline"
+      },
+      "ups_delay_reboot": {
+        "default": "mdi:timelapse"
+      },
+      "ups_delay_shutdown": {
+        "default": "mdi:timelapse"
+      },
+      "ups_delay_start": {
+        "default": "mdi:timelapse"
       },
       "ups_display_language": {
         "default": "mdi:information-outline"
@@ -124,6 +328,18 @@
         "default": "mdi:gauge"
       },
       "ups_load_high": {
+        "default": "mdi:gauge"
+      },
+      "ups_power": {
+        "default": "mdi:gauge"
+      },
+      "ups_power_nominal": {
+        "default": "mdi:gauge"
+      },
+      "ups_realpower": {
+        "default": "mdi:gauge"
+      },
+      "ups_realpower_nominal": {
         "default": "mdi:gauge"
       },
       "ups_shutdown": {
@@ -144,11 +360,26 @@
       "ups_status_display": {
         "default": "mdi:information-outline"
       },
+      "ups_temperature": {
+        "default": "mdi:thermometer"
+      },
       "ups_test_date": {
         "default": "mdi:calendar"
       },
+      "ups_test_interval": {
+        "default": "mdi:timelapse"
+      },
       "ups_test_result": {
         "default": "mdi:information-outline"
+      },
+      "ups_timer_reboot": {
+        "default": "mdi:timer-outline"
+      },
+      "ups_timer_shutdown": {
+        "default": "mdi:timer-outline"
+      },
+      "ups_timer_start": {
+        "default": "mdi:timer-outline"
       },
       "ups_type": {
         "default": "mdi:information-outline"

--- a/homeassistant/components/nut/icons.json
+++ b/homeassistant/components/nut/icons.json
@@ -6,14 +6,8 @@
       }
     },
     "sensor": {
-      "ambient_humidity": {
-        "default": "mdi:water-percent"
-      },
       "ambient_humidity_status": {
         "default": "mdi:information-outline"
-      },
-      "ambient_temperature": {
-        "default": "mdi:thermometer"
       },
       "ambient_temperature_status": {
         "default": "mdi:information-outline"
@@ -23,9 +17,6 @@
       },
       "battery_capacity": {
         "default": "mdi:flash"
-      },
-      "battery_charge": {
-        "default": "mdi:percent-box"
       },
       "battery_charge_low": {
         "default": "mdi:gauge"
@@ -38,12 +29,6 @@
       },
       "battery_charger_status": {
         "default": "mdi:information-outline"
-      },
-      "battery_currrent": {
-        "default": "mdi:gauge"
-      },
-      "battery_currrent_total": {
-        "default": "mdi:gauge"
       },
       "battery_date": {
         "default": "mdi:calendar"
@@ -58,22 +43,16 @@
         "default": "mdi:information-outline"
       },
       "battery_runtime": {
-        "default": "mdi:timer-outline"
+        "default": "mdi:clock-outline"
       },
       "battery_runtime_low": {
-        "default": "mdi:timer-alert-outline"
+        "default": "mdi:clock-alert-outline"
       },
       "battery_runtime_restart": {
-        "default": "mdi:timer-alert-outline"
-      },
-      "battery_temperature": {
-        "default": "mdi:thermometer"
+        "default": "mdi:clock-start"
       },
       "battery_type": {
         "default": "mdi:information-outline"
-      },
-      "battery_voltage": {
-        "default": "mdi:current-dc"
       },
       "battery_voltage_high": {
         "default": "mdi:battery-high"
@@ -81,137 +60,32 @@
       "battery_voltage_low": {
         "default": "mdi:battery-low"
       },
-      "battery_voltage_nominal": {
-        "default": "mdi:current-dc"
-      },
-      "input_bypass_current": {
-        "default": "mdi:gauge"
-      },
-      "input_bypass_frequency": {
-        "default": "mdi:sine-wave"
-      },
-      "input_bypass_l1_current": {
-        "default": "mdi:gauge"
-      },
-      "input_bypass_l1_n_voltage": {
-        "default": "mdi:sine-wave"
-      },
-      "input_bypass_l1_real_power": {
-        "default": "mdi:gauge"
-      },
-      "input_bypass_l2_current": {
-        "default": "mdi:gauge"
-      },
-      "input_bypass_l2_n_voltage": {
-        "default": "mdi:sine-wave"
-      },
-      "input_bypass_l2_real_power": {
-        "default": "mdi:gauge"
-      },
-      "input_bypass_l3_current": {
-        "default": "mdi:gauge"
-      },
-      "input_bypass_l3_n_voltage": {
-        "default": "mdi:sine-wave"
-      },
-      "input_bypass_l3_real_power": {
-        "default": "mdi:gauge"
-      },
       "input_bypass_phases": {
-        "default": "mdi:information-outline"
-      },
-      "input_bypass_realpower": {
-        "default": "mdi:gauge"
-      },
-      "input_bypass_voltage": {
         "default": "mdi:sine-wave"
-      },
-      "input_current": {
-        "default": "mdi:current-ac"
       },
       "input_current_status": {
         "default": "mdi:information-outline"
       },
-      "input_frequency": {
-        "default": "mdi:sine-wave"
-      },
-      "input_frequency_nominal": {
-        "default": "mdi:sine-wave"
-      },
       "input_frequency_status": {
         "default": "mdi:information-outline"
       },
-      "input_l1_current": {
-        "default": "mdi:current-ac"
-      },
-      "input_l1_frequency": {
-        "default": "mdi:sine-wave"
-      },
-      "input_l1_n_voltage": {
-        "default": "mdi:sine-wave"
-      },
-      "input_l1_realpower": {
-        "default": "mdi:gauge"
-      },
-      "input_l2_current": {
-        "default": "mdi:current-ac"
-      },
-      "input_l2_frequency": {
-        "default": "mdi:sine-wave"
-      },
-      "input_l2_n_voltage": {
-        "default": "mdi:sine-wave"
-      },
-      "input_l2_realpower": {
-        "default": "mdi:gauge"
-      },
-      "input_l3_current": {
-        "default": "mdi:current-ac"
-      },
-      "input_l3_frequency": {
-        "default": "mdi:sine-wave"
-      },
-      "input_l3_n_voltage": {
-        "default": "mdi:sine-wave"
-      },
-      "input_l3_realpower": {
-        "default": "mdi:gauge"
-      },
       "input_load": {
-        "default": "mdi:gauge"
+        "default": "mdi:percent-box-outline"
       },
       "input_phases": {
-        "default": "mdi:information-outline"
-      },
-      "input_power": {
-        "default": "mdi:gauge"
-      },
-      "input_realpower": {
-        "default": "mdi:gauge"
+        "default": "mdi:sine-wave"
       },
       "input_sensitivity": {
         "default": "mdi:information-outline"
       },
-      "input_transfer_high": {
-        "default": "mdi:battery-alert-variant-outline"
-      },
-      "input_transfer_low": {
-        "default": "mdi:battery-alert-variant-outline"
-      },
       "input_transfer_reason": {
         "default": "mdi:information-outline"
-      },
-      "input_voltage": {
-        "default": "mdi:sine-wave"
-      },
-      "input_voltage_nominal": {
-        "default": "mdi:sine-wave"
       },
       "input_voltage_status": {
         "default": "mdi:information-outline"
       },
       "outlet_number_current": {
-        "default": "mdi:gauge"
+        "default": "mdi:current-ac"
       },
       "outlet_number_current_status": {
         "default": "mdi:information-outline"
@@ -222,79 +96,16 @@
       "outlet_number_power": {
         "default": "mdi:gauge"
       },
-      "outlet_number_realpower": {
-        "default": "mdi:gauge"
-      },
-      "outlet_voltage": {
-        "default": "mdi:gauge"
-      },
-      "output_current": {
-        "default": "mdi:current-ac"
-      },
-      "output_current_nominal": {
-        "default": "mdi:current-ac"
-      },
-      "output_frequency": {
-        "default": "mdi:sine-wave"
-      },
-      "output_frequency_nominal": {
-        "default": "mdi:sine-wave"
-      },
-      "output_l1_current": {
-        "default": "mdi:current-ac"
-      },
-      "output_l1_n_voltage": {
-        "default": "mdi:sine-wave"
-      },
       "output_l1_power_percent": {
-        "default": "mdi:percent-box"
-      },
-      "output_l1_realpower": {
-        "default": "mdi:gauge"
-      },
-      "output_l2_current": {
-        "default": "mdi:current-ac"
-      },
-      "output_l2_n_voltage": {
-        "default": "mdi:sine-wave"
+        "default": "mdi:percent-circle-outline"
       },
       "output_l2_power_percent": {
-        "default": "mdi:percent-box"
-      },
-      "output_l2_realpower": {
-        "default": "mdi:gauge"
-      },
-      "output_l3_current": {
-        "default": "mdi:current-ac"
-      },
-      "output_l3_n_voltage": {
-        "default": "mdi:sine-wave"
+        "default": "mdi:percent-circle-outline"
       },
       "output_l3_power_percent": {
-        "default": "mdi:percent-box"
-      },
-      "output_l3_realpower": {
-        "default": "mdi:gauge"
+        "default": "mdi:percent-circle-outline"
       },
       "output_phases": {
-        "default": "mdi:information-outline"
-      },
-      "output_power": {
-        "default": "mdi:gauge"
-      },
-      "output_power_nominal": {
-        "default": "mdi:gauge"
-      },
-      "output_realpower": {
-        "default": "mdi:gauge"
-      },
-      "output_realpower_nominal": {
-        "default": "mdi:gauge"
-      },
-      "output_voltage": {
-        "default": "mdi:sine-wave"
-      },
-      "output_voltage_nominal": {
         "default": "mdi:sine-wave"
       },
       "ups_alarm": {
@@ -319,28 +130,16 @@
         "default": "mdi:information-outline"
       },
       "ups_efficiency": {
-        "default": "mdi:gauge"
+        "default": "mdi:percent-outline"
       },
       "ups_id": {
         "default": "mdi:information-outline"
       },
       "ups_load": {
-        "default": "mdi:gauge"
+        "default": "mdi:percent-box-outline"
       },
       "ups_load_high": {
-        "default": "mdi:gauge"
-      },
-      "ups_power": {
-        "default": "mdi:gauge"
-      },
-      "ups_power_nominal": {
-        "default": "mdi:gauge"
-      },
-      "ups_realpower": {
-        "default": "mdi:gauge"
-      },
-      "ups_realpower_nominal": {
-        "default": "mdi:gauge"
+        "default": "mdi:percent-box-outline"
       },
       "ups_shutdown": {
         "default": "mdi:information-outline"
@@ -360,9 +159,6 @@
       "ups_status_display": {
         "default": "mdi:information-outline"
       },
-      "ups_temperature": {
-        "default": "mdi:thermometer"
-      },
       "ups_test_date": {
         "default": "mdi:calendar"
       },
@@ -371,15 +167,6 @@
       },
       "ups_test_result": {
         "default": "mdi:information-outline"
-      },
-      "ups_timer_reboot": {
-        "default": "mdi:timer-outline"
-      },
-      "ups_timer_shutdown": {
-        "default": "mdi:timer-outline"
-      },
-      "ups_timer_start": {
-        "default": "mdi:timer-outline"
       },
       "ups_type": {
         "default": "mdi:information-outline"

--- a/homeassistant/components/nut/icons.json
+++ b/homeassistant/components/nut/icons.json
@@ -162,6 +162,15 @@
       "ups_test_result": {
         "default": "mdi:information-outline"
       },
+      "ups_timer_reboot": {
+        "default": "mdi:timer-refresh-outline"
+      },
+      "ups_timer_shutdown": {
+        "default": "mdi:timer-stop-outline"
+      },
+      "ups_timer_start": {
+        "default": "mdi:timer-play-outline"
+      },
       "ups_type": {
         "default": "mdi:information-outline"
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve the default icons for the NUT sensors by (1) removing icons for sensors with a specified device class where the default class icon is appropriate, (2) adding icons for sensors with a specified device class but where another icon is more appropriate (or differentiating) than the default icon, and (3) changing existing icon selections to better align to the sensor purpose.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
