### PR TITLE
 Add SMLIGHT button entities for second radio

### DIFF
--- a/homeassistant/components/smlight/button.py
+++ b/homeassistant/components/smlight/button.py
@@ -70,7 +70,6 @@ async def async_setup_entry(
     """Set up SMLIGHT buttons based on a config entry."""
     coordinator = entry.runtime_data.data
     radios = coordinator.data.info.radios
-    assert radios is not None
 
     async_add_entities(SmButton(coordinator, button) for button in BUTTONS)
     entity_created = [False, False]

--- a/homeassistant/components/smlight/button.py
+++ b/homeassistant/components/smlight/button.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 class SmButtonDescription(ButtonEntityDescription):
     """Class to describe a Button entity."""
 
-    press_fn: Callable[[CmdWrapper], Awaitable[None]]
+    press_fn: Callable[[CmdWrapper, int], Awaitable[None]]
 
 
 BUTTONS: list[SmButtonDescription] = [
@@ -38,19 +38,19 @@ BUTTONS: list[SmButtonDescription] = [
         key="core_restart",
         translation_key="core_restart",
         device_class=ButtonDeviceClass.RESTART,
-        press_fn=lambda cmd: cmd.reboot(),
+        press_fn=lambda cmd, idx: cmd.reboot(),
     ),
     SmButtonDescription(
         key="zigbee_restart",
         translation_key="zigbee_restart",
         device_class=ButtonDeviceClass.RESTART,
-        press_fn=lambda cmd: cmd.zb_restart(),
+        press_fn=lambda cmd, idx: cmd.zb_restart(),
     ),
     SmButtonDescription(
         key="zigbee_flash_mode",
         translation_key="zigbee_flash_mode",
         entity_registry_enabled_default=False,
-        press_fn=lambda cmd: cmd.zb_bootloader(),
+        press_fn=lambda cmd, idx: cmd.zb_bootloader(),
     ),
 ]
 
@@ -58,7 +58,7 @@ ROUTER = SmButtonDescription(
     key="reconnect_zigbee_router",
     translation_key="reconnect_zigbee_router",
     entity_registry_enabled_default=False,
-    press_fn=lambda cmd: cmd.zb_router(),
+    press_fn=lambda cmd, idx: cmd.zb_router(idx=idx),
 )
 
 
@@ -69,23 +69,33 @@ async def async_setup_entry(
 ) -> None:
     """Set up SMLIGHT buttons based on a config entry."""
     coordinator = entry.runtime_data.data
+    radios = coordinator.data.info.radios
+    assert radios is not None
 
     async_add_entities(SmButton(coordinator, button) for button in BUTTONS)
-    entity_created = False
+    entity_created = [False, False]
 
     @callback
     def _check_router(startup: bool = False) -> None:
-        nonlocal entity_created
+        def router_entity(router: SmButtonDescription, idx: int) -> None:
+            nonlocal entity_created
+            zb_type = coordinator.data.info.radios[idx].zb_type
 
-        if coordinator.data.info.zb_type == 1 and not entity_created:
-            async_add_entities([SmButton(coordinator, ROUTER)])
-            entity_created = True
-        elif coordinator.data.info.zb_type != 1 and (startup or entity_created):
-            entity_registry = er.async_get(hass)
-            if entity_id := entity_registry.async_get_entity_id(
-                BUTTON_DOMAIN, DOMAIN, f"{coordinator.unique_id}-{ROUTER.key}"
-            ):
-                entity_registry.async_remove(entity_id)
+            if zb_type == 1 and not entity_created[idx]:
+                async_add_entities([SmButton(coordinator, router, idx)])
+                entity_created[idx] = True
+            elif zb_type != 1 and (startup or entity_created[idx]):
+                entity_registry = er.async_get(hass)
+                button = f"_{idx}" if idx else ""
+                if entity_id := entity_registry.async_get_entity_id(
+                    BUTTON_DOMAIN,
+                    DOMAIN,
+                    f"{coordinator.unique_id}-{router.key}{button}",
+                ):
+                    entity_registry.async_remove(entity_id)
+
+        for idx, _ in enumerate(radios):
+            router_entity(ROUTER, idx)
 
     coordinator.async_add_listener(_check_router)
     _check_router(startup=True)
@@ -102,13 +112,16 @@ class SmButton(SmEntity, ButtonEntity):
         self,
         coordinator: SmDataUpdateCoordinator,
         description: SmButtonDescription,
+        idx: int = 0,
     ) -> None:
         """Initialize SLZB-06 button entity."""
         super().__init__(coordinator)
 
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
+        self.idx = idx
+        button = f"_{idx}" if idx else ""
+        self._attr_unique_id = f"{coordinator.unique_id}-{description.key}{button}"
 
     async def async_press(self) -> None:
         """Trigger button press."""
-        await self.entity_description.press_fn(self.coordinator.client.cmds)
+        await self.entity_description.press_fn(self.coordinator.client.cmds, self.idx)

--- a/tests/components/smlight/test_button.py
+++ b/tests/components/smlight/test_button.py
@@ -3,18 +3,22 @@
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
-from pysmlight import Info
+from pysmlight import Info, Radio
 import pytest
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
-from homeassistant.components.smlight.const import SCAN_INTERVAL
+from homeassistant.components.smlight.const import DOMAIN, SCAN_INTERVAL
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import setup_integration
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    load_json_object_fixture,
+)
 
 
 @pytest.fixture
@@ -23,7 +27,7 @@ def platforms() -> Platform | list[Platform]:
     return [Platform.BUTTON]
 
 
-MOCK_ROUTER = Info(MAC="AA:BB:CC:DD:EE:FF", zb_type=1)
+MOCK_ROUTER = Info(MAC="AA:BB:CC:DD:EE:FF", radios=[Radio(zb_type=1)])
 
 
 @pytest.mark.parametrize(
@@ -67,7 +71,7 @@ async def test_buttons(
     )
 
     assert len(mock_method.mock_calls) == 1
-    mock_method.assert_called_with()
+    mock_method.assert_called()
 
 
 @pytest.mark.parametrize("entity_id", ["zigbee_flash_mode", "reconnect_zigbee_router"])
@@ -88,6 +92,29 @@ async def test_disabled_by_default_buttons(
     assert (entry := entity_registry.async_get(f"button.mock_title_{entity_id}"))
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_zigbee2_router_button(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test creation of second radio router button (if available)."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = Info.from_dict(
+        load_json_object_fixture("info-MR1.json", DOMAIN)
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("button.mock_title_reconnect_zigbee_router")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    entry = entity_registry.async_get("button.mock_title_reconnect_zigbee_router")
+    assert entry is not None
+    assert entry.unique_id == "aa:bb:cc:dd:ee:ff-reconnect_zigbee_router_1"
 
 
 async def test_remove_router_reconnect(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SMLIGHT are releasing a new device SLZB-MR1 which adds a second Zigbee radio to the SLZB device. This follows on from PR #137403 and is the last PR for supporting this device.

Adjust button entites to support router reconnect button for the second radio, this is only displayed if router firmware is installed on second radio. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
