### PR TITLE
Allow max to be equal with min for mqtt number config validation

### DIFF
--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -70,8 +70,8 @@ MQTT_NUMBER_ATTRIBUTES_BLOCKED = frozenset(
 
 def validate_config(config: ConfigType) -> ConfigType:
     """Validate that the configuration is valid, throws if it isn't."""
-    if config[CONF_MIN] >= config[CONF_MAX]:
-        raise vol.Invalid(f"'{CONF_MAX}' must be > '{CONF_MIN}'")
+    if config[CONF_MIN] > config[CONF_MAX]:
+        raise vol.Invalid(f"{CONF_MAX} must be >= {CONF_MIN}")
 
     return config
 

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -835,32 +835,57 @@ async def test_entity_debug_info_message(
 
 
 @pytest.mark.parametrize(
-    "hass_config",
+    ("hass_config", "min_number", "max_number", "step"),
     [
-        {
-            mqtt.DOMAIN: {
-                number.DOMAIN: {
-                    "state_topic": "test/state_number",
-                    "command_topic": "test/cmd_number",
-                    "name": "Test Number",
-                    "min": 5,
-                    "max": 110,
-                    "step": 20,
+        (
+            {
+                mqtt.DOMAIN: {
+                    number.DOMAIN: {
+                        "state_topic": "test/state_number",
+                        "command_topic": "test/cmd_number",
+                        "name": "Test Number",
+                        "min": 5,
+                        "max": 110,
+                        "step": 20,
+                    }
                 }
-            }
-        }
+            },
+            5,
+            110,
+            20,
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    number.DOMAIN: {
+                        "state_topic": "test/state_number",
+                        "command_topic": "test/cmd_number",
+                        "name": "Test Number",
+                        "min": 100,
+                        "max": 100,
+                    }
+                }
+            },
+            100,
+            100,
+            1,
+        ),
     ],
 )
 async def test_min_max_step_attributes(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    min_number: float,
+    max_number: float,
+    step: float,
 ) -> None:
     """Test min/max/step attributes."""
     await mqtt_mock_entry()
 
     state = hass.states.get("number.test_number")
-    assert state.attributes.get(ATTR_MIN) == 5
-    assert state.attributes.get(ATTR_MAX) == 110
-    assert state.attributes.get(ATTR_STEP) == 20
+    assert state.attributes.get(ATTR_MIN) == min_number
+    assert state.attributes.get(ATTR_MAX) == max_number
+    assert state.attributes.get(ATTR_STEP) == step
 
 
 @pytest.mark.parametrize(
@@ -885,7 +910,7 @@ async def test_invalid_min_max_attributes(
 ) -> None:
     """Test invalid min/max attributes."""
     assert await mqtt_mock_entry()
-    assert f"'{CONF_MAX}' must be > '{CONF_MIN}'" in caplog.text
+    assert f"{CONF_MAX} must be >= {CONF_MIN}" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The MQTT number validation should not be stricter than its base entity validation which allows max and min to be the same.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #142327
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
