### PR TITLE
Add websocket endpoint to get automation descriptions

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -318,7 +318,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     websocket_api.async_register_command(hass, websocket_config)
-    websocket_api.async_register_command(hass, websocket_describe_all_automations)
+    websocket_api.async_register_command(hass, websocket_all_automation_descriptions)
 
     return True
 
@@ -1198,10 +1198,10 @@ def websocket_config(
 
 @websocket_api.websocket_command(
     {
-        "type": "automation/describe_all",
+        "type": "automation/description/all",
     }
 )
-def websocket_describe_all_automations(
+def websocket_all_automation_descriptions(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -318,6 +318,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     websocket_api.async_register_command(hass, websocket_config)
+    websocket_api.async_register_command(hass, websocket_describe_all_automations)
 
     return True
 
@@ -1191,5 +1192,26 @@ def websocket_config(
         msg["id"],
         {
             "config": automation.raw_config,
+        },
+    )
+
+
+@websocket_api.websocket_command(
+    {
+        "type": "automation/describe_all",
+    }
+)
+def websocket_describe_all_automations(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Describe automations."""
+    connection.send_result(
+        msg["id"],
+        {
+            automation.entity_id: {"description": automation.raw_config["description"]}
+            for automation in hass.data[DATA_COMPONENT].entities
+            if automation.raw_config is not None
         },
     )

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -3151,6 +3151,36 @@ async def test_websocket_config(
     assert msg["error"]["code"] == "not_found"
 
 
+async def test_websocket_describe_all(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test describe_all command."""
+    config = {
+        "alias": "hello",
+        "description": "hello world",
+        "triggers": {"trigger": "event", "event_type": "test_event"},
+        "actions": {"action": "test.automation", "data": 100},
+    }
+    assert await async_setup_component(
+        hass, automation.DOMAIN, {automation.DOMAIN: config}
+    )
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 5,
+            "type": "automation/describe_all",
+        }
+    )
+
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {
+        "automation.hello": {
+            "description": "hello world",
+        }
+    }
+
+
 async def test_automation_turns_off_other_automation(hass: HomeAssistant) -> None:
     """Test an automation that turns off another automation."""
     hass.set_state(CoreState.not_running)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -3154,7 +3154,7 @@ async def test_websocket_config(
 async def test_websocket_all_descriptions(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test describe_all command."""
+    """Test automation/description/all command."""
     config = {
         "alias": "hello",
         "description": "hello world",

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -3151,7 +3151,7 @@ async def test_websocket_config(
     assert msg["error"]["code"] == "not_found"
 
 
-async def test_websocket_describe_all(
+async def test_websocket_all_descriptions(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test describe_all command."""
@@ -3168,7 +3168,7 @@ async def test_websocket_describe_all(
     await client.send_json(
         {
             "id": 5,
-            "type": "automation/describe_all",
+            "type": "automation/description/all",
         }
     )
 


### PR DESCRIPTION
## Proposed change
Add a new websocket endpoint gets all automation descriptions, which we can then use to retrieve them from the frontend and display them e.g. as a tooltip on the automations list.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/24945

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
