### PR TITLE
Hide broken ZBT-1 config entries on the hardware page

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/hardware.py
+++ b/homeassistant/components/homeassistant_sky_connect/hardware.py
@@ -20,14 +20,8 @@ EXPECTED_ENTRY_VERSION = (
 def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
     """Return board info."""
     entries = hass.config_entries.async_entries(DOMAIN)
-    info = []
-
-    for entry in entries:
-        # Ignore unmigrated config entries in the hardware page
-        if (entry.version, entry.minor_version) < EXPECTED_ENTRY_VERSION:
-            continue
-
-        hw_info = HardwareInfo(
+    return [
+        HardwareInfo(
             board=None,
             config_entries=[entry.entry_id],
             dongle=USBInfo(
@@ -40,7 +34,7 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
             name=get_hardware_variant(entry).full_name,
             url=DOCUMENTATION_URL,
         )
-
-        info.append(hw_info)
-
-    return info
+        for entry in entries
+        # Ignore unmigrated config entries in the hardware page
+        if (entry.version, entry.minor_version) < EXPECTED_ENTRY_VERSION
+    ]

--- a/homeassistant/components/homeassistant_sky_connect/hardware.py
+++ b/homeassistant/components/homeassistant_sky_connect/hardware.py
@@ -6,7 +6,7 @@ from homeassistant.components.hardware.models import HardwareInfo, USBInfo
 from homeassistant.core import HomeAssistant, callback
 
 from .config_flow import HomeAssistantSkyConnectConfigFlow
-from .const import DOMAIN, MANUFACTURER, PID, PRODUCT, SERIAL_NUMBER, VID
+from .const import DOMAIN
 from .util import get_hardware_variant
 
 DOCUMENTATION_URL = "https://skyconnect.home-assistant.io/documentation/"
@@ -25,11 +25,11 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
             board=None,
             config_entries=[entry.entry_id],
             dongle=USBInfo(
-                vid=entry.data[VID],
-                pid=entry.data[PID],
-                serial_number=entry.data[SERIAL_NUMBER],
-                manufacturer=entry.data[MANUFACTURER],
-                description=entry.data[PRODUCT],
+                vid=entry.data["vid"],
+                pid=entry.data["pid"],
+                serial_number=entry.data["serial_number"],
+                manufacturer=entry.data["manufacturer"],
+                description=entry.data["product"],
             ),
             name=get_hardware_variant(entry).full_name,
             url=DOCUMENTATION_URL,

--- a/homeassistant/components/homeassistant_sky_connect/hardware.py
+++ b/homeassistant/components/homeassistant_sky_connect/hardware.py
@@ -36,5 +36,5 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
         )
         for entry in entries
         # Ignore unmigrated config entries in the hardware page
-        if (entry.version, entry.minor_version) < EXPECTED_ENTRY_VERSION
+        if (entry.version, entry.minor_version) == EXPECTED_ENTRY_VERSION
     ]

--- a/tests/components/homeassistant_sky_connect/test_hardware.py
+++ b/tests/components/homeassistant_sky_connect/test_hardware.py
@@ -28,6 +28,10 @@ CONFIG_ENTRY_DATA_2 = {
     "firmware": "ezsp",
 }
 
+CONFIG_ENTRY_DATA_BAD = {
+    "device": "/dev/serial/by-id/usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1_a87b7d75b18beb119fe564a0f320645d-if00-port0",
+}
+
 
 async def test_hardware_info(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, addon_store_info
@@ -59,8 +63,18 @@ async def test_hardware_info(
         minor_version=2,
     )
     config_entry_2.add_to_hass(hass)
-
     assert await hass.config_entries.async_setup(config_entry_2.entry_id)
+
+    config_entry_bad = MockConfigEntry(
+        data=CONFIG_ENTRY_DATA_BAD,
+        domain=DOMAIN,
+        options={},
+        title="Home Assistant Connect ZBT-1",
+        unique_id="unique_3",
+        version=1,
+        minor_version=2,
+    )
+    config_entry_bad.add_to_hass(hass)
 
     client = await hass_ws_client(hass)
 
@@ -97,5 +111,6 @@ async def test_hardware_info(
                 "name": "Home Assistant Connect ZBT-1",
                 "url": "https://skyconnect.home-assistant.io/documentation/",
             },
+            # Bad entry is skipped
         ]
     }

--- a/tests/components/homeassistant_sky_connect/test_hardware.py
+++ b/tests/components/homeassistant_sky_connect/test_hardware.py
@@ -75,6 +75,7 @@ async def test_hardware_info(
         minor_version=2,
     )
     config_entry_bad.add_to_hass(hass)
+    assert not await hass.config_entries.async_setup(config_entry_bad.entry_id)
 
     client = await hass_ws_client(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Unmigrated ZBT-1 config entries crash the hardware page. This was present in all earlier releases but https://github.com/home-assistant/core/pull/141959 did not fix the frontend issue.

This PR hides them from the output of `homeassistant_sky_connect.hardware.async_info(hass)`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #141744
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
