### PR TITLE
Fix System Bridge wait timeout wait condition

### DIFF
--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -11,6 +11,7 @@ from systembridgeconnector.exceptions import (
     AuthenticationException,
     ConnectionClosedException,
     ConnectionErrorException,
+    DataMissingException,
 )
 from systembridgeconnector.version import Version
 from systembridgemodels.keyboard_key import KeyboardKey
@@ -184,7 +185,7 @@ async def async_setup_entry(
                 "host": entry.data[CONF_HOST],
             },
         ) from exception
-    except TimeoutError as exception:
+    except (DataMissingException, TimeoutError) as exception:
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="timeout",

--- a/homeassistant/components/system_bridge/const.py
+++ b/homeassistant/components/system_bridge/const.py
@@ -18,4 +18,6 @@ MODULES: Final[list[Module]] = [
     Module.SYSTEM,
 ]
 
-DATA_WAIT_TIMEOUT: Final[int] = 10
+DATA_WAIT_TIMEOUT: Final[int] = 20
+
+GET_DATA_WAIT_TIMEOUT: Final[int] = 15

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -33,7 +33,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, MODULES
+from .const import DOMAIN, GET_DATA_WAIT_TIMEOUT, MODULES
 from .data import SystemBridgeData
 
 
@@ -119,7 +119,10 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
         """Get data from WebSocket."""
         await self.check_websocket_connected()
 
-        modules_data = await self.websocket_client.get_data(GetData(modules=modules))
+        modules_data = await self.websocket_client.get_data(
+            GetData(modules=modules),
+            timeout=GET_DATA_WAIT_TIMEOUT,
+        )
 
         # Merge new data with existing data
         for module in MODULES:

--- a/tests/components/system_bridge/test_init.py
+++ b/tests/components/system_bridge/test_init.py
@@ -81,3 +81,53 @@ async def test_migration_minor_future_version(hass: HomeAssistant) -> None:
     assert config_entry.minor_version == config_entry_minor_version
     assert config_entry.data == config_entry_data
     assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_setup_timeout(hass: HomeAssistant) -> None:
+    """Test setup with timeout error."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=FIXTURE_UUID,
+        data=FIXTURE_USER_INPUT,
+        version=SystemBridgeConfigFlow.VERSION,
+        minor_version=SystemBridgeConfigFlow.MINOR_VERSION,
+    )
+
+    with patch(
+        "systembridgeconnector.version.Version.check_supported",
+        side_effect=TimeoutError,
+    ):
+        config_entry.add_to_hass(hass)
+        result = await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert result is False
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_coordinator_get_data_timeout(hass: HomeAssistant) -> None:
+    """Test coordinator handling timeout during get_data."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=FIXTURE_UUID,
+        data=FIXTURE_USER_INPUT,
+        version=SystemBridgeConfigFlow.VERSION,
+        minor_version=SystemBridgeConfigFlow.MINOR_VERSION,
+    )
+
+    with (
+        patch(
+            "systembridgeconnector.version.Version.check_supported",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.system_bridge.coordinator.SystemBridgeDataUpdateCoordinator.async_get_data",
+            side_effect=TimeoutError,
+        ),
+    ):
+        config_entry.add_to_hass(hass)
+        result = await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert result is False
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes a small race condition with waiting for data from System Bridge. Due to the default timeout being the same as Home Assistant, the timeout does not occur from the connector package. This causes issues when trying to debug the main application. It doesn't particularly affect the users as they will get the same timeout message.

- Increased timeout to allow for slower connections
- Gave a 5 second window for get data and asyncio timeout

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x]  The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
