### PR TITLE
USB integration refactor for easier testing

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -3,19 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Coroutine, Sequence
+from collections.abc import Callable, Coroutine
 import dataclasses
 from datetime import datetime, timedelta
 import fnmatch
 from functools import partial
 import logging
 import os
-import sys
 from typing import Any, overload
 
 from aiousbwatcher import AIOUSBWatcher, InotifyNotAvailableError
-from serial.tools.list_ports import comports
-from serial.tools.list_ports_common import ListPortInfo
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -43,7 +40,7 @@ from homeassistant.loader import USBMatcher, async_get_usb
 
 from .const import DOMAIN
 from .models import USBDevice
-from .utils import usb_device_from_port
+from .utils import scan_serial_ports
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -241,6 +238,13 @@ def _is_matching(device: USBDevice, matcher: USBMatcher | USBCallbackMatcher) ->
     return True
 
 
+async def async_request_scan(hass: HomeAssistant) -> None:
+    """Request a serial scan."""
+    usb_discovery: USBDiscovery = hass.data[DOMAIN]
+    if not usb_discovery.observer_active:
+        await usb_discovery.async_request_scan()
+
+
 class USBDiscovery:
     """Manage USB Discovery."""
 
@@ -417,34 +421,9 @@ class USBDiscovery:
                 service_info,
             )
 
-    async def _async_process_ports(self, ports: Sequence[ListPortInfo]) -> None:
+    async def _async_process_ports(self, usb_devices: set[USBDevice]) -> None:
         """Process each discovered port."""
-        _LOGGER.debug("Processing ports: %r", ports)
-        usb_devices = {
-            usb_device_from_port(port)
-            for port in ports
-            if port.vid is not None or port.pid is not None
-        }
         _LOGGER.debug("USB devices: %r", usb_devices)
-
-        # CP2102N chips create *two* serial ports on macOS: `/dev/cu.usbserial-` and
-        # `/dev/cu.SLAB_USBtoUART*`. The former does not work and we should ignore them.
-        if sys.platform == "darwin":
-            silabs_serials = {
-                dev.serial_number
-                for dev in usb_devices
-                if dev.device.startswith("/dev/cu.SLAB_USBtoUART")
-            }
-
-            usb_devices = {
-                dev
-                for dev in usb_devices
-                if dev.serial_number not in silabs_serials
-                or (
-                    dev.serial_number in silabs_serials
-                    and dev.device.startswith("/dev/cu.SLAB_USBtoUART")
-                )
-            }
 
         added_devices = usb_devices - self._last_processed_devices
         removed_devices = self._last_processed_devices - usb_devices
@@ -480,11 +459,10 @@ class USBDiscovery:
 
     async def _async_scan_serial(self) -> None:
         """Scan serial ports."""
-        _LOGGER.debug("Executing comports scan")
+        _LOGGER.debug("Executing serial port scan")
         async with self._scan_lock:
-            await self._async_process_ports(
-                await self.hass.async_add_executor_job(comports)
-            )
+            ports = await self.hass.async_add_executor_job(scan_serial_ports)
+            await self._async_process_ports(ports)
         if self.initial_scan_done:
             return
 
@@ -521,9 +499,7 @@ async def websocket_usb_scan(
     msg: dict[str, Any],
 ) -> None:
     """Scan for new usb devices."""
-    usb_discovery: USBDiscovery = hass.data[DOMAIN]
-    if not usb_discovery.observer_active:
-        await usb_discovery.async_request_scan()
+    await async_request_scan(hass)
     connection.send_result(msg["id"])
 
 

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -40,7 +40,10 @@ from homeassistant.loader import USBMatcher, async_get_usb
 
 from .const import DOMAIN
 from .models import USBDevice
-from .utils import scan_serial_ports
+from .utils import (
+    scan_serial_ports,
+    usb_device_from_port,  # noqa: F401
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Sequence
 import dataclasses
 from datetime import datetime, timedelta
 import fnmatch
@@ -421,13 +421,14 @@ class USBDiscovery:
                 service_info,
             )
 
-    async def _async_process_ports(self, usb_devices: set[USBDevice]) -> None:
+    async def _async_process_ports(self, usb_devices: Sequence[USBDevice]) -> None:
         """Process each discovered port."""
         _LOGGER.debug("USB devices: %r", usb_devices)
 
-        added_devices = usb_devices - self._last_processed_devices
-        removed_devices = self._last_processed_devices - usb_devices
-        self._last_processed_devices = usb_devices
+        devices = set(usb_devices)
+        added_devices = devices - self._last_processed_devices
+        removed_devices = self._last_processed_devices - devices
+        self._last_processed_devices = devices
 
         _LOGGER.debug(
             "Added devices: %r, removed devices: %r", added_devices, removed_devices
@@ -440,7 +441,7 @@ class USBDiscovery:
                 except Exception:
                     _LOGGER.exception("Error in USB port event callback")
 
-        for usb_device in usb_devices:
+        for usb_device in devices:
             await self._async_process_discovered_usb_device(usb_device)
 
     @hass_callback

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -241,10 +241,10 @@ def _is_matching(device: USBDevice, matcher: USBMatcher | USBCallbackMatcher) ->
     return True
 
 
-async def async_request_scan(hass: HomeAssistant) -> None:
+async def async_request_scan(hass: HomeAssistant, *, force: bool = False) -> None:
     """Request a serial scan."""
     usb_discovery: USBDiscovery = hass.data[DOMAIN]
-    if not usb_discovery.observer_active:
+    if not usb_discovery.observer_active or force:
         await usb_discovery.async_request_scan()
 
 

--- a/homeassistant/components/usb/utils.py
+++ b/homeassistant/components/usb/utils.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import dataclasses
+import os.path
+import sys
+
+from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
 
 from .models import USBDevice
@@ -17,3 +22,60 @@ def usb_device_from_port(port: ListPortInfo) -> USBDevice:
         manufacturer=port.manufacturer,
         description=port.description,
     )
+
+
+def get_serial_by_id_mapping() -> dict[str, str]:
+    """Return a mapping of /dev/serial/by-id to /dev/tty."""
+    by_id = "/dev/serial/by-id"
+    if not os.path.isdir(by_id):
+        return {}
+
+    mapping = {}
+    for entry in os.scandir(by_id):
+        if not entry.is_symlink():
+            continue
+        mapping[entry.path] = os.path.realpath(entry.path)
+    return mapping
+
+
+def scan_serial_ports() -> set[USBDevice]:
+    """Scan for serial ports."""
+    ports = comports()
+    serial_by_id_mapping = get_serial_by_id_mapping()
+
+    usb_devices = {
+        usb_device_from_port(port)
+        for port in ports
+        if port.vid is not None or port.pid is not None
+    }
+
+    # Update the USB device path to point to the unique serial port, if one exists
+    usb_devices = {
+        (
+            dataclasses.replace(device, device=serial_by_id_mapping[device.device])
+            if device.device in serial_by_id_mapping
+            else device
+        )
+        for device in usb_devices
+    }
+
+    # CP2102N chips create *two* serial ports on macOS: `/dev/cu.usbserial-` and
+    # `/dev/cu.SLAB_USBtoUART*`. The former does not work and we should ignore them.
+    if sys.platform == "darwin":
+        silabs_serials = {
+            dev.serial_number
+            for dev in usb_devices
+            if dev.device.startswith("/dev/cu.SLAB_USBtoUART")
+        }
+
+        usb_devices = {
+            dev
+            for dev in usb_devices
+            if dev.serial_number not in silabs_serials
+            or (
+                dev.serial_number in silabs_serials
+                and dev.device.startswith("/dev/cu.SLAB_USBtoUART")
+            )
+        }
+
+    return usb_devices


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I'm running into unit testing issues when interfacing with the `usb` integration and have refactored the USB integration to:

1. isolate the `pyserial` dependency for serial port scanning as an internal component, allowing us to swap it out in the future without external API changes.
2. internally convert pyserial `ListPortInfo` objects into `USBDevice` as early as possible to remove the `pyserial` test-time dependencies from other integrations. There are many but these objects are currently API-compatible so it's not an issue.
3. separate the various stages of serial port object processing to simplify unit testing mocks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
