### PR TITLE
Add translations for connection closed errors in Android TV Remote

### DIFF
--- a/homeassistant/components/androidtv_remote/entity.py
+++ b/homeassistant/components/androidtv_remote/entity.py
@@ -73,7 +73,7 @@ class AndroidTVRemoteBaseEntity(Entity):
             self._api.send_key_command(key_code, direction)
         except ConnectionClosed as exc:
             raise HomeAssistantError(
-                "Connection to Android TV device is closed"
+                translation_domain=DOMAIN, translation_key="connection_closed"
             ) from exc
 
     def _send_launch_app_command(self, app_link: str) -> None:
@@ -85,5 +85,5 @@ class AndroidTVRemoteBaseEntity(Entity):
             self._api.send_launch_app_command(app_link)
         except ConnectionClosed as exc:
             raise HomeAssistantError(
-                "Connection to Android TV device is closed"
+                translation_domain=DOMAIN, translation_key="connection_closed"
             ) from exc

--- a/homeassistant/components/androidtv_remote/media_player.py
+++ b/homeassistant/components/androidtv_remote/media_player.py
@@ -21,7 +21,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AndroidTVRemoteConfigEntry
-from .const import CONF_APP_ICON, CONF_APP_NAME
+from .const import CONF_APP_ICON, CONF_APP_NAME, DOMAIN
 from .entity import AndroidTVRemoteBaseEntity
 
 PARALLEL_UPDATES = 0
@@ -233,5 +233,5 @@ class AndroidTVRemoteMediaPlayerEntity(AndroidTVRemoteBaseEntity, MediaPlayerEnt
                 await asyncio.sleep(delay_secs)
         except ConnectionClosed as exc:
             raise HomeAssistantError(
-                "Connection to Android TV device is closed"
+                translation_domain=DOMAIN, translation_key="connection_closed"
             ) from exc

--- a/homeassistant/components/androidtv_remote/strings.json
+++ b/homeassistant/components/androidtv_remote/strings.json
@@ -54,5 +54,10 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "connection_closed": {
+      "message": "Connection to the Android TV device is closed"
+    }
   }
 }

--- a/tests/components/androidtv_remote/test_media_player.py
+++ b/tests/components/androidtv_remote/test_media_player.py
@@ -391,7 +391,9 @@ async def test_media_player_connection_closed(
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
     mock_api.send_key_command.side_effect = ConnectionClosed()
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError, match="Connection to the Android TV device is closed"
+    ):
         await hass.services.async_call(
             "media_player",
             "media_pause",
@@ -400,7 +402,9 @@ async def test_media_player_connection_closed(
         )
 
     mock_api.send_launch_app_command.side_effect = ConnectionClosed()
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError, match="Connection to the Android TV device is closed"
+    ):
         await hass.services.async_call(
             "media_player",
             "play_media",

--- a/tests/components/androidtv_remote/test_remote.py
+++ b/tests/components/androidtv_remote/test_remote.py
@@ -183,7 +183,9 @@ async def test_remote_connection_closed(
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
     mock_api.send_key_command.side_effect = ConnectionClosed()
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError, match="Connection to the Android TV device is closed"
+    ):
         await hass.services.async_call(
             "remote",
             "send_command",
@@ -197,7 +199,9 @@ async def test_remote_connection_closed(
     assert mock_api.send_key_command.mock_calls == [call("DPAD_LEFT", "SHORT")]
 
     mock_api.send_launch_app_command.side_effect = ConnectionClosed()
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError, match="Connection to the Android TV device is closed"
+    ):
         await hass.services.async_call(
             "remote",
             "turn_on",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
