### PR TITLE
Fix data in old SkyConnect integration config entries or delete them

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DESCRIPTION, DEVICE, DOMAIN, FIRMWARE, FIRMWARE_VERSION, PRODUCT
+from .const import DESCRIPTION, DEVICE, DOMAIN, FIRMWARE, FIRMWARE_VERSION, PRODUCT, VID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +22,12 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the ZBT-1 integration."""
+
+    for entry in list(hass.config_entries.async_entries(DOMAIN)):
+        # Old SkyConnect entries do not contain enough information to set up or migrate
+        if VID not in entry.data:
+            _LOGGER.debug("Removing old SkyConnect entry %s", entry.entry_id)
+            await hass.config_entries.async_remove(entry.entry_id)
 
     @callback
     def async_port_event_callback(

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -81,7 +81,7 @@ class HomeAssistantSkyConnectConfigFlow(
     """Handle a config flow for Home Assistant SkyConnect."""
 
     VERSION = 1
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the config flow."""

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -65,7 +65,7 @@ async def test_config_entry_migration_v2(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(config_entry.entry_id)
 
     assert config_entry.version == 1
-    assert config_entry.minor_version == 3
+    assert config_entry.minor_version == 4
     assert config_entry.data == {
         "description": "SkyConnect v1.0",
         "device": "/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
@@ -281,13 +281,16 @@ async def test_bad_config_entry_fixing(hass: HomeAssistant) -> None:
 
     assert hass.config_entries.async_get_entry(new_entry.entry_id) is not None
     assert hass.config_entries.async_get_entry(old_entry.entry_id) is not None
-    assert hass.config_entries.async_get_entry(bad_entry.entry_id) is None
     assert hass.config_entries.async_get_entry(fixable_entry.entry_id) is not None
 
     updated_entry = hass.config_entries.async_get_entry(fixable_entry.entry_id)
+    assert updated_entry is not None
     assert updated_entry.data[VID] == "10C4"
     assert updated_entry.data[PID] == "EA60"
     assert updated_entry.data[SERIAL_NUMBER] == "4f5f3b26d59f8714a78b599690741999"
     assert updated_entry.data[MANUFACTURER] == "Nabu Casa"
     assert updated_entry.data[PRODUCT] == "SkyConnect v1.0"
     assert updated_entry.data[DESCRIPTION] == "SkyConnect v1.0"
+
+    untouched_bad_entry = hass.config_entries.async_get_entry(bad_entry.entry_id)
+    assert untouched_bad_entry.minor_version == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Old SkyConnect config entries were created without any information beyond the serial port path. This causes the integration to fail to start up, since we rely on this data when creating entities and device registry entries.

To fix this, this PR performs an in-place data migration or config entry deletion:
1. If the device is available, we fix the config entry and allow it to load.
2. If the device is unavailable, we delete the config entry.

A future PR will auto-setup the ZBT-1, SkyConnect, and Yellow config entries (skipping discovery) if they are detected to be in use by ZHA or OTBR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #141744
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
