### PR TITLE
Added KEBA device activation/deactivation switch

### DIFF
--- a/homeassistant/components/keba/switch.py
+++ b/homeassistant/components/keba/switch.py
@@ -1,0 +1,61 @@
+"""Support for KEBA charging station switch."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from . import DOMAIN, KebaHandler
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the KEBA charging station platform."""
+    if discovery_info is None:
+        return
+
+    keba: KebaHandler = hass.data[DOMAIN]
+
+    switches = [KebaSwitchUser(keba, "Charging", "charging")]
+    async_add_entities(switches)
+
+
+class KebaSwitchUser(SwitchEntity):
+    """The entity class for KEBA charging stations switch."""
+
+    _attr_should_poll = False
+
+    def __init__(self, keba: KebaHandler, name: str, entity_type: str) -> None:
+        """Initialize the KEBA switch."""
+        self._keba = keba
+        self._attr_is_on = True
+        self._attr_name = f"{keba.device_name} {name}"
+        self._attr_unique_id = f"{keba.device_id}_{entity_type}"
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Lock wallbox."""
+        await self._keba.async_disable_ev()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Unlock wallbox."""
+        await self._keba.async_enable_ev()
+
+    async def async_update(self) -> None:
+        """Attempt to retrieve on off state from the switch."""
+        self._attr_is_on = self._keba.get_value("Enable user") == 1
+
+    def update_callback(self) -> None:
+        """Schedule a state update."""
+        self.async_schedule_update_ha_state(True)
+
+    async def async_added_to_hass(self) -> None:
+        """Add update callback after being added to hass."""
+        self._keba.add_update_listener(self.update_callback)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
My KEBA p30 wallbox has no RFID reader and therefore the implemented lock does not work. 
I have added a switch implementation to enable/disable the wall box device to enable/disable charging.
In the past I implemented it with a lock but the feedback was that I should use a switch.  #117038
And because the lock does not work in my device, I added a configuration option `add_lock_to_homeassistant`
to remove the KEBA lock from Home Assistant.
 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38494
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
