### PR TITLE
Use a constant for sensor statistics issues

### DIFF
--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -78,6 +78,8 @@ WARN_UNSUPPORTED_UNIT: HassKey[set[str]] = HassKey(f"{DOMAIN}_warn_unsupported_u
 WARN_UNSTABLE_UNIT: HassKey[set[str]] = HassKey(f"{DOMAIN}_warn_unstable_unit")
 # Link to dev statistics where issues around LTS can be fixed
 LINK_DEV_STATISTICS = "https://my.home-assistant.io/redirect/developer_statistics"
+STATE_CLASS_REMOVED_ISSUE = "state_class_removed"
+UNITS_CHANGED_ISSUE = "units_changed"
 
 
 def _get_sensor_states(hass: HomeAssistant) -> list[State]:
@@ -697,7 +699,7 @@ def _update_issues(
             if numeric and state_class is None:
                 # Sensor no longer has a valid state class
                 report_issue(
-                    "state_class_removed",
+                    STATE_CLASS_REMOVED_ISSUE,
                     entity_id,
                     {"statistic_id": entity_id},
                 )
@@ -708,7 +710,7 @@ def _update_issues(
                 if numeric and not _equivalent_units({state_unit, metadata_unit}):
                     # The unit has changed, and it's not possible to convert
                     report_issue(
-                        "units_changed",
+                        UNITS_CHANGED_ISSUE,
                         entity_id,
                         {
                             "statistic_id": entity_id,
@@ -722,7 +724,7 @@ def _update_issues(
                 valid_units = (unit or "<None>" for unit in converter.VALID_UNITS)
                 valid_units_str = ", ".join(sorted(valid_units))
                 report_issue(
-                    "units_changed",
+                    UNITS_CHANGED_ISSUE,
                     entity_id,
                     {
                         "statistic_id": entity_id,
@@ -754,7 +756,7 @@ def update_statistics_issues(
                 issue.domain != DOMAIN
                 or not (issue_data := issue.data)
                 or issue_data.get("issue_type")
-                not in ("state_class_removed", "units_changed")
+                not in (STATE_CLASS_REMOVED_ISSUE, UNITS_CHANGED_ISSUE)
             ):
                 continue
             issues.add(issue.issue_id)

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -36,6 +36,10 @@ from homeassistant.components.recorder.statistics import (
 )
 from homeassistant.components.recorder.util import get_instance, session_scope
 from homeassistant.components.sensor import ATTR_OPTIONS, DOMAIN, SensorDeviceClass
+from homeassistant.components.sensor.recorder import (
+    STATE_CLASS_REMOVED_ISSUE,
+    UNITS_CHANGED_ISSUE,
+)
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import issue_registry as ir
@@ -4428,11 +4432,11 @@ async def test_validate_unit_change_convertible(
                     "statistic_id": "sensor.test",
                     "supported_unit": supported_unit,
                 },
-                "type": "units_changed",
+                "type": UNITS_CHANGED_ISSUE,
             }
         ],
     }
-    await assert_validation_result(hass, client, expected, {"units_changed"})
+    await assert_validation_result(hass, client, expected, {UNITS_CHANGED_ISSUE})
 
     # Unavailable state - empty response
     hass.states.async_set(
@@ -4653,11 +4657,11 @@ async def test_validate_statistics_unit_change_no_device_class(
                     "statistic_id": "sensor.test",
                     "supported_unit": supported_unit,
                 },
-                "type": "units_changed",
+                "type": UNITS_CHANGED_ISSUE,
             }
         ],
     }
-    await assert_validation_result(hass, client, expected, {"units_changed"})
+    await assert_validation_result(hass, client, expected, {UNITS_CHANGED_ISSUE})
 
     # Unavailable state - empty response
     hass.states.async_set(
@@ -4769,11 +4773,11 @@ async def test_validate_statistics_state_class_removed(
         "sensor.test": [
             {
                 "data": {"statistic_id": "sensor.test"},
-                "type": "state_class_removed",
+                "type": STATE_CLASS_REMOVED_ISSUE,
             }
         ],
     }
-    await assert_validation_result(hass, client, expected, {"state_class_removed"})
+    await assert_validation_result(hass, client, expected, {STATE_CLASS_REMOVED_ISSUE})
 
     # Unavailable state - empty response
     hass.states.async_set(
@@ -4837,11 +4841,11 @@ async def test_validate_statistics_state_class_removed_issue_cleaned_up(
         "sensor.test": [
             {
                 "data": {"statistic_id": "sensor.test"},
-                "type": "state_class_removed",
+                "type": STATE_CLASS_REMOVED_ISSUE,
             }
         ],
     }
-    await assert_validation_result(hass, client, expected, {"state_class_removed"})
+    await assert_validation_result(hass, client, expected, {STATE_CLASS_REMOVED_ISSUE})
 
     # Remove the statistics - empty response
     get_instance(hass).async_clear_statistics(["sensor.test"])
@@ -5086,11 +5090,11 @@ async def test_validate_statistics_unit_change_no_conversion(
                     "statistic_id": "sensor.test",
                     "supported_unit": unit1,
                 },
-                "type": "units_changed",
+                "type": UNITS_CHANGED_ISSUE,
             }
         ],
     }
-    await assert_validation_result(hass, client, expected, {"units_changed"})
+    await assert_validation_result(hass, client, expected, {UNITS_CHANGED_ISSUE})
 
     # Unavailable state - empty response
     hass.states.async_set(
@@ -5267,11 +5271,11 @@ async def test_validate_statistics_unit_change_equivalent_units_2(
                     "statistic_id": "sensor.test",
                     "supported_unit": supported_unit,
                 },
-                "type": "units_changed",
+                "type": UNITS_CHANGED_ISSUE,
             }
         ],
     }
-    await assert_validation_result(hass, client, expected, {"units_changed"})
+    await assert_validation_result(hass, client, expected, {UNITS_CHANGED_ISSUE})
 
     # Run statistics one hour later, metadata will not be updated
     await async_recorder_block_till_done(hass)
@@ -5280,7 +5284,7 @@ async def test_validate_statistics_unit_change_equivalent_units_2(
     await assert_statistic_ids(
         hass, [{"statistic_id": "sensor.test", "unit_of_measurement": unit1}]
     )
-    await assert_validation_result(hass, client, expected, {"units_changed"})
+    await assert_validation_result(hass, client, expected, {UNITS_CHANGED_ISSUE})
 
 
 async def test_validate_statistics_other_domain(
@@ -5369,7 +5373,7 @@ async def test_update_statistics_issues(
     now = await one_hour_stats(now)
     expected = {
         "state_class_removed_sensor.test": {
-            "issue_type": "state_class_removed",
+            "issue_type": STATE_CLASS_REMOVED_ISSUE,
             "statistic_id": "sensor.test",
         }
     }
@@ -5573,8 +5577,8 @@ async def test_clean_up_repairs(
     create_issue("test", "test_issue", None)
     create_issue(DOMAIN, "test_issue_1", None)
     create_issue(DOMAIN, "test_issue_2", {"issue_type": "another_issue"})
-    create_issue(DOMAIN, "test_issue_3", {"issue_type": "state_class_removed"})
-    create_issue(DOMAIN, "test_issue_4", {"issue_type": "units_changed"})
+    create_issue(DOMAIN, "test_issue_3", {"issue_type": STATE_CLASS_REMOVED_ISSUE})
+    create_issue(DOMAIN, "test_issue_4", {"issue_type": UNITS_CHANGED_ISSUE})
 
     # Check the issues
     assert set(issue_registry.issues) == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Requested in https://github.com/home-assistant/core/pull/138453#discussion_r2013547511

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
