### PR TITLE
Update support to external library pypglab to version 0.0.5

### DIFF
--- a/homeassistant/components/pglab/__init__.py
+++ b/homeassistant/components/pglab/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pypglab.mqtt import (
     Client as PyPGLabMqttClient,
     Sub_State as PyPGLabSubState,
-    Subcribe_CallBack as PyPGLabSubscribeCallBack,
+    Subscribe_CallBack as PyPGLabSubscribeCallBack,
 )
 
 from homeassistant.components import mqtt

--- a/homeassistant/components/pglab/coordinator.py
+++ b/homeassistant/components/pglab/coordinator.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from pypglab.const import SENSOR_REBOOT_TIME, SENSOR_TEMPERATURE, SENSOR_VOLTAGE
 from pypglab.device import Device as PyPGLabDevice
-from pypglab.sensor import Sensor as PyPGLabSensors
+from pypglab.sensor import StatusSensor as PyPGLabSensors
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -31,7 +31,7 @@ class PGLabSensorsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Initialize."""
 
         # get a reference of PG Lab device internal sensors state
-        self._sensors: PyPGLabSensors = pglab_device.sensors
+        self._sensors: PyPGLabSensors = pglab_device.status_sensor
 
         super().__init__(
             hass,

--- a/homeassistant/components/pglab/discovery.py
+++ b/homeassistant/components/pglab/discovery.py
@@ -220,7 +220,7 @@ class PGLabDiscovery:
                 configuration_url=f"http://{pglab_device.ip}/",
                 connections={(CONNECTION_NETWORK_MAC, pglab_device.mac)},
                 identifiers={(DOMAIN, pglab_device.id)},
-                manufacturer=pglab_device.manufactor,
+                manufacturer=pglab_device.manufacturer,
                 model=pglab_device.type,
                 name=pglab_device.name,
                 sw_version=pglab_device.firmware_version,

--- a/homeassistant/components/pglab/entity.py
+++ b/homeassistant/components/pglab/entity.py
@@ -37,7 +37,7 @@ class PGLabBaseEntity(Entity):
             sw_version=pglab_device.firmware_version,
             hw_version=pglab_device.hardware_version,
             model=pglab_device.type,
-            manufacturer=pglab_device.manufactor,
+            manufacturer=pglab_device.manufacturer,
             configuration_url=f"http://{pglab_device.ip}/",
             connections={(CONNECTION_NETWORK_MAC, pglab_device.mac)},
         )

--- a/homeassistant/components/pglab/manifest.json
+++ b/homeassistant/components/pglab/manifest.json
@@ -9,6 +9,6 @@
   "loggers": ["pglab"],
   "mqtt": ["pglab/discovery/#"],
   "quality_scale": "bronze",
-  "requirements": ["pypglab==0.0.3"],
+  "requirements": ["pypglab==0.0.5"],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2223,7 +2223,7 @@ pypca==0.0.7
 pypck==0.8.5
 
 # homeassistant.components.pglab
-pypglab==0.0.3
+pypglab==0.0.5
 
 # homeassistant.components.pjlink
 pypjlink2==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1814,7 +1814,7 @@ pypalazzetti==0.1.19
 pypck==0.8.5
 
 # homeassistant.components.pglab
-pypglab==0.0.3
+pypglab==0.0.5
 
 # homeassistant.components.pjlink
 pypjlink2==1.2.1

--- a/tests/components/pglab/test_common.py
+++ b/tests/components/pglab/test_common.py
@@ -1,0 +1,50 @@
+"""Common code for PG LAB Electronics tests."""
+
+import json
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import async_fire_mqtt_message
+
+
+def get_device_discovery_payload(
+    number_of_shutters: int,
+    number_of_boards: int,
+    device_name: str = "test",
+) -> dict[str, any]:
+    """Return the device discovery payload."""
+
+    # be sure the number of shutters and boards are in the correct range
+    assert 0 <= number_of_boards <= 8
+    assert 0 <= number_of_shutters <= (number_of_boards * 4)
+
+    # define the number of E-RELAY boards connected to E-BOARD
+    boards = "1" * number_of_boards + "0" * (8 - number_of_boards)
+
+    return {
+        "ip": "192.168.1.16",
+        "mac": "80:34:28:1B:18:5A",
+        "name": device_name,
+        "hw": "1.0.7",
+        "fw": "1.0.0",
+        "type": "E-BOARD",
+        "id": "E-BOARD-DD53AC85",
+        "manufacturer": "PG LAB Electronics",
+        "params": {"shutters": number_of_shutters, "boards": boards},
+    }
+
+
+async def send_discovery_message(
+    hass: HomeAssistant,
+    payload: dict[str, any] | None,
+) -> None:
+    """Send the discovery message to make E-BOARD device discoverable."""
+
+    topic = "pglab/discovery/E-BOARD-DD53AC85/config"
+
+    async_fire_mqtt_message(
+        hass,
+        topic,
+        json.dumps(payload if payload is not None else ""),
+    )
+    await hass.async_block_till_done()

--- a/tests/components/pglab/test_cover.py
+++ b/tests/components/pglab/test_cover.py
@@ -1,7 +1,5 @@
 """The tests for the PG LAB Electronics cover."""
 
-import json
-
 from homeassistant.components import cover
 from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
@@ -18,6 +16,8 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+
+from .test_common import get_device_discovery_payload, send_discovery_message
 
 from tests.common import async_fire_mqtt_message
 from tests.typing import MqttMockHAClient
@@ -43,25 +43,13 @@ async def test_cover_features(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
 ) -> None:
     """Test cover features."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 4, "boards": "10000000"},
-    }
 
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=4,
+        number_of_boards=1,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     assert len(hass.states.async_all("cover")) == 4
 
@@ -75,25 +63,13 @@ async def test_cover_availability(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
 ) -> None:
     """Check if covers are properly created."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 6, "boards": "11000000"},
-    }
 
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=6,
+        number_of_boards=2,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # We are creating 6 covers using two E-RELAY devices connected to E-BOARD.
     # Now we are going to check if all covers are created and their state is unknown.
@@ -111,25 +87,12 @@ async def test_cover_change_state_via_mqtt(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
 ) -> None:
     """Test state update via MQTT."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 2, "boards": "10000000"},
-    }
-
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=2,
+        number_of_boards=1,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # Check initial state is unknown
     cover = hass.states.get("cover.test_shutter_0")
@@ -165,25 +128,13 @@ async def test_cover_mqtt_state_by_calling_service(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
 ) -> None:
     """Calling service to OPEN/CLOSE cover and check mqtt state."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 2, "boards": "10000000"},
-    }
 
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=2,
+        number_of_boards=1,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     cover = hass.states.get("cover.test_shutter_0")
     assert cover.state == STATE_UNKNOWN

--- a/tests/components/pglab/test_discovery.py
+++ b/tests/components/pglab/test_discovery.py
@@ -1,13 +1,12 @@
 """The tests for the PG LAB Electronics  discovery device."""
 
-import json
-
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from tests.common import async_fire_mqtt_message
+from .test_common import get_device_discovery_payload, send_discovery_message
+
 from tests.typing import MqttMockHAClient
 
 
@@ -19,25 +18,13 @@ async def test_device_discover(
     setup_pglab,
 ) -> None:
     """Test setting up a device."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "11000000"},
-    }
 
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=0,
+        number_of_boards=2,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # Verify device and registry entries are created
     device_entry = device_reg.async_get_device(
@@ -60,25 +47,12 @@ async def test_device_update(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test update a device."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "11000000"},
-    }
-
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=0,
+        number_of_boards=2,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # Verify device is created
     device_entry = device_reg.async_get_device(
@@ -90,12 +64,7 @@ async def test_device_update(
     payload["fw"] = "1.0.1"
     payload["hw"] = "1.0.8"
 
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
-    )
-    await hass.async_block_till_done()
+    await send_discovery_message(hass, payload)
 
     # Verify device is created
     device_entry = device_reg.async_get_device(
@@ -114,25 +83,12 @@ async def test_device_remove(
     setup_pglab,
 ) -> None:
     """Test remove a device."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "11000000"},
-    }
-
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=0,
+        number_of_boards=2,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # Verify device is created
     device_entry = device_reg.async_get_device(
@@ -140,12 +96,7 @@ async def test_device_remove(
     )
     assert device_entry is not None
 
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        "",
-    )
-    await hass.async_block_till_done()
+    await send_discovery_message(hass, None)
 
     # Verify device entry is removed
     device_entry = device_reg.async_get_device(

--- a/tests/components/pglab/test_sensor.py
+++ b/tests/components/pglab/test_sensor.py
@@ -8,32 +8,10 @@ from syrupy import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
 
+from .test_common import get_device_discovery_payload, send_discovery_message
+
 from tests.common import async_fire_mqtt_message
 from tests.typing import MqttMockHAClient
-
-
-async def send_discovery_message(hass: HomeAssistant) -> None:
-    """Send mqtt discovery message."""
-
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "00000000"},
-    }
-
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
-    )
-    await hass.async_block_till_done()
 
 
 @freeze_time("2024-02-26 01:21:34")
@@ -55,7 +33,12 @@ async def test_sensors(
     """Check if sensors are properly created and updated."""
 
     # send the discovery message to make E-BOARD device discoverable
-    await send_discovery_message(hass)
+    payload = get_device_discovery_payload(
+        number_of_shutters=0,
+        number_of_boards=0,
+    )
+
+    await send_discovery_message(hass, payload)
 
     # check initial sensors state
     state = hass.states.get(f"sensor.test_{sensor_suffix}")

--- a/tests/components/pglab/test_switch.py
+++ b/tests/components/pglab/test_switch.py
@@ -1,7 +1,6 @@
 """The tests for the PG LAB Electronics switch."""
 
 from datetime import timedelta
-import json
 
 from homeassistant import config_entries
 from homeassistant.components.switch import (
@@ -19,6 +18,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
+
+from .test_common import get_device_discovery_payload, send_discovery_message
 
 from tests.common import async_fire_mqtt_message, async_fire_time_changed
 from tests.typing import MqttMockHAClient
@@ -38,25 +39,13 @@ async def test_available_relay(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
 ) -> None:
     """Check if relay are properly created when two E-Relay boards are connected."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "11000000"},
-    }
 
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=0,
+        number_of_boards=2,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     for i in range(16):
         state = hass.states.get(f"switch.test_relay_{i}")
@@ -68,25 +57,13 @@ async def test_change_state_via_mqtt(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
 ) -> None:
     """Test state update via MQTT."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "10000000"},
-    }
 
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=0,
+        number_of_boards=1,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # Simulate response from the device
     state = hass.states.get("switch.test_relay_0")
@@ -123,25 +100,13 @@ async def test_mqtt_state_by_calling_service(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_pglab
 ) -> None:
     """Calling service to turn ON/OFF relay and check mqtt state."""
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "10000000"},
-    }
 
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=0,
+        number_of_boards=1,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # Turn relay ON
     await call_service(hass, "switch.test_relay_0", SERVICE_TURN_ON)
@@ -177,26 +142,13 @@ async def test_discovery_update(
 ) -> None:
     """Update discovery message and  check if relay are property updated."""
 
-    # publish the first discovery message
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "first_test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "10000000"},
-    }
-
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        device_name="first_test",
+        number_of_shutters=0,
+        number_of_boards=1,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # test the available relay in the first configuration
     for i in range(8):
@@ -206,25 +158,13 @@ async def test_discovery_update(
 
     # prepare a new message ... the same device but renamed
     # and with different relay configuration
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "second_test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "11000000"},
-    }
-
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        device_name="second_test",
+        number_of_shutters=0,
+        number_of_boards=2,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # be sure that old relay are been removed
     for i in range(8):
@@ -245,25 +185,12 @@ async def test_disable_entity_state_change_via_mqtt(
 ) -> None:
     """Test state update via MQTT of disable entity."""
 
-    topic = "pglab/discovery/E-Board-DD53AC85/config"
-    payload = {
-        "ip": "192.168.1.16",
-        "mac": "80:34:28:1B:18:5A",
-        "name": "test",
-        "hw": "1.0.7",
-        "fw": "1.0.0",
-        "type": "E-Board",
-        "id": "E-Board-DD53AC85",
-        "manufacturer": "PG LAB Electronics",
-        "params": {"shutters": 0, "boards": "10000000"},
-    }
-
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
+    payload = get_device_discovery_payload(
+        number_of_shutters=0,
+        number_of_boards=1,
     )
-    await hass.async_block_till_done()
+
+    await send_discovery_message(hass, payload)
 
     # Be sure that the entity relay_0 is available
     state = hass.states.get("switch.test_relay_0")
@@ -298,12 +225,7 @@ async def test_disable_entity_state_change_via_mqtt(
     await hass.async_block_till_done()
 
     # Re-send the discovery message
-    async_fire_mqtt_message(
-        hass,
-        topic,
-        json.dumps(payload),
-    )
-    await hass.async_block_till_done()
+    await send_discovery_message(hass, payload)
 
     # Be sure that the state is not changed
     state = hass.states.get("switch.test_relay_0")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR change PG LAB Integration to work with the new external library pypglab 0.0.5.
There is no breaking change or behavioral change.
Mainly the new version of pyglab fix some spelling mistake and make more clear some class name.

The new pypglab expose the MQTT discovery message in a sligtly different format. Some fields of the discovery message
are now all upper case ( "type", "id"). 
This PR update the test for this reason and contains refactoring of some common test functionality.
The send of the discovery is now in a common function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
