### PR TITLE
Deprecate fridge door sensor in SmartThings

### DIFF
--- a/homeassistant/components/smartthings/binary_sensor.py
+++ b/homeassistant/components/smartthings/binary_sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from pysmartthings import Attribute, Capability, Category, SmartThings
+from pysmartthings import Attribute, Capability, Category, SmartThings, Status
 
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.binary_sensor import (
@@ -38,6 +38,9 @@ class SmartThingsBinarySensorEntityDescription(BinarySensorEntityDescription):
     category: set[Category] | None = None
     exists_fn: Callable[[str], bool] | None = None
     component_translation_key: dict[str, str] | None = None
+    deprecated_fn: Callable[
+        [dict[str, dict[Capability | str, dict[Attribute | str, Status]]]], str | None
+    ] = lambda _: None
 
 
 CAPABILITY_TO_SENSORS: dict[
@@ -66,6 +69,11 @@ CAPABILITY_TO_SENSORS: dict[
                 "freezer": "freezer_door",
                 "cooler": "cooler_door",
             },
+            deprecated_fn=(
+                lambda status: "fridge_door"
+                if "freezer" in status and "cooler" in status
+                else None
+            ),
         )
     },
     Capability.FILTER_STATUS: {
@@ -133,6 +141,7 @@ CAPABILITY_TO_SENSORS: dict[
             translation_key="valve",
             device_class=BinarySensorDeviceClass.OPENING,
             is_on_key="open",
+            deprecated_fn=lambda _: "valve",
         )
     },
     Capability.WATER_SENSOR: {
@@ -242,7 +251,7 @@ class SmartThingsBinarySensor(SmartThingsEntity, BinarySensorEntity):
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         await super().async_added_to_hass()
-        if self.capability is not Capability.VALVE:
+        if (issue := self.entity_description.deprecated_fn(self.device.status)) is None:
             return
         automations = automations_with_entity(self.hass, self.entity_id)
         scripts = scripts_with_entity(self.hass, self.entity_id)
@@ -273,11 +282,11 @@ class SmartThingsBinarySensor(SmartThingsEntity, BinarySensorEntity):
         async_create_issue(
             self.hass,
             DOMAIN,
-            f"deprecated_binary_valve_{self.entity_id}",
+            f"deprecated_binary_{issue}_{self.entity_id}",
             breaks_in_ha_version="2025.10.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
-            translation_key="deprecated_binary_valve",
+            translation_key=f"deprecated_binary_{issue}",
             translation_placeholders={
                 "entity": self.entity_id,
                 "items": "\n".join(items_list),
@@ -287,6 +296,8 @@ class SmartThingsBinarySensor(SmartThingsEntity, BinarySensorEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed from hass."""
         await super().async_will_remove_from_hass()
+        if (issue := self.entity_description.deprecated_fn(self.device.status)) is None:
+            return
         async_delete_issue(
-            self.hass, DOMAIN, f"deprecated_binary_valve_{self.entity_id}"
+            self.hass, DOMAIN, f"deprecated_binary_{issue}_{self.entity_id}"
         )

--- a/homeassistant/components/smartthings/strings.json
+++ b/homeassistant/components/smartthings/strings.json
@@ -470,6 +470,10 @@
     "deprecated_binary_valve": {
       "title": "Deprecated valve binary sensor detected in some automations or scripts",
       "description": "The valve binary sensor `{entity}` is deprecated and is used in the following automations or scripts:\n{items}\n\nA valve entity with controls is available and should be used going forward; Please use it on the above automations or scripts to fix this issue."
+    },
+    "deprecated_binary_fridge_door": {
+      "title": "Deprecated refrigerator door binary sensor detected in some automations or scripts",
+      "description": "The refrigerator door binary sensor `{entity}` is deprecated and is used in the following automations or scripts:\n{items}\n\nSeparate entities for cooler and freezer door are available and should be used going forward; Please use it on the above automations or scripts to fix this issue."
     }
   }
 }

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -59,16 +59,23 @@ async def test_state_update(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-@pytest.mark.parametrize("device_fixture", ["virtual_valve"])
+@pytest.mark.parametrize(
+    ("device_fixture", "issue_string", "entity_id"),
+    [
+        ("virtual_valve", "valve", "binary_sensor.volvo_valve"),
+        ("da_ref_normal_000001", "fridge_door", "binary_sensor.refrigerator_door"),
+    ],
+)
 async def test_create_issue(
     hass: HomeAssistant,
     devices: AsyncMock,
     mock_config_entry: MockConfigEntry,
     issue_registry: ir.IssueRegistry,
+    issue_string: str,
+    entity_id: str,
 ) -> None:
     """Test we create an issue when an automation or script is using a deprecated entity."""
-    entity_id = "binary_sensor.volvo_valve"
-    issue_id = f"deprecated_binary_valve_{entity_id}"
+    issue_id = f"deprecated_binary_{issue_string}_{entity_id}"
 
     assert await async_setup_component(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The door entity for refrigerators have been deprecated. Instead, a separate entity for the freezer and cooler have been added. Please update your automations and scripts accordingly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate fridge door sensor in SmartThings

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
