### PR TITLE
Maintain unique Matter entity names

### DIFF
--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -135,7 +135,7 @@ class MatterEntity(Entity):
                     EntityCategory.DIAGNOSTIC,
                 ]:
                     # Cluster attributes can result in multiple CONFIG and DIAGNOSTIC entities for an endpoint,
-                    # to maintian unique names, use standard HA name and don't overwrite the attribute names if they are in the CONFIG or DIAGNOSTIC category
+                    # to maintain unique names, use standard HA name and don't overwrite the attribute names if they are in the CONFIG or DIAGNOSTIC category
                     self._attr_name = label_value
                 break
 

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -18,6 +18,7 @@ from matter_server.common.helpers.util import (
 from matter_server.common.models import EventType, ServerInfoMessage
 from propcache.api import cached_property
 
+from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -114,7 +115,7 @@ class MatterEntity(Entity):
 
         # prefer the label attribute for the entity name
         # Matter has a way for users and/or vendors to specify a name for an endpoint
-        # which is always preferred over a standard HA (generated) name
+        # which is preferred over a standard HA (generated) name for control and event entities
         for attr in (
             clusters.FixedLabel.Attributes.LabelList,
             clusters.UserLabel.Attributes.LabelList,
@@ -129,7 +130,12 @@ class MatterEntity(Entity):
                 # in the case the label is only the label id, use it as postfix only
                 if label_value.isnumeric():
                     self._name_postfix = label_value
-                else:
+                elif self.entity_category not in [
+                    EntityCategory.CONFIG,
+                    EntityCategory.DIAGNOSTIC,
+                ]:
+                    # Cluster attributes can result in multiple CONFIG and DIAGNOSTIC entities for an endpoint,
+                    # to maintian unique names, use standard HA name and don't overwrite the attribute names if they are in the CONFIG or DIAGNOSTIC category
                     self._attr_name = label_value
                 break
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
(no breaking changes)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

For Matter devices, the entity.py code makes use of the FixedLabel or UserLabel clusters to apply manufacturer-defined names to entities. This works well for event entities (such as those created for Generic Switch button press entities) as well as control entities, however, in the case of Diagnostic and Config entities, it is common for multiple entities to be created from the same endpoint - if a FixedLabel is on that endpoint, all these entities will end up with the same name. 

This problem is shown in the example below in which a FixedLabel is on the endpoint and has the name "OnOffLight". In this case, all of the transition time entities for the Level Change cluster end up renamed as "OnOffLight" and the user has no way of knowing what each is for. Using the label still makes sense for the control entity, but not the CONFIG and DIAGNOSTIC entities. This PR fixes that issue by only using FixedLabel or UserLabel for control or event entities.


As an example, on the Inovelli VTM30 device, this is how the attributes entities look without the fix:

![image](https://github.com/user-attachments/assets/0b938408-cec4-49bc-b418-b9af40a82dfa)

As you can see, the attributes all get renamed by the FixedLabel value and a user can't tell them appart

After applying this fix, they now are correct and each entity retains a unique name from strings.py:

![image](https://github.com/user-attachments/assets/66d4c0fa-46f8-4572-b828-ff30537ec706)

            

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
