### PR TITLE
Fix empty actions

### DIFF
--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -214,7 +214,8 @@ class AlarmControlPanelTemplate(TemplateEntity, AlarmControlPanelEntity, Restore
             ),
             (CONF_TRIGGER_ACTION, AlarmControlPanelEntityFeature.TRIGGER),
         ):
-            if action_config := config.get(action_id):
+            # Scripts can be an empty list, therefore we need to check for None
+            if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
                 self._attr_supported_features |= supported_feature
 

--- a/homeassistant/components/template/button.py
+++ b/homeassistant/components/template/button.py
@@ -120,7 +120,8 @@ class TemplateButtonEntity(TemplateEntity, ButtonEntity):
         """Initialize the button."""
         super().__init__(hass, config=config, unique_id=unique_id)
         assert self._attr_name is not None
-        if action := config.get(CONF_PRESS):
+        # Scripts can be an empty list, therefore we need to check for None
+        if (action := config.get(CONF_PRESS)) is not None:
             self.add_script(CONF_PRESS, action, self._attr_name, DOMAIN)
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_state = None

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -172,7 +172,8 @@ class CoverTemplate(TemplateEntity, CoverEntity):
             (POSITION_ACTION, CoverEntityFeature.SET_POSITION),
             (TILT_ACTION, TILT_FEATURES),
         ):
-            if action_config := config.get(action_id):
+            # Scripts can be an empty list, therefore we need to check for None
+            if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
                 self._attr_supported_features |= supported_feature
 

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -157,7 +157,8 @@ class TemplateFan(TemplateEntity, FanEntity):
             CONF_SET_OSCILLATING_ACTION,
             CONF_SET_DIRECTION_ACTION,
         ):
-            if action_config := config.get(action_id):
+            # Scripts can be an empty list, therefore we need to check for None
+            if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
 
         self._state: bool | None = False

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -335,7 +335,7 @@ class LightTemplate(TemplateEntity, LightEntity):
             self._color_mode = next(iter(self._supported_color_modes))
 
         self._attr_supported_features = LightEntityFeature(0)
-        if self._action_scripts.get(CONF_EFFECT_ACTION):
+        if (self._action_scripts.get(CONF_EFFECT_ACTION)) is not None:
             self._attr_supported_features |= LightEntityFeature.EFFECT
         if self._supports_transition is True:
             self._attr_supported_features |= LightEntityFeature.TRANSITION

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -296,7 +296,8 @@ class LightTemplate(TemplateEntity, LightEntity):
         self._supports_transition_template = config.get(CONF_SUPPORTS_TRANSITION)
 
         for action_id in (CONF_ON_ACTION, CONF_OFF_ACTION, CONF_EFFECT_ACTION):
-            if action_config := config.get(action_id):
+            # Scripts can be an empty list, therefore we need to check for None
+            if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
 
         self._state = False
@@ -323,7 +324,8 @@ class LightTemplate(TemplateEntity, LightEntity):
             (CONF_RGBW_ACTION, ColorMode.RGBW),
             (CONF_RGBWW_ACTION, ColorMode.RGBWW),
         ):
-            if action_config := config.get(action_id):
+            # Scripts can be an empty list, therefore we need to check for None
+            if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
                 color_modes.add(color_mode)
         self._supported_color_modes = filter_supported_color_modes(color_modes)

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -98,7 +98,8 @@ class TemplateLock(TemplateEntity, LockEntity):
             (CONF_UNLOCK, 0),
             (CONF_OPEN, LockEntityFeature.OPEN),
         ):
-            if action_config := config.get(action_id):
+            # Scripts can be an empty list, therefore we need to check for None
+            if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
                 self._attr_supported_features |= supported_feature
         self._code_format_template = config.get(CONF_CODE_FORMAT_TEMPLATE)

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -141,7 +141,8 @@ class TemplateSelect(TemplateEntity, SelectEntity):
         super().__init__(hass, config=config, unique_id=unique_id)
         assert self._attr_name is not None
         self._value_template = config[CONF_STATE]
-        if select_option := config.get(CONF_SELECT_OPTION):
+        # Scripts can be an empty list, therefore we need to check for None
+        if (select_option := config.get(CONF_SELECT_OPTION)) is not None:
             self.add_script(CONF_SELECT_OPTION, select_option, self._attr_name, DOMAIN)
         self._options_template = config[ATTR_OPTIONS]
         self._attr_assumed_state = self._optimistic = config.get(CONF_OPTIMISTIC, False)
@@ -197,7 +198,8 @@ class TriggerSelectEntity(TriggerEntity, SelectEntity):
     ) -> None:
         """Initialize the entity."""
         super().__init__(hass, coordinator, config)
-        if select_option := config.get(CONF_SELECT_OPTION):
+        # Scripts can be an empty list, therefore we need to check for None
+        if (select_option := config.get(CONF_SELECT_OPTION)) is not None:
             self.add_script(
                 CONF_SELECT_OPTION,
                 select_option,

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -226,9 +226,10 @@ class SwitchTemplate(TemplateEntity, SwitchEntity, RestoreEntity):
             assert name is not None
         self._template = config.get(CONF_STATE)
 
-        if on_action := config.get(CONF_TURN_ON):
+        # Scripts can be an empty list, therefore we need to check for None
+        if (on_action := config.get(CONF_TURN_ON)) is not None:
             self.add_script(CONF_TURN_ON, on_action, name, DOMAIN)
-        if off_action := config.get(CONF_TURN_OFF):
+        if (off_action := config.get(CONF_TURN_OFF)) is not None:
             self.add_script(CONF_TURN_OFF, off_action, name, DOMAIN)
 
         self._state: bool | None = False

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -158,7 +158,8 @@ class TemplateVacuum(TemplateEntity, StateVacuumEntity):
             (SERVICE_LOCATE, VacuumEntityFeature.LOCATE),
             (SERVICE_SET_FAN_SPEED, VacuumEntityFeature.FAN_SPEED),
         ):
-            if action_config := config.get(action_id):
+            # Scripts can be an empty list, therefore we need to check for None
+            if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
                 self._attr_supported_features |= supported_feature
 

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -82,6 +82,15 @@ OPTIMISTIC_TEMPLATE_ALARM_CONFIG = {
         "data": {"code": "{{ this.entity_id }}"},
     },
 }
+EMPTY_ACTIONS = {
+    "arm_away": [],
+    "arm_home": [],
+    "arm_night": [],
+    "arm_vacation": [],
+    "arm_custom_bypass": [],
+    "disarm": [],
+    "trigger": [],
+}
 
 
 TEMPLATE_ALARM_CONFIG = {
@@ -171,6 +180,12 @@ async def test_setup_config_entry(
             "alarm_control_panel": {
                 "platform": "template",
                 "panels": {"test_template_panel": OPTIMISTIC_TEMPLATE_ALARM_CONFIG},
+            }
+        },
+        {
+            "alarm_control_panel": {
+                "platform": "template",
+                "panels": {"test_template_panel": EMPTY_ACTIONS},
             }
         },
     ],

--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -93,6 +93,45 @@ async def test_missing_optional_config(hass: HomeAssistant) -> None:
     _verify(hass, STATE_UNKNOWN)
 
 
+async def test_missing_emtpy_press_action_config(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test: missing optional template is ok."""
+    with assert_setup_component(1, "template"):
+        assert await setup.async_setup_component(
+            hass,
+            "template",
+            {
+                "template": {
+                    "button": {
+                        "press": [],
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    _verify(hass, STATE_UNKNOWN)
+
+    now = dt.datetime.now(dt.UTC)
+    freezer.move_to(now)
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {CONF_ENTITY_ID: _TEST_BUTTON},
+        blocking=True,
+    )
+
+    _verify(
+        hass,
+        now.isoformat(),
+    )
+
+
 async def test_missing_required_keys(hass: HomeAssistant) -> None:
     """Test: missing required fields will fail."""
     with assert_setup_component(0, "template"):

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -4,7 +4,7 @@ import pytest
 
 from homeassistant import setup
 from homeassistant.components import lock
-from homeassistant.components.lock import LockState
+from homeassistant.components.lock import LockEntityFeature, LockState
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_ENTITY_ID,
@@ -14,6 +14,8 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
+
+from tests.common import assert_setup_component
 
 OPTIMISTIC_LOCK_CONFIG = {
     "platform": "template",
@@ -718,3 +720,48 @@ async def test_unique_id(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all("lock")) == 1
+
+
+async def test_emtpy_action_config(hass: HomeAssistant) -> None:
+    """Test configuration with empty script."""
+    with assert_setup_component(1, lock.DOMAIN):
+        assert await setup.async_setup_component(
+            hass,
+            lock.DOMAIN,
+            {
+                lock.DOMAIN: {
+                    "platform": "template",
+                    "lock": [],
+                    "unlock": [],
+                    "open": [],
+                    "name": "test_template_lock",
+                },
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("lock.test_template_lock")
+    assert state.attributes["supported_features"] == LockEntityFeature.OPEN
+
+    await hass.services.async_call(
+        lock.DOMAIN,
+        lock.SERVICE_UNLOCK,
+        {ATTR_ENTITY_ID: "lock.test_template_lock"},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("lock.test_template_lock")
+    assert state.state == LockState.UNLOCKED
+
+    await hass.services.async_call(
+        lock.DOMAIN,
+        lock.SERVICE_LOCK,
+        {ATTR_ENTITY_ID: "lock.test_template_lock"},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("lock.test_template_lock")
+    assert state.state == LockState.LOCKED

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -731,10 +731,12 @@ async def test_emtpy_action_config(hass: HomeAssistant) -> None:
             {
                 lock.DOMAIN: {
                     "platform": "template",
+                    "value_template": "{{ 0 == 1 }}",
                     "lock": [],
                     "unlock": [],
                     "open": [],
                     "name": "test_template_lock",
+                    "optimistic": True,
                 },
             },
         )

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -1,8 +1,12 @@
 """The tests for the Template number platform."""
 
+from typing import Any
+
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant import setup
+from homeassistant.components import template
 from homeassistant.components.input_number import (
     ATTR_VALUE as INPUT_NUMBER_ATTR_VALUE,
     DOMAIN as INPUT_NUMBER_DOMAIN,
@@ -18,6 +22,7 @@ from homeassistant.components.number import (
 )
 from homeassistant.components.template import DOMAIN
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_ICON,
     CONF_ENTITY_ID,
     CONF_UNIT_OF_MEASUREMENT,
@@ -25,10 +30,14 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from .conftest import ConfigurationStyle
 
 from tests.common import MockConfigEntry, assert_setup_component, async_capture_events
 
-_TEST_NUMBER = "number.template_number"
+_TEST_OBJECT_ID = "template_number"
+_TEST_NUMBER = f"number.{_TEST_OBJECT_ID}"
 # Represent for number's value
 _VALUE_INPUT_NUMBER = "input_number.value"
 # Represent for number's minimum
@@ -48,6 +57,66 @@ _VALUE_INPUT_NUMBER_CONFIG = {
         "mode": "slider",
     }
 }
+
+TEST_EVENT_TRIGGER = {
+    "trigger": {"platform": "event", "event_type": "test_event"},
+    "variables": {"type": "{{ trigger.event.data.type }}"},
+    "action": [{"event": "action_event", "event_data": {"type": "{{ type }}"}}],
+}
+
+
+async def async_setup_modern_format(
+    hass: HomeAssistant, count: int, number_config: dict[str, Any]
+) -> None:
+    """Do setup of light integration via new format."""
+    config = {"template": {"number": number_config}}
+
+    with assert_setup_component(count, template.DOMAIN):
+        assert await async_setup_component(
+            hass,
+            template.DOMAIN,
+            config,
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+
+async def async_setup_trigger_format(
+    hass: HomeAssistant, count: int, number_config: dict[str, Any]
+) -> None:
+    """Do setup of light integration via new format."""
+    config = {"template": {**TEST_EVENT_TRIGGER, "number": number_config}}
+
+    with assert_setup_component(count, template.DOMAIN):
+        assert await async_setup_component(
+            hass,
+            template.DOMAIN,
+            config,
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
+async def setup_number(
+    hass: HomeAssistant,
+    count: int,
+    style: ConfigurationStyle,
+    number_config: dict[str, Any],
+) -> None:
+    """Do setup of light integration."""
+    if style == ConfigurationStyle.MODERN:
+        await async_setup_modern_format(
+            hass, count, {"name": _TEST_OBJECT_ID, **number_config}
+        )
+    elif style == ConfigurationStyle.TRIGGER:
+        await async_setup_trigger_format(
+            hass, count, {"name": _TEST_OBJECT_ID, **number_config}
+        )
 
 
 async def test_setup_config_entry(
@@ -565,3 +634,36 @@ async def test_device_id(
     template_entity = entity_registry.async_get("number.my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
+
+
+@pytest.mark.parametrize(
+    ("count", "number_config"),
+    [
+        (
+            1,
+            {
+                "state": "{{ 1 }}",
+                "set_value": [],
+                "step": "{{ 1 }}",
+                "optimistic": True,
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style",
+    [
+        ConfigurationStyle.MODERN,
+    ],
+)
+async def test_empty_action_config(hass: HomeAssistant, setup_number) -> None:
+    """Test configuration with empty script."""
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: _TEST_NUMBER, "value": 4},
+        blocking=True,
+    )
+
+    state = hass.states.get(_TEST_NUMBER)
+    assert float(state.state) == 4

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -6,7 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant import setup
-from homeassistant.components import template
+from homeassistant.components import number, template
 from homeassistant.components.input_number import (
     ATTR_VALUE as INPUT_NUMBER_ATTR_VALUE,
     DOMAIN as INPUT_NUMBER_DOMAIN,
@@ -58,36 +58,12 @@ _VALUE_INPUT_NUMBER_CONFIG = {
     }
 }
 
-TEST_EVENT_TRIGGER = {
-    "trigger": {"platform": "event", "event_type": "test_event"},
-    "variables": {"type": "{{ trigger.event.data.type }}"},
-    "action": [{"event": "action_event", "event_data": {"type": "{{ type }}"}}],
-}
-
 
 async def async_setup_modern_format(
     hass: HomeAssistant, count: int, number_config: dict[str, Any]
 ) -> None:
-    """Do setup of light integration via new format."""
+    """Do setup of number integration via new format."""
     config = {"template": {"number": number_config}}
-
-    with assert_setup_component(count, template.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            template.DOMAIN,
-            config,
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-
-async def async_setup_trigger_format(
-    hass: HomeAssistant, count: int, number_config: dict[str, Any]
-) -> None:
-    """Do setup of light integration via new format."""
-    config = {"template": {**TEST_EVENT_TRIGGER, "number": number_config}}
 
     with assert_setup_component(count, template.DOMAIN):
         assert await async_setup_component(
@@ -108,13 +84,9 @@ async def setup_number(
     style: ConfigurationStyle,
     number_config: dict[str, Any],
 ) -> None:
-    """Do setup of light integration."""
+    """Do setup of number integration."""
     if style == ConfigurationStyle.MODERN:
         await async_setup_modern_format(
-            hass, count, {"name": _TEST_OBJECT_ID, **number_config}
-        )
-    elif style == ConfigurationStyle.TRIGGER:
-        await async_setup_trigger_format(
             hass, count, {"name": _TEST_OBJECT_ID, **number_config}
         )
 
@@ -659,8 +631,8 @@ async def test_device_id(
 async def test_empty_action_config(hass: HomeAssistant, setup_number) -> None:
     """Test configuration with empty script."""
     await hass.services.async_call(
-        "number",
-        "set_value",
+        number.DOMAIN,
+        number.SERVICE_SET_VALUE,
         {ATTR_ENTITY_ID: _TEST_NUMBER, "value": 4},
         blocking=True,
     )

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -981,3 +981,49 @@ async def test_device_id(
     template_entity = entity_registry.async_get("switch.my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
+
+
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
+    ("style", "switch_config"),
+    [
+        (
+            ConfigurationStyle.LEGACY,
+            {
+                TEST_OBJECT_ID: {
+                    "turn_on": [],
+                    "turn_off": [],
+                },
+            },
+        ),
+        (
+            ConfigurationStyle.MODERN,
+            {
+                "name": TEST_OBJECT_ID,
+                "turn_on": [],
+                "turn_off": [],
+            },
+        ),
+    ],
+)
+async def test_empty_action_config(hass: HomeAssistant, setup_switch) -> None:
+    """Test configuration with empty script."""
+    await hass.services.async_call(
+        switch.DOMAIN,
+        switch.SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: TEST_ENTITY_ID},
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_ENTITY_ID)
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        switch.DOMAIN,
+        switch.SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: TEST_ENTITY_ID},
+        blocking=True,
+    )
+
+    state = hass.states.get(TEST_ENTITY_ID)
+    assert state.state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes a number of issues brought up in 2025.4 related to empty actions in template entities.  When fixing this and adding tests, I found a number of other inconsistencies and bugs in various platforms.  In these cases, it's not possible to functionally test empty actions because empty actions can only be tested against optimistic entities or entities with supported features based on the supplied actions.

This issues are:
* https://github.com/home-assistant/core/issues/142279
* https://github.com/home-assistant/core/issues/142281
* https://github.com/home-assistant/core/issues/142232 - This is a special case, it supports optimistic modes, however the modes are tied to templates instead of actions making it impossible to test when creating an entity from a configuration.

When these issues are addressed, tests cases for this PR will be added.  Until then, they will be omitted.  All other platforms & configuration styles have been properly tested.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes https://github.com/home-assistant/core/issues/142240
  - fixes https://github.com/home-assistant/core/issues/142182 
  - fixes https://github.com/home-assistant/core/issues/142108
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
