### PR TITLE
Allow excluding modules from noisy logs check

### DIFF
--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -29,16 +29,21 @@ class HomeAssistantQueueListener(logging.handlers.QueueListener):
     LOG_COUNTS_RESET_INTERVAL = 300
     MAX_LOGS_COUNT = 200
 
+    EXCLUDED_LOG_COUNT_MODULES = [
+        "homeassistant.setup",
+        "homeassistant.components.automation",
+        "homeassistant.components.script",
+    ]
+
     _last_reset: float
     _log_counts: dict[str, int]
-    _warned_modules: set[str]
 
     def __init__(
         self, queue: SimpleQueue[logging.Handler], *handlers: logging.Handler
     ) -> None:
         """Initialize the handler."""
         super().__init__(queue, *handlers)
-        self._warned_modules = set()
+        self._module_log_count_skip_flags: dict[str, bool] = {__name__: True}
         self._reset_counters(time.time())
 
     @override
@@ -53,7 +58,7 @@ class HomeAssistantQueueListener(logging.handlers.QueueListener):
             self._reset_counters(record.created)
 
         module_name = record.name
-        if module_name == __name__ or module_name in self._warned_modules:
+        if self._check_skip_flag(module_name):
             return
 
         self._log_counts[module_name] += 1
@@ -66,12 +71,25 @@ class HomeAssistantQueueListener(logging.handlers.QueueListener):
             module_name,
             module_count,
         )
-        self._warned_modules.add(module_name)
+        self._module_log_count_skip_flags[module_name] = True
 
     def _reset_counters(self, time_sec: float) -> None:
         _LOGGER.debug("Resetting log counters")
         self._last_reset = time_sec
         self._log_counts = defaultdict(int)
+
+    def _check_skip_flag(self, module_name: str) -> bool:
+        skip_flag: bool | None = self._module_log_count_skip_flags.get(module_name)
+        if skip_flag:
+            return True
+
+        if skip_flag is None and any(
+            module_name.startswith(prefix) for prefix in self.EXCLUDED_LOG_COUNT_MODULES
+        ):
+            self._module_log_count_skip_flags[module_name] = True
+            return True
+
+        return False
 
 
 class HomeAssistantQueueHandler(logging.handlers.QueueHandler):

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -60,13 +60,11 @@ class HomeAssistantQueueListener(logging.handlers.QueueListener):
 
         module_name = record.name
 
-        skip_flag: bool | None = self._module_log_count_skip_flags.get(module_name)
-        if skip_flag:
+        if skip_flag := self._module_log_count_skip_flags.get(module_name):
             return
 
-        if skip_flag is None:
-            if self._update_skip_flags(module_name):
-                return
+        if skip_flag is None and self._update_skip_flags(module_name):
+            return
 
         self._log_counts[module_name] += 1
         module_count = self._log_counts[module_name]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As discussed with the Core team, this adds an exclude list to avoid having to reduce the log level to debug for things that could be important to keep at info, but which could be frequently logged by its nature, such as automations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
