### PR TITLE
Abort if a flow is removed during a step

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1511,12 +1511,6 @@ class ConfigEntriesFlowManager(
     ) -> None:
         """Clean up after a config flow."""
 
-        # Mark the step as done.
-        # We do this to avoid a circular dependency where async_finish_flow sets up a
-        # new entry, which needs the integration to be set up, which is waiting for
-        # init to be done.
-        self._set_pending_import_done(flow)
-
         # Clean up issue if this is a reauth flow
         if flow.context["source"] == SOURCE_REAUTH:
             if (entry_id := flow.context.get("entry_id")) is not None and (
@@ -1587,6 +1581,12 @@ class ConfigEntriesFlowManager(
 
         if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
+
+        # Mark the step as done.
+        # We do this to avoid a circular dependency where async_finish_flow sets up a
+        # new entry, which needs the integration to be set up, which is waiting for
+        # init to be done.
+        self._set_pending_import_done(flow)
 
         # Avoid adding a config entry for a integration
         # that only supports a single config entry, but already has an entry

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1395,9 +1395,7 @@ async def test_reauth_issue_flow_aborted(
     issue = await _test_reauth_issue(hass, manager, issue_registry)
 
     manager.flow.async_abort(issue.data["flow_id"])
-    # This can be considered a bug, we should make sure the issue is always
-    # removed when the reauth flow is aborted.
-    assert len(issue_registry.issues) == 1
+    assert len(issue_registry.issues) == 0
 
 
 async def _test_reauth_issue(

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -305,13 +305,7 @@ async def test_create_saves_data(manager: MockFlowManager) -> None:
 
 
 async def test_create_aborted_flow(manager: MockFlowManager) -> None:
-    """Test return create_entry from aborted flow.
-
-    Note: The entry is created even if the flow is already aborted, then the
-    flow raises an UnknownFlow exception. This behavior is not logical, and
-    we should consider changing it to not create the entry if the flow is
-    aborted.
-    """
+    """Test return create_entry from aborted flow."""
 
     @manager.mock_reg_handler("test")
     class TestFlow(data_entry_flow.FlowHandler):
@@ -325,14 +319,8 @@ async def test_create_aborted_flow(manager: MockFlowManager) -> None:
         await manager.async_init("test")
     assert len(manager.async_progress()) == 0
 
-    # The entry is created even if the flow is aborted
-    assert len(manager.mock_created_entries) == 1
-
-    entry = manager.mock_created_entries[0]
-    assert entry["handler"] == "test"
-    assert entry["title"] == "Test Title"
-    assert entry["data"] == "Test Data"
-    assert entry["source"] is None
+    # No entry should be created if the flow is aborted
+    assert len(manager.mock_created_entries) == 0
 
 
 async def test_create_calls_async_flow_removed(manager: MockFlowManager) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Abort early if a flow is removed during a step, instead of going ahead creating an entry

To still give flow managers the opportunity to clean up, a new method `FlowManager.async_flow_removed` is added, which is meant to be implemented by classed derived from `FlowManager`.

In this PR, an `async_flow_removed` method is added to `ConfigEntriesFlowManager`, the method cleans up reauth issues which ensures reauth issues are always cleaned up when a reauth flow is aborted, not only if the reauth flow returns abort.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
