### PR TITLE
Fix entity names for HA hardware firmware update entities

### DIFF
--- a/homeassistant/components/homeassistant_hardware/update.py
+++ b/homeassistant/components/homeassistant_hardware/update.py
@@ -95,8 +95,7 @@ class BaseFirmwareUpdateEntity(
     _attr_supported_features = (
         UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
     )
-    # Until this entity can be associated with a device, we must manually name it
-    _attr_has_entity_name = False
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -195,10 +194,6 @@ class BaseFirmwareUpdateEntity(
 
     def _update_attributes(self) -> None:
         """Recompute the attributes of the entity."""
-
-        # This entity is not currently associated with a device so we must manually
-        # give it a name
-        self._attr_name = f"{self._config_entry.title} Update"
         self._attr_title = self.entity_description.firmware_name or "Unknown"
 
         if (

--- a/homeassistant/components/homeassistant_sky_connect/update.py
+++ b/homeassistant/components/homeassistant_sky_connect/update.py
@@ -168,7 +168,6 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
     """SkyConnect firmware update entity."""
 
     bootloader_reset_type = None
-    _attr_has_entity_name = True
 
     def __init__(
         self,

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -152,7 +152,7 @@
   },
   "entity": {
     "update": {
-      "firmware": {
+      "radio_firmware": {
         "name": "Radio firmware"
       }
     }

--- a/homeassistant/components/homeassistant_yellow/update.py
+++ b/homeassistant/components/homeassistant_yellow/update.py
@@ -44,6 +44,7 @@ FIRMWARE_ENTITY_DESCRIPTIONS: dict[
 ] = {
     ApplicationType.EZSP: FirmwareUpdateEntityDescription(
         key="radio_firmware",
+        translation_key="radio_firmware",
         display_precision=0,
         device_class=UpdateDeviceClass.FIRMWARE,
         entity_category=EntityCategory.CONFIG,
@@ -55,6 +56,7 @@ FIRMWARE_ENTITY_DESCRIPTIONS: dict[
     ),
     ApplicationType.SPINEL: FirmwareUpdateEntityDescription(
         key="radio_firmware",
+        translation_key="radio_firmware",
         display_precision=0,
         device_class=UpdateDeviceClass.FIRMWARE,
         entity_category=EntityCategory.CONFIG,
@@ -65,7 +67,8 @@ FIRMWARE_ENTITY_DESCRIPTIONS: dict[
         firmware_name="OpenThread RCP",
     ),
     ApplicationType.CPC: FirmwareUpdateEntityDescription(
-        key="firmware",
+        key="radio_firmware",
+        translation_key="radio_firmware",
         display_precision=0,
         device_class=UpdateDeviceClass.FIRMWARE,
         entity_category=EntityCategory.CONFIG,
@@ -76,7 +79,8 @@ FIRMWARE_ENTITY_DESCRIPTIONS: dict[
         firmware_name="Multiprotocol",
     ),
     ApplicationType.GECKO_BOOTLOADER: FirmwareUpdateEntityDescription(
-        key="firmware",
+        key="radio_firmware",
+        translation_key="radio_firmware",
         display_precision=0,
         device_class=UpdateDeviceClass.FIRMWARE,
         entity_category=EntityCategory.CONFIG,
@@ -88,6 +92,7 @@ FIRMWARE_ENTITY_DESCRIPTIONS: dict[
     ),
     None: FirmwareUpdateEntityDescription(
         key="radio_firmware",
+        translation_key="radio_firmware",
         display_precision=0,
         device_class=UpdateDeviceClass.FIRMWARE,
         entity_category=EntityCategory.CONFIG,
@@ -168,7 +173,6 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
     """Yellow firmware update entity."""
 
     bootloader_reset_type = "yellow"  # Triggers a GPIO reset
-    _attr_has_entity_name = True
 
     def __init__(
         self,

--- a/tests/components/homeassistant_hardware/test_update.py
+++ b/tests/components/homeassistant_hardware/test_update.py
@@ -43,6 +43,7 @@ from homeassistant.core import (
 )
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -61,7 +62,7 @@ from tests.common import (
 TEST_DOMAIN = "test"
 TEST_DEVICE = "/dev/serial/by-id/some-unique-serial-device-12345"
 TEST_FIRMWARE_RELEASES_URL = "https://example.org/firmware"
-TEST_UPDATE_ENTITY_ID = "update.test_firmware"
+TEST_UPDATE_ENTITY_ID = "update.mock_name_firmware"
 TEST_MANIFEST = FirmwareManifest(
     url=URL("https://example.org/firmware"),
     html_url=URL("https://example.org/release_notes"),
@@ -205,6 +206,12 @@ class MockFirmwareUpdateEntity(BaseFirmwareUpdateEntity):
         """Initialize the mock SkyConnect firmware update entity."""
         super().__init__(device, config_entry, update_coordinator, entity_description)
         self._attr_unique_id = self.entity_description.key
+        self._attr_device_info = DeviceInfo(
+            identifiers={(TEST_DOMAIN, "yellow")},
+            name="Mock Name",
+            model="Mock Model",
+            manufacturer="Mock Manufacturer",
+        )
 
         # Use the cached firmware info if it exists
         if self._config_entry.data["firmware"] is not None:

--- a/tests/components/homeassistant_yellow/test_update.py
+++ b/tests/components/homeassistant_yellow/test_update.py
@@ -17,7 +17,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
-UPDATE_ENTITY_ID = "update.home_assistant_yellow_firmware"
+UPDATE_ENTITY_ID = "update.home_assistant_yellow_radio_firmware"
 
 
 async def test_yellow_update_entity(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We were still setting `_attr_name` in the firmware update entity, which is not correct. I've updated the translation keys for both devices so the names will show up properly. The Yellow uses "Radio firmware" instead of "Firmware":

<img width="528" alt="image" src="https://github.com/user-attachments/assets/5e9d2cc7-703f-4fc0-aa05-36fb82be47a7" />
<img width="314" alt="image" src="https://github.com/user-attachments/assets/eace6847-78af-44ac-9bb5-96ea3e5396d1" />
<img width="502" alt="image" src="https://github.com/user-attachments/assets/c15c534a-6a13-413b-aa67-7a0dd6ba51c1" />
<img width="262" alt="image" src="https://github.com/user-attachments/assets/59ea91a8-7cdd-4b26-bcf1-44d9f0600f2d" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
