### PR TITLE
Remove "meter" from entity names of `rainforest_eagle` sensors

### DIFF
--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -59,7 +59,7 @@ async def async_setup_entry(
                 coordinator,
                 SensorEntityDescription(
                     key="zigbee:Price",
-                    translation_key="meter_price",
+                    translation_key="energy_price",
                     native_unit_of_measurement=f"{coordinator.data['zigbee:PriceCurrency']}/{UnitOfEnergy.KILO_WATT_HOUR}",
                     state_class=SensorStateClass.MEASUREMENT,
                 ),

--- a/homeassistant/components/rainforest_eagle/strings.json
+++ b/homeassistant/components/rainforest_eagle/strings.json
@@ -5,7 +5,7 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "cloud_id": "Cloud ID",
-          "install_code": "Installation Code"
+          "install_code": "Installation code"
         },
         "data_description": {
           "host": "The hostname or IP address of your Rainforest gateway."
@@ -24,16 +24,16 @@
   "entity": {
     "sensor": {
       "power_demand": {
-        "name": "Meter power demand"
+        "name": "Power demand"
       },
       "total_energy_delivered": {
-        "name": "Total meter energy delivered"
+        "name": "Total energy delivered"
       },
       "total_energy_received": {
-        "name": "Total meter energy received"
+        "name": "Total energy received"
       },
-      "meter_price": {
-        "name": "Meter price"
+      "energy_price": {
+        "name": "Energy price"
       }
     }
   }

--- a/tests/components/rainforest_eagle/test_sensor.py
+++ b/tests/components/rainforest_eagle/test_sensor.py
@@ -10,17 +10,17 @@ async def test_sensors_200(hass: HomeAssistant, setup_rainforest_200) -> None:
     """Test the sensors."""
     assert len(hass.states.async_all()) == 3
 
-    demand = hass.states.get("sensor.eagle_200_meter_power_demand")
+    demand = hass.states.get("sensor.eagle_200_power_demand")
     assert demand is not None
     assert demand.state == "1.152000"
     assert demand.attributes["unit_of_measurement"] == "kW"
 
-    delivered = hass.states.get("sensor.eagle_200_total_meter_energy_delivered")
+    delivered = hass.states.get("sensor.eagle_200_total_energy_delivered")
     assert delivered is not None
     assert delivered.state == "45251.285000"
     assert delivered.attributes["unit_of_measurement"] == "kWh"
 
-    received = hass.states.get("sensor.eagle_200_total_meter_energy_received")
+    received = hass.states.get("sensor.eagle_200_total_energy_received")
     assert received is not None
     assert received.state == "232.232000"
     assert received.attributes["unit_of_measurement"] == "kWh"
@@ -33,7 +33,7 @@ async def test_sensors_200(hass: HomeAssistant, setup_rainforest_200) -> None:
 
     assert len(hass.states.async_all()) == 4
 
-    price = hass.states.get("sensor.eagle_200_meter_price")
+    price = hass.states.get("sensor.eagle_200_energy_price")
     assert price is not None
     assert price.state == "0.053990"
     assert price.attributes["unit_of_measurement"] == "USD/kWh"
@@ -43,17 +43,17 @@ async def test_sensors_100(hass: HomeAssistant, setup_rainforest_100) -> None:
     """Test the sensors."""
     assert len(hass.states.async_all()) == 3
 
-    demand = hass.states.get("sensor.eagle_100_meter_power_demand")
+    demand = hass.states.get("sensor.eagle_100_power_demand")
     assert demand is not None
     assert demand.state == "1.152000"
     assert demand.attributes["unit_of_measurement"] == "kW"
 
-    delivered = hass.states.get("sensor.eagle_100_total_meter_energy_delivered")
+    delivered = hass.states.get("sensor.eagle_100_total_energy_delivered")
     assert delivered is not None
     assert delivered.state == "45251.285000"
     assert delivered.attributes["unit_of_measurement"] == "kWh"
 
-    received = hass.states.get("sensor.eagle_100_total_meter_energy_received")
+    received = hass.states.get("sensor.eagle_100_total_energy_received")
     assert received is not None
     assert received.state == "232.232000"
     assert received.attributes["unit_of_measurement"] == "kWh"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

(This PR applies the same fixes as https://github.com/home-assistant/core/pull/141487 for the `rainforest_raven`integration) 

In `rainforest_eagle` the three sensors
- `power_demand`
- `total_energy_delivered`
- `total_energy_received`

currently add "meter" in their friendly names.

This does not provide any useful information and is rather irritating instead – it sounds like these are the power demands or consumption of the meter itself. But they are the measured values.

This commit removes "meter" from the names making them simpler and more precise, too.

For consistency the naming of `meter_price` is changed to `energy_price`.

In addition the sentence-casing of "Installation code" is fixed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
