### PR TITLE
Fix ESPHome entities not being removed when the ESPHome config removes an entire platform

### DIFF
--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -95,7 +95,7 @@ async def platform_async_setup_entry(
     info and state updates.
     """
     entry_data = entry.runtime_data
-    entry_data.info[info_type] = {}
+    entry_data.info.setdefault(info_type, {})
     platform = entity_platform.async_get_current_platform()
     on_static_info_update = functools.partial(
         async_static_info_updated,

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -95,7 +95,7 @@ async def platform_async_setup_entry(
     info and state updates.
     """
     entry_data = entry.runtime_data
-    entry_data.info.setdefault(info_type, {})
+    entry_data.info[info_type] = {}
     platform = entity_platform.async_get_current_platform()
     on_static_info_update = functools.partial(
         async_static_info_updated,

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -319,11 +319,13 @@ class RuntimeEntryData:
                 infos_by_type[info_type] = []
             infos_by_type[info_type].append(info)
 
-        callbacks_by_type = self.entity_info_callbacks
-        for type_, entity_infos in infos_by_type.items():
-            if callbacks_ := callbacks_by_type.get(type_):
-                for callback_ in callbacks_:
-                    callback_(entity_infos)
+        for type_, callbacks_ in self.entity_info_callbacks.items():
+            # If all entities for a type are removed, we
+            # still need to call the callbacks with an empty list
+            # to make sure the entities are removed.
+            entity_infos = infos_by_type.get(type_, [])
+            for callback_ in callbacks_:
+                callback_(entity_infos)
 
         # Finally update static info subscriptions
         for callback_ in self.static_info_update_subscriptions:

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -319,12 +319,12 @@ class RuntimeEntryData:
                 infos_by_type[info_type] = []
             infos_by_type[info_type].append(info)
 
-        for type_, callbacks_ in self.entity_info_callbacks.items():
+        for type_, callbacks in self.entity_info_callbacks.items():
             # If all entities for a type are removed, we
             # still need to call the callbacks with an empty list
             # to make sure the entities are removed.
             entity_infos = infos_by_type.get(type_, [])
-            for callback_ in callbacks_:
+            for callback_ in callbacks:
                 callback_(entity_infos)
 
         # Finally update static info subscriptions

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -312,7 +312,9 @@ class RuntimeEntryData:
 
         # Make a dict of the EntityInfo by type and send
         # them to the listeners for each specific EntityInfo type
-        infos_by_type: dict[type[EntityInfo], list[EntityInfo]] = defaultdict(list)
+        infos_by_type: defaultdict[type[EntityInfo], list[EntityInfo]] = defaultdict(
+            list
+        )
         for info in infos:
             infos_by_type[type(info)].append(info)
 

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -312,12 +312,9 @@ class RuntimeEntryData:
 
         # Make a dict of the EntityInfo by type and send
         # them to the listeners for each specific EntityInfo type
-        infos_by_type: dict[type[EntityInfo], list[EntityInfo]] = {}
+        infos_by_type: dict[type[EntityInfo], list[EntityInfo]] = defaultdict(list)
         for info in infos:
-            info_type = type(info)
-            if info_type not in infos_by_type:
-                infos_by_type[info_type] = []
-            infos_by_type[info_type].append(info)
+            infos_by_type[type(info)].append(info)
 
         for type_, callbacks in self.entity_info_callbacks.items():
             # If all entities for a type are removed, we

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -260,6 +260,76 @@ async def test_entities_removed_after_reload(
     assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 1
 
 
+async def test_entities_for_entire_platform_removed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_client: APIClient,
+    hass_storage: dict[str, Any],
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+) -> None:
+    """Test removing all entities for a specific platform when static info changes."""
+    entity_info = [
+        BinarySensorInfo(
+            object_id="mybinary_sensor_to_be_removed",
+            key=1,
+            name="my binary_sensor to be removed",
+            unique_id="mybinary_sensor_to_be_removed",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    user_service = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    entry = mock_device.entry
+    entry_id = entry.entry_id
+    storage_key = f"esphome.{entry_id}"
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert state is not None
+    assert state.state == STATE_ON
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 1
+
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert state is not None
+    reg_entry = entity_registry.async_get(
+        "binary_sensor.test_mybinary_sensor_to_be_removed"
+    )
+    assert reg_entry is not None
+    assert state.attributes[ATTR_RESTORED] is True
+
+    entity_info = []
+    states = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+        entry=entry,
+    )
+    assert mock_device.entry.entry_id == entry_id
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
+    assert state is None
+    reg_entry = entity_registry.async_get(
+        "binary_sensor.test_mybinary_sensor_to_be_removed"
+    )
+    assert reg_entry is None
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 0
+
+
 async def test_entity_info_object_ids(
     hass: HomeAssistant,
     mock_client: APIClient,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
TLDR: if all entities for a specific platform i.e. `sensor` were removed from the ESPHome config, they would not get removed in HA. Remove only worked if there was at least one entity on that platform remaining.

If all entities on a platform were removed from the ESPHome config, the callback for the platform would not fire which meant the entities would not get removed.  Make sure the callback fires with an empty list when everything on the platform is removed.

Everything worked correctly if there was at least one entity remaining on the platform. The problem would only happen if all the entities for a platform were removed from the ESPHome config.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140756
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
