### PR TITLE
Move Whirlpool test and clean unused code

### DIFF
--- a/homeassistant/components/whirlpool/climate.py
+++ b/homeassistant/components/whirlpool/climate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from whirlpool.aircon import Aircon, FanSpeed as AirconFanSpeed, Mode as AirconMode
@@ -25,9 +24,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import WhirlpoolConfigEntry
 from .entity import WhirlpoolEntity
-
-_LOGGER = logging.getLogger(__name__)
-
 
 AIRCON_MODE_MAP = {
     AirconMode.Cool: HVACMode.COOL,
@@ -75,7 +71,6 @@ class AirConEntity(WhirlpoolEntity, ClimateEntity):
     """Representation of an air conditioner."""
 
     _attr_fan_modes = SUPPORTED_FAN_MODES
-    _attr_has_entity_name = True
     _attr_name = None
     _attr_hvac_modes = SUPPORTED_HVAC_MODES
     _attr_max_temp = SUPPORTED_MAX_TEMP

--- a/tests/components/whirlpool/test_climate.py
+++ b/tests/components/whirlpool/test_climate.py
@@ -63,16 +63,6 @@ async def update_ac_state(
     return hass.states.get(entity_id)
 
 
-async def test_no_appliances(
-    hass: HomeAssistant, mock_appliances_manager_api: MagicMock
-) -> None:
-    """Test the setup of the climate entities when there are no appliances available."""
-    mock_appliances_manager_api.return_value.aircons = []
-    mock_appliances_manager_api.return_value.washer_dryers = []
-    await init_integration(hass)
-    assert len(hass.states.async_all()) == 0
-
-
 async def test_static_attributes(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/whirlpool/test_config_flow.py
+++ b/tests/components/whirlpool/test_config_flow.py
@@ -135,7 +135,7 @@ async def test_form_auth_error(
 
 @pytest.mark.usefixtures("mock_auth_api", "mock_appliances_manager_api")
 async def test_form_already_configured(hass: HomeAssistant, region, brand) -> None:
-    """Test we handle cannot connect error."""
+    """Test that configuring the integration twice with the same data fails."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
         data=CONFIG_INPUT | {"region": region[0], "brand": brand[0]},

--- a/tests/components/whirlpool/test_init.py
+++ b/tests/components/whirlpool/test_init.py
@@ -75,6 +75,16 @@ async def test_setup_brand_fallback(
     mock_backend_selector_api.assert_called_once_with(Brand.Whirlpool, region[1])
 
 
+async def test_setup_no_appliances(
+    hass: HomeAssistant, mock_appliances_manager_api: MagicMock
+) -> None:
+    """Test setup when there are no appliances available."""
+    mock_appliances_manager_api.return_value.aircons = []
+    mock_appliances_manager_api.return_value.washer_dryers = []
+    await init_integration(hass)
+    assert len(hass.states.async_all()) == 0
+
+
 async def test_setup_http_exception(
     hass: HomeAssistant,
     mock_auth_api: MagicMock,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean unused stuff and move a test to `test_init.py` since that is where it belongs now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
