### PR TITLE
Add translation field mappings to Data Entry Flow forms

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -47,7 +47,12 @@ from .core import (
     HomeAssistant,
     callback,
 )
-from .data_entry_flow import FLOW_NOT_COMPLETE_STEPS, FlowContext, FlowResult
+from .data_entry_flow import (
+    FLOW_NOT_COMPLETE_STEPS,
+    FlowContext,
+    FlowResult,
+    TranslationFieldMapping,
+)
 from .exceptions import (
     ConfigEntryAuthFailed,
     ConfigEntryError,
@@ -3250,6 +3255,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         description_placeholders: Mapping[str, str] | None = None,
         last_step: bool | None = None,
         preview: str | None = None,
+        translation_field_mappings: Mapping[str, TranslationFieldMapping] | None = None,
     ) -> ConfigFlowResult:
         """Return the definition of a form to gather user input.
 
@@ -3270,6 +3276,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
             description_placeholders=description_placeholders,
             last_step=last_step,
             preview=preview,
+            translation_field_mappings=translation_field_mappings,
         )
 
     def is_matching(self, other_flow: Self) -> bool:

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 import logging
 from types import MappingProxyType
-from typing import Any, Generic, Required, TypedDict, TypeVar, cast
+from typing import Any, Generic, NotRequired, Required, TypedDict, TypeVar, cast
 
 import voluptuous as vol
 
@@ -144,6 +144,7 @@ class FlowResult(TypedDict, Generic[_FlowContextT, _HandlerT], total=False):
     result: Any
     step_id: str
     title: str
+    translation_field_mappings: Mapping[str, TranslationFieldMapping] | None
     translation_domain: str
     type: FlowResultType
     url: str
@@ -692,6 +693,7 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         description_placeholders: Mapping[str, str] | None = None,
         last_step: bool | None = None,
         preview: str | None = None,
+        translation_field_mappings: Mapping[str, TranslationFieldMapping] | None = None,
     ) -> _FlowResultT:
         """Return the definition of a form to gather user input.
 
@@ -706,6 +708,7 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             description_placeholders=description_placeholders,
             last_step=last_step,  # Display next or submit button in frontend
             preview=preview,  # Display preview component in frontend
+            translation_field_mappings=translation_field_mappings,
         )
         if step_id is not None:
             flow_result["step_id"] = step_id
@@ -915,3 +918,10 @@ class section:
     def __call__(self, value: Any) -> Any:
         """Validate input."""
         return self.schema(value)
+
+
+class TranslationFieldMapping(TypedDict):
+    """TypedDict for translation field mapping."""
+
+    translation_key: str
+    description_placeholders: NotRequired[Mapping[str, str]]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Provide a way to translate dynamic fields/sections in the form `data_schema` of Config / Options / Subentry flows.

_[Reusing the documentation from the related documentation PR]_
Add a `translation_field_mappings` dictionary to map each dynamic field key to its corresponding translation key `translation_key` and its specific translation placeholders `description_placeholders` if needed.

These specific placeholders are used only within these specific field translation strings and for this dynamic field key, allowing different values to be used for each dynamic field. They are merged with the `description_placeholders` form placeholders and take precedence in case of conflict.

### Example
```python
async def async_step_example(self, user_input=None):
    """Example step."""
    errors: dict[str, str] = {}
    if user_input:
        return self.async_create_entry(
            title="MyIntegration",
            data=user_input,
        )
    
    fake_dynamic_items = [
        {
            "id": "1",
            "name": "Garage"
        },
        {
            "id": "2",
            "name": "Kitchen"
        }
    ]
    data_schema: VolDictType = {
        vol.Required("static_field"): str,
    }
    translation_field_mappings: dict[str, TranslationFieldMapping] = {}
    for item in fake_dynamic_items:
        translation_field_mappings[item.id] = {
            "translation_key": "room",
            "description_placeholders": {
                "room_name": item.name,
                "room_id": item.id,
            },
        }
        data_schema[vol.Required(item.id)] = section(
            vol.Schema(
                {
                    vol.Required("entry"): str,
                    vol.Required("exit"): str,
                },
            ),
            {"collapsed": False},
        )

    return self.async_show_form(
        step_id="example",
        data_schema=vol.Schema(data_schema),
        translation_field_mappings=translation_field_mappings,
        errors=errors,
    )
```

Which can be used with the following `strings.json` (shortened for brevity):

```json
{
  "config": {
    "step": {
      "example": {
        "title": "Example title",
        "data": {
          "static_field": "Static field",
        },
        "sections": {
          "room": {
            "name": "Room {room_name}",
            "description": "With id {room_id}",
            "data": {
              "entry": "Entry",
              "exit": "Exit"
            }
          }
        }
      }
    }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue:
  - an old PR implementing a way to translate dynamic fields in form data_schema: #4195
  -  an issue feature request: https://github.com/home-assistant/core/issues/92619
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2619
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/24771

This feature has already been asked a few times in the past and I think it can be really useful to add dynamic content to forms and provide better config flow.

Unlike the old PR that implemented dynamic labels, this one should cover more use cases of dynamic field translation (labels and helpers for fields and sections, errors, etc.) while still keeping the translations centralized in the dedicated files.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
