### PR TITLE
Fix import issues related to onboarding views

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -45,6 +45,7 @@ ifaddr==0.2.0
 Jinja2==3.1.6
 lru-dict==1.3.0
 mutagen==1.47.0
+numpy==2.2.2
 orjson==3.10.16
 packaging>=23.1
 paho-mqtt==2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ dependencies = [
   # hass-nabucasa is imported by helpers which don't depend on the cloud
   # integration
   "hass-nabucasa==0.94.0",
+  # hassil is indirectly imported from onboarding via the import chain
+  # onboarding->cloud->assist_pipeline->conversation->hassil. Onboarding needs
+  # to be setup in stage 0, but we don't want to also promote cloud with all its
+  # dependencies to stage 0.
+  "hassil==2.2.3",
   # When bumping httpx, please check the version pins of
   # httpcore, anyio, and h11 in gen_requirements_all
   "httpx==0.28.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,11 @@ dependencies = [
   # dependencies to stage 0.
   "pyspeex-noise==1.0.2",
   "python-slugify==8.0.4",
+  # PyTurboJPEG is indirectly imported from onboarding via the import chain
+  # onboarding->cloud->camera->pyturbojpeg. Onboarding needs
+  # to be setup in stage 0, but we don't want to also promote cloud with all its
+  # dependencies to stage 0.
+  "PyTurboJPEG==1.7.5",
   "PyYAML==6.0.2",
   "requests==2.32.3",
   "securetar==2025.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,11 @@ dependencies = [
   "ciso8601==2.3.2",
   "cronsim==2.6",
   "fnv-hash-fast==1.4.0",
+  # ha-ffmpeg is indirectly imported from onboarding via the import chain
+  # onboarding->cloud->assist_pipeline->tts->ffmpeg. Onboarding needs
+  # to be setup in stage 0, but we don't want to also promote cloud with all its
+  # dependencies to stage 0.
+  "ha-ffmpeg==3.2.2",
   # hass-nabucasa is imported by helpers which don't depend on the cloud
   # integration
   "hass-nabucasa==0.94.0",
@@ -65,6 +70,11 @@ dependencies = [
   "ifaddr==0.2.0",
   "Jinja2==3.1.6",
   "lru-dict==1.3.0",
+  # mutagen is indirectly imported from onboarding via the import chain
+  # onboarding->cloud->assist_pipeline->tts->mutagen. Onboarding needs
+  # to be setup in stage 0, but we don't want to also promote cloud with all its
+  # dependencies to stage 0.
+  "mutagen==1.47.0",
   # numpy is indirectly imported from onboarding via the import chain
   # onboarding->cloud->alexa->camera->stream->numpy. Onboarding needs
   # to be setup in stage 0, but we don't want to also promote cloud with all its
@@ -79,6 +89,16 @@ dependencies = [
   "orjson==3.10.16",
   "packaging>=23.1",
   "psutil-home-assistant==0.0.1",
+  # pymicro_vad is indirectly imported from onboarding via the import chain
+  # onboarding->cloud->assist_pipeline->pymicro_vad. Onboarding needs
+  # to be setup in stage 0, but we don't want to also promote cloud with all its
+  # dependencies to stage 0.
+  "pymicro-vad==1.0.1",
+  # pyspeex-noise is indirectly imported from onboarding via the import chain
+  # onboarding->cloud->assist_pipeline->pyspeex_noise. Onboarding needs
+  # to be setup in stage 0, but we don't want to also promote cloud with all its
+  # dependencies to stage 0.
+  "pyspeex-noise==1.0.2",
   "python-slugify==8.0.4",
   "PyYAML==6.0.2",
   "requests==2.32.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,19 @@ dependencies = [
   # httpcore, anyio, and h11 in gen_requirements_all
   "httpx==0.28.1",
   "home-assistant-bluetooth==1.13.1",
+  # home_assistant_intents is indirectly imported from onboarding via the import chain
+  # onboarding->cloud->assist_pipeline->conversation->home_assistant_intents. Onboarding needs
+  # to be setup in stage 0, but we don't want to also promote cloud with all its
+  # dependencies to stage 0.
+  "home-assistant-intents==2025.3.28",
   "ifaddr==0.2.0",
   "Jinja2==3.1.6",
   "lru-dict==1.3.0",
+  # numpy is indirectly imported from onboarding via the import chain
+  # onboarding->cloud->alexa->camera->stream->numpy. Onboarding needs
+  # to be setup in stage 0, but we don't want to also promote cloud with all its
+  # dependencies to stage 0.
+  "numpy==2.2.2",
   "PyJWT==2.10.1",
   # PyJWT has loose dependency. We want the latest one.
   "cryptography==44.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,9 +26,11 @@ hass-nabucasa==0.94.0
 hassil==2.2.3
 httpx==0.28.1
 home-assistant-bluetooth==1.13.1
+home-assistant-intents==2025.3.28
 ifaddr==0.2.0
 Jinja2==3.1.6
 lru-dict==1.3.0
+numpy==2.2.2
 PyJWT==2.10.1
 cryptography==44.0.1
 Pillow==11.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ ciso8601==2.3.2
 cronsim==2.6
 fnv-hash-fast==1.4.0
 hass-nabucasa==0.94.0
+hassil==2.2.3
 httpx==0.28.1
 home-assistant-bluetooth==1.13.1
 ifaddr==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ certifi>=2021.5.30
 ciso8601==2.3.2
 cronsim==2.6
 fnv-hash-fast==1.4.0
+ha-ffmpeg==3.2.2
 hass-nabucasa==0.94.0
 hassil==2.2.3
 httpx==0.28.1
@@ -30,6 +31,7 @@ home-assistant-intents==2025.3.28
 ifaddr==0.2.0
 Jinja2==3.1.6
 lru-dict==1.3.0
+mutagen==1.47.0
 numpy==2.2.2
 PyJWT==2.10.1
 cryptography==44.0.1
@@ -39,6 +41,8 @@ pyOpenSSL==25.0.0
 orjson==3.10.16
 packaging>=23.1
 psutil-home-assistant==0.0.1
+pymicro-vad==1.0.1
+pyspeex-noise==1.0.2
 python-slugify==8.0.4
 PyYAML==6.0.2
 requests==2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ psutil-home-assistant==0.0.1
 pymicro-vad==1.0.1
 pyspeex-noise==1.0.2
 python-slugify==8.0.4
+PyTurboJPEG==1.7.5
 PyYAML==6.0.2
 requests==2.32.3
 securetar==2025.2.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix two import issues related to onboarding views:
- Always install the `hassil` library
- Avoid importing `hassil` in the `asyncio` event loop

Ths problem is that `hassil` is indirectly imported from onboarding via the import chain
onboarding->cloud->assist_pipeline->conversation->hassil. Onboarding needs to be setup in stage 0, but we don't want to also promote cloud with all its dependencies to stage 0.

This is meant as a short-term solution, while exploring a better solution, for example to allow integrations to express in their manifest that they need to be able to import from other integrations, but don't require the other integration to be set up before it, i.e. a weaker version of `dependencies` and `after_dependencies`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
