### PR TITLE
Improve enphase_envoy diagnostics error handling to retain collected data

### DIFF
--- a/tests/components/enphase_envoy/snapshots/test_diagnostics.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_diagnostics.ambr
@@ -1373,7 +1373,66 @@
       ]),
     }),
     'fixtures': dict({
-      'Error': "EnvoyError('Test')",
+      '/admin/lib/tariff_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/api/v1/production/inverters_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/api/v1/production_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/info_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ensemble/dry_contacts_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ensemble/generator_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ensemble/inventory_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ensemble/power_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ensemble/secctrl_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ensemble/status_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/meters/readings_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/meters_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/sc/pvlimit_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ss/dry_contact_settings_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ss/gen_config_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ss/gen_schedule_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/ivp/ss/pel_settings_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/production.json?details=1_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/production.json_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
+      '/production_log': dict({
+        'Error': "EnvoyError('Test')",
+      }),
     }),
     'raw_data': dict({
       'varies_by': 'firmware_version',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enphase_envoy integration diagnostics report can collect detail information from the Envoy device. Currently the error handling is done outside the collection method. If an error occurs, this results in abandoning the data collection and not reporting already  collected information.

This PR moves the error handling into the collection method in order to retain the collected data on error, as well as try to continue to collect other data upon an error.

- Move error handling code in diagnostics.py
- Update the diagnostics snapshot test file for new behavior

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
