### PR TITLE
Correct template fan optimistic mode and supported features

### DIFF
--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -149,17 +149,21 @@ class TemplateFan(TemplateEntity, FanEntity):
         self._oscillating_template = config.get(CONF_OSCILLATING_TEMPLATE)
         self._direction_template = config.get(CONF_DIRECTION_TEMPLATE)
 
-        for action_id in (
-            CONF_ON_ACTION,
-            CONF_OFF_ACTION,
-            CONF_SET_PERCENTAGE_ACTION,
-            CONF_SET_PRESET_MODE_ACTION,
-            CONF_SET_OSCILLATING_ACTION,
-            CONF_SET_DIRECTION_ACTION,
+        self._attr_supported_features |= (
+            FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON
+        )
+        for action_id, supported_feature in (
+            (CONF_ON_ACTION, 0),
+            (CONF_OFF_ACTION, 0),
+            (CONF_SET_PERCENTAGE_ACTION, FanEntityFeature.SET_SPEED),
+            (CONF_SET_PRESET_MODE_ACTION, FanEntityFeature.PRESET_MODE),
+            (CONF_SET_OSCILLATING_ACTION, FanEntityFeature.OSCILLATE),
+            (CONF_SET_DIRECTION_ACTION, FanEntityFeature.DIRECTION),
         ):
             # Scripts can be an empty list, therefore we need to check for None
             if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
+                self._attr_supported_features |= supported_feature
 
         self._state: bool | None = False
         self._percentage: int | None = None
@@ -172,19 +176,6 @@ class TemplateFan(TemplateEntity, FanEntity):
 
         # List of valid preset modes
         self._preset_modes: list[str] | None = config.get(CONF_PRESET_MODES)
-
-        if self._percentage_template:
-            self._attr_supported_features |= FanEntityFeature.SET_SPEED
-        if self._preset_mode_template and self._preset_modes:
-            self._attr_supported_features |= FanEntityFeature.PRESET_MODE
-        if self._oscillating_template:
-            self._attr_supported_features |= FanEntityFeature.OSCILLATE
-        if self._direction_template:
-            self._attr_supported_features |= FanEntityFeature.DIRECTION
-        self._attr_supported_features |= (
-            FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON
-        )
-
         self._attr_assumed_state = self._template is None
 
     @property
@@ -270,6 +261,8 @@ class TemplateFan(TemplateEntity, FanEntity):
 
         if self._template is None:
             self._state = percentage != 0
+
+        if self._template is None or self._percentage_template is None:
             self.async_write_ha_state()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -285,32 +278,39 @@ class TemplateFan(TemplateEntity, FanEntity):
 
         if self._template is None:
             self._state = True
+
+        if self._template is None or self._preset_mode_template is None:
             self.async_write_ha_state()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation of the fan."""
-        if (script := self._action_scripts.get(CONF_SET_OSCILLATING_ACTION)) is None:
-            return
-
         self._oscillating = oscillating
-        await self.async_run_script(
-            script,
-            run_variables={ATTR_OSCILLATING: self.oscillating},
-            context=self._context,
-        )
+        if (
+            script := self._action_scripts.get(CONF_SET_OSCILLATING_ACTION)
+        ) is not None:
+            await self.async_run_script(
+                script,
+                run_variables={ATTR_OSCILLATING: self.oscillating},
+                context=self._context,
+            )
+
+        if self._oscillating_template is None:
+            self.async_write_ha_state()
 
     async def async_set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
-        if (script := self._action_scripts.get(CONF_SET_DIRECTION_ACTION)) is None:
-            return
-
         if direction in _VALID_DIRECTIONS:
             self._direction = direction
-            await self.async_run_script(
-                script,
-                run_variables={ATTR_DIRECTION: direction},
-                context=self._context,
-            )
+            if (
+                script := self._action_scripts.get(CONF_SET_DIRECTION_ACTION)
+            ) is not None:
+                await self.async_run_script(
+                    script,
+                    run_variables={ATTR_DIRECTION: direction},
+                    context=self._context,
+                )
+            if self._direction_template is None:
+                self.async_write_ha_state()
         else:
             _LOGGER.error(
                 "Received invalid direction: %s for entity %s. Expected: %s",


### PR DESCRIPTION
The supported features for fans were tied to the existence of templates, yet the templates themselves were not tied to paired actions.  This could lead to a configuration where a supported feature was active, yet the template fan didn't have an action to run.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Tie supported features to actions.  I.e.  when a configuration has `set_percentage` actions, the supported fan feature reflects that.

This change also inadvertently exposed issues with optimistic values in template fans.  You couldn't really create an optimistic fan because of this.  You were required to have a template, making it not optimistic.

With that being said, this PR also fixes all optimistic issues with template fans.  Users can now create any combination of optimistic fans.  e.g.  optimistic oscillation, non-optimistic-state. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/142232
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
