### PR TITLE
Set device connection MAC address for networked devices in NUT

### DIFF
--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -157,8 +157,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: NutConfigEntry) -> bool:
     )
 
     connections: set[tuple[str, str]] | None = None
-    if data.device_info.macaddr is not None:
-        connections = {(CONNECTION_NETWORK_MAC, data.device_info.macaddr)}
+    if data.device_info.mac_address is not None:
+        connections = {(CONNECTION_NETWORK_MAC, data.device_info.mac_address)}
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
@@ -252,7 +252,7 @@ class NUTDeviceInfo:
     model_id: str | None = None
     firmware: str | None = None
     serial: str | None = None
-    macaddr: str | None = None
+    mac_address: str | None = None
     device_location: str | None = None
 
 
@@ -316,12 +316,18 @@ class PyNUTData:
         model_id: str | None = self._status.get("device.part")
         firmware = _firmware_from_status(self._status)
         serial = _serial_from_status(self._status)
-        macaddr: str | None = self._status.get("device.macaddr")
-        if macaddr is not None:
-            macaddr = format_mac(macaddr.rstrip().replace(" ", ":"))
+        mac_address: str | None = self._status.get("device.macaddr")
+        if mac_address is not None:
+            mac_address = format_mac(mac_address.rstrip().replace(" ", ":"))
         device_location: str | None = self._status.get("device.location")
         return NUTDeviceInfo(
-            manufacturer, model, model_id, firmware, serial, macaddr, device_location
+            manufacturer,
+            model,
+            model_id,
+            firmware,
+            serial,
+            mac_address,
+            device_location,
         )
 
     async def _async_get_status(self) -> dict[str, str]:

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -155,10 +156,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: NutConfigEntry) -> bool:
         coordinator, data, unique_id, user_available_commands
     )
 
+    connections: set[tuple[str, str]] | None = None
+    if data.device_info.macaddr is not None:
+        connections = {(CONNECTION_NETWORK_MAC, data.device_info.macaddr)}
+
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, unique_id)},
+        connections=connections,
         name=data.name.title(),
         manufacturer=data.device_info.manufacturer,
         model=data.device_info.model,
@@ -246,6 +252,7 @@ class NUTDeviceInfo:
     model_id: str | None = None
     firmware: str | None = None
     serial: str | None = None
+    macaddr: str | None = None
     device_location: str | None = None
 
 
@@ -309,9 +316,12 @@ class PyNUTData:
         model_id: str | None = self._status.get("device.part")
         firmware = _firmware_from_status(self._status)
         serial = _serial_from_status(self._status)
+        macaddr: str | None = self._status.get("device.macaddr")
+        if macaddr is not None:
+            macaddr = format_mac(macaddr.rstrip().replace(" ", ":"))
         device_location: str | None = self._status.get("device.location")
         return NUTDeviceInfo(
-            manufacturer, model, model_id, firmware, serial, device_location
+            manufacturer, model, model_id, firmware, serial, macaddr, device_location
         )
 
     async def _async_get_status(self) -> dict[str, str]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the NUT device's MAC address to the connections list if the device is networked and the MAC address is reported by the NUT server.  This allows the MAC address to be shown on the device information page.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
