### PR TITLE
Add Reporting of Lock Events

### DIFF
--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -173,7 +173,7 @@ DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP = {
         3: "Lock Operation Error: Forced User Event",  # [O]
         4: "Lock Operation Error: Unlatch",  # [M]
     },
-    4: {  # Lock User Chage (USR)
+    4: {  # Lock User Change (USR)
         0: "Lock User Change: Unspecified",  # [O]
         1: "Lock User Change: Programming Code",  # [O]
         2: "Lock User Change: User Index",  # [M]

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -22,19 +22,6 @@ from .entity import MatterEntity
 from .helpers import get_matter
 from .models import MatterDiscoverySchema
 
-SwitchFeature = clusters.Switch.Bitmaps.Feature
-
-EVENT_TYPES_MAP = {
-    # mapping from raw event id's to translation keys
-    0: "switch_latched",  # clusters.Switch.Events.SwitchLatched
-    1: "initial_press",  # clusters.Switch.Events.InitialPress
-    2: "long_press",  # clusters.Switch.Events.LongPress
-    3: "short_release",  # clusters.Switch.Events.ShortRelease
-    4: "long_release",  # clusters.Switch.Events.LongRelease
-    5: "multi_press_ongoing",  # clusters.Switch.Events.MultiPressOngoing
-    6: "multi_press_complete",  # clusters.Switch.Events.MultiPressComplete
-}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -46,7 +33,21 @@ async def async_setup_entry(
     matter.register_platform_handler(Platform.EVENT, async_add_entities)
 
 
-class MatterEventEntity(MatterEntity, EventEntity):
+SwitchFeature = clusters.Switch.Bitmaps.Feature
+
+GENERIC_SWITCH_EVENT_TYPES_MAP = {
+    # mapping from raw event id's to translation keys
+    0: "switch_latched",  # clusters.Switch.Events.SwitchLatched
+    1: "initial_press",  # clusters.Switch.Events.InitialPress
+    2: "long_press",  # clusters.Switch.Events.LongPress
+    3: "short_release",  # clusters.Switch.Events.ShortRelease
+    4: "long_release",  # clusters.Switch.Events.LongRelease
+    5: "multi_press_ongoing",  # clusters.Switch.Events.MultiPressOngoing
+    6: "multi_press_complete",  # clusters.Switch.Events.MultiPressComplete
+}
+
+
+class MatterGenericSwitchEventEntity(MatterEntity, EventEntity):
     """Representation of a Matter Event entity."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -116,7 +117,7 @@ class MatterEventEntity(MatterEntity, EventEntity):
             presses = (data.data or {}).get("totalNumberOfPressesCounted", 1)
             event_type = f"multi_press_{presses}"
         else:
-            event_type = EVENT_TYPES_MAP[data.event_id]
+            event_type = GENERIC_SWITCH_EVENT_TYPES_MAP[data.event_id]
 
         if event_type not in self.event_types:
             # this should not happen, but guard for bad things
@@ -128,6 +129,279 @@ class MatterEventEntity(MatterEntity, EventEntity):
         self.async_write_ha_state()
 
 
+DoorLockFeature = clusters.DoorLock.Bitmaps.Feature
+DOOR_LOCK_EVENT_TYPES = {
+    # mapping from raw event id's to translation keys
+    0: "Alarm: (Any)",  # [M]
+    1: "Door State Change: (Any)",  # [DPS]
+    2: "Lock Operation: (Any)",  # [M]
+    3: "Lock Operation Error: (Any)",  # [M]
+    4: "Lock User Change: (Any)",  # [USR]
+}
+
+DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP = {
+    # mapping from raw event id's to translation keys
+    0: {  # DoorLockAlarm (M)
+        0: "Alarm: Lock Jammed",  # M
+        1: "Alarm: Lock Factory Reset",  # O
+        3: "Alarm: Lock Radio Power Cycled",  # O
+        4: "Alarm: Wrong Code Entry Limit",  # [USR]
+        5: "Alarm: Front Esceutcheon Removed",  # O
+        6: "Alarm: Door Forced Open",  # [DPS]
+        7: "Alarm: Door Ajar",  # [DPS]
+        8: "Alarm: Forced User",  # [USR]
+    },
+    1: {  # DoorStateChange (DPS)
+        0: "Door State: Door Open",  # DPS
+        1: "Door State: Door Closed",  # DPS
+        2: "Door State: Door Jammed",  # [DPS]
+        3: "Door State: Door Forced Open",  # [DPS]
+        4: "Door State: Door Unspecified Error",  # [DPS]
+        5: "Door State: Door Ajar",  # [DPS]
+    },
+    2: {  # Lock Operation (M)
+        0: "Lock Operation: Lock",  # [M]
+        1: "Lock Operation: Unlock",  # [M]
+        2: "Lock Operation: Non Access User Event",  # [O]
+        3: "Lock Operation: Forced User Event",  # [O]
+        4: "Lock Operation: Unlatch",  # [M]
+    },
+    3: {  # Lock Operation Error (M)
+        0: "Lock Operation Error: Lock",  # [M]
+        1: "Lock Operation Error: Unlock",  # [M]
+        2: "Lock Operation Error: Non Access User Event",  # [O]
+        3: "Lock Operation Error: Forced User Event",  # [O]
+        4: "Lock Operation Error: Unlatch",  # [M]
+    },
+    4: {  # Lock User Chage (USR)
+        0: "Lock User Change: Unspecified",  # [O]
+        1: "Lock User Change: Programming Code",  # [O]
+        2: "Lock User Change: User Index",  # [M]
+        3: "Lock User Change: Week Day Schedule",  # [WDSCH]
+        4: "Lock User Change: Year Day Schedule",  # [YDSCH]
+        5: "Lock User Change: Holiday Schedule",  # [HDSCH]
+        6: "Lock User Change: PIN",  # [PIN]
+        7: "Lock User Change: RFID",  # [RID]
+        8: "Lock User Change: Fingerprint",  # [FGP]
+        9: "Lock User Change: Finger Vein",  # [FGP]
+        10: "Lock User Change: Face",  # [FACE]
+        11: "Lock User Change: Aliero Crednetial Issuer Key",  # [Aliro]
+        12: "Lock User Change: Aliro Evictable Endpoint Key",  # [Aliro]
+        13: "Lock User Change: Aliro Non Evictable Endpoint Key",  # [Aliro]
+    },
+}
+
+DOOR_LOCK_OPERATION_SOURCE = {
+    # mapping from raw event id's to translation keys
+    0: "Unspecified",  # [O]
+    1: "Manual",  # [O]
+    2: "Proprietary Remote",  # [O]
+    3: "Keypad",  # [O]
+    4: "Auto",  # [O]
+    5: "Button",  # [O]
+    6: "Schedule",  # [HDSCH]
+    7: "Remote",  # [M]
+    8: "RFID",  # [RID]
+    9: "Biometric",  # [USR]
+    10: "Aliro",  # [Aliro]
+}
+
+DOOR_LOCK_DATA_OPERATION_TYPE = {
+    0: "Add",
+    1: "Clear",
+    2: "Modify",
+}
+
+
+class MatterDoorLockEventEntity(MatterEntity, EventEntity):
+    """Representation of a Matter Event entity."""
+
+    DoorLockFeatureFeature = clusters.DoorLock.Bitmaps.Feature
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the entity."""
+        super().__init__(*args, **kwargs)
+        # fill the event types based on the features the DoorLock supports
+        event_types: list[str] = []
+        feature_map = int(
+            self.get_matter_attribute_value(clusters.DoorLock.Attributes.FeatureMap)
+        )
+        # DoorLockAlarm
+        event_types.append(DOOR_LOCK_EVENT_TYPES[0])
+        # Start with the Mandatory and Optional features
+        alarm_codes: list[int] = [0, 1, 3, 5]
+        # Add others based on feature_map
+        if feature_map & DoorLockFeature.kDoorPositionSensor:
+            alarm_codes.extend([6, 7])
+        if feature_map & DoorLockFeature.kUser:
+            alarm_codes.extend([4, 8])
+        alarm_codes.sort()
+        for alarm_type_key in alarm_codes:
+            event_types.append(DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[0][alarm_type_key])  # noqa: PERF401
+
+        # DoorStateChange
+        if feature_map & DoorLockFeature.kDoorPositionSensor:
+            event_types.append(DOOR_LOCK_EVENT_TYPES[1])
+            event_types.extend(DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[1].values())
+
+        # LockOperation and LockOperationError
+        for door_lock_event_id in (
+            2,
+            3,
+        ):  # LockOperation is ID = 2, LockOperationError is ID = 3
+            event_types.append(DOOR_LOCK_EVENT_TYPES[door_lock_event_id])
+            for operation_value in DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[
+                door_lock_event_id
+            ].values():
+                event_types.append(
+                    operation_value + ": (Any)"
+                )  # Use this event in triggers operation source subtype doesn't matter (Any subtype)
+
+                # Add a third level of events for the particular operation source type from Matter Cluster Spec. 5.2.6.16
+                # Start with Mandatory + Optional operation source type from Matter Cluster Spec. 5.2.6.16
+                operation_source: list[int] = [0, 1, 2, 3, 4, 5, 7]
+
+                if feature_map & DoorLockFeature.kHolidaySchedules:
+                    operation_source.extend([6])
+                if feature_map & DoorLockFeature.kRfidCredential:
+                    operation_source.extend([8])
+                if feature_map & DoorLockFeature.kUser:
+                    operation_source.extend([9])
+                if feature_map & DoorLockFeature.kAliroProvisioning:
+                    operation_source.extend([10])
+
+                operation_source.sort()
+                for source_type in operation_source:
+                    event_types.append(  # noqa: PERF401
+                        f"{operation_value}: {DOOR_LOCK_OPERATION_SOURCE[source_type]}"
+                    )
+
+        # LockUserChange
+        if feature_map & DoorLockFeature.kUser:
+            event_types.append(DOOR_LOCK_EVENT_TYPES[4])
+            user_change_types: list[int] = [0, 1, 2]
+            if feature_map & DoorLockFeature.kWeekDayAccessSchedules:
+                user_change_types.extend([3])
+            if feature_map & DoorLockFeature.kYearDayAccessSchedules:
+                user_change_types.extend([4])
+            if feature_map & DoorLockFeature.kHolidaySchedules:
+                user_change_types.extend([5])
+            if feature_map & DoorLockFeature.kPinCredential:
+                user_change_types.extend([6])
+            if feature_map & DoorLockFeature.kRfidCredential:
+                user_change_types.extend([7])
+            if feature_map & DoorLockFeature.kFingerCredentials:
+                user_change_types.extend([8, 9])
+            if feature_map & DoorLockFeature.kFaceCredentials:
+                user_change_types.extend([10])
+            if feature_map & DoorLockFeature.kAliroProvisioning:
+                user_change_types.extend([11])
+
+            user_change_types.sort()
+
+            for change_type_key in user_change_types:
+                event_types.append(
+                    f"{DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[4][change_type_key]}: (Any)"
+                )
+                event_types.append(
+                    f"{DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[4][change_type_key]}: Add"
+                )
+                event_types.append(
+                    f"{DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[4][change_type_key]}: Clear"
+                )
+                event_types.append(
+                    f"{DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[4][change_type_key]}: Modify"
+                )
+
+        self._attr_event_types = event_types
+
+    async def async_added_to_hass(self) -> None:
+        """Handle being added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        # subscribe to NodeEvent events
+        self._unsubscribes.append(
+            self.matter_client.subscribe_events(
+                callback=self._on_matter_node_event,
+                event_filter=EventType.NODE_EVENT,
+                node_filter=self._endpoint.node.node_id,
+            )
+        )
+
+    def _update_from_device(self) -> None:
+        """Call when Node attribute(s) changed."""
+
+    @callback
+    def _on_matter_node_event(
+        self,
+        event: EventType,
+        data: MatterNodeEvent,
+    ) -> None:
+        """Call on NodeEvent."""
+        if (data.endpoint_id != self._endpoint.endpoint_id) or (
+            data.cluster_id != clusters.DoorLock.id
+        ):
+            return
+
+        # Up to 3 HomeAssistant events may be created for each DoorLock Event specified in Section 5.2.11 of the Matter Application Cluster standard.
+        # This allows automation triggers with different degrees of specificity
+
+        # Event 1 conveys that a one of the high-level events in the Events table of Section 5.2.11 has occurred.
+        # Event 1 is designated as "(Any)" event since triggering on Event 1 will include all further subcategories of the event.
+        self._trigger_event(DOOR_LOCK_EVENT_TYPES[data.event_id], data.data)
+        self.async_write_ha_state()
+
+        # Additional events (up to 3 total) may be generated as set out below
+        match data.event_id:
+            case clusters.DoorLock.Events.DoorLockAlarm.event_id:
+                # Event 2 is an event that further conveys the Alarm Code information from Matter App. Cluster Spec. 5.2.6.7.
+                event_type = DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[data.event_id][
+                    data.data["alarmCode"]
+                ]
+                self._trigger_event(event_type, data.data)
+                self.async_write_ha_state()
+
+            case clusters.DoorLock.Events.DoorStateChange.event_id:
+                # Event 2 is an event that further conveys the Alarm Code information from Matter App. Cluster Spec. 5.2.6.11.
+                event_type = DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[data.event_id][
+                    data.data["doorState"]
+                ]
+                self._trigger_event(event_type, data.data)
+                self.async_write_ha_state()
+
+            case (
+                clusters.DoorLock.Events.LockOperation.event_id
+                | clusters.DoorLock.Events.LockOperationError.event_id
+            ):  # This case applies to both LockOperation or LockOperationError event types
+                event_type = DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[data.event_id][
+                    data.data["lockOperationType"]
+                ]
+
+                # Event 2 is an event that conveys the LockOperationType information from Matter App. Cluster Spec. 5.2.6.13.
+                # This is designated as "(Any)" event since triggering on this will include all further subcategories
+                self._trigger_event(f"{event_type}: (Any)", data.data)
+                self.async_write_ha_state()
+
+                # Event 3 is an event that further conveys the operationSource information from Matter App. Cluster Spec. Section 5.2.6.16
+                event_type = f"{event_type}: {DOOR_LOCK_OPERATION_SOURCE[data.data['operationSource']]}"
+                self._trigger_event(event_type, data.data)
+                self.async_write_ha_state()
+
+            case clusters.DoorLock.Events.LockUserChange.event_id:
+                event_type = DOOR_LOCK_EVENT_TYPES_EXTENDED_MAP[data.event_id][
+                    data.data["lockDataType"]
+                ]
+                # Event 2 is an event that further conveys the LockDataType information from Matter App. Cluster Spec. 5.2.6.12.
+                # This is designated as "(Any)" event since triggering on this will include all further subcategories
+                self._trigger_event(f"{event_type}: (Any)", data.data)
+                self.async_write_ha_state()
+
+                # Event 3 is an event that further conveys the DataOperationType information from Matter App. Cluster Spec. Section 5.2.6.10
+                event_type = f"{event_type}: {DOOR_LOCK_DATA_OPERATION_TYPE[data.data['dataOperationType']]}"
+                self._trigger_event(event_type, data.data)
+                self.async_write_ha_state()
+
+
 # Discovery schema(s) to map Matter Attributes to HA entities
 DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
@@ -137,7 +411,7 @@ DISCOVERY_SCHEMAS = [
             device_class=EventDeviceClass.BUTTON,
             translation_key="button",
         ),
-        entity_class=MatterEventEntity,
+        entity_class=MatterGenericSwitchEventEntity,
         required_attributes=(
             clusters.Switch.Attributes.CurrentPosition,
             clusters.Switch.Attributes.FeatureMap,
@@ -147,6 +421,18 @@ DISCOVERY_SCHEMAS = [
             clusters.Switch.Attributes.NumberOfPositions,
             clusters.FixedLabel.Attributes.LabelList,
         ),
+        allow_multi=True,  # also used for sensor (current position) entity
+    ),
+    MatterDiscoverySchema(
+        platform=Platform.EVENT,
+        entity_description=EventEntityDescription(
+            key="DoorLockEvents",
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="button",
+        ),
+        entity_class=MatterDoorLockEventEntity,
+        required_attributes=(clusters.DoorLock.Attributes.LockState,),
+        device_type=(device_types.DoorLock,),
         allow_multi=True,  # also used for sensor (current position) entity
     ),
 ]

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -76,6 +76,15 @@
       },
       "muted": {
         "name": "Muted"
+      },
+      "evse_charging_status": {
+        "name": "Charging status"
+      },
+      "evse_plug": {
+        "name": "Plug state"
+      },
+      "evse_supply_charging_state": {
+        "name": "Supply charging state"
       }
     },
     "button": {
@@ -111,6 +120,7 @@
         "state_attributes": {
           "event_type": {
             "state": {
+              "any_button_interaction": "(Any button interaction)",
               "switch_latched": "Switch latched",
               "initial_press": "Pressed",
               "long_press": "Held down",
@@ -135,9 +145,9 @@
         "state_attributes": {
           "preset_mode": {
             "state": {
-              "low": "Low",
-              "medium": "Medium",
-              "high": "High",
+              "low": "[%key:common::state::low%]",
+              "medium": "[%key:common::state::medium%]",
+              "high": "[%key:common::state::high%]",
               "auto": "Auto",
               "natural_wind": "Natural wind",
               "sleep_wind": "Sleep wind"
@@ -160,7 +170,7 @@
         "name": "On/Off transition time"
       },
       "altitude": {
-        "name": "Altitude above Sea Level"
+        "name": "Altitude above sea level"
       },
       "temperature_offset": {
         "name": "Temperature offset"
@@ -189,9 +199,9 @@
       "sensitivity_level": {
         "name": "Sensitivity",
         "state": {
-          "low": "[%key:component::matter::entity::fan::fan::state_attributes::preset_mode::state::low%]",
+          "low": "[%key:common::state::low%]",
           "standard": "Standard",
-          "high": "[%key:component::matter::entity::fan::fan::state_attributes::preset_mode::state::high%]"
+          "high": "[%key:common::state::high%]"
         }
       },
       "startup_on_off": {
@@ -230,7 +240,7 @@
         "name": "Contamination state",
         "state": {
           "normal": "Normal",
-          "low": "[%key:component::matter::entity::fan::fan::state_attributes::preset_mode::state::low%]",
+          "low": "[%key:common::state::low%]",
           "warning": "Warning",
           "critical": "Critical"
         }
@@ -258,7 +268,7 @@
       "operational_state": {
         "name": "Operational state",
         "state": {
-          "stopped": "Stopped",
+          "stopped": "[%key:common::state::stopped%]",
           "running": "Running",
           "paused": "[%key:common::state::paused%]",
           "error": "Error",
@@ -278,6 +288,42 @@
       },
       "current_phase": {
         "name": "Current phase"
+      },
+      "evse_fault_state": {
+        "name": "Fault state",
+        "state": {
+          "no_error": "OK",
+          "meter_failure": "Meter failure",
+          "over_voltage": "Overvoltage",
+          "under_voltage": "Undervoltage",
+          "over_current": "Overcurrent",
+          "contact_wet_failure": "Contact wet failure",
+          "contact_dry_failure": "Contact dry failure",
+          "power_loss": "Power loss",
+          "power_quality": "Power quality",
+          "pilot_short_circuit": "Pilot short circuit",
+          "emergency_stop": "Emergency stop",
+          "ev_disconnected": "EV disconnected",
+          "wrong_power_supply": "Wrong power supply",
+          "live_neutral_swap": "Live/neutral swap",
+          "over_temperature": "Overtemperature",
+          "other": "Other fault"
+        }
+      },
+      "evse_circuit_capacity": {
+        "name": "Circuit capacity"
+      },
+      "evse_charge_current": {
+        "name": "Charge current"
+      },
+      "evse_min_charge_current": {
+        "name": "Min charge current"
+      },
+      "evse_max_charge_current": {
+        "name": "Max charge current"
+      },
+      "evse_user_max_charge_current": {
+        "name": "User max charge current"
       }
     },
     "switch": {
@@ -289,6 +335,9 @@
       },
       "child_lock": {
         "name": "Child lock"
+      },
+      "evse_charging_switch": {
+        "name": "Enable charging"
       }
     },
     "vacuum": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### 1. Brief Summary
This PR adds reporting of lock events which will now appear on a device's web page and can be use for automations. 
![image](https://github.com/user-attachments/assets/adfdaa9f-d48f-43d2-a3e0-c1545937a374)

### 2. Reporting of Events

This code provides for the reporting of up to 3 events for every lock action. Matter lock events start with the 5 main events set out in Matter Application Cluster Spec. section 5.2.11

However, as these are very high-level, I have also provided a second level where a second matter event is generated providing a more detailed report. For example, for the Alarm event, there is also a second event that includes the details from Section 5.2.6.7 of the spec.

Some events will then be broken down into a third event providing more details.

Thus, for example, for a "Lock Operation" from the keypad, the following events will be generated:
"Lock Operation : (Any)"
"Lock Operation: Lock (Any)"
"Lock Operation: Lock: Keypad"

Thus, for example, if a user wants an automation that triggers on any lock operation, they would select the first of these 3. If they wanted only lock operations, regardless of how the locking was caused, they could use the second event, and if they only want locking from a keypad, use the third event as an automation trigger.

Since there isn't a good way to determine if Optional events and sub-events are implemented, I have included all Optional categories. However, if the device's FeatureMap can be used to trim down the list of events, that has been done.





## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
