### PR TITLE
Allow dns hostnames to be retained for SMLIGHT user flow.

### DIFF
--- a/homeassistant/components/smlight/config_flow.py
+++ b/homeassistant/components/smlight/config_flow.py
@@ -53,7 +53,6 @@ class SmlightConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 if not await self._async_check_auth_required(user_input):
                     info = await self.client.get_info()
-                    self._host = str(info.device_ip)
                     self._device_name = str(info.hostname)
 
                     if info.model not in Devices:
@@ -79,7 +78,6 @@ class SmlightConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 if not await self._async_check_auth_required(user_input):
                     info = await self.client.get_info()
-                    self._host = str(info.device_ip)
                     self._device_name = str(info.hostname)
 
                     if info.model not in Devices:

--- a/tests/components/smlight/conftest.py
+++ b/tests/components/smlight/conftest.py
@@ -21,6 +21,7 @@ from tests.common import (
 
 MOCK_DEVICE_NAME = "slzb-06"
 MOCK_HOST = "192.168.1.161"
+MOCK_HOSTNAME = "slzb-06p7.lan"
 MOCK_USERNAME = "test-user"
 MOCK_PASSWORD = "test-pass"
 

--- a/tests/components/smlight/test_config_flow.py
+++ b/tests/components/smlight/test_config_flow.py
@@ -15,7 +15,13 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .conftest import MOCK_DEVICE_NAME, MOCK_HOST, MOCK_PASSWORD, MOCK_USERNAME
+from .conftest import (
+    MOCK_DEVICE_NAME,
+    MOCK_HOST,
+    MOCK_HOSTNAME,
+    MOCK_PASSWORD,
+    MOCK_USERNAME,
+)
 
 from tests.common import MockConfigEntry
 
@@ -53,14 +59,14 @@ async def test_user_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_HOST: "slzb-06p7.local",
+            CONF_HOST: MOCK_HOSTNAME,
         },
     )
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "SLZB-06p7"
     assert result2["data"] == {
-        CONF_HOST: MOCK_HOST,
+        CONF_HOST: MOCK_HOSTNAME,
     }
     assert result2["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
     assert len(mock_setup_entry.mock_calls) == 1
@@ -82,7 +88,7 @@ async def test_user_flow_auth(
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_HOST: "slzb-06p7.local",
+            CONF_HOST: MOCK_HOSTNAME,
         },
     )
     assert result2["type"] is FlowResultType.FORM
@@ -100,7 +106,7 @@ async def test_user_flow_auth(
     assert result3["data"] == {
         CONF_USERNAME: MOCK_USERNAME,
         CONF_PASSWORD: MOCK_PASSWORD,
-        CONF_HOST: MOCK_HOST,
+        CONF_HOST: MOCK_HOSTNAME,
     }
     assert result3["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow using hostname or static IP for user flow .Previously  we overwriting the value here with `info.device_up`. This returns the local IP, which may not always match the IP we connected to. This happens for example when connected over a VPN.

This can allow using the device when it is on a different subnet or remote device. If the device is on the same subnet then the hostname wil stilll get overwritten by Zeroconf and/or dhcp discovery.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140395
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
