### PR TITLE
Bump ZHA to 0.0.54

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.53"],
+  "requirements": ["zha==0.0.54"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -610,6 +610,12 @@
       },
       "flow_switch": {
         "name": "Flow switch"
+      },
+      "water_leak": {
+        "name": "Water leak"
+      },
+      "water_supply": {
+        "name": "Water supply"
       }
     },
     "button": {
@@ -1101,6 +1107,27 @@
       },
       "shutdown_timer": {
         "name": "Shutdown timer"
+      },
+      "calibration_vertical_run_time_up": {
+        "name": "Calibration vertical run time up"
+      },
+      "calibration_vertical_run_time_down": {
+        "name": "Calibration vertical run time down"
+      },
+      "calibration_rotation_run_time_up": {
+        "name": "Calibration rotation run time up"
+      },
+      "calibration_rotation_run_time_down": {
+        "name": "Calibration rotation run time down"
+      },
+      "impulse_mode_duration": {
+        "name": "Impulse mode duration"
+      },
+      "water_duration": {
+        "name": "Water duration"
+      },
+      "water_interval": {
+        "name": "Water interval"
       }
     },
     "select": {
@@ -1319,6 +1346,9 @@
       },
       "hysteresis_mode": {
         "name": "Hysteresis mode"
+      },
+      "speed": {
+        "name": "Speed"
       }
     },
     "sensor": {
@@ -1666,6 +1696,9 @@
       },
       "last_watering_duration": {
         "name": "Last watering duration"
+      },
+      "device_status": {
+        "name": "Device status"
       }
     },
     "switch": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3152,7 +3152,7 @@ zeroconf==0.146.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.53
+zha==0.0.54
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2542,7 +2542,7 @@ zeroconf==0.146.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.53
+zha==0.0.54
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.62.0


### PR DESCRIPTION
## Proposed change
This bumps ZHA to [0.0.54](https://github.com/zigpy/zha/releases/tag/0.0.54) (full diff: https://github.com/zigpy/zha/compare/0.0.53...0.0.54). These dependency upgrades are bundled with it: 

- `zha-quirks` [0.0.135](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.135)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.134...0.0.135

- `zigpy` [0.78.0](https://github.com/zigpy/zigpy/releases/tag/0.78.0)
full diff: https://github.com/zigpy/zigpy/compare/0.77.1...0.78.0

- `bellows` [0.44.0](https://github.com/zigpy/bellows/releases/tag/0.44.0)
full diff: https://github.com/zigpy/bellows/compare/0.43.0...0.44.0

- `zigpy-znp` [v0.14.0](https://github.com/zigpy/zigpy-znp/releases/tag/v0.14.0)
full diff: https://github.com/zigpy/zigpy-znp/compare/v0.13.1...v0.14.0


This ZHA release also massively improves cover handling (thanks to @jeverley), which has been somewhat broken since a long time. See https://github.com/zigpy/zha/pull/376 for details.
The HA tests are updated to account for the correct behavior. There were a lot of issues with these tests that are now fixed (including lift and tilt being swapped before).

This zigpy release also adds application level retrying and opens serial ports exclusively to avoid other processes interrupting ZHA.

This zha-quirks release also adds a few entities via the quirks v2 API. The entity names are added to `strings.json`.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issues:
  - fixes https://github.com/home-assistant/core/issues/140797 (quirks PR)
  - fixes https://github.com/home-assistant/core/issues/86752 (quirks PR + ZHA cover PR)
  - fixes https://github.com/home-assistant/core/issues/137327 (ZHA cover PR)
  - fixes https://github.com/home-assistant/core/issues/98933 (ZHA cover PR)
  - fixes https://github.com/home-assistant/core/issues/93836 (ZHA cover PR)
  - fixes https://github.com/home-assistant/core/issues/115660 (ZHA cover PR)
  - fixes https://github.com/home-assistant/core/issues/98933 (ZHA cover PR)
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
