### PR TITLE
Improve exception handling in Pterodactyl

### DIFF
--- a/homeassistant/components/pterodactyl/button.py
+++ b/homeassistant/components/pterodactyl/button.py
@@ -9,7 +9,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .api import PterodactylCommand, PterodactylConnectionError
+from .api import (
+    PterodactylAuthorizationError,
+    PterodactylCommand,
+    PterodactylConnectionError,
+)
 from .coordinator import PterodactylConfigEntry, PterodactylCoordinator
 from .entity import PterodactylEntity
 
@@ -94,5 +98,9 @@ class PterodactylButtonEntity(PterodactylEntity, ButtonEntity):
             )
         except PterodactylConnectionError as err:
             raise HomeAssistantError(
-                f"Failed to send action '{self.entity_description.key}'"
+                f"Failed to send action '{self.entity_description.key}': Connection error"
+            ) from err
+        except PterodactylAuthorizationError as err:
+            raise HomeAssistantError(
+                f"Failed to send action '{self.entity_description.key}': Unauthorized"
             ) from err

--- a/homeassistant/components/pterodactyl/config_flow.py
+++ b/homeassistant/components/pterodactyl/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_API_KEY, CONF_URL
 
 from .api import (
     PterodactylAPI,
-    PterodactylConfigurationError,
+    PterodactylAuthorizationError,
     PterodactylConnectionError,
 )
 from .const import DOMAIN
@@ -49,7 +49,9 @@ class PterodactylConfigFlow(ConfigFlow, domain=DOMAIN):
 
             try:
                 await api.async_init()
-            except (PterodactylConfigurationError, PterodactylConnectionError):
+            except PterodactylAuthorizationError:
+                errors["base"] = "invalid_auth"
+            except PterodactylConnectionError:
                 errors["base"] = "cannot_connect"
             except Exception:
                 _LOGGER.exception("Unexpected exception occurred during config flow")

--- a/homeassistant/components/pterodactyl/coordinator.py
+++ b/homeassistant/components/pterodactyl/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import (
     PterodactylAPI,
-    PterodactylConfigurationError,
+    PterodactylAuthorizationError,
     PterodactylConnectionError,
     PterodactylData,
 )
@@ -55,12 +55,12 @@ class PterodactylCoordinator(DataUpdateCoordinator[dict[str, PterodactylData]]):
 
         try:
             await self.api.async_init()
-        except PterodactylConfigurationError as error:
+        except (PterodactylAuthorizationError, PterodactylConnectionError) as error:
             raise UpdateFailed(error) from error
 
     async def _async_update_data(self) -> dict[str, PterodactylData]:
         """Get updated data from the Pterodactyl server."""
         try:
             return await self.api.async_get_data()
-        except PterodactylConnectionError as error:
+        except (PterodactylAuthorizationError, PterodactylConnectionError) as error:
             raise UpdateFailed(error) from error

--- a/homeassistant/components/pterodactyl/strings.json
+++ b/homeassistant/components/pterodactyl/strings.json
@@ -14,6 +14,7 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**1) Remove unnecessary catch of pydactyl.exceptions.ClientConfigError:**
This exception is raised, when not all parameters are set in PterodactylClient(), which is not possible in this integration, as these parameters (URL & API key) are required inputs in the config flow.

**2) Remove unnecessary catch of pydactyl.exceptions.PydactylError:**
This is the base exception class of pydactyl, not required to catch.

**3) Catch requests.exceptions.ConnectionError:**
This exception is not catched by pydactyl and is raised if for example the URL cannot be reached.

**4) Catch requests.exceptions.HTTPError:**
In case of a response code 401 (unauthorized) pydactyl doesn not catch it. This is raised if the API key is incorrect.

**5) Simplify config flow tests:**
All errors within the config flow are now tested with one parametrized test case.

**Note:**
Reauthorization flow will be added in a follow up PR to keep this PR as small as possible.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n.a.
- This PR is related to issue: n.a.
- Link to documentation pull request: n.a.
- Link to developer documentation pull request: n.a.
- Link to frontend pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
