### PR TITLE
Add device class ENUM and options for sensors in NUT

### DIFF
--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -40,12 +40,30 @@ AMBIENT_SENSORS = {
     "ambient.temperature",
     "ambient.temperature.status",
 }
-AMBIENT_THRESHOLD_STATUS_OPTIONS = [
+BATTERY_CHARGER_STATUS_OPTIONS = [
+    "charging",
+    "discharging",
+    "floating",
+    "resting",
+    "unknown",
+    "disabled",
+    "off",
+]
+FREQUENCY_STATUS_OPTIONS = [
+    "good",
+    "out-of-range",
+]
+THRESHOLD_STATUS_OPTIONS = [
     "good",
     "warning-low",
     "critical-low",
     "warning-high",
     "critical-high",
+]
+UPS_BEEPER_STATUS_OPTIONS = [
+    "enabled",
+    "disabled",
+    "muted",
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -64,7 +82,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         key="ambient.humidity.status",
         translation_key="ambient_humidity_status",
         device_class=SensorDeviceClass.ENUM,
-        options=AMBIENT_THRESHOLD_STATUS_OPTIONS,
+        options=THRESHOLD_STATUS_OPTIONS,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "ambient.temperature": SensorEntityDescription(
@@ -79,7 +97,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         key="ambient.temperature.status",
         translation_key="ambient_temperature_status",
         device_class=SensorDeviceClass.ENUM,
-        options=AMBIENT_THRESHOLD_STATUS_OPTIONS,
+        options=THRESHOLD_STATUS_OPTIONS,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "battery.alarm.threshold": SensorEntityDescription(
@@ -126,6 +144,8 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "battery.charger.status": SensorEntityDescription(
         key="battery.charger.status",
         translation_key="battery_charger_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=BATTERY_CHARGER_STATUS_OPTIONS,
     ),
     "battery.current": SensorEntityDescription(
         key="battery.current",
@@ -374,6 +394,8 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "input.current.status": SensorEntityDescription(
         key="input.current.status",
         translation_key="input_current_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=THRESHOLD_STATUS_OPTIONS,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -397,6 +419,8 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "input.frequency.status": SensorEntityDescription(
         key="input.frequency.status",
         translation_key="input_frequency_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=FREQUENCY_STATUS_OPTIONS,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -792,6 +816,8 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "ups.beeper.status": SensorEntityDescription(
         key="ups.beeper.status",
         translation_key="ups_beeper_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=UPS_BEEPER_STATUS_OPTIONS,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -104,7 +104,18 @@
       "battery_charge_low": { "name": "Low battery setpoint" },
       "battery_charge_restart": { "name": "Minimum battery to start" },
       "battery_charge_warning": { "name": "Warning battery setpoint" },
-      "battery_charger_status": { "name": "Charging status" },
+      "battery_charger_status": {
+        "name": "Charging status",
+        "state": {
+          "charging": "Charging",
+          "discharging": "Discharging",
+          "floating": "Floating",
+          "resting": "Resting",
+          "unknown": "Unknown",
+          "disabled": "Disabled",
+          "off": "Off"
+        }
+      },
       "battery_current": { "name": "Battery current" },
       "battery_current_total": { "name": "Total battery current" },
       "battery_date": { "name": "Battery date" },
@@ -135,10 +146,25 @@
       "input_bypass_realpower": { "name": "Input bypass real power" },
       "input_bypass_voltage": { "name": "Input bypass voltage" },
       "input_current": { "name": "Input current" },
-      "input_current_status": { "name": "Input current status" },
+      "input_current_status": {
+        "name": "Input current status",
+        "state": {
+          "good": "[%key:component::nut::entity::sensor::ambient_humidity_status::state::good%]",
+          "warning-low": "[%key:component::nut::entity::sensor::ambient_humidity_status::state::warning-low%]",
+          "critical-low": "[%key:component::nut::entity::sensor::ambient_humidity_status::state::critical-low%]",
+          "warning-high": "[%key:component::nut::entity::sensor::ambient_humidity_status::state::warning-high%]",
+          "critical-high": "[%key:component::nut::entity::sensor::ambient_humidity_status::state::critical-high%]"
+        }
+      },
       "input_frequency": { "name": "Input frequency" },
       "input_frequency_nominal": { "name": "Input nominal frequency" },
-      "input_frequency_status": { "name": "Input frequency status" },
+      "input_frequency_status": {
+        "name": "Input frequency status",
+        "state": {
+          "good": "Good",
+          "out-of-range": "Out of range"
+        }
+      },
       "input_l1_current": { "name": "Input L1 current" },
       "input_l1_frequency": { "name": "Input L1 line frequency" },
       "input_l1_n_voltage": { "name": "Input L1 voltage" },
@@ -194,7 +220,14 @@
       "output_voltage": { "name": "Output voltage" },
       "output_voltage_nominal": { "name": "Nominal output voltage" },
       "ups_alarm": { "name": "Alarms" },
-      "ups_beeper_status": { "name": "Beeper status" },
+      "ups_beeper_status": {
+        "name": "Beeper status",
+        "state": {
+          "enabled": "Enabled",
+          "disabled": "Disabled",
+          "muted": "Muted"
+        }
+      },
       "ups_contacts": { "name": "External contacts" },
       "ups_delay_reboot": { "name": "UPS reboot delay" },
       "ups_delay_shutdown": { "name": "UPS shutdown delay" },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR sets the device class to SensorDeviceClass.ENUM and specifies the numerated options for several historical sensors.  The ENUM options is based on a combination of the NUT documentation and NUT source code.  Where required, the option set is expanded to include states produced by specific NUT drivers even when not documented.  The strings.json file has been updated to provide translation for these states.

Sensors that should be binary sensors instead of regular sensors have not been updated.  A separate PR will move them to binary sensors.

Sensors where the states vary widely by driver and/or manufacturer have not been updated, even when there is an enumerated set of states for any specific NUT driver or manufacturer.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
