### PR TITLE
Fix HKC showing hvac_action as idle when fan is active and heat cool target is off

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -659,9 +659,6 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         # e.g. a thermostat is "heating" a room to 75 degrees Fahrenheit.
         # Can be 0 - 2 (Off, Heat, Cool)
 
-        # If the HVAC is switched off, it must be idle
-        # This works around a bug in some devices (like Eve radiator valves) that
-        # return they are heating when they are not.
         target = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_CURRENT)
         current_hass_value = CURRENT_MODE_HOMEKIT_TO_HASS.get(value)
@@ -676,6 +673,9 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         ):
             return HVACAction.FAN
 
+        # If the HVAC is switched off, it must be idle
+        # This works around a bug in some devices (like Eve radiator valves) that
+        # return they are heating when they are not.
         if target == HeatingCoolingTargetValues.OFF:
             return HVACAction.IDLE
 

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -663,9 +663,6 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         # This works around a bug in some devices (like Eve radiator valves) that
         # return they are heating when they are not.
         target = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if target == HeatingCoolingTargetValues.OFF:
-            return HVACAction.IDLE
-
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_CURRENT)
         current_hass_value = CURRENT_MODE_HOMEKIT_TO_HASS.get(value)
 
@@ -678,6 +675,9 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
             == CurrentFanStateValues.ACTIVE
         ):
             return HVACAction.FAN
+
+        if target == HeatingCoolingTargetValues.OFF:
+            return HVACAction.IDLE
 
         return current_hass_value
 

--- a/tests/components/homekit_controller/fixtures/ecobee3_lite.json
+++ b/tests/components/homekit_controller/fixtures/ecobee3_lite.json
@@ -1,0 +1,3436 @@
+[
+  {
+    "aid": 1,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee3 lite",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Thermostat",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "4.8.70226",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "34AB8811-AC7F-4340-BAC3-FD6A85F9943B",
+            "iid": 11,
+            "perms": ["pr", "hd"],
+            "format": "string",
+            "value": "4.1;3fac0fb4",
+            "maxLen": 64
+          },
+          {
+            "type": "00000220-0000-1000-8000-0026BB765291",
+            "iid": 10,
+            "perms": ["pr", "hd"],
+            "format": "data",
+            "value": "u4qz9YgSXzQ="
+          },
+          {
+            "type": "000000A6-0000-1000-8000-0026BB765291",
+            "iid": 9,
+            "perms": ["pr", "ev"],
+            "format": "uint32",
+            "value": 0,
+            "description": "Accessory Flags"
+          }
+        ]
+      },
+      {
+        "iid": 30,
+        "type": "000000A2-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000037-0000-1000-8000-0026BB765291",
+            "iid": 31,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.1.0",
+            "description": "Version",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 16,
+        "type": "0000004A-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000000F-0000-1000-8000-0026BB765291",
+            "iid": 17,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Current Heating Cooling State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1,
+            "valid-values": [0, 1, 2]
+          },
+          {
+            "type": "00000033-0000-1000-8000-0026BB765291",
+            "iid": 18,
+            "perms": ["pr", "pw", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Target Heating Cooling State",
+            "minValue": 0,
+            "maxValue": 3,
+            "minStep": 1,
+            "valid-values": [0, 1, 2, 3]
+          },
+          {
+            "type": "00000011-0000-1000-8000-0026BB765291",
+            "iid": 19,
+            "perms": ["pr", "ev"],
+            "format": "float",
+            "value": 21.2,
+            "description": "Current Temperature",
+            "unit": "celsius",
+            "minValue": 0,
+            "maxValue": 40.0,
+            "minStep": 0.1
+          },
+          {
+            "type": "00000035-0000-1000-8000-0026BB765291",
+            "iid": 20,
+            "perms": ["pr", "pw", "ev"],
+            "format": "float",
+            "value": 22.2,
+            "description": "Target Temperature",
+            "unit": "celsius",
+            "minValue": 7.2,
+            "maxValue": 33.3,
+            "minStep": 0.1
+          },
+          {
+            "type": "00000036-0000-1000-8000-0026BB765291",
+            "iid": 21,
+            "perms": ["pr", "pw", "ev"],
+            "format": "uint8",
+            "value": 1,
+            "description": "Temperature Display Units",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1,
+            "valid-values": [0, 1]
+          },
+          {
+            "type": "0000000D-0000-1000-8000-0026BB765291",
+            "iid": 22,
+            "perms": ["pr", "pw", "ev"],
+            "format": "float",
+            "value": 25.0,
+            "description": "Cooling Threshold Temperature",
+            "unit": "celsius",
+            "minValue": 18.3,
+            "maxValue": 33.3,
+            "minStep": 0.1
+          },
+          {
+            "type": "00000012-0000-1000-8000-0026BB765291",
+            "iid": 23,
+            "perms": ["pr", "pw", "ev"],
+            "format": "float",
+            "value": 22.2,
+            "description": "Heating Threshold Temperature",
+            "unit": "celsius",
+            "minValue": 7.2,
+            "maxValue": 26.1,
+            "minStep": 0.1
+          },
+          {
+            "type": "00000010-0000-1000-8000-0026BB765291",
+            "iid": 24,
+            "perms": ["pr", "ev"],
+            "format": "float",
+            "value": 45.0,
+            "description": "Current Relative Humidity",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100.0,
+            "minStep": 1.0
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 27,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Thermostat",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "000000BF-0000-1000-8000-0026BB765291",
+            "iid": 75,
+            "perms": ["pr", "pw", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Target Fan State",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "000000AF-0000-1000-8000-0026BB765291",
+            "iid": 76,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Current Fan State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "B7DDB9A3-54BB-4572-91D2-F1F5B0510F8C",
+            "iid": 33,
+            "perms": ["pr"],
+            "format": "uint8",
+            "value": 3,
+            "minValue": 0,
+            "maxValue": 3,
+            "minStep": 1
+          },
+          {
+            "type": "E4489BBC-5227-4569-93E5-B345E3E5508F",
+            "iid": 34,
+            "perms": ["pr", "pw"],
+            "format": "float",
+            "value": 22.2,
+            "unit": "celsius",
+            "minValue": 7.2,
+            "maxValue": 26.1,
+            "minStep": 0.1
+          },
+          {
+            "type": "7D381BAA-20F9-40E5-9BE9-AEB92D4BECEF",
+            "iid": 35,
+            "perms": ["pr", "pw"],
+            "format": "float",
+            "value": 25.0,
+            "unit": "celsius",
+            "minValue": 18.3,
+            "maxValue": 33.3,
+            "minStep": 0.1
+          },
+          {
+            "type": "73AAB542-892A-4439-879A-D2A883724B69",
+            "iid": 36,
+            "perms": ["pr", "pw"],
+            "format": "float",
+            "value": 17.8,
+            "unit": "celsius",
+            "minValue": 7.2,
+            "maxValue": 26.1,
+            "minStep": 0.1
+          },
+          {
+            "type": "5DA985F0-898A-4850-B987-B76C6C78D670",
+            "iid": 37,
+            "perms": ["pr", "pw"],
+            "format": "float",
+            "value": 25.6,
+            "unit": "celsius",
+            "minValue": 18.3,
+            "maxValue": 33.3,
+            "minStep": 0.1
+          },
+          {
+            "type": "05B97374-6DC0-439B-A0FA-CA33F612D425",
+            "iid": 38,
+            "perms": ["pr", "pw"],
+            "format": "float",
+            "value": 20.0,
+            "unit": "celsius",
+            "minValue": 7.2,
+            "maxValue": 26.1,
+            "minStep": 0.1
+          },
+          {
+            "type": "A251F6E7-AC46-4190-9C5D-3D06277BDF9F",
+            "iid": 39,
+            "perms": ["pr", "pw"],
+            "format": "float",
+            "value": 24.4,
+            "unit": "celsius",
+            "minValue": 18.3,
+            "maxValue": 33.3,
+            "minStep": 0.1
+          },
+          {
+            "type": "1B300BC2-CFFC-47FF-89F9-BD6CCF5F2853",
+            "iid": 40,
+            "perms": ["pw"],
+            "format": "uint8",
+            "minValue": 0,
+            "maxValue": 3,
+            "minStep": 1
+          },
+          {
+            "type": "1621F556-1367-443C-AF19-82AF018E99DE",
+            "iid": 41,
+            "perms": ["pr", "pw"],
+            "format": "string",
+            "value": "2025-04-06T23:30:00-05:00R",
+            "maxLen": 64
+          },
+          {
+            "type": "FA128DE6-9D7D-49A4-B6D8-4E4E234DEE38",
+            "iid": 48,
+            "perms": ["pw"],
+            "format": "bool"
+          },
+          {
+            "type": "4A6AE4F6-036C-495D-87CC-B3702B437741",
+            "iid": 49,
+            "perms": ["pr"],
+            "format": "uint8",
+            "value": 1,
+            "minValue": 0,
+            "maxValue": 4,
+            "minStep": 1
+          },
+          {
+            "type": "DB7BF261-7042-4194-8BD1-3AA22830AEDD",
+            "iid": 50,
+            "perms": ["pr"],
+            "format": "uint8",
+            "value": 0,
+            "minValue": 0,
+            "maxValue": 3,
+            "minStep": 1
+          },
+          {
+            "type": "41935E3E-B54D-42E9-B8B9-D33C6319F0AF",
+            "iid": 51,
+            "perms": ["pr"],
+            "format": "bool",
+            "value": false
+          },
+          {
+            "type": "C35DA3C0-E004-40E3-B153-46655CDD9214",
+            "iid": 52,
+            "perms": ["pr", "pw"],
+            "format": "uint8",
+            "value": 100,
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "48F62AEC-4171-4B4A-8F0E-1EEB6708B3FB",
+            "iid": 53,
+            "perms": ["pr"],
+            "format": "uint8",
+            "value": 100,
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "1B1515F2-CC45-409F-991F-C480987F92C3",
+            "iid": 54,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "The Hive is humming along. You have no pending alerts or reminders.",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4295608971,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBRSE4",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 208,
+        "type": "0000008A-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000011-0000-1000-8000-0026BB765291",
+            "iid": 209,
+            "perms": ["pr", "ev"],
+            "format": "float",
+            "value": 22.4,
+            "description": "Current Temperature",
+            "unit": "celsius",
+            "minValue": 0,
+            "maxValue": 100.0,
+            "minStep": 0.1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 210,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR Temperature",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 211,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 212,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 1,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 691,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 691,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4295608960,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBRSE4",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 208,
+        "type": "0000008A-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000011-0000-1000-8000-0026BB765291",
+            "iid": 209,
+            "perms": ["pr", "ev"],
+            "format": "float",
+            "value": 20.3,
+            "description": "Current Temperature",
+            "unit": "celsius",
+            "minValue": 0,
+            "maxValue": 100.0,
+            "minStep": 0.1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 210,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement Temperature",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 211,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 212,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 9158,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 9158,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4295016858,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBRSE4",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 208,
+        "type": "0000008A-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000011-0000-1000-8000-0026BB765291",
+            "iid": 209,
+            "perms": ["pr", "ev"],
+            "format": "float",
+            "value": 21.0,
+            "description": "Current Temperature",
+            "unit": "celsius",
+            "minValue": 0,
+            "maxValue": 100.0,
+            "minStep": 0.1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 210,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room Temperature",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 211,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 212,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": -1,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": -1,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4295016969,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBRSE4",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 208,
+        "type": "0000008A-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000011-0000-1000-8000-0026BB765291",
+            "iid": 209,
+            "perms": ["pr", "ev"],
+            "format": "float",
+            "value": 21.6,
+            "description": "Current Temperature",
+            "unit": "celsius",
+            "minValue": 0,
+            "maxValue": 100.0,
+            "minStep": 0.1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 210,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR Temperature",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 211,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 212,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": -1,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": -1,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4298584118,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR Window",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBDWC01",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR Window",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR Window Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 1421,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR Window Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 821,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 224,
+        "type": "00000080-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000006A-0000-1000-8000-0026BB765291",
+            "iid": 225,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Contact Sensor State",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 226,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Master BR Window Contact",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4298649931,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Loft window",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBDWC01",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Loft window",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Loft window Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 327,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Loft window Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 328,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 224,
+        "type": "00000080-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000006A-0000-1000-8000-0026BB765291",
+            "iid": 225,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Contact Sensor State",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 226,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Loft window Contact",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4298527970,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Front Door",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBDWC01",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Front Door",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 1,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Front Door Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 1473,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Front Door Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 873,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 224,
+        "type": "00000080-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000006A-0000-1000-8000-0026BB765291",
+            "iid": 225,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Contact Sensor State",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 226,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Front Door Contact",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4298527962,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Garage Door",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBDWC01",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Garage Door",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 1,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Garage Door Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 1189,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Garage Door Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 888,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 224,
+        "type": "00000080-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000006A-0000-1000-8000-0026BB765291",
+            "iid": 225,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Contact Sensor State",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 226,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Garage Door Contact",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4298360914,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement Window 1",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBDWC01",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement Window 1",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement Window 1 Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": -1,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement Window 1 Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": -1,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 224,
+        "type": "00000080-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000006A-0000-1000-8000-0026BB765291",
+            "iid": 225,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Contact Sensor State",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 226,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Basement Window 1 Contact",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4298360921,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Deck Door",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBDWC01",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Deck Door",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Deck Door Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 944,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Deck Door Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 884,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 224,
+        "type": "00000080-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000006A-0000-1000-8000-0026BB765291",
+            "iid": 225,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Contact Sensor State",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 226,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Deck Door Contact",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4298360712,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room Window 1",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBDWC01",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room Window 1",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 1,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room Window 1 Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 1923,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room Window 1 Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 625,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 224,
+        "type": "00000080-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000006A-0000-1000-8000-0026BB765291",
+            "iid": 225,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Contact Sensor State",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 226,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Living Room Window 1 Contact",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "aid": 4298568508,
+    "services": [
+      {
+        "iid": 1,
+        "type": "0000003E-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 2,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR Window",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000020-0000-1000-8000-0026BB765291",
+            "iid": 3,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "ecobee Inc.",
+            "description": "Manufacturer",
+            "maxLen": 64
+          },
+          {
+            "type": "00000030-0000-1000-8000-0026BB765291",
+            "iid": 4,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "**REDACTED**",
+            "description": "Serial Number",
+            "maxLen": 64
+          },
+          {
+            "type": "00000021-0000-1000-8000-0026BB765291",
+            "iid": 5,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "EBDWC01",
+            "description": "Model",
+            "maxLen": 64
+          },
+          {
+            "type": "00000052-0000-1000-8000-0026BB765291",
+            "iid": 8,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "1.0.0",
+            "description": "Firmware Revision",
+            "maxLen": 64
+          },
+          {
+            "type": "00000014-0000-1000-8000-0026BB765291",
+            "iid": 6,
+            "perms": ["pw"],
+            "format": "bool",
+            "description": "Identify"
+          }
+        ]
+      },
+      {
+        "iid": 192,
+        "type": "00000096-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000008F-0000-1000-8000-0026BB765291",
+            "iid": 193,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 2,
+            "description": "Charging State",
+            "minValue": 0,
+            "maxValue": 2,
+            "minStep": 1
+          },
+          {
+            "type": "00000068-0000-1000-8000-0026BB765291",
+            "iid": 194,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 100,
+            "description": "Battery Level",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 195,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 196,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR Window",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      },
+      {
+        "iid": 57,
+        "type": "00000086-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000071-0000-1000-8000-0026BB765291",
+            "iid": 65,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Occupancy Detected",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 29,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR Window Occupancy",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 117,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 116,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "A8F798E0-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 68,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 9060,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 56,
+        "type": "00000085-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "00000022-0000-1000-8000-0026BB765291",
+            "iid": 66,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": false,
+            "description": "Motion Detected"
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 28,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR Window Motion",
+            "description": "Name",
+            "maxLen": 64
+          },
+          {
+            "type": "00000075-0000-1000-8000-0026BB765291",
+            "iid": 101,
+            "perms": ["pr", "ev"],
+            "format": "bool",
+            "value": true,
+            "description": "Status Active"
+          },
+          {
+            "type": "00000079-0000-1000-8000-0026BB765291",
+            "iid": 100,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Status Low Battery",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "BFE61C70-4A40-11E6-BDF4-0800200C9A66",
+            "iid": 67,
+            "perms": ["pr"],
+            "format": "int",
+            "value": 9060,
+            "unit": "seconds",
+            "minValue": -1,
+            "maxValue": 86400,
+            "minStep": 1
+          }
+        ]
+      },
+      {
+        "iid": 224,
+        "type": "00000080-0000-1000-8000-0026BB765291",
+        "characteristics": [
+          {
+            "type": "0000006A-0000-1000-8000-0026BB765291",
+            "iid": 225,
+            "perms": ["pr", "ev"],
+            "format": "uint8",
+            "value": 0,
+            "description": "Contact Sensor State",
+            "minValue": 0,
+            "maxValue": 1,
+            "minStep": 1
+          },
+          {
+            "type": "00000023-0000-1000-8000-0026BB765291",
+            "iid": 226,
+            "perms": ["pr"],
+            "format": "string",
+            "value": "Upstairs BR Window Contact",
+            "description": "Name",
+            "maxLen": 64
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -4195,6 +4195,3464 @@
     }),
   ])
 # ---
+# name: test_snapshots[ecobee3_lite]
+  list([
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4295608960',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBRSE4',
+        'model_id': None,
+        'name': 'Basement',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.basement_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Basement Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608960_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Basement Motion',
+            }),
+            'entity_id': 'binary_sensor.basement_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.basement_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Basement Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608960_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Basement Occupancy',
+            }),
+            'entity_id': 'binary_sensor.basement_occupancy',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.basement_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Basement Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608960_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Basement Identify',
+            }),
+            'entity_id': 'button.basement_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.basement_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Basement Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608960_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Basement Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.basement_battery',
+            'state': '100',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': None,
+            'entity_id': 'sensor.basement_temperature',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+            'original_icon': None,
+            'original_name': 'Basement Temperature',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608960_208',
+            'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'temperature',
+              'friendly_name': 'Basement Temperature',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+            }),
+            'entity_id': 'sensor.basement_temperature',
+            'state': '20.3',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4298360914',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBDWC01',
+        'model_id': None,
+        'name': 'Basement Window 1',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.basement_window_1_contact',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+            'original_icon': None,
+            'original_name': 'Basement Window 1 Contact',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360914_224',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'opening',
+              'friendly_name': 'Basement Window 1 Contact',
+            }),
+            'entity_id': 'binary_sensor.basement_window_1_contact',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.basement_window_1_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Basement Window 1 Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360914_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Basement Window 1 Motion',
+            }),
+            'entity_id': 'binary_sensor.basement_window_1_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.basement_window_1_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Basement Window 1 Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360914_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Basement Window 1 Occupancy',
+            }),
+            'entity_id': 'binary_sensor.basement_window_1_occupancy',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.basement_window_1_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Basement Window 1 Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360914_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Basement Window 1 Identify',
+            }),
+            'entity_id': 'button.basement_window_1_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.basement_window_1_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Basement Window 1 Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360914_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Basement Window 1 Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.basement_window_1_battery',
+            'state': '100',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4298360921',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBDWC01',
+        'model_id': None,
+        'name': 'Deck Door',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.deck_door_contact',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+            'original_icon': None,
+            'original_name': 'Deck Door Contact',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360921_224',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'opening',
+              'friendly_name': 'Deck Door Contact',
+            }),
+            'entity_id': 'binary_sensor.deck_door_contact',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.deck_door_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Deck Door Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360921_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Deck Door Motion',
+            }),
+            'entity_id': 'binary_sensor.deck_door_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.deck_door_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Deck Door Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360921_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Deck Door Occupancy',
+            }),
+            'entity_id': 'binary_sensor.deck_door_occupancy',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.deck_door_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Deck Door Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360921_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Deck Door Identify',
+            }),
+            'entity_id': 'button.deck_door_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.deck_door_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Deck Door Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360921_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Deck Door Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.deck_door_battery',
+            'state': '100',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4298527970',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBDWC01',
+        'model_id': None,
+        'name': 'Front Door',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.front_door_contact',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+            'original_icon': None,
+            'original_name': 'Front Door Contact',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527970_224',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'opening',
+              'friendly_name': 'Front Door Contact',
+            }),
+            'entity_id': 'binary_sensor.front_door_contact',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.front_door_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Front Door Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527970_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Front Door Motion',
+            }),
+            'entity_id': 'binary_sensor.front_door_motion',
+            'state': 'on',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.front_door_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Front Door Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527970_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Front Door Occupancy',
+            }),
+            'entity_id': 'binary_sensor.front_door_occupancy',
+            'state': 'on',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.front_door_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Front Door Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527970_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Front Door Identify',
+            }),
+            'entity_id': 'button.front_door_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.front_door_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Front Door Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527970_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Front Door Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.front_door_battery',
+            'state': '100',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4298527962',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBDWC01',
+        'model_id': None,
+        'name': 'Garage Door',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.garage_door_contact',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+            'original_icon': None,
+            'original_name': 'Garage Door Contact',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527962_224',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'opening',
+              'friendly_name': 'Garage Door Contact',
+            }),
+            'entity_id': 'binary_sensor.garage_door_contact',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.garage_door_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Garage Door Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527962_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Garage Door Motion',
+            }),
+            'entity_id': 'binary_sensor.garage_door_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.garage_door_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Garage Door Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527962_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Garage Door Occupancy',
+            }),
+            'entity_id': 'binary_sensor.garage_door_occupancy',
+            'state': 'on',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.garage_door_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Garage Door Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527962_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Garage Door Identify',
+            }),
+            'entity_id': 'button.garage_door_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.garage_door_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Garage Door Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298527962_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Garage Door Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.garage_door_battery',
+            'state': '100',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4295016858',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBRSE4',
+        'model_id': None,
+        'name': 'Living Room',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.living_room_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Living Room Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016858_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Living Room Motion',
+            }),
+            'entity_id': 'binary_sensor.living_room_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.living_room_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Living Room Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016858_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Living Room Occupancy',
+            }),
+            'entity_id': 'binary_sensor.living_room_occupancy',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.living_room_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Living Room Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016858_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Living Room Identify',
+            }),
+            'entity_id': 'button.living_room_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.living_room_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Living Room Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016858_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Living Room Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.living_room_battery',
+            'state': '100',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': None,
+            'entity_id': 'sensor.living_room_temperature',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+            'original_icon': None,
+            'original_name': 'Living Room Temperature',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016858_208',
+            'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'temperature',
+              'friendly_name': 'Living Room Temperature',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+            }),
+            'entity_id': 'sensor.living_room_temperature',
+            'state': '21.0',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4298360712',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBDWC01',
+        'model_id': None,
+        'name': 'Living Room Window 1',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.living_room_window_1_contact',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+            'original_icon': None,
+            'original_name': 'Living Room Window 1 Contact',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360712_224',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'opening',
+              'friendly_name': 'Living Room Window 1 Contact',
+            }),
+            'entity_id': 'binary_sensor.living_room_window_1_contact',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.living_room_window_1_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Living Room Window 1 Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360712_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Living Room Window 1 Motion',
+            }),
+            'entity_id': 'binary_sensor.living_room_window_1_motion',
+            'state': 'on',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.living_room_window_1_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Living Room Window 1 Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360712_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Living Room Window 1 Occupancy',
+            }),
+            'entity_id': 'binary_sensor.living_room_window_1_occupancy',
+            'state': 'on',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.living_room_window_1_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Living Room Window 1 Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360712_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Living Room Window 1 Identify',
+            }),
+            'entity_id': 'button.living_room_window_1_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.living_room_window_1_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Living Room Window 1 Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298360712_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Living Room Window 1 Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.living_room_window_1_battery',
+            'state': '100',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4298649931',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBDWC01',
+        'model_id': None,
+        'name': 'Loft window',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.loft_window_contact',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+            'original_icon': None,
+            'original_name': 'Loft window Contact',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298649931_224',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'opening',
+              'friendly_name': 'Loft window Contact',
+            }),
+            'entity_id': 'binary_sensor.loft_window_contact',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.loft_window_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Loft window Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298649931_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Loft window Motion',
+            }),
+            'entity_id': 'binary_sensor.loft_window_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.loft_window_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Loft window Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298649931_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Loft window Occupancy',
+            }),
+            'entity_id': 'binary_sensor.loft_window_occupancy',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.loft_window_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Loft window Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298649931_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Loft window Identify',
+            }),
+            'entity_id': 'button.loft_window_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.loft_window_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Loft window Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298649931_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Loft window Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.loft_window_battery',
+            'state': '100',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4295608971',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBRSE4',
+        'model_id': None,
+        'name': 'Master BR',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.master_br_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Master BR Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608971_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Master BR Motion',
+            }),
+            'entity_id': 'binary_sensor.master_br_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.master_br_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Master BR Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608971_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Master BR Occupancy',
+            }),
+            'entity_id': 'binary_sensor.master_br_occupancy',
+            'state': 'on',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.master_br_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Master BR Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608971_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Master BR Identify',
+            }),
+            'entity_id': 'button.master_br_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.master_br_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Master BR Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608971_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Master BR Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.master_br_battery',
+            'state': '100',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': None,
+            'entity_id': 'sensor.master_br_temperature',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+            'original_icon': None,
+            'original_name': 'Master BR Temperature',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295608971_208',
+            'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'temperature',
+              'friendly_name': 'Master BR Temperature',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+            }),
+            'entity_id': 'sensor.master_br_temperature',
+            'state': '22.4',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4298584118',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBDWC01',
+        'model_id': None,
+        'name': 'Master BR Window',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.master_br_window_contact',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+            'original_icon': None,
+            'original_name': 'Master BR Window Contact',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298584118_224',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'opening',
+              'friendly_name': 'Master BR Window Contact',
+            }),
+            'entity_id': 'binary_sensor.master_br_window_contact',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.master_br_window_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Master BR Window Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298584118_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Master BR Window Motion',
+            }),
+            'entity_id': 'binary_sensor.master_br_window_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.master_br_window_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Master BR Window Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298584118_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Master BR Window Occupancy',
+            }),
+            'entity_id': 'binary_sensor.master_br_window_occupancy',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.master_br_window_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Master BR Window Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298584118_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Master BR Window Identify',
+            }),
+            'entity_id': 'button.master_br_window_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.master_br_window_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Master BR Window Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298584118_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Master BR Window Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.master_br_window_battery',
+            'state': '100',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:1',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'ecobee3 lite',
+        'model_id': None,
+        'name': 'Thermostat',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '4.8.70226',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': None,
+            'entity_id': 'button.thermostat_clear_hold',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': None,
+            'original_icon': None,
+            'original_name': 'Thermostat Clear Hold',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_1_16_48',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'friendly_name': 'Thermostat Clear Hold',
+            }),
+            'entity_id': 'button.thermostat_clear_hold',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.thermostat_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Thermostat Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_1_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Thermostat Identify',
+            }),
+            'entity_id': 'button.thermostat_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'fan_modes': list([
+                'on',
+                'auto',
+              ]),
+              'hvac_modes': list([
+                <HVACMode.OFF: 'off'>,
+                <HVACMode.HEAT: 'heat'>,
+                <HVACMode.COOL: 'cool'>,
+                <HVACMode.HEAT_COOL: 'heat_cool'>,
+              ]),
+              'max_temp': 35,
+              'min_temp': 7,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'climate',
+            'entity_category': None,
+            'entity_id': 'climate.thermostat',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': None,
+            'original_icon': None,
+            'original_name': 'Thermostat',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': <ClimateEntityFeature: 395>,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_1_16',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'current_humidity': 45.0,
+              'current_temperature': 21.2,
+              'fan_mode': 'on',
+              'fan_modes': list([
+                'on',
+                'auto',
+              ]),
+              'friendly_name': 'Thermostat',
+              'hvac_action': <HVACAction.FAN: 'fan'>,
+              'hvac_modes': list([
+                <HVACMode.OFF: 'off'>,
+                <HVACMode.HEAT: 'heat'>,
+                <HVACMode.COOL: 'cool'>,
+                <HVACMode.HEAT_COOL: 'heat_cool'>,
+              ]),
+              'max_temp': 35,
+              'min_temp': 7,
+              'supported_features': <ClimateEntityFeature: 395>,
+              'target_temp_high': None,
+              'target_temp_low': None,
+              'temperature': None,
+            }),
+            'entity_id': 'climate.thermostat',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'options': list([
+                'home',
+                'sleep',
+                'away',
+              ]),
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'select',
+            'entity_category': None,
+            'entity_id': 'select.thermostat_current_mode',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': None,
+            'original_icon': None,
+            'original_name': 'Thermostat Current Mode',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': 'ecobee_mode',
+            'unique_id': '00:00:00:00:00:00_1_16_33',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'friendly_name': 'Thermostat Current Mode',
+              'options': list([
+                'home',
+                'sleep',
+                'away',
+              ]),
+            }),
+            'entity_id': 'select.thermostat_current_mode',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'options': list([
+                'celsius',
+                'fahrenheit',
+              ]),
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'select',
+            'entity_category': <EntityCategory.CONFIG: 'config'>,
+            'entity_id': 'select.thermostat_temperature_display_units',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': None,
+            'original_icon': None,
+            'original_name': 'Thermostat Temperature Display Units',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': 'temperature_display_units',
+            'unique_id': '00:00:00:00:00:00_1_16_21',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'friendly_name': 'Thermostat Temperature Display Units',
+              'options': list([
+                'celsius',
+                'fahrenheit',
+              ]),
+            }),
+            'entity_id': 'select.thermostat_temperature_display_units',
+            'state': 'fahrenheit',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': None,
+            'entity_id': 'sensor.thermostat_current_humidity',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+            'original_icon': None,
+            'original_name': 'Thermostat Current Humidity',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_1_16_24',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'humidity',
+              'friendly_name': 'Thermostat Current Humidity',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.thermostat_current_humidity',
+            'state': '45.0',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': None,
+            'entity_id': 'sensor.thermostat_current_temperature',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+            'original_icon': None,
+            'original_name': 'Thermostat Current Temperature',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_1_16_19',
+            'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'temperature',
+              'friendly_name': 'Thermostat Current Temperature',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+            }),
+            'entity_id': 'sensor.thermostat_current_temperature',
+            'state': '21.2',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4295016969',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBRSE4',
+        'model_id': None,
+        'name': 'Upstairs BR',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.upstairs_br_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Upstairs BR Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016969_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Upstairs BR Motion',
+            }),
+            'entity_id': 'binary_sensor.upstairs_br_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.upstairs_br_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Upstairs BR Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016969_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Upstairs BR Occupancy',
+            }),
+            'entity_id': 'binary_sensor.upstairs_br_occupancy',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.upstairs_br_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Upstairs BR Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016969_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Upstairs BR Identify',
+            }),
+            'entity_id': 'button.upstairs_br_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.upstairs_br_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Upstairs BR Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016969_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Upstairs BR Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.upstairs_br_battery',
+            'state': '100',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': None,
+            'entity_id': 'sensor.upstairs_br_temperature',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+            'original_icon': None,
+            'original_name': 'Upstairs BR Temperature',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4295016969_208',
+            'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'temperature',
+              'friendly_name': 'Upstairs BR Temperature',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+            }),
+            'entity_id': 'sensor.upstairs_br_temperature',
+            'state': '21.6',
+          }),
+        }),
+      ]),
+    }),
+    dict({
+      'device': dict({
+        'area_id': None,
+        'config_entries': list([
+          'TestData',
+        ]),
+        'config_entries_subentries': dict({
+          'TestData': list([
+            None,
+          ]),
+        }),
+        'configuration_url': None,
+        'connections': list([
+        ]),
+        'disabled_by': None,
+        'entry_type': None,
+        'hw_version': '',
+        'identifiers': list([
+          list([
+            'homekit_controller:accessory-id',
+            '00:00:00:00:00:00:aid:4298568508',
+          ]),
+        ]),
+        'is_new': False,
+        'labels': list([
+        ]),
+        'manufacturer': 'ecobee Inc.',
+        'model': 'EBDWC01',
+        'model_id': None,
+        'name': 'Upstairs BR Window',
+        'name_by_user': None,
+        'primary_config_entry': 'TestData',
+        'serial_number': '**REDACTED**',
+        'suggested_area': None,
+        'sw_version': '1.0.0',
+      }),
+      'entities': list([
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.upstairs_br_window_contact',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+            'original_icon': None,
+            'original_name': 'Upstairs BR Window Contact',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298568508_224',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'opening',
+              'friendly_name': 'Upstairs BR Window Contact',
+            }),
+            'entity_id': 'binary_sensor.upstairs_br_window_contact',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.upstairs_br_window_motion',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+            'original_icon': None,
+            'original_name': 'Upstairs BR Window Motion',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298568508_56',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'motion',
+              'friendly_name': 'Upstairs BR Window Motion',
+            }),
+            'entity_id': 'binary_sensor.upstairs_br_window_motion',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'binary_sensor',
+            'entity_category': None,
+            'entity_id': 'binary_sensor.upstairs_br_window_occupancy',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+            'original_icon': None,
+            'original_name': 'Upstairs BR Window Occupancy',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298568508_57',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'occupancy',
+              'friendly_name': 'Upstairs BR Window Occupancy',
+            }),
+            'entity_id': 'binary_sensor.upstairs_br_window_occupancy',
+            'state': 'off',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': None,
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'button',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'button.upstairs_br_window_identify',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+            'original_icon': None,
+            'original_name': 'Upstairs BR Window Identify',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298568508_1_6',
+            'unit_of_measurement': None,
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'identify',
+              'friendly_name': 'Upstairs BR Window Identify',
+            }),
+            'entity_id': 'button.upstairs_br_window_identify',
+            'state': 'unknown',
+          }),
+        }),
+        dict({
+          'entry': dict({
+            'aliases': list([
+            ]),
+            'area_id': None,
+            'capabilities': dict({
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+            }),
+            'categories': dict({
+            }),
+            'config_entry_id': 'TestData',
+            'config_subentry_id': None,
+            'device_class': None,
+            'disabled_by': None,
+            'domain': 'sensor',
+            'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+            'entity_id': 'sensor.upstairs_br_window_battery',
+            'has_entity_name': False,
+            'hidden_by': None,
+            'icon': None,
+            'labels': list([
+            ]),
+            'name': None,
+            'options': dict({
+            }),
+            'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+            'original_icon': 'mdi:battery-unknown',
+            'original_name': 'Upstairs BR Window Battery',
+            'platform': 'homekit_controller',
+            'previous_unique_id': None,
+            'supported_features': 0,
+            'translation_key': None,
+            'unique_id': '00:00:00:00:00:00_4298568508_192',
+            'unit_of_measurement': '%',
+          }),
+          'state': dict({
+            'attributes': dict({
+              'device_class': 'battery',
+              'friendly_name': 'Upstairs BR Window Battery',
+              'icon': 'mdi:battery',
+              'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+              'unit_of_measurement': '%',
+            }),
+            'entity_id': 'sensor.upstairs_br_window_battery',
+            'state': '100',
+          }),
+        }),
+      ]),
+    }),
+  ])
+# ---
 # name: test_snapshots[ecobee3_no_sensors]
   list([
     dict({


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes #142442

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
