### PR TITLE
Fix ESPHome update entities being loaded before device_info is available

### DIFF
--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -286,9 +286,9 @@ class RuntimeEntryData:
 
         if self.device_info:
             # Only load the update platform is the device_info is set
-            # When we restore the entry, the device_info is not set yet
+            # When we restore the entry, the device_info may not be set yet
             # and we don't want to load the update platform since it needs
-            # non-restored data.
+            # a complete device_info.
             if async_get_dashboard(hass):
                 needed_platforms.add(Platform.UPDATE)
             if self.device_info.voice_assistant_feature_flags_compat(self.api_version):

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -285,11 +285,11 @@ class RuntimeEntryData:
         needed_platforms: set[Platform] = set()
 
         if self.device_info:
-            # Only load the update platform is the device_info is set
-            # When we restore the entry, the device_info may not be set yet
-            # and we don't want to load the update platform since it needs
-            # a complete device_info.
             if async_get_dashboard(hass):
+                # Only load the update platform is the device_info is set
+                # When we restore the entry, the device_info may not be set yet
+                # and we don't want to load the update platform since it needs
+                # a complete device_info.
                 needed_platforms.add(Platform.UPDATE)
             if self.device_info.voice_assistant_feature_flags_compat(self.api_version):
                 needed_platforms.add(Platform.BINARY_SENSOR)

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -286,7 +286,7 @@ class RuntimeEntryData:
 
         if self.device_info:
             if async_get_dashboard(hass):
-                # Only load the update platform is the device_info is set
+                # Only load the update platform if the device_info is set
                 # When we restore the entry, the device_info may not be set yet
                 # and we don't want to load the update platform since it needs
                 # a complete device_info.

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -282,15 +282,18 @@ class RuntimeEntryData:
     ) -> None:
         """Distribute an update of static infos to all platforms."""
         # First, load all platforms
-        needed_platforms = set()
-        if async_get_dashboard(hass):
-            needed_platforms.add(Platform.UPDATE)
+        needed_platforms: set[Platform] = set()
 
-        if self.device_info and self.device_info.voice_assistant_feature_flags_compat(
-            self.api_version
-        ):
-            needed_platforms.add(Platform.BINARY_SENSOR)
-            needed_platforms.add(Platform.SELECT)
+        if self.device_info:
+            # Only load the update platform is the device_info is set
+            # When we restore the entry, the device_info is not set yet
+            # and we don't want to load the update platform since it needs
+            # non-restored data.
+            if async_get_dashboard(hass):
+                needed_platforms.add(Platform.UPDATE)
+            if self.device_info.voice_assistant_feature_flags_compat(self.api_version):
+                needed_platforms.add(Platform.BINARY_SENSOR)
+                needed_platforms.add(Platform.SELECT)
 
         ent_reg = er.async_get(hass)
         registry_get_entity = ent_reg.async_get_entity_id

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -86,26 +86,28 @@ def stub_reconnect():
 )
 async def test_update_entity(
     hass: HomeAssistant,
-    stub_reconnect,
-    mock_config_entry,
-    mock_device_info,
     mock_dashboard: dict[str, Any],
-    devices_payload,
-    expected_state,
-    expected_attributes,
+    devices_payload: list[dict[str, Any]],
+    expected_state: str,
+    expected_attributes: dict[str, Any],
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
 ) -> None:
     """Test ESPHome update entity."""
     mock_dashboard["configured"] = devices_payload
     await async_get_dashboard(hass).async_refresh()
 
-    with patch(
-        "homeassistant.components.esphome.update.DomainData.get_entry_data",
-        return_value=Mock(available=True, device_info=mock_device_info, info={}),
-    ):
-        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=[],
+        user_service=[],
+        states=[],
+    )
 
-    state = hass.states.get("update.none_firmware")
+    state = hass.states.get("update.test_firmware")
     assert state is not None
     assert state.state == expected_state
     for key, expected_value in expected_attributes.items():
@@ -130,7 +132,7 @@ async def test_update_entity(
         await hass.services.async_call(
             "update",
             "install",
-            {"entity_id": "update.none_firmware"},
+            {"entity_id": "update.test_firmware"},
             blocking=True,
         )
 
@@ -155,7 +157,7 @@ async def test_update_entity(
         await hass.services.async_call(
             "update",
             "install",
-            {"entity_id": "update.none_firmware"},
+            {"entity_id": "update.test_firmware"},
             blocking=True,
         )
 
@@ -177,7 +179,7 @@ async def test_update_entity(
         await hass.services.async_call(
             "update",
             "install",
-            {"entity_id": "update.none_firmware"},
+            {"entity_id": "update.test_firmware"},
             blocking=True,
         )
 
@@ -274,28 +276,30 @@ async def test_update_device_state_for_availability(
 
 async def test_update_entity_dashboard_not_available_startup(
     hass: HomeAssistant,
-    stub_reconnect,
-    mock_config_entry,
-    mock_device_info,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
     mock_dashboard: dict[str, Any],
 ) -> None:
     """Test ESPHome update entity when dashboard is not available at startup."""
     with (
-        patch(
-            "homeassistant.components.esphome.update.DomainData.get_entry_data",
-            return_value=Mock(available=True, device_info=mock_device_info, info={}),
-        ),
         patch(
             "esphome_dashboard_api.ESPHomeDashboardAPI.get_devices",
             side_effect=TimeoutError,
         ),
     ):
         await async_get_dashboard(hass).async_refresh()
-        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+        await mock_esphome_device(
+            mock_client=mock_client,
+            entity_info=[],
+            user_service=[],
+            states=[],
+        )
 
     # We have a dashboard but it is not available
-    state = hass.states.get("update.none_firmware")
+    state = hass.states.get("update.test_firmware")
     assert state is None
 
     mock_dashboard["configured"] = [
@@ -308,7 +312,7 @@ async def test_update_entity_dashboard_not_available_startup(
     await async_get_dashboard(hass).async_refresh()
     await hass.async_block_till_done()
 
-    state = hass.states.get("update.none_firmware")
+    state = hass.states.get("update.test_firmware")
     assert state.state == STATE_ON
     expected_attributes = {
         "latest_version": "2023.2.0-dev",


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since we load platforms when restoring config, the update platform could be loaded before the connection to the device was finished which meant device_info could still be empty. Wait until device_info is available to load the update platform.

fixes #135906
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
