### PR TITLE
Add template list functions: intersect, difference, symmetric_difference, union

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2785,6 +2785,50 @@ def flatten(value: Iterable[Any], levels: int | None = None) -> list[Any]:
     return flattened
 
 
+def intersect(value: Iterable[Any], other: Iterable[Any]) -> list[Any]:
+    """Return the common elements between two lists."""
+    if not isinstance(value, Iterable) or isinstance(value, str):
+        raise TypeError(f"intersect expected a list, got {type(value).__name__}")
+    if not isinstance(other, Iterable) or isinstance(other, str):
+        raise TypeError(f"intersect expected a list, got {type(other).__name__}")
+
+    return list(set(value) & set(other))
+
+
+def difference(value: Iterable[Any], other: Iterable[Any]) -> list[Any]:
+    """Return elements in first list that are not in second list."""
+    if not isinstance(value, Iterable) or isinstance(value, str):
+        raise TypeError(f"difference expected a list, got {type(value).__name__}")
+    if not isinstance(other, Iterable) or isinstance(other, str):
+        raise TypeError(f"difference expected a list, got {type(other).__name__}")
+
+    return list(set(value) - set(other))
+
+
+def union(value: Iterable[Any], other: Iterable[Any]) -> list[Any]:
+    """Return all unique elements from both lists combined."""
+    if not isinstance(value, Iterable) or isinstance(value, str):
+        raise TypeError(f"union expected a list, got {type(value).__name__}")
+    if not isinstance(other, Iterable) or isinstance(other, str):
+        raise TypeError(f"union expected a list, got {type(other).__name__}")
+
+    return list(set(value) | set(other))
+
+
+def symmetric_difference(value: Iterable[Any], other: Iterable[Any]) -> list[Any]:
+    """Return elements that are in either list but not in both."""
+    if not isinstance(value, Iterable) or isinstance(value, str):
+        raise TypeError(
+            f"symmetric_difference expected a list, got {type(value).__name__}"
+        )
+    if not isinstance(other, Iterable) or isinstance(other, str):
+        raise TypeError(
+            f"symmetric_difference expected a list, got {type(other).__name__}"
+        )
+
+    return list(set(value) ^ set(other))
+
+
 def combine(*args: Any, recursive: bool = False) -> dict[Any, Any]:
     """Combine multiple dictionaries into one."""
     if not args:
@@ -2996,11 +3040,13 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["bool"] = forgiving_boolean
         self.globals["combine"] = combine
         self.globals["cos"] = cosine
+        self.globals["difference"] = difference
         self.globals["e"] = math.e
         self.globals["flatten"] = flatten
         self.globals["float"] = forgiving_float
         self.globals["iif"] = iif
         self.globals["int"] = forgiving_int
+        self.globals["intersect"] = intersect
         self.globals["is_number"] = is_number
         self.globals["log"] = logarithm
         self.globals["max"] = min_max_from_filter(self.filters["max"], "max")
@@ -3020,11 +3066,13 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["sqrt"] = square_root
         self.globals["statistical_mode"] = statistical_mode
         self.globals["strptime"] = strptime
+        self.globals["symmetric_difference"] = symmetric_difference
         self.globals["tan"] = tangent
         self.globals["tau"] = math.pi * 2
         self.globals["timedelta"] = timedelta
         self.globals["tuple"] = _to_tuple
         self.globals["typeof"] = typeof
+        self.globals["union"] = union
         self.globals["unpack"] = struct_unpack
         self.globals["urlencode"] = urlencode
         self.globals["version"] = version
@@ -3049,11 +3097,13 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["combine"] = combine
         self.filters["contains"] = contains
         self.filters["cos"] = cosine
+        self.filters["difference"] = difference
         self.filters["flatten"] = flatten
         self.filters["float"] = forgiving_float_filter
         self.filters["from_json"] = from_json
         self.filters["iif"] = iif
         self.filters["int"] = forgiving_int_filter
+        self.filters["intersect"] = intersect
         self.filters["is_defined"] = fail_when_undefined
         self.filters["is_number"] = is_number
         self.filters["log"] = logarithm
@@ -3078,12 +3128,14 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["slugify"] = slugify
         self.filters["sqrt"] = square_root
         self.filters["statistical_mode"] = statistical_mode
+        self.filters["symmetric_difference"] = symmetric_difference
         self.filters["tan"] = tangent
         self.filters["timestamp_custom"] = timestamp_custom
         self.filters["timestamp_local"] = timestamp_local
         self.filters["timestamp_utc"] = timestamp_utc
         self.filters["to_json"] = to_json
         self.filters["typeof"] = typeof
+        self.filters["union"] = union
         self.filters["unpack"] = struct_unpack
         self.filters["version"] = version
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -6790,6 +6790,184 @@ def test_flatten(hass: HomeAssistant) -> None:
         template.Template("{{ flatten() }}", hass).async_render()
 
 
+def test_intersect(hass: HomeAssistant) -> None:
+    """Test the intersect function and filter."""
+    assert list(
+        template.Template(
+            "{{ intersect([1, 2, 5, 3, 4, 10], [1, 2, 3, 4, 5, 11, 99]) }}", hass
+        ).async_render()
+    ) == unordered([1, 2, 3, 4, 5])
+
+    assert list(
+        template.Template(
+            "{{ [1, 2, 5, 3, 4, 10] | intersect([1, 2, 3, 4, 5, 11, 99]) }}", hass
+        ).async_render()
+    ) == unordered([1, 2, 3, 4, 5])
+
+    assert list(
+        template.Template(
+            "{{ intersect(['a', 'b', 'c'], ['b', 'c', 'd']) }}", hass
+        ).async_render()
+    ) == unordered(["b", "c"])
+
+    assert list(
+        template.Template(
+            "{{ ['a', 'b', 'c'] | intersect(['b', 'c', 'd']) }}", hass
+        ).async_render()
+    ) == unordered(["b", "c"])
+
+    assert (
+        template.Template("{{ intersect([], [1, 2, 3]) }}", hass).async_render() == []
+    )
+
+    assert (
+        template.Template("{{ [] | intersect([1, 2, 3]) }}", hass).async_render() == []
+    )
+
+    with pytest.raises(TemplateError, match="intersect expected a list, got str"):
+        template.Template("{{ 'string' | intersect([1, 2, 3]) }}", hass).async_render()
+
+    with pytest.raises(TemplateError, match="intersect expected a list, got str"):
+        template.Template("{{ [1, 2, 3] | intersect('string') }}", hass).async_render()
+
+
+def test_difference(hass: HomeAssistant) -> None:
+    """Test the difference function and filter."""
+    assert list(
+        template.Template(
+            "{{ difference([1, 2, 5, 3, 4, 10], [1, 2, 3, 4, 5, 11, 99]) }}", hass
+        ).async_render()
+    ) == [10]
+
+    assert list(
+        template.Template(
+            "{{ [1, 2, 5, 3, 4, 10] | difference([1, 2, 3, 4, 5, 11, 99]) }}", hass
+        ).async_render()
+    ) == [10]
+
+    assert list(
+        template.Template(
+            "{{ difference(['a', 'b', 'c'], ['b', 'c', 'd']) }}", hass
+        ).async_render()
+    ) == ["a"]
+
+    assert list(
+        template.Template(
+            "{{ ['a', 'b', 'c'] | difference(['b', 'c', 'd']) }}", hass
+        ).async_render()
+    ) == ["a"]
+
+    assert (
+        template.Template("{{ difference([], [1, 2, 3]) }}", hass).async_render() == []
+    )
+
+    assert (
+        template.Template("{{ [] | difference([1, 2, 3]) }}", hass).async_render() == []
+    )
+
+    with pytest.raises(TemplateError, match="difference expected a list, got str"):
+        template.Template("{{ 'string' | difference([1, 2, 3]) }}", hass).async_render()
+
+    with pytest.raises(TemplateError, match="difference expected a list, got str"):
+        template.Template("{{ [1, 2, 3] | difference('string') }}", hass).async_render()
+
+
+def test_union(hass: HomeAssistant) -> None:
+    """Test the union function and filter."""
+    assert list(
+        template.Template(
+            "{{ union([1, 2, 5, 3, 4, 10], [1, 2, 3, 4, 5, 11, 99]) }}", hass
+        ).async_render()
+    ) == unordered([1, 2, 3, 4, 5, 10, 11, 99])
+
+    assert list(
+        template.Template(
+            "{{ [1, 2, 5, 3, 4, 10] | union([1, 2, 3, 4, 5, 11, 99]) }}", hass
+        ).async_render()
+    ) == unordered([1, 2, 3, 4, 5, 10, 11, 99])
+
+    assert list(
+        template.Template(
+            "{{ union(['a', 'b', 'c'], ['b', 'c', 'd']) }}", hass
+        ).async_render()
+    ) == unordered(["a", "b", "c", "d"])
+
+    assert list(
+        template.Template(
+            "{{ ['a', 'b', 'c'] | union(['b', 'c', 'd']) }}", hass
+        ).async_render()
+    ) == unordered(["a", "b", "c", "d"])
+
+    assert list(
+        template.Template("{{ union([], [1, 2, 3]) }}", hass).async_render()
+    ) == unordered([1, 2, 3])
+
+    assert list(
+        template.Template("{{ [] | union([1, 2, 3]) }}", hass).async_render()
+    ) == unordered([1, 2, 3])
+
+    with pytest.raises(TemplateError, match="union expected a list, got str"):
+        template.Template("{{ 'string' | union([1, 2, 3]) }}", hass).async_render()
+
+    with pytest.raises(TemplateError, match="union expected a list, got str"):
+        template.Template("{{ [1, 2, 3] | union('string') }}", hass).async_render()
+
+
+def test_symmetric_difference(hass: HomeAssistant) -> None:
+    """Test the symmetric_difference function and filter."""
+    assert list(
+        template.Template(
+            "{{ symmetric_difference([1, 2, 5, 3, 4, 10], [1, 2, 3, 4, 5, 11, 99]) }}",
+            hass,
+        ).async_render()
+    ) == unordered([10, 11, 99])
+
+    assert list(
+        template.Template(
+            "{{ [1, 2, 5, 3, 4, 10] | symmetric_difference([1, 2, 3, 4, 5, 11, 99]) }}",
+            hass,
+        ).async_render()
+    ) == unordered([10, 11, 99])
+
+    assert list(
+        template.Template(
+            "{{ symmetric_difference(['a', 'b', 'c'], ['b', 'c', 'd']) }}", hass
+        ).async_render()
+    ) == unordered(["a", "d"])
+
+    assert list(
+        template.Template(
+            "{{ ['a', 'b', 'c'] | symmetric_difference(['b', 'c', 'd']) }}", hass
+        ).async_render()
+    ) == unordered(["a", "d"])
+
+    assert list(
+        template.Template(
+            "{{ symmetric_difference([], [1, 2, 3]) }}", hass
+        ).async_render()
+    ) == unordered([1, 2, 3])
+
+    assert list(
+        template.Template(
+            "{{ [] | symmetric_difference([1, 2, 3]) }}", hass
+        ).async_render()
+    ) == unordered([1, 2, 3])
+
+    with pytest.raises(
+        TemplateError, match="symmetric_difference expected a list, got str"
+    ):
+        template.Template(
+            "{{ 'string' | symmetric_difference([1, 2, 3]) }}", hass
+        ).async_render()
+
+    with pytest.raises(
+        TemplateError, match="symmetric_difference expected a list, got str"
+    ):
+        template.Template(
+            "{{ [1, 2, 3] | symmetric_difference('string') }}", hass
+        ).async_render()
+
+
 def test_md5(hass: HomeAssistant) -> None:
     """Test the md5 function and filter."""
     assert (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add template functions and filters for list operations: `intersect()`, `difference()`, `symmetric_difference()`, `union()`

These functions provide set-like operations for lists in templates, making it easier to work with collections of values.

Signatures:
```py
intersect(value: Iterable[Any], other: Iterable[Any]) -> list[Any]
difference(value: Iterable[Any], other: Iterable[Any]) -> list[Any]
symmetric_difference(value: Iterable[Any], other: Iterable[Any]) -> list[Any]
union(value: Iterable[Any], other: Iterable[Any]) -> list[Any]
```

Examples:
```bash
# Find common elements between lists
{{ intersect([1, 2, 5, 3, 4, 10], [1, 2, 3, 4, 5, 11, 99]) }} # renders as `[1, 2, 3, 4, 5]`
{{ [1, 2, 5, 3, 4, 10] | intersect([1, 2, 3, 4, 5, 11, 99]) }} # renders as `[1, 2, 3, 4, 5]`

# Find elements in the first list, not inthe  second list
{{ difference([1, 2, 5, 3, 4, 10], [1, 2, 3, 4, 5, 11, 99]) }} # renders as `[10]`
{{ [1, 2, 5, 3, 4, 10] | difference([1, 2, 3, 4, 5, 11, 99]) }} # renders as `[10]`

# Find elements that are in either list but not in both
{{ symmetric_difference([1, 2, 5, 3, 4, 10], [1, 2, 3, 4, 5, 11, 99]) }} # renders as `[10, 11, 99]`
{{ [1, 2, 5, 3, 4, 10] | symmetric_difference([1, 2, 3, 4, 5, 11, 99]) }} # renders as `[10, 11, 99]`

# Combine all unique elements from two lists
{{ union([1, 2, 5, 3, 4, 10], [1, 2, 3, 4, 5, 11, 99]) }} # renders as `[1, 2, 3, 4, 5, 10, 11, 99]`
{{ [1, 2, 5, 3, 4, 10] | union([1, 2, 3, 4, 5, 11, 99]) }} # renders as `[1, 2, 3, 4, 5, 10, 11, 99]`
```

Each function can be used either as a function or as a filter and works with any iterable input. The functions handle both numeric and string values, making them versatile for various use cases in templates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38190
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
