### PR TITLE
Improve Z-Wave reconfigure flow

### DIFF
--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -214,6 +214,7 @@
       "addon_install_failed": "[%key:component::zwave_js::config::abort::addon_install_failed%]",
       "addon_set_config_failed": "[%key:component::zwave_js::config::abort::addon_set_config_failed%]",
       "addon_start_failed": "[%key:component::zwave_js::config::abort::addon_start_failed%]",
+      "addon_stop_failed": "Failed to stop the Z-Wave add-on.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "different_device": "The connected USB device is not the same as previously configured for this config entry. Please instead create a new config entry for the new device."

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -70,6 +70,15 @@ def setup_entry_fixture() -> Generator[AsyncMock]:
         yield mock_setup_entry
 
 
+@pytest.fixture(name="unload_entry")
+def unload_entry_fixture() -> Generator[AsyncMock]:
+    """Mock entry unload."""
+    with patch(
+        "homeassistant.components.zwave_js.async_unload_entry", return_value=True
+    ) as mock_unload_entry:
+        yield mock_unload_entry
+
+
 @pytest.fixture(name="supervisor")
 def mock_supervisor_fixture() -> Generator[None]:
     """Mock Supervisor."""
@@ -2010,6 +2019,104 @@ async def test_options_not_addon(
     assert entry.data["integration_created_addon"] is False
     assert client.connect.call_count == 2
     assert client.disconnect.call_count == 1
+
+
+@pytest.mark.usefixtures("supervisor")
+async def test_options_not_addon_with_addon(
+    hass: HomeAssistant,
+    setup_entry: AsyncMock,
+    unload_entry: AsyncMock,
+    integration: MockConfigEntry,
+    stop_addon: AsyncMock,
+) -> None:
+    """Test options flow opting out of add-on on Supervisor with add-on."""
+    entry = integration
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, "url": "ws://host1:3001", "use_addon": True},
+        unique_id="1234",
+    )
+
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert unload_entry.call_count == 0
+    setup_entry.reset_mock()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"use_addon": False}
+    )
+
+    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert setup_entry.call_count == 0
+    assert unload_entry.call_count == 1
+    assert stop_addon.call_count == 1
+    assert stop_addon.call_args == call("core_zwave_js")
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "url": "ws://localhost:3000",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.data["url"] == "ws://localhost:3000"
+    assert entry.data["use_addon"] is False
+    assert entry.data["integration_created_addon"] is False
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert setup_entry.call_count == 1
+    assert unload_entry.call_count == 1
+
+
+@pytest.mark.usefixtures("supervisor")
+async def test_options_not_addon_with_addon_stop_fail(
+    hass: HomeAssistant,
+    setup_entry: AsyncMock,
+    unload_entry: AsyncMock,
+    integration: MockConfigEntry,
+    stop_addon: AsyncMock,
+) -> None:
+    """Test options flow opting out of add-on and add-on stop error."""
+    stop_addon.side_effect = SupervisorError("Boom!")
+    entry = integration
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, "url": "ws://host1:3001", "use_addon": True},
+        unique_id="1234",
+    )
+
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert unload_entry.call_count == 0
+    setup_entry.reset_mock()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "on_supervisor"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"use_addon": False}
+    )
+    await hass.async_block_till_done()
+
+    assert stop_addon.call_count == 1
+    assert stop_addon.call_args == call("core_zwave_js")
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "addon_stop_failed"
+    assert entry.data["url"] == "ws://host1:3001"
+    assert entry.data["use_addon"] is True
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert setup_entry.call_count == 1
+    assert unload_entry.call_count == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Unload the config entry and stop the add-on when reconfiguring the Z-Wave integration from managed add-on to manual url, to avoid a conflict between the managed add-on and another user of the USB port.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
