### PR TITLE
Don't hardcode cloud/default_config as the only possible OAuth provider

### DIFF
--- a/homeassistant/components/smartthings/config_flow.py
+++ b/homeassistant/components/smartthings/config_flow.py
@@ -9,7 +9,10 @@ from pysmartthings import SmartThings
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2FlowHandler
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    AbstractOAuth2FlowHandler,
+    async_get_implementations,
+)
 
 from .const import CONF_LOCATION_ID, DOMAIN, OLD_DATA, REQUESTED_SCOPES, SCOPES
 
@@ -36,8 +39,9 @@ class SmartThingsConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Check we have the cloud integration set up."""
-        if "cloud" not in self.hass.config.components:
+        """Check for any OAuth implementations before asking for cloud."""
+        implementations = await async_get_implementations(self.hass, self.DOMAIN)
+        if not implementations:
             return self.async_abort(
                 reason="cloud_not_enabled",
                 description_placeholders={"default_config": "default_config"},

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -231,6 +231,7 @@ async def test_duplicate_entry(
 
 
 @pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.no_oauth_credentials
 async def test_no_cloud(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
@@ -238,7 +239,7 @@ async def test_no_cloud(
     mock_smartthings: AsyncMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Check we abort when cloud is not enabled."""
+    """Check if we abort when no OAuth implementations are available."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -412,6 +413,7 @@ async def test_reauth_account_mismatch(
 
 
 @pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.no_oauth_credentials
 async def test_reauthentication_no_cloud(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
@@ -590,6 +592,7 @@ async def test_migration_wrong_location(
 
 
 @pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.no_oauth_credentials
 async def test_migration_no_cloud(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,


### PR DESCRIPTION
## Proposed change

SmartThings integration currently only allows `cloud` as the only OAuth provider (enforced in #139700 due to #133623). 

Instead of hardcoding `default_config` (by the way, shouldn't it be `cloud` in the error message?), let's first check if this really doesn't work before showing prompt. I know configs without `default_config` are not supported by HA, but this way we can give some flexibility while still solving the original problem.

TL;DR: with this change, the dialog about `default_config` still shows up if `cloud` is not in the config. It just allows to get past this check if alternative OAuth provider is present.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #133623
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
