### PR TITLE
Add typed listeners to Teslemetry sensor platform

### DIFF
--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -128,7 +128,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         polling=True,
         streaming_listener=lambda x, y: x.listen_ChargerVoltage(y),
         streaming_firmware="2024.44.32",
->>>>>>> 862d240ec79 (wip)
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -629,12 +629,12 @@ class TeslemetryStreamSensorEntity(TeslemetryVehicleStreamEntity, RestoreSensor)
         if (sensor_data := await self.async_get_last_sensor_data()) is not None:
             self._attr_native_value = sensor_data.native_value
 
-        assert self.entity_description.streaming_listener
-        self.async_on_remove(
-            self.entity_description.streaming_listener(
-                self.vehicle.stream_vehicle, self._async_value_from_stream
+        if self.entity_description.streaming_listener is not None:
+            self.async_on_remove(
+                self.entity_description.streaming_listener(
+                    self.vehicle.stream_vehicle, self._async_value_from_stream
+                )
             )
-        )
 
     @cached_property
     def available(self) -> bool:

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -71,7 +71,7 @@ class TeslemetryVehicleSensorEntityDescription(SensorEntityDescription):
     polling_value_fn: Callable[[StateType], StateType] = lambda x: x
     nullable: bool = False
     streaming_listener: Callable[
-        [TeslemetryStreamVehicle, Callable[[typing.TypeVar('T') | None], None]],
+        [TeslemetryStreamVehicle, Callable[[str | int | float | None], None]],
         Callable[[], None],
     ] | None = None
     streaming_value_fn: Callable[[str | int | float], StateType] = lambda x: x
@@ -84,9 +84,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         polling=True,
         streaming_listener=lambda x, y: x.listen_DetailedChargeState(y),
         polling_value_fn=lambda value: CHARGE_STATES.get(str(value)),
-        streaming_value_fn=lambda value: CHARGE_STATES.get(
-            str(value).replace("DetailedChargeState", "")
-        ),
         options=list(CHARGE_STATES.values()),
         device_class=SensorDeviceClass.ENUM,
     ),
@@ -102,10 +99,12 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="charge_state_usable_battery_level",
         polling=True,
+        streaming_listener=lambda x, y: x.listen_Soc(y),
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         entity_registry_enabled_default=False,
+        suggested_display_precision=1,
     ),
     TeslemetryVehicleSensorEntityDescription(
         key="charge_state_charge_energy_added",
@@ -127,8 +126,9 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="charge_state_charger_voltage",
         polling=True,
-        streaming_key=Signal.CHARGER_VOLTAGE,
+        streaming_listener=lambda x, y: x.listen_ChargerVoltage(y),
         streaming_firmware="2024.44.32",
+>>>>>>> 862d240ec79 (wip)
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -83,7 +83,9 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="charge_state_charging_state",
         polling=True,
-        streaming_listener=lambda x, y: x.listen_DetailedChargeState(y),
+        streaming_listener=lambda x, y: x.listen_DetailedChargeState(
+            lambda z: None if z is None else y(z.lower())
+        ),
         polling_value_fn=lambda value: CHARGE_STATES.get(str(value)),
         options=list(CHARGE_STATES.values()),
         device_class=SensorDeviceClass.ENUM,

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -642,6 +642,7 @@ class TeslemetryStreamSensorEntity(TeslemetryVehicleStreamEntity, RestoreSensor)
     def _async_value_from_stream(self, value: StateType) -> None:
         """Update the value of the entity."""
         self._attr_native_value = value
+        self.async_write_ha_state()
 
 
 class TeslemetryVehicleSensorEntity(TeslemetryVehicleEntity, SensorEntity):
@@ -704,6 +705,7 @@ class TeslemetryStreamTimeSensorEntity(TeslemetryVehicleStreamEntity, SensorEnti
             self._attr_native_value = None
         else:
             self._attr_native_value = self._get_timestamp(value)
+        self.async_write_ha_state()
 
 
 class TeslemetryVehicleTimeSensorEntity(TeslemetryVehicleEntity, SensorEntity):

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -4499,6 +4499,9 @@
     }),
     'name': None,
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
     'original_icon': None,
@@ -5064,7 +5067,7 @@
   '2'
 # ---
 # name: test_sensors_streaming[sensor.test_charging-state]
-  'charging'
+  'unavailable'
 # ---
 # name: test_sensors_streaming[sensor.test_time_to_arrival-state]
   'unknown'

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -5067,7 +5067,7 @@
   '2'
 # ---
 # name: test_sensors_streaming[sensor.test_charging-state]
-  'unavailable'
+  'charging'
 # ---
 # name: test_sensors_streaming[sensor.test_time_to_arrival-state]
   'unknown'


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR requires https://github.com/home-assistant/core/pull/142234

Moves the sensor platform to using typed listeners.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
