### PR TITLE
Always set pause feature on Music Assistant mediaplayers

### DIFF
--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -94,6 +94,12 @@ SUPPORTED_FEATURES_BASE = (
     | MediaPlayerEntityFeature.MEDIA_ENQUEUE
     | MediaPlayerEntityFeature.MEDIA_ANNOUNCE
     | MediaPlayerEntityFeature.SEEK
+    # we always add pause support,
+    # regardless if the underlying player actually natively supports pause
+    # because the MA behavior is to internally handle pause with stop
+    # (and a resume position) and we'd like to keep the UX consistent
+    # background info: https://github.com/home-assistant/core/issues/140118
+    | MediaPlayerEntityFeature.PAUSE
 )
 
 QUEUE_OPTION_MAP = {
@@ -697,8 +703,6 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
         supported_features = SUPPORTED_FEATURES_BASE
         if PlayerFeature.SET_MEMBERS in self.player.supported_features:
             supported_features |= MediaPlayerEntityFeature.GROUPING
-        if PlayerFeature.PAUSE in self.player.supported_features:
-            supported_features |= MediaPlayerEntityFeature.PAUSE
         if self.player.mute_control != PLAYER_CONTROL_NONE:
             supported_features |= MediaPlayerEntityFeature.VOLUME_MUTE
         if self.player.volume_control != PLAYER_CONTROL_NONE:

--- a/tests/components/music_assistant/test_media_player.py
+++ b/tests/components/music_assistant/test_media_player.py
@@ -694,19 +694,6 @@ async def test_media_player_supported_features(
     assert state
     assert state.attributes["supported_features"] == expected_features
 
-    # remove pause capability from player, trigger subscription callback
-    # and check if the supported features got updated
-    music_assistant_client.players._players[mass_player_id].supported_features.remove(
-        PlayerFeature.PAUSE
-    )
-    await trigger_subscription_callback(
-        hass, music_assistant_client, EventType.PLAYER_CONFIG_UPDATED, mass_player_id
-    )
-    expected_features &= ~MediaPlayerEntityFeature.PAUSE
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.attributes["supported_features"] == expected_features
-
     # remove grouping capability from player, trigger subscription callback
     # and check if the supported features got updated
     music_assistant_client.players._players[mass_player_id].supported_features.remove(


### PR DESCRIPTION
## Proposed change

In a previous release we have strictly tied the HA media player features to actual player capabilities reported by Music Assistant players (which are rather dynamic given the broad player support of MA).
This works well except for one thing, which is pause support because the MA user interface does not distinguish between a player that does (not) support pause, it will silently use stop under the hood with a resume point. So this causes some confusion for users because in the HA interface they can suddenly not use pause anymore for players that do not support it.

After a bit back and forth discussion we decided that its best if the HA pattern follows the MA behavior so it feels more natural to a user.

Background story can be read in the linked issue report.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140118
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
