### PR TITLE
Fix Quickmode handling in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/fan.py
+++ b/homeassistant/components/vicare/fan.py
@@ -206,8 +206,7 @@ class ViCareFan(ViCareEntity, FanEntity):
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        if VentilationQuickmode.STANDBY in self._attributes["vicare_quickmodes"]:
-            self._api.activateVentilationQuickmode(str(VentilationQuickmode.STANDBY))
+        self._api.activateVentilationQuickmode(str(VentilationQuickmode.STANDBY))
 
     @property
     def icon(self) -> str | None:

--- a/homeassistant/components/vicare/fan.py
+++ b/homeassistant/components/vicare/fan.py
@@ -127,6 +127,7 @@ class ViCareFan(ViCareEntity, FanEntity):
 
     _attr_speed_count = len(ORDERED_NAMED_FAN_SPEEDS)
     _attr_translation_key = "ventilation"
+    _attributes: dict[str, Any] = {}
 
     def __init__(
         self,
@@ -155,7 +156,7 @@ class ViCareFan(ViCareEntity, FanEntity):
             self._attr_supported_features |= FanEntityFeature.SET_SPEED
 
         # evaluate quickmodes
-        quickmodes: list[str] = (
+        self._attributes["vicare_quickmodes"] = quickmodes = list[str](
             device.getVentilationQuickmodes()
             if is_supported(
                 "getVentilationQuickmodes",
@@ -196,26 +197,24 @@ class ViCareFan(ViCareEntity, FanEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the entity is on."""
-        if (
-            self._attr_supported_features & FanEntityFeature.TURN_OFF
-            and self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY)
-        ):
+        if VentilationQuickmode.STANDBY in self._attributes[
+            "vicare_quickmodes"
+        ] and self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY):
             return False
 
         return self.percentage is not None and self.percentage > 0
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-
-        self._api.activateVentilationQuickmode(str(VentilationQuickmode.STANDBY))
+        if VentilationQuickmode.STANDBY in self._attributes["vicare_quickmodes"]:
+            self._api.activateVentilationQuickmode(str(VentilationQuickmode.STANDBY))
 
     @property
     def icon(self) -> str | None:
         """Return the icon to use in the frontend."""
-        if (
-            self._attr_supported_features & FanEntityFeature.TURN_OFF
-            and self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY)
-        ):
+        if VentilationQuickmode.STANDBY in self._attributes[
+            "vicare_quickmodes"
+        ] and self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY):
             return "mdi:fan-off"
         if hasattr(self, "_attr_preset_mode"):
             if self._attr_preset_mode == VentilationMode.VENTILATION:
@@ -242,7 +241,9 @@ class ViCareFan(ViCareEntity, FanEntity):
         """Set the speed of the fan, as a percentage."""
         if self._attr_preset_mode != str(VentilationMode.PERMANENT):
             self.set_preset_mode(VentilationMode.PERMANENT)
-        elif self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY):
+        elif VentilationQuickmode.STANDBY in self._attributes[
+            "vicare_quickmodes"
+        ] and self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY):
             self._api.deactivateVentilationQuickmode(str(VentilationQuickmode.STANDBY))
 
         level = percentage_to_ordered_list_item(ORDERED_NAMED_FAN_SPEEDS, percentage)
@@ -254,3 +255,8 @@ class ViCareFan(ViCareEntity, FanEntity):
         target_mode = VentilationMode.to_vicare_mode(preset_mode)
         _LOGGER.debug("changing ventilation mode to %s", target_mode)
         self._api.activateVentilationMode(target_mode)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Show Device Attributes."""
+        return self._attributes

--- a/tests/components/vicare/snapshots/test_fan.ambr
+++ b/tests/components/vicare/snapshots/test_fan.ambr
@@ -55,6 +55,11 @@
         <VentilationMode.SENSOR_OVERRIDE: 'sensor_override'>,
       ]),
       'supported_features': <FanEntityFeature: 9>,
+      'vicare_quickmodes': list([
+        'comfort',
+        'eco',
+        'holiday',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'fan.model0_ventilation',
@@ -94,7 +99,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:fan-off',
+    'original_icon': 'mdi:fan',
     'original_name': 'Ventilation',
     'platform': 'vicare',
     'previous_unique_id': None,
@@ -108,7 +113,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'model1 Ventilation',
-      'icon': 'mdi:fan-off',
+      'icon': 'mdi:fan',
       'percentage': 0,
       'percentage_step': 25.0,
       'preset_mode': None,
@@ -118,6 +123,11 @@
         <VentilationMode.SENSOR_DRIVEN: 'sensor_driven'>,
       ]),
       'supported_features': <FanEntityFeature: 25>,
+      'vicare_quickmodes': list([
+        'comfort',
+        'eco',
+        'holiday',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'fan.model1_ventilation',
@@ -179,6 +189,11 @@
         <VentilationMode.STANDARD: 'standard'>,
       ]),
       'supported_features': <FanEntityFeature: 8>,
+      'vicare_quickmodes': list([
+        'comfort',
+        'eco',
+        'holiday',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'fan.model2_ventilation',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only check the Quickmode *standby* if Quickmodes are supported.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #139998
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
