### PR TITLE
Add preannounce boolean for announce/start conversation

### DIFF
--- a/homeassistant/components/assist_satellite/__init__.py
+++ b/homeassistant/components/assist_satellite/__init__.py
@@ -60,7 +60,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 {
                     vol.Optional("message"): str,
                     vol.Optional("media_id"): str,
-                    vol.Optional("preannounce_media_id"): vol.Any(str, None),
+                    vol.Optional("preannounce"): bool,
+                    vol.Optional("preannounce_media_id"): str,
                 }
             ),
             cv.has_at_least_one_key("message", "media_id"),
@@ -75,7 +76,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 {
                     vol.Optional("start_message"): str,
                     vol.Optional("start_media_id"): str,
-                    vol.Optional("preannounce_media_id"): vol.Any(str, None),
+                    vol.Optional("preannounce"): bool,
+                    vol.Optional("preannounce_media_id"): str,
                     vol.Optional("extra_system_prompt"): str,
                 }
             ),

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -180,7 +180,8 @@ class AssistSatelliteEntity(entity.Entity):
         self,
         message: str | None = None,
         media_id: str | None = None,
-        preannounce_media_id: str | None = PREANNOUNCE_URL,
+        preannounce: bool = True,
+        preannounce_media_id: str = PREANNOUNCE_URL,
     ) -> None:
         """Play and show an announcement on the satellite.
 
@@ -190,8 +191,8 @@ class AssistSatelliteEntity(entity.Entity):
         If media_id is provided, it is played directly. It is possible
         to omit the message and the satellite will not show any text.
 
+        If preannounce is True, a sound is played before the announcement.
         If preannounce_media_id is provided, it overrides the default sound.
-        If preannounce_media_id is None, no sound is played.
 
         Calls async_announce with message and media id.
         """
@@ -201,7 +202,9 @@ class AssistSatelliteEntity(entity.Entity):
             message = ""
 
         announcement = await self._resolve_announcement_media_id(
-            message, media_id, preannounce_media_id
+            message,
+            media_id,
+            preannounce_media_id=preannounce_media_id if preannounce else None,
         )
 
         if self._is_announcing:
@@ -229,6 +232,7 @@ class AssistSatelliteEntity(entity.Entity):
         start_message: str | None = None,
         start_media_id: str | None = None,
         extra_system_prompt: str | None = None,
+        preannounce: bool = True,
         preannounce_media_id: str | None = PREANNOUNCE_URL,
     ) -> None:
         """Start a conversation from the satellite.
@@ -239,8 +243,8 @@ class AssistSatelliteEntity(entity.Entity):
         If start_media_id is provided, it is played directly. It is possible
         to omit the message and the satellite will not show any text.
 
-        If preannounce_media_id is provided, it is played before the announcement.
-        If preannounce_media_id is None, no sound is played.
+        If preannounce is True, a sound is played before the start message or media.
+        If preannounce_media_id is provided, it overrides the default sound.
 
         Calls async_start_conversation.
         """
@@ -257,7 +261,9 @@ class AssistSatelliteEntity(entity.Entity):
             start_message = ""
 
         announcement = await self._resolve_announcement_media_id(
-            start_message, start_media_id, preannounce_media_id
+            start_message,
+            start_media_id,
+            preannounce_media_id=preannounce_media_id if preannounce else None,
         )
 
         if self._is_announcing:

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -233,7 +233,7 @@ class AssistSatelliteEntity(entity.Entity):
         start_media_id: str | None = None,
         extra_system_prompt: str | None = None,
         preannounce: bool = True,
-        preannounce_media_id: str | None = PREANNOUNCE_URL,
+        preannounce_media_id: str = PREANNOUNCE_URL,
     ) -> None:
         """Start a conversation from the satellite.
 

--- a/homeassistant/components/assist_satellite/services.yaml
+++ b/homeassistant/components/assist_satellite/services.yaml
@@ -15,6 +15,11 @@ announce:
       required: false
       selector:
         text:
+    preannounce:
+      required: false
+      default: true
+      selector:
+        boolean:
     preannounce_media_id:
       required: false
       selector:
@@ -40,6 +45,11 @@ start_conversation:
       required: false
       selector:
         text:
+    preannounce:
+      required: false
+      default: true
+      selector:
+        boolean:
     preannounce_media_id:
       required: false
       selector:

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -29,7 +29,7 @@
           "description": "Play a sound before the announcement."
         },
         "preannounce_media_id": {
-          "name": "Preannounce Media ID",
+          "name": "Preannounce media ID",
           "description": "The media ID to play before the announcement."
         }
       }
@@ -55,7 +55,7 @@
           "description": "Play a sound before the start message or media."
         },
         "preannounce_media_id": {
-          "name": "Preannounce Media ID",
+          "name": "Preannounce media ID",
           "description": "The media ID to play before the start message or media."
         }
       }

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -30,7 +30,7 @@
         },
         "preannounce_media_id": {
           "name": "Preannounce media ID",
-          "description": "The media ID to play before the announcement."
+          "description": "Custom media ID to play before the announcement."
         }
       }
     },
@@ -56,7 +56,7 @@
         },
         "preannounce_media_id": {
           "name": "Preannounce media ID",
-          "description": "The media ID to play before the start message or media."
+          "description": "Custom media ID to play before the start message or media."
         }
       }
     }

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -24,6 +24,10 @@
           "name": "Media ID",
           "description": "The media ID to announce instead of using text-to-speech."
         },
+        "preannounce": {
+          "name": "Preannounce",
+          "description": "Play a sound before the announcement."
+        },
         "preannounce_media_id": {
           "name": "Preannounce Media ID",
           "description": "The media ID to play before the announcement."
@@ -45,6 +49,10 @@
         "extra_system_prompt": {
           "name": "Extra system prompt",
           "description": "Provide background information to the AI about the request."
+        },
+        "preannounce": {
+          "name": "Preannounce",
+          "description": "Play a sound before the start message or media."
         },
         "preannounce_media_id": {
           "name": "Preannounce Media ID",

--- a/homeassistant/components/assist_satellite/websocket_api.py
+++ b/homeassistant/components/assist_satellite/websocket_api.py
@@ -199,7 +199,7 @@ async def websocket_test_connection(
     hass.async_create_background_task(
         satellite.async_internal_announce(
             media_id=f"{CONNECTION_TEST_URL_BASE}/{connection_id}",
-            preannounce_media_id=None,
+            preannounce=False,
         ),
         f"assist_satellite_connection_test_{msg['entity_id']}",
     )

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -186,7 +186,7 @@ async def test_new_pipeline_cancels_pipeline(
     ("service_data", "expected_params"),
     [
         (
-            {"message": "Hello", "preannounce_media_id": None},
+            {"message": "Hello", "preannounce": False},
             AssistSatelliteAnnouncement(
                 message="Hello",
                 media_id="http://10.10.10.10:8123/api/tts_proxy/test-token",
@@ -199,7 +199,7 @@ async def test_new_pipeline_cancels_pipeline(
             {
                 "message": "Hello",
                 "media_id": "media-source://given",
-                "preannounce_media_id": None,
+                "preannounce": False,
             },
             AssistSatelliteAnnouncement(
                 message="Hello",
@@ -210,7 +210,7 @@ async def test_new_pipeline_cancels_pipeline(
             ),
         ),
         (
-            {"media_id": "http://example.com/bla.mp3", "preannounce_media_id": None},
+            {"media_id": "http://example.com/bla.mp3", "preannounce": False},
             AssistSatelliteAnnouncement(
                 message="",
                 media_id="http://example.com/bla.mp3",
@@ -541,7 +541,7 @@ async def test_vad_sensitivity_entity_not_found(
             {
                 "start_message": "Hello",
                 "extra_system_prompt": "Better system prompt",
-                "preannounce_media_id": None,
+                "preannounce": False,
             },
             (
                 "mock-conversation-id",
@@ -559,7 +559,7 @@ async def test_vad_sensitivity_entity_not_found(
             {
                 "start_message": "Hello",
                 "start_media_id": "media-source://given",
-                "preannounce_media_id": None,
+                "preannounce": False,
             },
             (
                 "mock-conversation-id",
@@ -576,7 +576,7 @@ async def test_vad_sensitivity_entity_not_found(
         (
             {
                 "start_media_id": "http://example.com/given.mp3",
-                "preannounce_media_id": None,
+                "preannounce": False,
             },
             (
                 "mock-conversation-id",

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -1221,7 +1221,7 @@ async def test_announce_message(
                 {
                     "entity_id": satellite.entity_id,
                     "message": "test-text",
-                    "preannounce_media_id": None,
+                    "preannounce": False,
                 },
                 blocking=True,
             )
@@ -1311,7 +1311,7 @@ async def test_announce_media_id(
                 {
                     "entity_id": satellite.entity_id,
                     "media_id": "https://www.home-assistant.io/resolved.mp3",
-                    "preannounce_media_id": None,
+                    "preannounce": False,
                 },
                 blocking=True,
             )
@@ -1522,7 +1522,7 @@ async def test_start_conversation_message(
                 {
                     "entity_id": satellite.entity_id,
                     "start_message": "test-text",
-                    "preannounce_media_id": None,
+                    "preannounce": False,
                 },
                 blocking=True,
             )
@@ -1631,7 +1631,7 @@ async def test_start_conversation_media_id(
                 {
                     "entity_id": satellite.entity_id,
                     "start_media_id": "https://www.home-assistant.io/resolved.mp3",
-                    "preannounce_media_id": None,
+                    "preannounce": False,
                 },
                 blocking=True,
             )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a `preannounce` boolean field to the Assist satellite announce and start conversation services. When set to `True` (the default), the default pre-announcement sound is played. This can be overridden by setting `preannounce_media_id`.

https://github.com/home-assistant/architecture/discussions/1213#discussioncomment-12674421

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38294
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
