### PR TITLE
Replace hard coded attributes with constants for test cases in NUT

### DIFF
--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -7,6 +7,9 @@ import pytest
 from homeassistant.components.nut.const import DOMAIN
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_HOST,
     CONF_PORT,
     CONF_RESOURCES,
@@ -53,9 +56,9 @@ async def test_ups_devices(
     assert state.state == "100"
 
     expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
+        ATTR_DEVICE_CLASS: "battery",
+        ATTR_FRIENDLY_NAME: "Ups1 Battery charge",
+        ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
@@ -88,9 +91,9 @@ async def test_ups_devices_with_unique_ids(
     assert state.state == "100"
 
     expected_attributes = {
-        "device_class": "battery",
-        "friendly_name": "Ups1 Battery charge",
-        "unit_of_measurement": PERCENTAGE,
+        ATTR_DEVICE_CLASS: "battery",
+        ATTR_FRIENDLY_NAME: "Ups1 Battery charge",
+        ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     }
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
@@ -126,10 +129,10 @@ async def test_pdu_devices_with_unique_ids(
         device_id="sensor.ups1_input_voltage",
         state_value="122.91",
         expected_attributes={
-            "device_class": SensorDeviceClass.VOLTAGE,
+            ATTR_DEVICE_CLASS: SensorDeviceClass.VOLTAGE,
             "state_class": SensorStateClass.MEASUREMENT,
-            "friendly_name": "Ups1 Input voltage",
-            "unit_of_measurement": UnitOfElectricPotential.VOLT,
+            ATTR_FRIENDLY_NAME: "Ups1 Input voltage",
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfElectricPotential.VOLT,
         },
     )
 
@@ -141,8 +144,8 @@ async def test_pdu_devices_with_unique_ids(
         device_id="sensor.ups1_ambient_humidity_status",
         state_value="good",
         expected_attributes={
-            "device_class": SensorDeviceClass.ENUM,
-            "friendly_name": "Ups1 Ambient humidity status",
+            ATTR_DEVICE_CLASS: SensorDeviceClass.ENUM,
+            ATTR_FRIENDLY_NAME: "Ups1 Ambient humidity status",
         },
     )
 
@@ -154,8 +157,8 @@ async def test_pdu_devices_with_unique_ids(
         device_id="sensor.ups1_ambient_temperature_status",
         state_value="good",
         expected_attributes={
-            "device_class": SensorDeviceClass.ENUM,
-            "friendly_name": "Ups1 Ambient temperature status",
+            ATTR_DEVICE_CLASS: SensorDeviceClass.ENUM,
+            ATTR_FRIENDLY_NAME: "Ups1 Ambient temperature status",
         },
     )
 
@@ -305,9 +308,9 @@ async def test_pdu_dynamic_outlets(
         device_id="sensor.ups1_outlet_a1_current",
         state_value="0",
         expected_attributes={
-            "device_class": SensorDeviceClass.CURRENT,
-            "friendly_name": "Ups1 Outlet A1 current",
-            "unit_of_measurement": UnitOfElectricCurrent.AMPERE,
+            ATTR_DEVICE_CLASS: SensorDeviceClass.CURRENT,
+            ATTR_FRIENDLY_NAME: "Ups1 Outlet A1 current",
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfElectricCurrent.AMPERE,
         },
     )
 
@@ -319,9 +322,9 @@ async def test_pdu_dynamic_outlets(
         device_id="sensor.ups1_outlet_a24_current",
         state_value="0.19",
         expected_attributes={
-            "device_class": SensorDeviceClass.CURRENT,
-            "friendly_name": "Ups1 Outlet A24 current",
-            "unit_of_measurement": UnitOfElectricCurrent.AMPERE,
+            ATTR_DEVICE_CLASS: SensorDeviceClass.CURRENT,
+            ATTR_FRIENDLY_NAME: "Ups1 Outlet A24 current",
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfElectricCurrent.AMPERE,
         },
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The NUT pytest sensor test cases for NUT use hardcoded attributes.  This PR replaces those with constants for better code quality and maintainability.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
