### PR TITLE
Do not fetch disconnected Home Connect appliances

### DIFF
--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -75,7 +75,7 @@ class HomeConnectApplianceData:
         self.status.update(other.status)
 
     @classmethod
-    def Empty(cls, appliance: HomeAppliance) -> HomeConnectApplianceData:
+    def empty(cls, appliance: HomeAppliance) -> HomeConnectApplianceData:
         """Return empty data."""
         return cls(
             commands=set(),
@@ -375,7 +375,7 @@ class HomeConnectCoordinator(
                 model=appliance.vib,
             )
             if appliance.ha_id not in self.data:
-                self.data[appliance.ha_id] = HomeConnectApplianceData.Empty(appliance)
+                self.data[appliance.ha_id] = HomeConnectApplianceData.empty(appliance)
             else:
                 self.data[appliance.ha_id].info.connected = appliance.connected
                 old_appliances.remove(appliance.ha_id)
@@ -419,7 +419,7 @@ class HomeConnectCoordinator(
             if appliance_data_to_update:
                 appliance_data_to_update.info.connected = False
                 return appliance_data_to_update
-            return HomeConnectApplianceData.Empty(appliance)
+            return HomeConnectApplianceData.empty(appliance)
         try:
             settings = {
                 setting.key: setting

--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -74,6 +74,19 @@ class HomeConnectApplianceData:
         self.settings.update(other.settings)
         self.status.update(other.status)
 
+    @classmethod
+    def Empty(cls, appliance: HomeAppliance) -> HomeConnectApplianceData:
+        """Return empty data."""
+        return cls(
+            commands=set(),
+            events={},
+            info=appliance,
+            options={},
+            programs=[],
+            settings={},
+            status={},
+        )
+
 
 class HomeConnectCoordinator(
     DataUpdateCoordinator[dict[str, HomeConnectApplianceData]]
@@ -362,15 +375,7 @@ class HomeConnectCoordinator(
                 model=appliance.vib,
             )
             if appliance.ha_id not in self.data:
-                self.data[appliance.ha_id] = HomeConnectApplianceData(
-                    commands=set(),
-                    events={},
-                    info=appliance,
-                    options={},
-                    programs=[],
-                    settings={},
-                    status={},
-                )
+                self.data[appliance.ha_id] = HomeConnectApplianceData.Empty(appliance)
             else:
                 self.data[appliance.ha_id].info.connected = appliance.connected
                 old_appliances.remove(appliance.ha_id)
@@ -406,6 +411,15 @@ class HomeConnectCoordinator(
             name=appliance.name,
             model=appliance.vib,
         )
+        if not appliance.connected:
+            _LOGGER.debug(
+                "Appliance %s is not connected, skipping data fetch",
+                appliance.ha_id,
+            )
+            if appliance_data_to_update:
+                appliance_data_to_update.info.connected = False
+                return appliance_data_to_update
+            return HomeConnectApplianceData.Empty(appliance)
         try:
             settings = {
                 setting.key: setting

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -54,6 +54,14 @@ from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
+INITIAL_FETCH_CLIENT_METHODS = [
+    "get_settings",
+    "get_status",
+    "get_all_programs",
+    "get_available_commands",
+    "get_available_program",
+]
+
 
 @pytest.fixture
 def platforms() -> list[str]:
@@ -215,14 +223,31 @@ async def test_coordinator_failure_refresh_and_stream(
 
 
 @pytest.mark.parametrize(
+    "appliance",
+    ["Dishwasher"],
+    indirect=True,
+)
+async def test_coordinator_not_fetching_on_disconnected_appliance(
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    setup_credentials: None,
+    client: MagicMock,
+    appliance: HomeAppliance,
+) -> None:
+    """Test that the coordinator does not fetch anything on disconnected appliance."""
+    appliance.connected = False
+
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    await integration_setup(client)
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    for method in INITIAL_FETCH_CLIENT_METHODS:
+        assert getattr(client, method).call_count == 0
+
+
+@pytest.mark.parametrize(
     "mock_method",
-    [
-        "get_settings",
-        "get_status",
-        "get_all_programs",
-        "get_available_commands",
-        "get_available_program",
-    ],
+    INITIAL_FETCH_CLIENT_METHODS,
 )
 async def test_coordinator_update_failing(
     mock_method: str,
@@ -552,3 +577,35 @@ async def test_devices_updated_on_refresh(
     assert not device_registry.async_get_device({(DOMAIN, appliances[0].ha_id)})
     for appliance in appliances[2:3]:
         assert device_registry.async_get_device({(DOMAIN, appliance.ha_id)})
+
+
+@pytest.mark.parametrize("appliance", ["Washer"], indirect=True)
+async def test_paired_disconnected_devices_not_fetching(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    setup_credentials: None,
+    client: MagicMock,
+    appliance: HomeAppliance,
+) -> None:
+    """Test that removed devices are correctly removed from and added to hass on API events."""
+    client.get_home_appliances = AsyncMock(return_value=ArrayOfHomeAppliances([]))
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert await integration_setup(client)
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    appliance.connected = False
+    await client.add_events(
+        [
+            EventMessage(
+                appliance.ha_id,
+                EventType.PAIRED,
+                data=ArrayOfEvents([]),
+            )
+        ]
+    )
+    await hass.async_block_till_done()
+
+    client.get_specific_appliance.assert_awaited_once_with(appliance.ha_id)
+    for method in INITIAL_FETCH_CLIENT_METHODS:
+        assert getattr(client, method).call_count == 0

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -588,7 +588,7 @@ async def test_paired_disconnected_devices_not_fetching(
     client: MagicMock,
     appliance: HomeAppliance,
 ) -> None:
-    """Test that Home Connect API is not fetch after pairing a disconnected device."""
+    """Test that Home Connect API is not fetched after pairing a disconnected device."""
     client.get_home_appliances = AsyncMock(return_value=ArrayOfHomeAppliances([]))
     assert config_entry.state == ConfigEntryState.NOT_LOADED
     assert await integration_setup(client)

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -588,7 +588,7 @@ async def test_paired_disconnected_devices_not_fetching(
     client: MagicMock,
     appliance: HomeAppliance,
 ) -> None:
-    """Test that removed devices are correctly removed from and added to hass on API events."""
+    """Test that Home Connect API is not fetch after pairing a disconnected device."""
     client.get_home_appliances = AsyncMock(return_value=ArrayOfHomeAppliances([]))
     assert config_entry.state == ConfigEntryState.NOT_LOADED
     assert await integration_setup(client)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Home Connect integration attempted to fetch appliance settings, status, commands, etc., while the appliance was not connected. This caused the API rate limit error to be triggered if many appliances were disconnected (which can be common as some are disconnected while turned off).

This PR makes the necessary changes to prevent the integration from fetching data for disconnected appliances.

See the following logs for more context (ty @ConradReichel!)
[home-assistant_home_connect_2025-04-01T13-36-07.420Z_REDACTED.log](https://github.com/user-attachments/files/19590392/home-assistant_home_connect_2025-04-01T13-36-07.420Z.log)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #139328
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
