### PR TITLE
Fix misleading friendly names of `pvoutput` sensors

### DIFF
--- a/homeassistant/components/pvoutput/strings.json
+++ b/homeassistant/components/pvoutput/strings.json
@@ -27,19 +27,19 @@
   "entity": {
     "sensor": {
       "energy_consumption": {
-        "name": "Energy consumed"
+        "name": "Energy consumption"
       },
       "energy_generation": {
-        "name": "Energy generated"
+        "name": "Energy generation"
       },
       "efficiency": {
         "name": "Efficiency"
       },
       "power_consumption": {
-        "name": "Power consumed"
+        "name": "Power consumption"
       },
       "power_generation": {
-        "name": "Power generated"
+        "name": "Power generation"
       }
     }
   }

--- a/tests/components/pvoutput/test_sensor.py
+++ b/tests/components/pvoutput/test_sensor.py
@@ -30,8 +30,8 @@ async def test_sensors(
 ) -> None:
     """Test the PVOutput sensors."""
 
-    state = hass.states.get("sensor.frenck_s_solar_farm_energy_consumed")
-    entry = entity_registry.async_get("sensor.frenck_s_solar_farm_energy_consumed")
+    state = hass.states.get("sensor.frenck_s_solar_farm_energy_consumption")
+    entry = entity_registry.async_get("sensor.frenck_s_solar_farm_energy_consumption")
     assert entry
     assert state
     assert entry.unique_id == "12345_energy_consumption"
@@ -40,14 +40,14 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Frenck's Solar Farm Energy consumed"
+        == "Frenck's Solar Farm Energy consumption"
     )
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.TOTAL_INCREASING
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.WATT_HOUR
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.frenck_s_solar_farm_energy_generated")
-    entry = entity_registry.async_get("sensor.frenck_s_solar_farm_energy_generated")
+    state = hass.states.get("sensor.frenck_s_solar_farm_energy_generation")
+    entry = entity_registry.async_get("sensor.frenck_s_solar_farm_energy_generation")
     assert entry
     assert state
     assert entry.unique_id == "12345_energy_generation"
@@ -56,7 +56,7 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Frenck's Solar Farm Energy generated"
+        == "Frenck's Solar Farm Energy generation"
     )
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.TOTAL_INCREASING
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.WATT_HOUR
@@ -78,8 +78,8 @@ async def test_sensors(
     assert ATTR_DEVICE_CLASS not in state.attributes
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.frenck_s_solar_farm_power_consumed")
-    entry = entity_registry.async_get("sensor.frenck_s_solar_farm_power_consumed")
+    state = hass.states.get("sensor.frenck_s_solar_farm_power_consumption")
+    entry = entity_registry.async_get("sensor.frenck_s_solar_farm_power_consumption")
     assert entry
     assert state
     assert entry.unique_id == "12345_power_consumption"
@@ -87,14 +87,14 @@ async def test_sensors(
     assert state.state == "2500.0"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
     assert (
-        state.attributes.get(ATTR_FRIENDLY_NAME) == "Frenck's Solar Farm Power consumed"
+        state.attributes.get(ATTR_FRIENDLY_NAME) == "Frenck's Solar Farm Power consumption"
     )
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.frenck_s_solar_farm_power_generated")
-    entry = entity_registry.async_get("sensor.frenck_s_solar_farm_power_generated")
+    state = hass.states.get("sensor.frenck_s_solar_farm_power_generation")
+    entry = entity_registry.async_get("sensor.frenck_s_solar_farm_power_generation")
     assert entry
     assert state
     assert entry.unique_id == "12345_power_generation"
@@ -103,7 +103,7 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Frenck's Solar Farm Power generated"
+        == "Frenck's Solar Farm Power generation"
     )
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT

--- a/tests/components/pvoutput/test_sensor.py
+++ b/tests/components/pvoutput/test_sensor.py
@@ -87,7 +87,8 @@ async def test_sensors(
     assert state.state == "2500.0"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
     assert (
-        state.attributes.get(ATTR_FRIENDLY_NAME) == "Frenck's Solar Farm Power consumption"
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == "Frenck's Solar Farm Power consumption"
     )
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The friendly names of the
- `energy_consumption`
- `energy_generation` 
- `power_consumption`
- `power_generation`

sensors replace "consumption" with "consumed" and "generation" with "generated".

This does still work for the two energy sensors which are summing up the past, but for the two power sensors it is very misleading as power is always a momentary measurement.

This commit makes the friendly names consistent with their key names solving this issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
