### PR TITLE
Fix blocking call in Pterodactyl

### DIFF
--- a/homeassistant/components/pterodactyl/api.py
+++ b/homeassistant/components/pterodactyl/api.py
@@ -79,7 +79,9 @@ class PterodactylAPI:
 
             raise PterodactylConnectionError(error) from error
         else:
-            game_servers = paginated_response.collect()
+            game_servers = await self.hass.async_add_executor_job(
+                paginated_response.collect
+            )
             for game_server in game_servers:
                 self.identifiers.append(game_server["attributes"]["identifier"])
 

--- a/homeassistant/components/pterodactyl/api.py
+++ b/homeassistant/components/pterodactyl/api.py
@@ -63,15 +63,24 @@ class PterodactylAPI:
         self.pterodactyl = None
         self.identifiers = []
 
+    def get_game_servers(self) -> list[str]:
+        """Get all game servers."""
+        paginated_response = self.pterodactyl.client.servers.list_servers()  # type: ignore[union-attr]
+
+        return paginated_response.collect()
+
     async def async_init(self):
         """Initialize the Pterodactyl API."""
         self.pterodactyl = PterodactylClient(self.host, self.api_key)
 
         try:
-            paginated_response = await self.hass.async_add_executor_job(
-                self.pterodactyl.client.servers.list_servers
-            )
-        except (BadRequestError, PterodactylApiError, ConnectionError) as error:
+            game_servers = await self.hass.async_add_executor_job(self.get_game_servers)
+        except (
+            BadRequestError,
+            PterodactylApiError,
+            ConnectionError,
+            StopIteration,
+        ) as error:
             raise PterodactylConnectionError(error) from error
         except HTTPError as error:
             if error.response.status_code == 401:
@@ -79,9 +88,6 @@ class PterodactylAPI:
 
             raise PterodactylConnectionError(error) from error
         else:
-            game_servers = await self.hass.async_add_executor_job(
-                paginated_response.collect
-            )
             for game_server in game_servers:
                 self.identifiers.append(game_server["attributes"]["identifier"])
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
From https://github.com/home-assistant/core/issues/142508:

> RuntimeError: Caught blocking call to putrequest with args (, 'GET', '/api/client?page=2') inside the event loop by integration 'pterodactyl' at homeassistant/components/pterodactyl/api.py, line 74: game_servers = paginated_response.collect(). (offender: /usr/local/lib/python3.13/site-packages/sentry_sdk/integrations/stdlib.py, line 106: rv = real_putrequest(self, method, url, *args, **kwargs)), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+pterodactyl%22
> For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#putrequest

The `collect` function will not block if the response (`pydactyl.responses.PaginatedResponse`) from the server contains all pages. But if not all pages are contained, collect will fetch the missing pages from the server --> Blocking call in this situation.

It didn't occur with my server, as I only have 2 game servers running on it (response always contains all pages).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n.a.
- This PR is related to issue: https://github.com/home-assistant/core/issues/142508
- Link to documentation pull request: n.a.
- Link to developer documentation pull request: n.a.
- Link to frontend pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
