### PR TITLE
Populate hvac_modes list in opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -75,7 +75,7 @@ class OpenThermClimate(OpenThermStatusEntity, ClimateEntity):
         ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
     )
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_hvac_modes = []
+    _attr_hvac_modes = [HVACMode.HEAT]
     _attr_name = None
     _attr_preset_modes = []
     _attr_min_temp = 1
@@ -129,9 +129,11 @@ class OpenThermClimate(OpenThermStatusEntity, ClimateEntity):
         if ch_active and flame_on:
             self._attr_hvac_action = HVACAction.HEATING
             self._attr_hvac_mode = HVACMode.HEAT
+            self._attr_hvac_modes = [HVACMode.HEAT]
         elif cooling_active:
             self._attr_hvac_action = HVACAction.COOLING
             self._attr_hvac_mode = HVACMode.COOL
+            self._attr_hvac_modes = [HVACMode.COOL]
         else:
             self._attr_hvac_action = HVACAction.IDLE
 
@@ -181,6 +183,10 @@ class OpenThermClimate(OpenThermStatusEntity, ClimateEntity):
         if self._away_state_a or self._away_state_b:
             return PRESET_AWAY
         return PRESET_NONE
+
+    def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target hvac mode."""
+        _LOGGER.warning("Changing HVAC mode is not supported")
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -21,6 +21,7 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, CONF_ID, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -30,6 +31,7 @@ from .const import (
     CONF_SET_PRECISION,
     DATA_GATEWAYS,
     DATA_OPENTHERM_GW,
+    DOMAIN,
     THERMOSTAT_DEVICE_DESCRIPTION,
     OpenThermDataSource,
 )
@@ -186,7 +188,10 @@ class OpenThermClimate(OpenThermStatusEntity, ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        _LOGGER.warning("Changing HVAC mode is not supported")
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="change_hvac_mode_not_supported",
+        )
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -371,6 +371,11 @@
       }
     }
   },
+  "exceptions": {
+    "change_hvac_mode_not_supported": {
+      "message": "Changing HVAC mode is not supported."
+    }
+  },
   "services": {
     "reset_gateway": {
       "name": "Reset gateway",

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -355,6 +355,9 @@
     }
   },
   "exceptions": {
+    "change_hvac_mode_not_supported": {
+      "message": "Changing HVAC mode is not supported."
+    },
     "invalid_gateway_id": {
       "message": "Gateway {gw_id} not found or not loaded!"
     }
@@ -369,11 +372,6 @@
           "temporary_override_mode": "Temporary Setpoint Override Mode"
         }
       }
-    }
-  },
-  "exceptions": {
-    "change_hvac_mode_not_supported": {
-      "message": "Changing HVAC mode is not supported."
     }
   },
   "services": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Home Assistant's `climate` platform uses the HVAC Mode as the main state indicator. Within the OpenTherm Gateway and the OpenTherm protocol, there is no such thing as an HVAC Mode. As a result, we can not set an HVAC Mode, we can only infer the current mode used by the thermostat from the information we do have.
Since we can not set an HVAC Mode, the `hvac_modes` list was left empty to prevent the UI from showing the related buttons and modes in the climate card. When #125178 was implemented, this caused an issue (#141749) when taking a snapshot that includes the climate entity.
This PR aims to fix the snapshot issue while leaving other functionality intact (i.e. not a breaking change) by populating the `hvac_modes` list dynamically with only the currently active mode. This allows taking a snapshot without adding non-functional buttons to the climate card in the UI.
With this PR, we may still see errors when restoring a snapshot. If, for example, we take a snapshot while `HVACMode.HEAT` is active and restore it when `HVACMode.COOL` is active and thus the only item in the `hvac_modes` list then the `climate` platform will not be able to validate the HVACMode. Preventing that would require either a breaking change in the integration or an architectural change in the `climate` platform, or add non-functional buttons to the UI. As the OpenTherm Gateway is most popular in parts of Europe where cooling thermostats are relatively uncommon, most users will not encounter this issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #141749
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
