### PR TITLE
Flipr - Removal of obsolete code.

### DIFF
--- a/homeassistant/components/flipr/strings.json
+++ b/homeassistant/components/flipr/strings.json
@@ -50,11 +50,5 @@
         }
       }
     }
-  },
-  "issues": {
-    "duplicate_config": {
-      "title": "Multiple flipr configurations with the same account",
-      "description": "The Flipr integration has been updated to work account based rather than device based. This means that if you have 2 devices, you only need one configuration. For every account you have, please delete all but one configuration and restart Home Assistant for it to set up the devices linked to your account."
-    }
   }
 }

--- a/tests/components/flipr/test_init.py
+++ b/tests/components/flipr/test_init.py
@@ -2,9 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from homeassistant.components.flipr.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
@@ -29,62 +27,3 @@ async def test_unload_entry(
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
-
-
-async def test_duplicate_config_entries(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_flipr_client: AsyncMock,
-) -> None:
-    """Test duplicate config entries."""
-
-    mock_config_entry_dup = MockConfigEntry(
-        version=2,
-        domain=DOMAIN,
-        unique_id="toto@toto.com",
-        data={
-            CONF_EMAIL: "toto@toto.com",
-            CONF_PASSWORD: "myPassword",
-            "flipr_id": "myflipr_id_dup",
-        },
-    )
-
-    mock_config_entry.add_to_hass(hass)
-    # Initialize the first entry with default mock
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Initialize the second entry with another flipr id
-    mock_config_entry_dup.add_to_hass(hass)
-    assert not await hass.config_entries.async_setup(mock_config_entry_dup.entry_id)
-    await hass.async_block_till_done()
-    assert mock_config_entry_dup.state is ConfigEntryState.SETUP_ERROR
-
-
-async def test_migrate_entry(
-    hass: HomeAssistant,
-    mock_flipr_client: AsyncMock,
-) -> None:
-    """Test migrate config entry from v1 to v2."""
-
-    mock_config_entry_v1 = MockConfigEntry(
-        version=1,
-        domain=DOMAIN,
-        title="myfliprid",
-        unique_id="test_entry_unique_id",
-        data={
-            CONF_EMAIL: "toto@toto.com",
-            CONF_PASSWORD: "myPassword",
-            "flipr_id": "myfliprid",
-        },
-    )
-
-    await setup_integration(hass, mock_config_entry_v1)
-    assert mock_config_entry_v1.state is ConfigEntryState.LOADED
-    assert mock_config_entry_v1.version == 2
-    assert mock_config_entry_v1.unique_id == "toto@toto.com"
-    assert mock_config_entry_v1.data == {
-        CONF_EMAIL: "toto@toto.com",
-        CONF_PASSWORD: "myPassword",
-        "flipr_id": "myfliprid",
-    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

As discussed with @emontnemery in november, this PR is to remove the old code of flipr automatic upgrade from config v1 to v2.
It is done now as it was informed to the users that it will break in april 2025.

This PR could help remove the exception present in : https://github.com/home-assistant/core/pull/130058


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove old code : no particular change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/130058
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
