### PR TITLE
Validate MQTT device tracker location data before assigning

### DIFF
--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -184,15 +184,25 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
                     extra_state_attributes,
                 )
 
-            self._attr_location_accuracy = (
-                gps_accuracy
-                if ATTR_GPS_ACCURACY in extra_state_attributes
-                and isinstance(
+            if ATTR_GPS_ACCURACY in extra_state_attributes:
+                if isinstance(
                     gps_accuracy := extra_state_attributes[ATTR_GPS_ACCURACY],
                     (int, float),
-                )
-                else 0
-            )
+                ):
+                    self._attr_location_accuracy = gps_accuracy
+                else:
+                    _LOGGER.warning(
+                        "Extra state attributes received at % and template %s "
+                        "contain invalid GPS accuracy setting, "
+                        "gps_accuracy was set to 0 as the default. Got %s",
+                        self._config.get(CONF_JSON_ATTRS_TEMPLATE),
+                        self._config.get(CONF_JSON_ATTRS_TOPIC),
+                        extra_state_attributes,
+                    )
+                    self._attr_location_accuracy = 0
+
+            else:
+                self._attr_location_accuracy = 0
 
         self._attr_extra_state_attributes = {
             attribute: value

--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -28,7 +28,12 @@ from homeassistant.helpers.typing import ConfigType, VolSchemaType
 
 from . import subscription
 from .config import MQTT_BASE_SCHEMA
-from .const import CONF_JSON_ATTRS_TOPIC, CONF_PAYLOAD_RESET, CONF_STATE_TOPIC
+from .const import (
+    CONF_JSON_ATTRS_TEMPLATE,
+    CONF_JSON_ATTRS_TOPIC,
+    CONF_PAYLOAD_RESET,
+    CONF_STATE_TOPIC,
+)
 from .entity import MqttEntity, async_setup_entity_entry_helper
 from .models import MqttValueTemplate, ReceiveMessage
 from .schemas import MQTT_ENTITY_COMMON_SCHEMA
@@ -151,16 +156,44 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
         self, extra_state_attributes: dict[str, Any]
     ) -> None:
         """Extract the location from the extra state attributes."""
-        self._attr_latitude = extra_state_attributes.get(ATTR_LATITUDE)
-        self._attr_longitude = extra_state_attributes.get(ATTR_LONGITUDE)
         if (
             ATTR_LATITUDE in extra_state_attributes
             or ATTR_LONGITUDE in extra_state_attributes
         ):
-            # Reset manual set location
+            latitude: float | None
+            longitude: float | None
+            gps_accuracy: int
+            # Reset manually set location to allow automatic zone detection
             self._attr_location_name = None
+            if isinstance(
+                latitude := extra_state_attributes.get(ATTR_LATITUDE), (int, float)
+            ) and isinstance(
+                longitude := extra_state_attributes.get(ATTR_LONGITUDE), (int, float)
+            ):
+                self._attr_latitude = latitude
+                self._attr_longitude = longitude
+            else:
+                # Invalid or incomplete coordinates, reset location
+                self._attr_latitude = None
+                self._attr_longitude = None
+                _LOGGER.warning(
+                    "Extra state attributes received at % and template %s "
+                    "contain invalid or incomplete location info. Got %s",
+                    self._config.get(CONF_JSON_ATTRS_TEMPLATE),
+                    self._config.get(CONF_JSON_ATTRS_TOPIC),
+                    extra_state_attributes,
+                )
 
-        self._attr_location_accuracy = extra_state_attributes.get(ATTR_GPS_ACCURACY, 0)
+            self._attr_location_accuracy = (
+                gps_accuracy
+                if ATTR_GPS_ACCURACY in extra_state_attributes
+                and isinstance(
+                    gps_accuracy := extra_state_attributes[ATTR_GPS_ACCURACY],
+                    (int, float),
+                )
+                else 0
+            )
+
         self._attr_extra_state_attributes = {
             attribute: value
             for attribute, value in extra_state_attributes.items()

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -450,14 +450,82 @@ async def test_setting_device_tracker_location_via_lat_lon_message(
     assert state.attributes["latitude"] == 50.1
     assert state.attributes["longitude"] == -2.1
     assert state.attributes["gps_accuracy"] == 0
+    assert state.attributes["source_type"] == "gps"
     assert state.state == STATE_NOT_HOME
 
+    # incomplete coordinates results in unknown state
     async_fire_mqtt_message(hass, "attributes-topic", '{"longitude": -117.22743}')
     state = hass.states.get("device_tracker.test")
+    assert "latitude" not in state.attributes
+    assert "longitude" not in state.attributes
+    assert state.attributes["source_type"] == "gps"
     assert state.state == STATE_UNKNOWN
 
     async_fire_mqtt_message(hass, "attributes-topic", '{"latitude":32.87336}')
     state = hass.states.get("device_tracker.test")
+    assert "latitude" not in state.attributes
+    assert "longitude" not in state.attributes
+    assert state.attributes["source_type"] == "gps"
+    assert state.state == STATE_UNKNOWN
+
+    # invalid coordinates results in unknown state
+    async_fire_mqtt_message(
+        hass, "attributes-topic", '{"longitude": -117.22743, "latitude":null}'
+    )
+    state = hass.states.get("device_tracker.test")
+    assert "latitude" not in state.attributes
+    assert "longitude" not in state.attributes
+    assert state.attributes["source_type"] == "gps"
+    assert state.state == STATE_UNKNOWN
+
+    # Test number validation
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude": "32.87336","longitude": "-117.22743", "gps_accuracy": "1.5", "source_type": "router"}',
+    )
+    state = hass.states.get("device_tracker.test")
+    assert "latitude" not in state.attributes
+    assert "longitude" not in state.attributes
+    assert "gps_accuracy" not in state.attributes
+    # assert source_type is overridden by discovery
+    assert state.attributes["source_type"] == "router"
+    assert state.state == STATE_UNKNOWN
+
+    # Test with invalid GPS accuracy should default to 0,
+    # but location updates as expected
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude": 32.871234,"longitude": -117.21234, "gps_accuracy": "invalid", "source_type": "router"}',
+    )
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_NOT_HOME
+    assert state.attributes["latitude"] == 32.871234
+    assert state.attributes["longitude"] == -117.21234
+    assert state.attributes["gps_accuracy"] == 0
+    assert state.attributes["source_type"] == "router"
+
+    # Test with invalid latitude
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude": null,"longitude": "-117.22743", "gps_accuracy": 1, "source_type": "router"}',
+    )
+    state = hass.states.get("device_tracker.test")
+    assert "latitude" not in state.attributes
+    assert "longitude" not in state.attributes
+    assert state.state == STATE_UNKNOWN
+
+    # Test with invalid longitude
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude": 32.87336,"longitude": "unknown", "gps_accuracy": 1, "source_type": "router"}',
+    )
+    state = hass.states.get("device_tracker.test")
+    assert "latitude" not in state.attributes
+    assert "longitude" not in state.attributes
     assert state.state == STATE_UNKNOWN
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT device tracker should validate `longitude`, `latitude` and `gps_accuracy` before assigning the properties.
Strings would case zone calculation to fail.

The location attributes from the received JSON extra state properties, but these need extra validation, other attributes are stored as extra state attributes.

Needs: ~https://github.com/home-assistant/core/pull/142671~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #141224
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
