### PR TITLE
Add Matter Binding command

### DIFF
--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -257,6 +257,7 @@ async def websocket_get_node_binding(
     matter: MatterAdapter,
     node: MatterNode,
 ) -> None:
+    """Get the bindings info in binding cluster at endpoints."""
     ret = {
         k: v.get_attribute_value(30, 0)
         for k, v in node.endpoints.items()
@@ -284,6 +285,7 @@ async def websocket_set_node_binding(
     matter: MatterAdapter,
     node: MatterNode,
 ) -> None:
+    """Set node bindings info in binding cluster of endpoint."""
     attribute_path = f"{msg['endpoint']}/30/0"
     result = await matter.matter_client.write_attribute(
         node_id=node.node_id,

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -241,6 +241,8 @@ async def websocket_node_diagnostics(
 
 
 from dataclasses import dataclass
+
+
 @dataclass
 class NodeBinding:
     node: int
@@ -253,7 +255,6 @@ class NodeBinding:
     {
         vol.Required(TYPE): "matter/get_node_binding",
         vol.Required(DEVICE_ID): str,
-        vol.Required("endpoint"): int,
     }
 )
 @websocket_api.async_response
@@ -267,19 +268,7 @@ async def websocket_get_node_binding(
     matter: MatterAdapter,
     node: MatterNode,
 ) -> None:
-    result = node.get_attribute_value(endpoint=msg["endpoint"], cluster=0x001E, attribute=0)
-    ret = [
-        dataclass_to_dict(
-            NodeBinding(
-                node=val.node,
-                group=val.group,
-                endpoint=val.endpoint,
-                cluster=val.cluster,
-                fabricIndex=val.fabricIndex,
-            )
-        )
-        for val in result
-    ]
+    ret = {k: v.get_attribute_value(30,0) for k, v in node.endpoints.items() if v.has_cluster(30)}
     connection.send_result(msg[ID], ret)
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -257,8 +257,13 @@ async def websocket_get_node_binding(
     matter: MatterAdapter,
     node: MatterNode,
 ) -> None:
-    ret = {k: v.get_attribute_value(30,0) for k, v in node.endpoints.items() if v.has_cluster(30)}
+    ret = {
+        k: v.get_attribute_value(30, 0)
+        for k, v in node.endpoints.items()
+        if v.has_cluster(30)
+    }
     connection.send_result(msg[ID], ret)
+
 
 @websocket_api.websocket_command(
     {
@@ -279,13 +284,14 @@ async def websocket_set_node_binding(
     matter: MatterAdapter,
     node: MatterNode,
 ) -> None:
-    attribute_path=f"{msg["endpoint"]}/30/0"
+    attribute_path = f"{msg['endpoint']}/30/0"
     result = await matter.matter_client.write_attribute(
         node_id=node.node_id,
         attribute_path=attribute_path,
         value=msg["bindings"],
     )
     connection.send_result(msg[ID], result)
+
 
 @websocket_api.websocket_command(
     {

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -240,17 +240,6 @@ async def websocket_node_diagnostics(
     connection.send_result(msg[ID], dataclass_to_dict(result))
 
 
-from dataclasses import dataclass
-
-
-@dataclass
-class NodeBinding:
-    node: int
-    group: int
-    endpoint: int
-    cluster: int
-    fabricIndex: int
-
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "matter/get_node_binding",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
add the matter binding command.

test_node_binding.py

```python
import asyncio
import websockets
import json
import random


async def connect_to_home_assistant():
    uri = "ws://127.0.0.1:8123/api/websocket"

    access_token = ""

    async with websockets.connect(uri) as websocket:
        auth_message = {"type": "auth", "access_token": access_token}
        auth_response = await websocket.recv()
        auth_response = json.loads(auth_response)
        if auth_response.get("type") == "auth_required":
            await websocket.send(json.dumps(auth_message))

        auth_response = await websocket.recv()

        set_node_binding_message = {
            "id": random.randint(1, 10),
            "type": "matter/set_node_binding",
            "device_id": "e71ed9cef0082c560af8e7e5504702a7",
            "endpoint": 1,
            "bindings": [
                {"1": 9, "3": 1, "254": 2},
                {"1": 10, "3": 1, "254": 2},
                {"1": 12, "3": 1, "254": 2},
            ],
        }
        data = json.dumps(set_node_binding_message)
        await websocket.send(data)
        response = await websocket.recv()
        print(response)

        get_node_binding_message = {
            "id": random.randint(1, 10),
            "type": "matter/get_node_binding",
            "device_id": "e71ed9cef0082c560af8e7e5504702a7",
        }
        data = json.dumps(get_node_binding_message)
        await websocket.send(data)
        response = await websocket.recv()
        print(response)


asyncio.run(connect_to_home_assistant())
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
