### PR TITLE
Fix potential deadlock in platform setup when it needs to wait for MQTT

### DIFF
--- a/homeassistant/components/arwn/manifest.json
+++ b/homeassistant/components/arwn/manifest.json
@@ -2,7 +2,6 @@
   "domain": "arwn",
   "name": "Ambient Radio Weather Network",
   "codeowners": [],
-  "dependencies": ["mqtt"],
   "documentation": "https://www.home-assistant.io/integrations/arwn",
   "iot_class": "local_polling",
   "quality_scale": "legacy"

--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -128,7 +128,7 @@ async def async_setup_platform(
 
         await mqtt.async_subscribe(hass, TOPIC, async_sensor_event_received, 0)
 
-    hass.create_task(_async_setup_mqtt(), "arwn setup")
+    hass.async_create_task(_async_setup_mqtt(), "arwn setup")
 
     @callback
     def async_sensor_event_received(msg: mqtt.ReceiveMessage) -> None:

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -199,34 +199,38 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the manual MQTT alarm platform."""
-    # Make sure MQTT integration is enabled and the client is available
-    # We cannot count on dependencies as the alarm_control_panel platform setup
-    # also will be triggered when mqtt is loading the `alarm_control_panel` platform
-    if not await mqtt.async_wait_for_mqtt_client(hass):
-        _LOGGER.error("MQTT integration is not available")
-        return
-    add_entities(
-        [
-            ManualMQTTAlarm(
-                hass,
-                config[CONF_NAME],
-                config.get(CONF_CODE),
-                config.get(CONF_CODE_TEMPLATE),
-                config.get(CONF_DISARM_AFTER_TRIGGER, DEFAULT_DISARM_AFTER_TRIGGER),
-                config.get(mqtt.CONF_STATE_TOPIC),
-                config.get(mqtt.CONF_COMMAND_TOPIC),
-                config.get(mqtt.CONF_QOS),
-                config.get(CONF_CODE_ARM_REQUIRED),
-                config.get(CONF_PAYLOAD_DISARM),
-                config.get(CONF_PAYLOAD_ARM_HOME),
-                config.get(CONF_PAYLOAD_ARM_AWAY),
-                config.get(CONF_PAYLOAD_ARM_NIGHT),
-                config.get(CONF_PAYLOAD_ARM_VACATION),
-                config.get(CONF_PAYLOAD_ARM_CUSTOM_BYPASS),
-                config,
-            )
-        ]
-    )
+
+    async def _async_setup_entities() -> None:
+        # Make sure MQTT integration is enabled and the client is available
+        # We cannot count on dependencies as the alarm_control_panel platform setup
+        # also will be triggered when mqtt is loading the `alarm_control_panel` platform
+        if not await mqtt.async_wait_for_mqtt_client(hass):
+            _LOGGER.error("MQTT integration is not available")
+            return
+        add_entities(
+            [
+                ManualMQTTAlarm(
+                    hass,
+                    config[CONF_NAME],
+                    config.get(CONF_CODE),
+                    config.get(CONF_CODE_TEMPLATE),
+                    config.get(CONF_DISARM_AFTER_TRIGGER, DEFAULT_DISARM_AFTER_TRIGGER),
+                    config.get(mqtt.CONF_STATE_TOPIC),
+                    config.get(mqtt.CONF_COMMAND_TOPIC),
+                    config.get(mqtt.CONF_QOS),
+                    config.get(CONF_CODE_ARM_REQUIRED),
+                    config.get(CONF_PAYLOAD_DISARM),
+                    config.get(CONF_PAYLOAD_ARM_HOME),
+                    config.get(CONF_PAYLOAD_ARM_AWAY),
+                    config.get(CONF_PAYLOAD_ARM_NIGHT),
+                    config.get(CONF_PAYLOAD_ARM_VACATION),
+                    config.get(CONF_PAYLOAD_ARM_CUSTOM_BYPASS),
+                    config,
+                )
+            ]
+        )
+
+    hass.create_task(_async_setup_entities(), "manual_mqtt setup")
 
 
 class ManualMQTTAlarm(AlarmControlPanelEntity):

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -230,7 +230,7 @@ async def async_setup_platform(
             ]
         )
 
-    hass.create_task(_async_setup_entities(), "manual_mqtt setup")
+    hass.async_create_task(_async_setup_entities(), "manual_mqtt setup")
 
 
 class ManualMQTTAlarm(AlarmControlPanelEntity):

--- a/homeassistant/components/manual_mqtt/manifest.json
+++ b/homeassistant/components/manual_mqtt/manifest.json
@@ -2,7 +2,6 @@
   "domain": "manual_mqtt",
   "name": "Manual MQTT Alarm Control Panel",
   "codeowners": [],
-  "dependencies": ["mqtt"],
   "documentation": "https://www.home-assistant.io/integrations/manual_mqtt",
   "iot_class": "local_push",
   "quality_scale": "legacy"

--- a/homeassistant/components/mqtt_json/device_tracker.py
+++ b/homeassistant/components/mqtt_json/device_tracker.py
@@ -59,7 +59,7 @@ async def async_setup_scanner(
 
         await _async_setup_scanner(hass, config, async_see)
 
-    hass.create_task(_async_wait_for_mqtt_and_set_up(), "mqtt_json setup")
+    hass.async_create_task(_async_wait_for_mqtt_and_set_up(), "mqtt_json setup")
     return True
 
 

--- a/homeassistant/components/mqtt_json/manifest.json
+++ b/homeassistant/components/mqtt_json/manifest.json
@@ -2,7 +2,6 @@
   "domain": "mqtt_json",
   "name": "MQTT JSON",
   "codeowners": [],
-  "dependencies": ["mqtt"],
   "documentation": "https://www.home-assistant.io/integrations/mqtt_json",
   "iot_class": "local_push",
   "quality_scale": "legacy"

--- a/homeassistant/components/mqtt_room/manifest.json
+++ b/homeassistant/components/mqtt_room/manifest.json
@@ -2,7 +2,6 @@
   "domain": "mqtt_room",
   "name": "MQTT Room Presence",
   "codeowners": [],
-  "dependencies": ["mqtt"],
   "documentation": "https://www.home-assistant.io/integrations/mqtt_room",
   "iot_class": "local_push",
   "quality_scale": "legacy"

--- a/homeassistant/components/mqtt_room/sensor.py
+++ b/homeassistant/components/mqtt_room/sensor.py
@@ -81,24 +81,28 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up MQTT room Sensor."""
-    # Make sure MQTT integration is enabled and the client is available
-    # We cannot count on dependencies as the sensor platform setup
-    # also will be triggered when mqtt is loading the `sensor` platform
-    if not await mqtt.async_wait_for_mqtt_client(hass):
-        _LOGGER.error("MQTT integration is not available")
-        return
-    async_add_entities(
-        [
-            MQTTRoomSensor(
-                config.get(CONF_NAME),
-                config[CONF_STATE_TOPIC],
-                config[CONF_DEVICE_ID],
-                config[CONF_TIMEOUT],
-                config[CONF_AWAY_TIMEOUT],
-                config.get(CONF_UNIQUE_ID),
-            )
-        ]
-    )
+
+    async def _async_setup_entities() -> None:
+        # Make sure MQTT integration is enabled and the client is available
+        # We cannot count on dependencies as the sensor platform setup
+        # also will be triggered when mqtt is loading the `sensor` platform
+        if not await mqtt.async_wait_for_mqtt_client(hass):
+            _LOGGER.error("MQTT integration is not available")
+            return
+        async_add_entities(
+            [
+                MQTTRoomSensor(
+                    config.get(CONF_NAME),
+                    config[CONF_STATE_TOPIC],
+                    config[CONF_DEVICE_ID],
+                    config[CONF_TIMEOUT],
+                    config[CONF_AWAY_TIMEOUT],
+                    config.get(CONF_UNIQUE_ID),
+                )
+            ]
+        )
+
+    hass.create_task(_async_setup_entities(), "mqtt_room setup")
 
 
 class MQTTRoomSensor(SensorEntity):

--- a/homeassistant/components/mqtt_room/sensor.py
+++ b/homeassistant/components/mqtt_room/sensor.py
@@ -102,7 +102,7 @@ async def async_setup_platform(
             ]
         )
 
-    hass.create_task(_async_setup_entities(), "mqtt_room setup")
+    hass.async_create_task(_async_setup_entities(), "mqtt_room setup")
 
 
 class MQTTRoomSensor(SensorEntity):

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -161,6 +161,12 @@ IGNORE_VIOLATIONS = {
     # This would be a circular dep
     ("http", "network"),
     ("http", "cloud"),
+    # These integrations use a platform setup and could cause a deadlock
+    # as they wait for the MQTT to set up.
+    ("arwn", "mqtt"),
+    ("manual_mqtt", "mqtt"),
+    ("mqtt_json", "mqtt"),
+    ("mqtt_room", "mqtt"),
     # This would be a circular dep
     ("zha", "homeassistant_hardware"),
     ("zha", "homeassistant_sky_connect"),

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -103,7 +103,7 @@ async def test_no_pending(
             }
         },
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     entity_id = "alarm_control_panel.test"
 
@@ -155,7 +155,7 @@ async def test_no_pending_when_code_not_req(
             }
         },
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     entity_id = "alarm_control_panel.test"
 
@@ -206,7 +206,7 @@ async def test_with_pending(
             }
         },
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     entity_id = "alarm_control_panel.test"
 

--- a/tests/components/mqtt_json/test_device_tracker.py
+++ b/tests/components/mqtt_json/test_device_tracker.py
@@ -65,7 +65,7 @@ async def test_setup_fails_without_mqtt_being_setup(
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     assert "MQTT integration is not available" in caplog.text
 
@@ -95,7 +95,7 @@ async def test_ensure_device_tracker_platform_validation(hass: HomeAssistant) ->
             DT_DOMAIN,
             {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
         )
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_sp.call_count == 1
 
 
@@ -110,7 +110,7 @@ async def test_json_message(hass: HomeAssistant) -> None:
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()
     state = hass.states.get("device_tracker.zanzito")
@@ -131,7 +131,7 @@ async def test_non_json_message(
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     caplog.set_level(logging.ERROR)
     caplog.clear()
@@ -153,7 +153,7 @@ async def test_incomplete_message(
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     caplog.set_level(logging.ERROR)
     caplog.clear()
@@ -177,7 +177,7 @@ async def test_single_level_wildcard_topic(hass: HomeAssistant) -> None:
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: subscription}}},
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()
@@ -198,7 +198,7 @@ async def test_multi_level_wildcard_topic(hass: HomeAssistant) -> None:
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: subscription}}},
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()
@@ -220,7 +220,7 @@ async def test_single_level_wildcard_topic_not_matching(hass: HomeAssistant) -> 
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: subscription}}},
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()
@@ -240,7 +240,7 @@ async def test_multi_level_wildcard_topic_not_matching(hass: HomeAssistant) -> N
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: subscription}}},
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()

--- a/tests/components/mqtt_room/test_sensor.py
+++ b/tests/components/mqtt_room/test_sensor.py
@@ -78,7 +78,7 @@ async def test_no_mqtt(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) ->
             }
         },
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     state = hass.states.get(SENSOR_STATE)
     assert state is None
     assert "MQTT integration is not available" in caplog.text
@@ -100,7 +100,7 @@ async def test_room_update(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> 
             }
         },
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     await send_message(hass, BEDROOM_TOPIC, FAR_MESSAGE)
     await assert_state(hass, BEDROOM)
@@ -141,7 +141,7 @@ async def test_unique_id_is_set(
             }
         },
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     state = hass.states.get(SENSOR_STATE)
     assert state.state is not None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Integrations that use a legacy platform setup and depend on MQTT, prevent the entity platform to setup, till MQTT was set up. This PR ensures the platform setup returns immediately to allow a fast entity platform setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #124987
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
