### PR TITLE
Add exception translation to NUT

### DIFF
--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -79,9 +79,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: NutConfigEntry) -> bool:
         try:
             return await data.async_update()
         except NUTLoginError as err:
-            raise ConfigEntryAuthFailed from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="device_authentication",
+                translation_placeholders={
+                    "err": str(err),
+                },
+            ) from err
         except NUTError as err:
-            raise UpdateFailed(f"Error fetching UPS state: {err}") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="data_fetch_error",
+                translation_placeholders={
+                    "err": str(err),
+                },
+            ) from err
 
     coordinator = DataUpdateCoordinator(
         hass,
@@ -328,7 +340,12 @@ class PyNUTData:
             await self._client.run_command(self._alias, command_name)
         except NUTError as err:
             raise HomeAssistantError(
-                f"Error running command {command_name}, {err}"
+                translation_domain=DOMAIN,
+                translation_key="nut_command_error",
+                translation_placeholders={
+                    "command_name": command_name,
+                    "err": str(err),
+                },
             ) from err
 
     async def async_list_commands(self) -> set[str] | None:

--- a/homeassistant/components/nut/device_action.py
+++ b/homeassistant/components/nut/device_action.py
@@ -51,7 +51,11 @@ async def async_call_action_from_config(
     runtime_data = _get_runtime_data_from_device_id(hass, device_id)
     if not runtime_data:
         raise InvalidDeviceAutomationConfig(
-            f"Unable to find a NUT device with id {device_id}"
+            translation_domain=DOMAIN,
+            translation_key="device_invalid",
+            translation_placeholders={
+                "device_id": device_id,
+            },
         )
     await runtime_data.data.async_run_command(command_name)
 

--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -227,7 +227,7 @@
       "message": "Device authentication error: {err}"
     },
     "device_invalid": {
-      "message": "Unable to find a NUT device with id {device_id}"
+      "message": "Unable to find a NUT device with ID {device_id}"
     },
     "nut_command_error": {
       "message": "Error running command {command_name}, {err}"

--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -218,5 +218,19 @@
     "switch": {
       "outlet_number_load_poweronoff": { "name": "Power outlet {outlet_name}" }
     }
+  },
+  "exceptions": {
+    "data_fetch_error": {
+      "message": "Error fetching UPS state: {err}"
+    },
+    "device_authentication": {
+      "message": "Device authentication error: {err}"
+    },
+    "device_invalid": {
+      "message": "Unable to find a NUT device with id {device_id}"
+    },
+    "nut_command_error": {
+      "message": "Error running command {command_name}, {err}"
+    }
   }
 }

--- a/tests/components/nut/test_device_action.py
+++ b/tests/components/nut/test_device_action.py
@@ -246,7 +246,7 @@ async def test_action_exception_invalid_device(hass: HomeAssistant) -> None:
     )
 
     device_id = "invalid_device_id"
-    error_message = f"Unable to find a NUT device with id {device_id}"
+    error_message = f"Unable to find a NUT device with ID {device_id}"
     with pytest.raises(InvalidDeviceAutomationConfig, match=error_message):
         await platform.async_call_action_from_config(
             hass,

--- a/tests/components/nut/test_device_action.py
+++ b/tests/components/nut/test_device_action.py
@@ -1,6 +1,6 @@
 """The tests for Network UPS Tools (NUT) device actions."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from aionut import NUTError
 import pytest
@@ -199,7 +199,8 @@ async def test_run_command_exception(
     """Test if run command raises exception with translation."""
 
     command_name = "beeper.enable"
-    run_command = AsyncMock(side_effect=NUTError())
+    nut_error_message = "Something wrong happened"
+    run_command = AsyncMock(side_effect=NUTError(nut_error_message))
     await async_init_integration(
         hass,
         list_vars={"ups.status": "OL"},
@@ -213,14 +214,8 @@ async def test_run_command_exception(
         hass, DOMAIN, DeviceAutomationType.ACTION
     )
 
-    error_message = f"Error running command {command_name}"
-    with (
-        patch(
-            "homeassistant.components.nut.AIONUTClient.run_command",
-            side_effect=NUTError,
-        ),
-        pytest.raises(HomeAssistantError, match=error_message),
-    ):
+    error_message = f"Error running command {command_name}, {nut_error_message}"
+    with pytest.raises(HomeAssistantError, match=error_message):
         await platform.async_call_action_from_config(
             hass,
             {

--- a/tests/components/nut/test_device_action.py
+++ b/tests/components/nut/test_device_action.py
@@ -1,6 +1,6 @@
 """The tests for Network UPS Tools (NUT) device actions."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aionut import NUTError
 import pytest
@@ -15,6 +15,7 @@ from homeassistant.components.nut import DOMAIN
 from homeassistant.components.nut.const import INTEGRATION_SUPPORTED_COMMANDS
 from homeassistant.const import CONF_DEVICE_ID, CONF_TYPE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -191,48 +192,44 @@ async def test_action(hass: HomeAssistant, device_registry: dr.DeviceRegistry) -
     run_command.assert_called_with("someUps", "beeper.disable")
 
 
-async def test_rund_command_exception(
+async def test_run_command_exception(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test logged error if run command raises exception."""
+    """Test if run command raises exception with translation."""
 
-    list_commands_return_value = {"beeper.enable": None}
-    error_message = "Something wrong happened"
-    run_command = AsyncMock(side_effect=NUTError(error_message))
+    command_name = "beeper.enable"
+    run_command = AsyncMock(side_effect=NUTError())
     await async_init_integration(
         hass,
         list_vars={"ups.status": "OL"},
-        list_commands_return_value=list_commands_return_value,
+        list_ups={"ups1": "UPS 1"},
+        list_commands_return_value={command_name: None},
         run_command=run_command,
     )
     device_entry = next(device for device in device_registry.devices.values())
 
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: [
-                {
-                    "trigger": {
-                        "platform": "event",
-                        "event_type": "test_some_event",
-                    },
-                    "action": {
-                        "domain": DOMAIN,
-                        "device_id": device_entry.id,
-                        "type": "beeper_enable",
-                    },
-                },
-            ]
-        },
+    platform = await device_automation.async_get_device_automation_platform(
+        hass, DOMAIN, DeviceAutomationType.ACTION
     )
 
-    hass.bus.async_fire("test_some_event")
-    await hass.async_block_till_done()
-
-    assert error_message in caplog.text
+    error_message = f"Error running command {command_name}"
+    with (
+        patch(
+            "homeassistant.components.nut.AIONUTClient.run_command",
+            side_effect=NUTError,
+        ),
+        pytest.raises(HomeAssistantError, match=error_message),
+    ):
+        await platform.async_call_action_from_config(
+            hass,
+            {
+                CONF_TYPE: command_name,
+                CONF_DEVICE_ID: device_entry.id,
+            },
+            {},
+            None,
+        )
 
 
 async def test_action_exception_invalid_device(hass: HomeAssistant) -> None:
@@ -248,10 +245,12 @@ async def test_action_exception_invalid_device(hass: HomeAssistant) -> None:
         hass, DOMAIN, DeviceAutomationType.ACTION
     )
 
-    with pytest.raises(InvalidDeviceAutomationConfig):
+    device_id = "invalid_device_id"
+    error_message = f"Unable to find a NUT device with id {device_id}"
+    with pytest.raises(InvalidDeviceAutomationConfig, match=error_message):
         await platform.async_call_action_from_config(
             hass,
-            {CONF_TYPE: "beeper.enable", CONF_DEVICE_ID: "invalid_device_id"},
+            {CONF_TYPE: "beeper.enable", CONF_DEVICE_ID: device_id},
             {},
             None,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
NUT exceptions currently return hardcoded f-strings.  This PR adds translation and translation placeholders for all NUT exceptions to provide internationalization.  Modify existing test cases to validate translation and translation placeholders.

Change error message string by capitalizing "ID".  Please let me know if this qualifies as a breaking change that requires additional documentation.

Minor test function rename for code cleanup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
