### PR TITLE
Bump roborock to silver

### DIFF
--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -17,6 +17,7 @@
   "documentation": "https://www.home-assistant.io/integrations/roborock",
   "iot_class": "local_polling",
   "loggers": ["roborock"],
+  "quality_scale": "silver",
   "requirements": [
     "python-roborock==2.16.1",
     "vacuum-map-parser-roborock==0.1.2"

--- a/homeassistant/components/roborock/quality_scale.yaml
+++ b/homeassistant/components/roborock/quality_scale.yaml
@@ -21,7 +21,7 @@ rules:
   test-before-setup: done
   unique-config-entry: done
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
@@ -29,7 +29,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
   # Gold
   devices: done

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1927,7 +1927,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "risco",
     "rituals_perfume_genie",
     "rmvtransport",
-    "roborock",
     "rocketchat",
     "roku",
     "romy",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Bronze
- [x] `action-setup` - Service actions are registered in async_setup [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/vacuum.py#L76)
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/coordinator.py#L324-L333)
- [x] `brands` - Has branding assets available for the integration [here](https://github.com/home-assistant/brands/tree/master/core_integrations/roborock)
- [x] `common-modules` - Place common patterns in common modules [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/entity.py#L1) [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/roborock_storage.py#L1) etc.
- [x] `config-flow-test-coverage` - Full test coverage for the config flow 100%
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/strings.json#L5-L6)
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/__init__.py#L48) [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/config_flow.py#L207-L208)
- [x] `dependency-transparency` - Dependency transparency [here](https://pypi.org/project/python-roborock/)
- [x] `docs-actions` - The documentation describes the provided service actions that can be used [here](https://www.home-assistant.io/integrations/roborock/#actions)
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service [here](https://www.home-assistant.io/integrations/roborock/)
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites [here](https://www.home-assistant.io/integrations/roborock/#configuration)
- [x] `docs-removal-instructions` - The documentation provides removal instructions [here](https://www.home-assistant.io/integrations/roborock/#removing-the-integration)
- [x] `entity-event-setup` - Entities event setup [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/entity.py#L141-L154)
- [x] `entity-unique-id` - Entities have a unique ID [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/entity.py#L40-L41)
- [x] `has-entity-name` - Entities use has_entity_name = True [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/entity.py#L31-L32)
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/__init__.py#L139-L140)
- [x] `test-before-configure` - Test a connection in the config flow [this verifies the cloud api](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/config_flow.py#L113-L123)
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/__init__.py#L90-L113)
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/config_flow.py#L65-L67)

## Silver
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/vacuum.py#L232-L236) [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/vacuum.py#L223-L228) [here .send() has built in exception handling](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/entity.py#L70-L82)
- [x] `config-entry-unloading` - Support config entry unloading [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/__init__.py#L309-L312)
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options [here](https://www.home-assistant.io/integrations/roborock/#options)
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters [none/here](https://www.home-assistant.io/integrations/roborock/#configuration)
- [x] `entity-unavailable` - Mark entity unavailable if appropriate [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/coordinator.py#L320-L324)
- [x] `integration-owner` - Has an integration owner [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/manifest.json#L4-L5)
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected [here](https://github.com/Python-roborock/python-roborock/blob/67235cf7aa3f71e2f6c4601a1db16c03f1c56940/roborock/local_api.py#L32)
- [x] `parallel-updates` - Set Parallel updates [here x all platforms](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/binary_sensor.py#L23-L24)
- [x] `reauthentication-flow` - Reauthentication flow [here](https://github.com/Lash-L/core/blob/977cc06456e953b5a0e526cf54b9dca1f2bf4a01/homeassistant/components/roborock/config_flow.py#L158-L179)
- [x] `test-coverage` - Above 95% test coverage for all integration modules [Only file below 95% is our storage at 94.83%](https://app.codecov.io/github/home-assistant/core/tree/dev/homeassistant%2Fcomponents%2Froborock)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
