### PR TITLE
Move roborock unique id to be based on roborock userid instead of email

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -180,17 +180,16 @@ async def _async_fix_unique_id(
         return True
 
     entries = hass.config_entries.async_entries(DOMAIN)
-    for existing_entry in entries:
-        if existing_entry.unique_id == new_unique_id:
-            _LOGGER.warning(
-                "Found duplicate unique id (%s); Removing duplicate entry",
-                new_unique_id,
-            )
-            hass.async_create_background_task(
-                hass.config_entries.async_remove(entry.entry_id),
-                "Remove roborock config entry",
-            )
-            return False
+    if any(entry.unique_id == new_unique_id for entry in entries):
+        _LOGGER.warning(
+            "Found existing duplicate config entry with unique id (%s); Removing this entry",
+            new_unique_id,
+        )
+        hass.async_create_background_task(
+            hass.config_entries.async_remove(entry.entry_id),
+            "Remove roborock config entry",
+        )
+        return False
 
     _LOGGER.debug("Updating unique id to %s", new_unique_id)
     hass.config_entries.async_update_entry(entry, unique_id=new_unique_id)

--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -193,11 +193,7 @@ async def _async_fix_unique_id(
             return False
 
     _LOGGER.debug("Updating unique id to %s", new_unique_id)
-    hass.config_entries.async_update_entry(
-        entry,
-        unique_id=new_unique_id,
-        data=entry.data,
-    )
+    hass.config_entries.async_update_entry(entry, unique_id=new_unique_id)
     return True
 
 

--- a/homeassistant/components/roborock/config_flow.py
+++ b/homeassistant/components/roborock/config_flow.py
@@ -48,6 +48,7 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Roborock."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/homeassistant/components/roborock/config_flow.py
+++ b/homeassistant/components/roborock/config_flow.py
@@ -62,8 +62,6 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             username = user_input[CONF_USERNAME]
-            await self.async_set_unique_id(username.lower())
-            self._abort_if_unique_id_configured(error="already_configured_account")
             self._username = username
             _LOGGER.debug("Requesting code for Roborock account")
             self._client = RoborockApiClient(
@@ -111,7 +109,7 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
             code = user_input[CONF_ENTRY_CODE]
             _LOGGER.debug("Logging into Roborock account using email provided code")
             try:
-                login_data = await self._client.code_login(code)
+                user_data = await self._client.code_login(code)
             except RoborockInvalidCode:
                 errors["base"] = "invalid_code"
             except RoborockException:
@@ -121,17 +119,21 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
+                await self.async_set_unique_id(user_data.rruid)
                 if self.source == SOURCE_REAUTH:
+                    self._abort_if_unique_id_mismatch(reason="wrong_account")
                     reauth_entry = self._get_reauth_entry()
+                    _LOGGER.debug("Existing=%s", reauth_entry.unique_id)
                     self.hass.config_entries.async_update_entry(
                         reauth_entry,
                         data={
                             **reauth_entry.data,
-                            CONF_USER_DATA: login_data.as_dict(),
+                            CONF_USER_DATA: user_data.as_dict(),
                         },
                     )
                     return self.async_abort(reason="reauth_successful")
-                return self._create_entry(self._client, self._username, login_data)
+                self._abort_if_unique_id_configured(error="already_configured_account")
+                return self._create_entry(self._client, self._username, user_data)
 
         return self.async_show_form(
             step_id="code",

--- a/homeassistant/components/roborock/config_flow.py
+++ b/homeassistant/components/roborock/config_flow.py
@@ -124,7 +124,6 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
                 if self.source == SOURCE_REAUTH:
                     self._abort_if_unique_id_mismatch(reason="wrong_account")
                     reauth_entry = self._get_reauth_entry()
-                    _LOGGER.debug("Existing=%s", reauth_entry.unique_id)
                     self.hass.config_entries.async_update_entry(
                         reauth_entry,
                         data={

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -35,7 +35,8 @@
     },
     "abort": {
       "already_configured_account": "[%key:common::config_flow::abort::already_configured_account%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "wrong_account": "Wrong account: Please authenticate with the right account."
     }
   },
   "options": {

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -216,6 +216,8 @@ def mock_roborock_entry(
         title=USER_EMAIL,
         data=config_entry_data,
         unique_id=config_entry_unique_id,
+        version=1,
+        minor_version=2,
     )
     mock_entry.add_to_hass(hass)
     return mock_entry

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -20,7 +20,6 @@ from homeassistant.components.roborock.const import (
 )
 from homeassistant.const import CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from .mock_data import (
     BASE_URL,
@@ -190,12 +189,6 @@ def bypass_api_fixture_v1_only(bypass_api_fixture) -> None:
         yield
 
 
-@pytest.fixture(name="config_entry_unique_id")
-def config_entry_unique_id_fixture() -> str:
-    """Fixture that returns the unique id for the config entry."""
-    return ROBOROCK_RRUID
-
-
 @pytest.fixture(name="config_entry_data")
 def config_entry_data_fixture() -> dict[str, Any]:
     """Fixture that returns the unique id for the config entry."""
@@ -208,14 +201,14 @@ def config_entry_data_fixture() -> dict[str, Any]:
 
 @pytest.fixture
 def mock_roborock_entry(
-    hass: HomeAssistant, config_entry_unique_id: str, config_entry_data: dict[str, Any]
+    hass: HomeAssistant, config_entry_data: dict[str, Any]
 ) -> MockConfigEntry:
     """Create a Roborock Entry that has not been setup."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
         title=USER_EMAIL,
         data=config_entry_data,
-        unique_id=config_entry_unique_id,
+        unique_id=ROBOROCK_RRUID,
         version=1,
         minor_version=2,
     )
@@ -237,13 +230,6 @@ async def mock_patforms_fixture(
     """Set up the Roborock platform."""
     with patch("homeassistant.components.roborock.PLATFORMS", platforms):
         yield
-
-
-@pytest.fixture
-async def setup_component(hass: HomeAssistant, bypass_api_fixture: Any) -> None:
-    """Set up the Roborock component, useful when you went to set up one config entry at a time."""
-    await async_setup_component(hass, DOMAIN, {})
-    await hass.async_block_till_done()
 
 
 @pytest.fixture

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -28,6 +28,7 @@ from .mock_data import (
     MULTI_MAP_LIST,
     NETWORK_INFO,
     PROP,
+    ROBOROCK_RRUID,
     SCENES,
     USER_DATA,
     USER_EMAIL,
@@ -188,8 +189,16 @@ def bypass_api_fixture_v1_only(bypass_api_fixture) -> None:
         yield
 
 
+@pytest.fixture(name="config_entry_unique_id")
+def config_entry_unique_id_fixture() -> str:
+    """Fixture that returns the unique id for the config entry."""
+    return ROBOROCK_RRUID
+
+
 @pytest.fixture
-def mock_roborock_entry(hass: HomeAssistant) -> MockConfigEntry:
+def mock_roborock_entry(
+    hass: HomeAssistant, config_entry_unique_id: str
+) -> MockConfigEntry:
     """Create a Roborock Entry that has not been setup."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -199,7 +208,7 @@ def mock_roborock_entry(hass: HomeAssistant) -> MockConfigEntry:
             CONF_USER_DATA: USER_DATA.as_dict(),
             CONF_BASE_URL: BASE_URL,
         },
-        unique_id=USER_EMAIL,
+        unique_id=config_entry_unique_id,
     )
     mock_entry.add_to_hass(hass)
     return mock_entry

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -28,6 +28,7 @@ USER_EMAIL = "user@domain.com"
 
 BASE_URL = "https://usiot.roborock.com"
 
+ROBOROCK_RRUID = "roboborock-userid-abc-123"
 USER_DATA = UserData.from_dict(
     {
         "tuyaname": "abc123",
@@ -35,7 +36,7 @@ USER_DATA = UserData.from_dict(
         "uid": 123456,
         "tokentype": "",
         "token": "abc123",
-        "rruid": "abc123",
+        "rruid": ROBOROCK_RRUID,
         "region": "us",
         "countrycode": "1",
         "country": "US",

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .mock_data import MOCK_CONFIG, NETWORK_INFO, USER_DATA, USER_EMAIL
+from .mock_data import MOCK_CONFIG, NETWORK_INFO, ROBOROCK_RRUID, USER_DATA, USER_EMAIL
 
 from tests.common import MockConfigEntry
 
@@ -64,6 +64,7 @@ async def test_config_flow_success(
             )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["context"]["unique_id"] == ROBOROCK_RRUID
     assert result["title"] == USER_EMAIL
     assert result["data"] == MOCK_CONFIG
     assert result["result"]
@@ -128,6 +129,7 @@ async def test_config_flow_failures_request_code(
             )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["context"]["unique_id"] == ROBOROCK_RRUID
     assert result["title"] == USER_EMAIL
     assert result["data"] == MOCK_CONFIG
     assert result["result"]
@@ -189,6 +191,7 @@ async def test_config_flow_failures_code_login(
             )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["context"]["unique_id"] == ROBOROCK_RRUID
     assert result["title"] == USER_EMAIL
     assert result["data"] == MOCK_CONFIG
     assert result["result"]
@@ -256,6 +259,7 @@ async def test_reauth_flow(
         )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+    assert mock_roborock_entry.unique_id == ROBOROCK_RRUID
     assert mock_roborock_entry.data["user_data"]["rriot"]["s"] == "new_password_hash"
 
 
@@ -264,7 +268,8 @@ async def test_account_already_configured(
     bypass_api_fixture,
     mock_roborock_entry: MockConfigEntry,
 ) -> None:
-    """Handle the config flow and make sure it succeeds."""
+    """Ensure the same account cannot be setup twice."""
+    assert mock_roborock_entry.unique_id == ROBOROCK_RRUID
     with patch(
         "homeassistant.components.roborock.async_setup_entry", return_value=True
     ):
@@ -280,8 +285,57 @@ async def test_account_already_configured(
                 result["flow_id"], {CONF_USERNAME: USER_EMAIL}
             )
 
+        assert result["step_id"] == "code"
+        assert result["type"] is FlowResultType.FORM
+        with patch(
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            return_value=USER_DATA,
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], user_input={CONF_ENTRY_CODE: "123456"}
+            )
             assert result["type"] is FlowResultType.ABORT
             assert result["reason"] == "already_configured_account"
+
+
+async def test_reauth_wrong_account(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Ensure that reauthentication must use the same account."""
+
+    # Start reauth
+    result = mock_roborock_entry.async_start_reauth(hass)
+    await hass.async_block_till_done()
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    [result] = flows
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.roborock.async_setup_entry", return_value=True
+    ):
+        with patch(
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], {CONF_USERNAME: USER_EMAIL}
+            )
+
+        assert result["step_id"] == "code"
+        assert result["type"] is FlowResultType.FORM
+        new_user_data = deepcopy(USER_DATA)
+        new_user_data.rruid = "new_rruid"
+        with patch(
+            "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
+            return_value=new_user_data,
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], user_input={CONF_ENTRY_CODE: "123456"}
+            )
+            assert result["type"] is FlowResultType.ABORT
+            assert result["reason"] == "wrong_account"
 
 
 async def test_discovery_not_setup(
@@ -322,6 +376,7 @@ async def test_discovery_not_setup(
             )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["context"]["unique_id"] == ROBOROCK_RRUID
     assert result["title"] == USER_EMAIL
     assert result["data"] == MOCK_CONFIG
     assert result["result"]
@@ -346,3 +401,4 @@ async def test_discovery_already_setup(
     )
 
     assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -16,7 +16,7 @@ from vacuum_map_parser_base.config.drawable import Drawable
 
 from homeassistant import config_entries
 from homeassistant.components.roborock.const import CONF_ENTRY_CODE, DOMAIN, DRAWABLES
-from homeassistant.const import CONF_USERNAME
+from homeassistant.const import CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
@@ -382,6 +382,7 @@ async def test_discovery_not_setup(
     assert result["result"]
 
 
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
 async def test_discovery_already_setup(
     hass: HomeAssistant,
     bypass_api_fixture,

--- a/tests/components/roborock/test_coordinator.py
+++ b/tests/components/roborock/test_coordinator.py
@@ -13,12 +13,19 @@ from homeassistant.components.roborock.const import (
     V1_LOCAL_IN_CLEANING_INTERVAL,
     V1_LOCAL_NOT_CLEANING_INTERVAL,
 )
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .mock_data import PROP
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.SENSOR]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -380,11 +380,11 @@ async def test_no_stale_device(
 @pytest.mark.parametrize(
     ("config_entry_unique_id", "expected_unique_id"),
     [
-        (ROBOROCK_RRUID, ROBOROCK_RRUID),
+        (ROBOROCK_RRUID, ROBOROCK_RRUID),  # No migration needed
         (USER_EMAIL, ROBOROCK_RRUID),
     ],
 )
-async def test_migrate_config_entry(
+async def test_migrate_config_entry_unique_id(
     hass: HomeAssistant,
     bypass_api_fixture,
     setup_entry: MockConfigEntry,

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -20,7 +20,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.setup import async_setup_component
 
-from .mock_data import HOME_DATA, NETWORK_INFO, NETWORK_INFO_2
+from .mock_data import (
+    HOME_DATA,
+    NETWORK_INFO,
+    NETWORK_INFO_2,
+    ROBOROCK_RRUID,
+    USER_EMAIL,
+)
 
 from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator
@@ -369,3 +375,22 @@ async def test_no_stale_device(
         mock_roborock_entry.entry_id
     )
     assert len(new_devices) == 6  # 2 for each robot, 1 for A01, 1 for Zeo
+
+
+@pytest.mark.parametrize(
+    ("config_entry_unique_id", "expected_unique_id"),
+    [
+        (ROBOROCK_RRUID, ROBOROCK_RRUID),
+        (USER_EMAIL, ROBOROCK_RRUID),
+    ],
+)
+async def test_migrate_config_entry(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    setup_entry: MockConfigEntry,
+    expected_unique_id: str,
+) -> None:
+    """Test unloading roboorck integration."""
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert setup_entry.state is ConfigEntryState.LOADED
+    assert setup_entry.unique_id == expected_unique_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change roborock unique id to be based on the `rruid` field rather than the username/email address. We have discovered that users can change their email address, meaning the existing id is not unique. This migrates the unique id entry
to the new format, and updates the configuration flow and tests to exercise the behavior.

This follows the approach used by `rainbird` which did a similar unique id migration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #106502
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
