### PR TITLE
Reload the ZBT-1 integration on USB state changes

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -10,10 +10,41 @@ from homeassistant.components.usb import USBDevice, async_register_port_event_ca
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.typing import ConfigType
 
-from .const import DESCRIPTION, DEVICE, FIRMWARE, FIRMWARE_VERSION, PRODUCT
+from .const import DESCRIPTION, DEVICE, DOMAIN, FIRMWARE, FIRMWARE_VERSION, PRODUCT
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the ZBT-1 integration."""
+
+    @callback
+    def async_port_event_callback(
+        added: set[USBDevice], removed: set[USBDevice]
+    ) -> None:
+        """Handle USB port events."""
+        current_entries = {
+            entry.data[DEVICE]: entry
+            for entry in hass.config_entries.async_entries(DOMAIN)
+        }
+
+        for device in added | removed:
+            path = device.device
+            entry = current_entries.get(path)
+
+            if entry is not None:
+                _LOGGER.debug(
+                    "Device %r has changed state, reloading config entry %s",
+                    path,
+                    entry,
+                )
+                hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+
+    async_register_port_event_callback(hass, async_port_event_callback)
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -23,28 +54,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_path = entry.data[DEVICE]
     if not await hass.async_add_executor_job(os.path.exists, device_path):
         raise ConfigEntryNotReady
-
-    @callback
-    def async_port_event_callback(
-        added: set[USBDevice], removed: set[USBDevice]
-    ) -> None:
-        """Handle USB port events."""
-        if not added and not removed:
-            return
-
-        for device in removed:
-            if device.device == device_path:
-                _LOGGER.debug(
-                    "Device %r has been unplugged, reloading config entry",
-                    device.device,
-                )
-                hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
-                return
-
-    # Handle the ZBT-1 being unplugged
-    entry.async_on_unload(
-        async_register_port_event_callback(hass, async_port_event_callback)
-    )
 
     await hass.config_entries.async_forward_entry_setups(entry, ["update"])
 

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -10,11 +10,14 @@ from homeassistant.components.usb import USBDevice, async_register_port_event_ca
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DESCRIPTION, DEVICE, DOMAIN, FIRMWARE, FIRMWARE_VERSION, PRODUCT
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -28,14 +28,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         added: set[USBDevice], removed: set[USBDevice]
     ) -> None:
         """Handle USB port events."""
-        current_entries = {
+        current_entries_by_path = {
             entry.data[DEVICE]: entry
             for entry in hass.config_entries.async_entries(DOMAIN)
         }
 
         for device in added | removed:
             path = device.device
-            entry = current_entries.get(path)
+            entry = current_entries_by_path.get(path)
 
             if entry is not None:
                 _LOGGER.debug(
@@ -43,7 +43,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     path,
                     entry,
                 )
-                hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+                hass.config_entries.async_schedule_reload(entry.entry_id)
 
     async_register_port_event_callback(hass, async_port_event_callback)
 

--- a/tests/components/homeassistant_sky_connect/conftest.py
+++ b/tests/components/homeassistant_sky_connect/conftest.py
@@ -47,3 +47,13 @@ def mock_zha_get_last_network_settings() -> Generator[None]:
         AsyncMock(return_value=None),
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_usb_path_exists() -> Generator[None]:
+    """Mock os.path.exists to allow the ZBT-1 integration to load."""
+    with patch(
+        "homeassistant.components.homeassistant_sky_connect.os.path.exists",
+        return_value=True,
+    ):
+        yield

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -122,14 +122,14 @@ async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         # Failed to set up, the device is missing
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
         mock_exists.return_value = True
         async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=30))
         await hass.async_block_till_done(wait_background_tasks=True)
 
         # Now it's ready
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_usb_device_reactivity(
@@ -177,7 +177,7 @@ async def test_usb_device_reactivity(
         await hass.async_block_till_done()
 
         # Failed to set up, the device is missing
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
         # Now we make it available but do not wait
         mock_exists.return_value = True
@@ -200,7 +200,7 @@ async def test_usb_device_reactivity(
         # It loads immediately
         await hass.async_block_till_done(wait_background_tasks=True)
         await hass.async_block_till_done(wait_background_tasks=True)
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
         # Wait for a bit for the USB scan debouncer to cool off
         async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=5))
@@ -213,4 +213,4 @@ async def test_usb_device_reactivity(
 
         # The integration has reloaded and is now in a failed state
         await hass.async_block_till_done(wait_background_tasks=True)
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -1,15 +1,44 @@
 """Test the Home Assistant SkyConnect integration."""
 
+from datetime import timedelta
 from unittest.mock import patch
+
+from serial.tools.list_ports_common import ListPortInfo
 
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
 )
 from homeassistant.components.homeassistant_sky_connect.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.typing import MockHAClientWebSocket, WebSocketGenerator
+
+
+def create_list_port_info(device: str, **kwargs) -> ListPortInfo:
+    """Create a ListPortInfo object."""
+    info = ListPortInfo(device)
+
+    for key, value in kwargs.items():
+        assert hasattr(info, key)
+        setattr(info, key, value)
+
+    return info
+
+
+async def async_request_scan(
+    hass: HomeAssistant, ws_client: MockHAClientWebSocket
+) -> None:
+    """Request a USB scan."""
+    await ws_client.send_json({"id": 1, "type": "usb/scan"})
+    response = await ws_client.receive_json()
+    assert response["success"]
+    await hass.async_block_till_done()
 
 
 async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
@@ -58,3 +87,123 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
     }
 
     await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:
+    """Test setup failing when the USB port is missing."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="some_unique_id",
+        data={
+            "description": "SkyConnect v1.0",
+            "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+            "vid": "10C4",
+            "pid": "EA60",
+            "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
+            "manufacturer": "Nabu Casa",
+            "product": "SkyConnect v1.0",
+            "firmware": "ezsp",
+            "firmware_version": "7.4.4.0",
+        },
+        version=1,
+        minor_version=3,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    # Set up the config entry
+    with patch(
+        "homeassistant.components.homeassistant_sky_connect.os.path.exists"
+    ) as mock_exists:
+        mock_exists.return_value = False
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Failed to set up, the device is missing
+        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+
+        mock_exists.return_value = True
+        async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=30))
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        # Now it's ready
+        assert config_entry.state == ConfigEntryState.LOADED
+
+
+async def test_usb_device_reactivity(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test setting up USB monitoring."""
+
+    assert await async_setup_component(hass, "usb", {"usb": {}})
+    await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+    ws_client = await hass_ws_client(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="some_unique_id",
+        data={
+            "description": "SkyConnect v1.0",
+            "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+            "vid": "10C4",
+            "pid": "EA60",
+            "serial_number": "3c0ed67c628beb11b1cd64a0f320645d",
+            "manufacturer": "Nabu Casa",
+            "product": "SkyConnect v1.0",
+            "firmware": "ezsp",
+            "firmware_version": "7.4.4.0",
+        },
+        version=1,
+        minor_version=3,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_sky_connect.os.path.exists"
+    ) as mock_exists:
+        mock_exists.return_value = False
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Failed to set up, the device is missing
+        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+
+        # Now we make it available but do not wait
+        mock_exists.return_value = True
+
+        with patch(
+            "homeassistant.components.usb.comports",
+            return_value=[
+                create_list_port_info(
+                    device="/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
+                    vid=0x10C4,
+                    pid=0xEA60,
+                    serial_number="3c0ed67c628beb11b1cd64a0f320645d",
+                    manufacturer="Nabu Casa",
+                    description="SkyConnect v1.0",
+                )
+            ],
+        ):
+            await async_request_scan(hass, ws_client)
+
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        # It loaded, no waiting
+        assert config_entry.state == ConfigEntryState.LOADED
+
+        # Wait for a bit for the USB scan debouncer to cool off
+        async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=5))
+
+        # Unplug the stick
+        mock_exists.return_value = False
+
+        with patch("homeassistant.components.usb.comports", return_value=[]):
+            await async_request_scan(hass, ws_client)
+
+        # The integration has reloaded and is now in a failed state
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert config_entry.state == ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
All other integrations that communicate with USB devices rely on USB serial communication to be interrupted in order for them to enter a failure state. The ZBT-1 integration does not have the capability to do this, unfortunately, because it does not communicate with any hardware by default.

To replicate this behavior and have the hardware integration match the state of the device, we subscribe to USB events directly from the `usb` integration and reload the ZBT-1 config entry, failing if the serial port is missing. This allows fast reactivity:

https://github.com/user-attachments/assets/4d15a484-b54f-46b1-8b67-d5a15e0b8790

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
