### PR TITLE
Do not deepcopy section schema when applying suggested values

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -666,7 +666,7 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
                 new_section_key = copy.copy(key)
                 schema[new_section_key] = val
                 val.schema = self.add_suggested_values_to_schema(
-                    copy.deepcopy(val.schema), suggested_values[key]
+                    val.schema, suggested_values[key]
                 )
                 continue
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -178,6 +178,10 @@ async def test_form_shows_with_added_suggested_values(manager: MockFlowManager) 
     assert markers[2] == "section_1"
     section_validator = form["data_schema"].schema["section_1"]
     assert isinstance(section_validator, data_entry_flow.section)
+    # The section class was not replaced
+    assert section_validator is schema.schema["section_1"]
+    # The section schema was not replaced
+    assert section_validator.schema is schema.schema["section_1"].schema
     section_markers = list(section_validator.schema.schema)
     assert len(section_markers) == 1
     assert section_markers[0] == "full_name"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix a regression introduced with #141227. `deepcopy` makes vol.schema to be copied as a dict, type object that is not recognized when it is serialized to the UI.

Using `deepcopy` is not needed as the helper only replaces the `vol.Marker` (keys) objects in the schema.
These are copied to a new dict together with the existing validators.

![afbeelding](https://github.com/user-attachments/assets/e0acf18e-20d6-484d-87cf-d544754f9903)

```log
Traceback (most recent call last):
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/aiohttp/web_protocol.py", line 480, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/aiohttp/web_app.py", line 569, in _handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/security_filter.py", line 92, in security_filter_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/forwarded.py", line 210, in forwarded_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/request_context.py", line 26, in request_context_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/ban.py", line 86, in ban_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/auth.py", line 242, in auth_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/headers.py", line 32, in headers_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/helpers/http.py", line 73, in handle
    result = await handler(request, **request.match_info)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/decorators.py", line 81, in with_admin
    return await func(self, request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/config/config_entries.py", line 272, in post
    return await super().post(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/data_validator.py", line 74, in wrapper
    return await method(view, request, data, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/helpers/data_entry_flow.py", line 76, in post
    return await self._post_impl(request, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/helpers/data_entry_flow.py", line 92, in _post_impl
    result = self._prepare_result_json(result)
  File "/workspaces/core/homeassistant/helpers/data_entry_flow.py", line 51, in _prepare_result_json
    data["data_schema"] = voluptuous_serialize.convert(
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        schema, custom_serializer=cv.custom_serializer
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/voluptuous_serialize/__init__.py", line 40, in convert
    pval = convert(value, custom_serializer=custom_serializer)
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/voluptuous_serialize/__init__.py", line 25, in convert
    val = custom_serializer(schema)
  File "/workspaces/core/homeassistant/helpers/config_validation.py", line 1115, in custom_serializer
    return _custom_serializer(schema, allow_section=True)
  File "/workspaces/core/homeassistant/helpers/config_validation.py", line 1138, in _custom_serializer
    "schema": voluptuous_serialize.convert(
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        schema.schema,
        ^^^^^^^^^^^^^^
    ...<2 lines>...
        ),
        ^^
    ),
    ^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/voluptuous_serialize/__init__.py", line 49, in convert
    pval["default"] = key.default()
                      ~~~~~~~~~~~^^
TypeError: 'Undefined' object is not callable
2025-03-24 13:35:18.800 DEBUG (MainThread) [homeassistant.components.mqtt.client] homeassistant.local: register write 22
2025-03-24 13:35:18.801 DEBUG (MainThread) [homeassistant.components.mqtt.client] homeassistant.local: unregister write 22
2025-03-24 13:35:53.085 ERROR (MainThread) [aiohttp.server] Error handling request from 172.17.0.1
Traceback (most recent call last):
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/aiohttp/web_protocol.py", line 480, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/aiohttp/web_app.py", line 569, in _handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/security_filter.py", line 92, in security_filter_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/forwarded.py", line 210, in forwarded_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/request_context.py", line 26, in request_context_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/ban.py", line 86, in ban_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/auth.py", line 242, in auth_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/headers.py", line 32, in headers_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/helpers/http.py", line 73, in handle
    result = await handler(request, **request.match_info)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/decorators.py", line 81, in with_admin
    return await func(self, request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/config/config_entries.py", line 272, in post
    return await super().post(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/http/data_validator.py", line 74, in wrapper
    return await method(view, request, data, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/helpers/data_entry_flow.py", line 76, in post
    return await self._post_impl(request, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/helpers/data_entry_flow.py", line 92, in _post_impl
    result = self._prepare_result_json(result)
  File "/workspaces/core/homeassistant/helpers/data_entry_flow.py", line 51, in _prepare_result_json
    data["data_schema"] = voluptuous_serialize.convert(
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        schema, custom_serializer=cv.custom_serializer
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/voluptuous_serialize/__init__.py", line 40, in convert
    pval = convert(value, custom_serializer=custom_serializer)
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/voluptuous_serialize/__init__.py", line 25, in convert
    val = custom_serializer(schema)
  File "/workspaces/core/homeassistant/helpers/config_validation.py", line 1115, in custom_serializer
    return _custom_serializer(schema, allow_section=True)
  File "/workspaces/core/homeassistant/helpers/config_validation.py", line 1138, in _custom_serializer
    "schema": voluptuous_serialize.convert(
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        schema.schema,
        ^^^^^^^^^^^^^^
    ...<2 lines>...
        ),
        ^^
    ),
    ^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/voluptuous_serialize/__init__.py", line 49, in convert
    pval["default"] = key.default()
                      ~~~~~~~~~~~^^
TypeError: 'Undefined' object is not callable
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
