### PR TITLE
Always set up after dependencies if they are scheduled to be loaded

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -214,6 +214,10 @@ async def _async_process_dependencies(
     }
 
     to_be_loaded = hass.data.get(DATA_SETUP_DONE, {})
+    # We don't want to just wait for the futures from `to_be_loaded` here.
+    # We want to ensure that our after_dependencies are always actually
+    # scheduled to be set up, as if for whatever reason they had not been,
+    # we would deadlock waiting for them here.
     for dep in integration.after_dependencies:
         if (
             dep not in dependencies_tasks

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -213,7 +213,6 @@ async def _async_process_dependencies(
         if dep not in hass.config.components
     }
 
-    after_dependencies_tasks: dict[str, asyncio.Future[bool]] = {}
     to_be_loaded = hass.data.get(DATA_SETUP_DONE, {})
     for dep in integration.after_dependencies:
         if (
@@ -221,9 +220,13 @@ async def _async_process_dependencies(
             and dep in to_be_loaded
             and dep not in hass.config.components
         ):
-            after_dependencies_tasks[dep] = to_be_loaded[dep]
+            dependencies_tasks[dep] = setup_futures.get(dep) or create_eager_task(
+                async_setup_component(hass, dep, config),
+                name=f"setup {dep} as after dependency of {integration.domain}",
+                loop=hass.loop,
+            )
 
-    if not dependencies_tasks and not after_dependencies_tasks:
+    if not dependencies_tasks:
         return []
 
     if dependencies_tasks:
@@ -232,17 +235,9 @@ async def _async_process_dependencies(
             integration.domain,
             dependencies_tasks.keys(),
         )
-    if after_dependencies_tasks:
-        _LOGGER.debug(
-            "Dependency %s will wait for after dependencies %s",
-            integration.domain,
-            after_dependencies_tasks.keys(),
-        )
 
     async with hass.timeout.async_freeze(integration.domain):
-        results = await asyncio.gather(
-            *dependencies_tasks.values(), *after_dependencies_tasks.values()
-        )
+        results = await asyncio.gather(*dependencies_tasks.values())
 
     failed = [
         domain for idx, domain in enumerate(dependencies_tasks) if not results[idx]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Always set up after dependencies.

We want to ensure the appropriate after dependencies are always set up, even if we were not able to calculate that we need them based on the manifests ahead of time. This can happen for example because we don't require base platforms to be explicitly listed as dependencies and those can in turn have their own dependencies and after dependencies.

Off course unlike dependencies, after dependencies still will not be set up if they are not required by the user configuration. In this regard nothing changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
