### PR TITLE
Deprecate None effect instead of breaking it for Hue

### DIFF
--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -197,5 +197,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "deprecated_effect_none": {
+      "title": "Light turned on with deprecated effect",
+      "description": "A light was turned on with the deprecated effect `None`. This has been replaced with `off`. Please update any automations, scenes, or scripts that use this effect."
+    }
   }
 }

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -28,6 +28,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import color as color_util
 
@@ -241,7 +242,7 @@ class HueLight(HueBaseEntity, LightEntity):
             effect_str = EFFECT_OFF
             self.logger.warning(
                 "Detected deprecated effect 'None' in %s, use 'off' instead. "
-                "This will stop working in a future version.",
+                "This will stop working in HA 2025.12",
                 self.entity_id,
             )
         if effect_str == EFFECT_OFF:
@@ -258,6 +259,11 @@ class HueLight(HueBaseEntity, LightEntity):
                 if transition is None:
                     # a transition is required for timed effect, default to 10 minutes
                     transition = 600000
+                if effect == TimedEffectStatus.UNKNOWN:
+                    # guard against invalid effect value
+                    raise HomeAssistantError(
+                        f"Effect {effect_str} is invalid for {self.entity_id}"
+                    )
             # we need to clear color values if an effect is applied
             color_temp = None
             xy_color = None

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -28,7 +28,6 @@ from homeassistant.components.light import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import color as color_util
 
@@ -259,11 +258,6 @@ class HueLight(HueBaseEntity, LightEntity):
                 if transition is None:
                     # a transition is required for timed effect, default to 10 minutes
                     transition = 600000
-                if effect == TimedEffectStatus.UNKNOWN:
-                    # guard against invalid effect value
-                    raise HomeAssistantError(
-                        f"Effect {effect_str} is invalid for {self.entity_id}"
-                    )
             # we need to clear color values if an effect is applied
             color_temp = None
             xy_color = None

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -29,6 +29,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.util import color as color_util
 
 from ..bridge import HueBridge
@@ -239,9 +240,18 @@ class HueLight(HueBaseEntity, LightEntity):
         if effect_str == DEPRECATED_EFFECT_NONE:
             # deprecated effect "None" is now "off"
             effect_str = EFFECT_OFF
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                "deprecated_effect_none",
+                breaks_in_ha_version="2025.10.0",
+                is_fixable=False,
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecated_effect_none",
+            )
             self.logger.warning(
                 "Detected deprecated effect 'None' in %s, use 'off' instead. "
-                "This will stop working in HA 2025.12",
+                "This will stop working in HA 2025.10",
                 self.entity_id,
             )
         if effect_str == EFFECT_OFF:

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -44,6 +44,9 @@ FALLBACK_MIN_KELVIN = 6500
 FALLBACK_MAX_KELVIN = 2000
 FALLBACK_KELVIN = 5800  # halfway
 
+# HA 2025.4 replaced the deprecated effect "None" with HA default "off"
+DEPRECATED_EFFECT_NONE = "None"
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -233,6 +236,14 @@ class HueLight(HueBaseEntity, LightEntity):
         self._color_temp_active = color_temp is not None
         flash = kwargs.get(ATTR_FLASH)
         effect = effect_str = kwargs.get(ATTR_EFFECT)
+        if effect_str == DEPRECATED_EFFECT_NONE:
+            # deprecated effect "None" is now "off"
+            effect_str = EFFECT_OFF
+            self.logger.warning(
+                "Detected deprecated effect 'None' in %s, use 'off' instead. "
+                "This will stop working in a future version.",
+                self.entity_id,
+            )
         if effect_str == EFFECT_OFF:
             # ignore effect if set to "off" and we have no effect active
             # the special effect "off" is only used to stop an active effect

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -3,8 +3,6 @@
 from unittest.mock import Mock
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS_PCT,
-    ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     DOMAIN as LIGHT_DOMAIN,
     ColorMode,
@@ -661,18 +659,6 @@ async def test_light_turn_on_service_deprecation(
 
     await setup_platform(hass, mock_bridge_v2, "light")
 
-    # now call the HA turn_on service
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {
-            ATTR_ENTITY_ID: test_light_id,
-            ATTR_BRIGHTNESS_PCT: 100,
-            ATTR_COLOR_TEMP_KELVIN: 300,
-        },
-        blocking=True,
-    )
-
     event = {
         "id": "3a6710fa-4474-4eba-b533-5e6e72968feb",
         "type": "light",
@@ -692,4 +678,4 @@ async def test_light_turn_on_service_deprecation(
         },
         blocking=True,
     )
-    assert mock_bridge_v2.mock_requests[1]["json"]["effects"]["effect"] == "no_effect"
+    assert mock_bridge_v2.mock_requests[0]["json"]["effects"]["effect"] == "no_effect"

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -2,9 +2,14 @@
 
 from unittest.mock import Mock
 
-from homeassistant.components.light import ColorMode
+from homeassistant.components.light import (
+    ATTR_EFFECT,
+    DOMAIN as LIGHT_DOMAIN,
+    ColorMode,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.util.json import JsonArrayType
 
 from .conftest import setup_platform
@@ -639,3 +644,28 @@ async def test_grouped_lights(
             mock_bridge_v2.mock_requests[index]["json"]["identify"]["action"]
             == "identify"
         )
+
+
+async def test_light_turn_on_service_deprecation(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test calling the turn on service on a light."""
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+
+    await setup_platform(hass, mock_bridge_v2, "light")
+
+    # test disable effect
+    # it should send a request with effect set to "no_effect"
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.hue_light_with_color_temperature_only",
+            ATTR_EFFECT: "None",
+        },
+        blocking=True,
+    )
+    assert mock_bridge_v2.mock_requests[0]["json"]["effects"]["effect"] == "no_effect"


### PR DESCRIPTION
## Proposed change

We introduced a breaking change by no longer allowing the effect "None" for Hue lights which in general would be fine for manual commands (as its user friendly replaced now with HA's builtin "off") but we didn't realize existing scenes need to be updated.

Instead of breaking this now, deprecate it in 2 steps.
For this release, log a warning in the log.
For the next release, issue a repair issue.
Remove the workaround in 2025.12

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #141758
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
