### PR TITLE
handle missing attribute fritz_guest_wifi.get_wifi_qr_code

### DIFF
--- a/homeassistant/components/fritz/image.py
+++ b/homeassistant/components/fritz/image.py
@@ -64,10 +64,15 @@ class FritzGuestWifiQRImage(FritzBoxBaseEntity, ImageEntity):
 
     async def _fetch_image(self) -> bytes:
         """Fetch the QR code from the Fritz!Box."""
-        qr_stream: BytesIO = await self.hass.async_add_executor_job(
-            self._avm_wrapper.fritz_guest_wifi.get_wifi_qr_code, "png"
-        )
-        qr_bytes = qr_stream.getvalue()
+        if hasattr(self._avm_wrapper.fritz_guest_wifi,'get_wifi_qr_code'):
+            qr_stream: BytesIO = await self.hass.async_add_executor_job(
+                self._avm_wrapper.fritz_guest_wifi.get_wifi_qr_code, "png"
+            )
+            qr_bytes = qr_stream.getvalue()
+        else:
+            _LOGGER.debug("fritz_guest_wifi.get_wifi_qr_code not available")
+            qr_bytes = b''
+
         _LOGGER.debug("fetched %s bytes", len(qr_bytes))
 
         return qr_bytes


### PR DESCRIPTION
    if the fritbox has no guest wifi configured there is no attribute get_wifi_qr_code
    available from the fritzconnection library available.
    As the request for get_wifi_qr_code is wrapped in the job, this is
    not handled by the exception from the async_update funktion.
    This prints every 30sec there is an annoying error message in the log.

    My solution is to check for existance of the attribute
    get_wifi_qr_code before starting the job to access it.

    As I am not the experienced python developper there might be a
    better solution to do this.
    Just use this as a first try and optimize it as needed.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
 If the fritbox has no guest wifi configured there is no attribute get_wifi_qr_code
 available from the fritzconnection library available.
 As the request for get_wifi_qr_code is wrapped in the job, this is
 not handled by the exception from the async_update funktion.
 This prints every 30sec there is an annoying error message in the log.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
My solution is to check for existance of the attribute
get_wifi_qr_code before starting the job to access it.

 As I am not the experienced python developper there might be a
 better solution to do this.
 Just use this as a first try and optimize it as needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
