### PR TITLE
Refactor Bring! integration to poll activity data at a slower interval

### DIFF
--- a/homeassistant/components/bring/__init__.py
+++ b/homeassistant/components/bring/__init__.py
@@ -10,7 +10,12 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .coordinator import BringConfigEntry, BringDataUpdateCoordinator
+from .coordinator import (
+    BringActivityCoordinator,
+    BringConfigEntry,
+    BringCoordinators,
+    BringDataUpdateCoordinator,
+)
 
 PLATFORMS: list[Platform] = [Platform.EVENT, Platform.SENSOR, Platform.TODO]
 
@@ -26,7 +31,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: BringConfigEntry) -> boo
     coordinator = BringDataUpdateCoordinator(hass, entry, bring)
     await coordinator.async_config_entry_first_refresh()
 
-    entry.runtime_data = coordinator
+    activity_coordinator = BringActivityCoordinator(hass, entry, coordinator)
+    await activity_coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = BringCoordinators(coordinator, activity_coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/bring/diagnostics.py
+++ b/homeassistant/components/bring/diagnostics.py
@@ -20,9 +20,12 @@ async def async_get_config_entry_diagnostics(
 
     return {
         "data": {
-            k: async_redact_data(v.to_dict(), TO_REDACT)
-            for k, v in config_entry.runtime_data.data.items()
+            k: v.to_dict() for k, v in config_entry.runtime_data.data.data.items()
         },
-        "lists": [lst.to_dict() for lst in config_entry.runtime_data.lists],
-        "user_settings": config_entry.runtime_data.user_settings.to_dict(),
+        "activity": {
+            k: async_redact_data(v.to_dict(), TO_REDACT)
+            for k, v in config_entry.runtime_data.activity.data.items()
+        },
+        "lists": [lst.to_dict() for lst in config_entry.runtime_data.data.lists],
+        "user_settings": config_entry.runtime_data.data.user_settings.to_dict(),
     }

--- a/homeassistant/components/bring/entity.py
+++ b/homeassistant/components/bring/entity.py
@@ -8,17 +8,17 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import BringDataUpdateCoordinator
+from .coordinator import BringBaseCoordinator
 
 
-class BringBaseEntity(CoordinatorEntity[BringDataUpdateCoordinator]):
+class BringBaseEntity(CoordinatorEntity[BringBaseCoordinator]):
     """Bring base entity."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
-        coordinator: BringDataUpdateCoordinator,
+        coordinator: BringBaseCoordinator,
         bring_list: BringList,
     ) -> None:
         """Initialize the entity."""
@@ -34,5 +34,7 @@ class BringBaseEntity(CoordinatorEntity[BringDataUpdateCoordinator]):
             },
             manufacturer="Bring! Labs AG",
             model="Bring! Grocery Shopping List",
-            configuration_url=f"https://web.getbring.com/app/lists/{list(self.coordinator.lists).index(bring_list)}",
+            configuration_url=f"https://web.getbring.com/app/lists/{list(self.coordinator.lists).index(bring_list)}"
+            if bring_list in self.coordinator.lists
+            else None,
         )

--- a/homeassistant/components/bring/event.py
+++ b/homeassistant/components/bring/event.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BringConfigEntry
-from .coordinator import BringDataUpdateCoordinator
+from .coordinator import BringActivityCoordinator
 from .entity import BringBaseEntity
 
 PARALLEL_UPDATES = 0
@@ -32,18 +32,18 @@ async def async_setup_entry(
         """Add event entities."""
         nonlocal lists_added
 
-        if new_lists := {lst.listUuid for lst in coordinator.lists} - lists_added:
+        if new_lists := {lst.listUuid for lst in coordinator.data.lists} - lists_added:
             async_add_entities(
                 BringEventEntity(
-                    coordinator,
+                    coordinator.activity,
                     bring_list,
                 )
-                for bring_list in coordinator.lists
+                for bring_list in coordinator.data.lists
                 if bring_list.listUuid in new_lists
             )
             lists_added |= new_lists
 
-    coordinator.async_add_listener(add_entities)
+    coordinator.activity.async_add_listener(add_entities)
     add_entities()
 
 
@@ -51,10 +51,11 @@ class BringEventEntity(BringBaseEntity, EventEntity):
     """An event entity."""
 
     _attr_translation_key = "activities"
+    coordinator: BringActivityCoordinator
 
     def __init__(
         self,
-        coordinator: BringDataUpdateCoordinator,
+        coordinator: BringActivityCoordinator,
         bring_list: BringList,
     ) -> None:
         """Initialize the entity."""

--- a/homeassistant/components/bring/sensor.py
+++ b/homeassistant/components/bring/sensor.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    coordinator = config_entry.runtime_data
+    coordinator = config_entry.runtime_data.data
     lists_added: set[str] = set()
 
     @callback
@@ -117,6 +117,7 @@ class BringSensorEntity(BringBaseEntity, SensorEntity):
     """A sensor entity."""
 
     entity_description: BringSensorEntityDescription
+    coordinator: BringDataUpdateCoordinator
 
     def __init__(
         self,

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -44,7 +44,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensor from a config entry created in the integrations UI."""
-    coordinator = config_entry.runtime_data
+    coordinator = config_entry.runtime_data.data
     lists_added: set[str] = set()
 
     @callback
@@ -88,6 +88,7 @@ class BringTodoListEntity(BringBaseEntity, TodoListEntity):
         | TodoListEntityFeature.DELETE_TODO_ITEM
         | TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
     )
+    coordinator: BringDataUpdateCoordinator
 
     def __init__(
         self, coordinator: BringDataUpdateCoordinator, bring_list: BringList

--- a/tests/components/bring/snapshots/test_diagnostics.ambr
+++ b/tests/components/bring/snapshots/test_diagnostics.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_diagnostics
   dict({
-    'data': dict({
+    'activity': dict({
       'b4776778-7f6c-496e-951b-92a35d3db0dd': dict({
         'activity': dict({
           'timeline': list([
@@ -78,58 +78,6 @@
           ]),
           'timestamp': '2025-01-01T03:09:33.036000+00:00',
           'totalEvents': 3,
-        }),
-        'content': dict({
-          'items': dict({
-            'purchase': list([
-              dict({
-                'attributes': list([
-                  dict({
-                    'content': dict({
-                      'convenient': True,
-                      'discounted': True,
-                      'urgent': True,
-                    }),
-                    'type': 'PURCHASE_CONDITIONS',
-                  }),
-                ]),
-                'itemId': 'Paprika',
-                'specification': 'Rot',
-                'uuid': 'b5d0790b-5f32-4d5c-91da-e29066f167de',
-              }),
-              dict({
-                'attributes': list([
-                  dict({
-                    'content': dict({
-                      'convenient': True,
-                      'discounted': True,
-                      'urgent': True,
-                    }),
-                    'type': 'PURCHASE_CONDITIONS',
-                  }),
-                ]),
-                'itemId': 'Pouletbrüstli',
-                'specification': 'Bio',
-                'uuid': '72d370ab-d8ca-4e41-b956-91df94795b4e',
-              }),
-            ]),
-            'recently': list([
-              dict({
-                'attributes': list([
-                ]),
-                'itemId': 'Ananas',
-                'specification': '',
-                'uuid': 'fc8db30a-647e-4e6c-9d71-3b85d6a2d954',
-              }),
-            ]),
-          }),
-          'status': 'REGISTERED',
-          'uuid': 'b4776778-7f6c-496e-951b-92a35d3db0dd',
-        }),
-        'lst': dict({
-          'listUuid': 'b4776778-7f6c-496e-951b-92a35d3db0dd',
-          'name': '**REDACTED**',
-          'theme': 'ch.publisheria.bring.theme.home',
         }),
         'users': dict({
           'users': list([
@@ -246,6 +194,101 @@
           'timestamp': '2025-01-01T03:09:33.036000+00:00',
           'totalEvents': 3,
         }),
+        'users': dict({
+          'users': list([
+            dict({
+              'country': 'DE',
+              'email': '**REDACTED**',
+              'language': 'de',
+              'name': '**REDACTED**',
+              'photoPath': '',
+              'plusExpiry': None,
+              'plusTryOut': False,
+              'publicUuid': '9a21fdfc-63a4-441a-afc1-ef3030605a9d',
+              'pushEnabled': True,
+            }),
+            dict({
+              'country': 'US',
+              'email': '**REDACTED**',
+              'language': 'en',
+              'name': '**REDACTED**',
+              'photoPath': '',
+              'plusExpiry': None,
+              'plusTryOut': False,
+              'publicUuid': '73af455f-c158-4004-a5e0-79f4f8a6d4bd',
+              'pushEnabled': True,
+            }),
+            dict({
+              'country': 'US',
+              'email': None,
+              'language': 'en',
+              'name': None,
+              'photoPath': None,
+              'plusExpiry': None,
+              'plusTryOut': False,
+              'publicUuid': '7d5e9d08-877a-4c36-8740-a9bf74ec690a',
+              'pushEnabled': True,
+            }),
+          ]),
+        }),
+      }),
+    }),
+    'data': dict({
+      'b4776778-7f6c-496e-951b-92a35d3db0dd': dict({
+        'content': dict({
+          'items': dict({
+            'purchase': list([
+              dict({
+                'attributes': list([
+                  dict({
+                    'content': dict({
+                      'convenient': True,
+                      'discounted': True,
+                      'urgent': True,
+                    }),
+                    'type': 'PURCHASE_CONDITIONS',
+                  }),
+                ]),
+                'itemId': 'Paprika',
+                'specification': 'Rot',
+                'uuid': 'b5d0790b-5f32-4d5c-91da-e29066f167de',
+              }),
+              dict({
+                'attributes': list([
+                  dict({
+                    'content': dict({
+                      'convenient': True,
+                      'discounted': True,
+                      'urgent': True,
+                    }),
+                    'type': 'PURCHASE_CONDITIONS',
+                  }),
+                ]),
+                'itemId': 'Pouletbrüstli',
+                'specification': 'Bio',
+                'uuid': '72d370ab-d8ca-4e41-b956-91df94795b4e',
+              }),
+            ]),
+            'recently': list([
+              dict({
+                'attributes': list([
+                ]),
+                'itemId': 'Ananas',
+                'specification': '',
+                'uuid': 'fc8db30a-647e-4e6c-9d71-3b85d6a2d954',
+              }),
+            ]),
+          }),
+          'status': 'REGISTERED',
+          'uuid': 'b4776778-7f6c-496e-951b-92a35d3db0dd',
+        }),
+        'lst': dict({
+          'listUuid': 'b4776778-7f6c-496e-951b-92a35d3db0dd',
+          'name': 'Baumarkt',
+          'theme': 'ch.publisheria.bring.theme.home',
+        }),
+      }),
+      'e542eef6-dba7-4c31-a52c-29e6ab9d83a5': dict({
         'content': dict({
           'items': dict({
             'purchase': list([
@@ -295,45 +338,8 @@
         }),
         'lst': dict({
           'listUuid': 'e542eef6-dba7-4c31-a52c-29e6ab9d83a5',
-          'name': '**REDACTED**',
+          'name': 'Einkauf',
           'theme': 'ch.publisheria.bring.theme.home',
-        }),
-        'users': dict({
-          'users': list([
-            dict({
-              'country': 'DE',
-              'email': '**REDACTED**',
-              'language': 'de',
-              'name': '**REDACTED**',
-              'photoPath': '',
-              'plusExpiry': None,
-              'plusTryOut': False,
-              'publicUuid': '9a21fdfc-63a4-441a-afc1-ef3030605a9d',
-              'pushEnabled': True,
-            }),
-            dict({
-              'country': 'US',
-              'email': '**REDACTED**',
-              'language': 'en',
-              'name': '**REDACTED**',
-              'photoPath': '',
-              'plusExpiry': None,
-              'plusTryOut': False,
-              'publicUuid': '73af455f-c158-4004-a5e0-79f4f8a6d4bd',
-              'pushEnabled': True,
-            }),
-            dict({
-              'country': 'US',
-              'email': None,
-              'language': 'en',
-              'name': None,
-              'photoPath': None,
-              'plusExpiry': None,
-              'plusTryOut': False,
-              'publicUuid': '7d5e9d08-877a-4c36-8740-a9bf74ec690a',
-              'pushEnabled': True,
-            }),
-          ]),
         }),
       }),
     }),

--- a/tests/components/bring/test_init.py
+++ b/tests/components/bring/test_init.py
@@ -142,6 +142,31 @@ async def test_config_entry_not_ready_udpdate_failed(
 @pytest.mark.parametrize(
     ("exception", "state"),
     [
+        (BringRequestException, ConfigEntryState.SETUP_RETRY),
+        (BringParseException, ConfigEntryState.SETUP_RETRY),
+        (BringAuthException, ConfigEntryState.SETUP_ERROR),
+    ],
+)
+async def test_activity_coordinator_errors(
+    hass: HomeAssistant,
+    bring_config_entry: MockConfigEntry,
+    mock_bring_client: AsyncMock,
+    exception: Exception,
+    state: ConfigEntryState,
+) -> None:
+    """Test config entry not ready from update failed in _async_update_data."""
+    mock_bring_client.get_activity.side_effect = exception
+
+    bring_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(bring_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert bring_config_entry.state is state
+
+
+@pytest.mark.parametrize(
+    ("exception", "state"),
+    [
         (BringAuthException, ConfigEntryState.SETUP_ERROR),
         (BringRequestException, ConfigEntryState.SETUP_RETRY),
         (BringParseException, ConfigEntryState.SETUP_RETRY),

--- a/tests/components/bring/test_util.py
+++ b/tests/components/bring/test_util.py
@@ -1,12 +1,6 @@
 """Test for utility functions of the Bring! integration."""
 
-from bring_api import (
-    BringActivityResponse,
-    BringItemsResponse,
-    BringListResponse,
-    BringUserSettingsResponse,
-)
-from bring_api.types import BringUsersResponse
+from bring_api import BringItemsResponse, BringListResponse, BringUserSettingsResponse
 import pytest
 
 from homeassistant.components.bring.const import DOMAIN
@@ -47,10 +41,8 @@ def test_sum_attributes(attribute: str, expected: int) -> None:
     """Test function sum_attributes."""
     items = BringItemsResponse.from_json(load_fixture("items.json", DOMAIN))
     lst = BringListResponse.from_json(load_fixture("lists.json", DOMAIN))
-    activity = BringActivityResponse.from_json(load_fixture("activity.json", DOMAIN))
-    users = BringUsersResponse.from_json(load_fixture("users.json", DOMAIN))
     result = sum_attributes(
-        BringData(lst.lists[0], items, activity, users),
+        BringData(lst.lists[0], items),
         attribute,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This implements a second coordinator that polls activity and user data at a much slower interval. This is required due to a request from Bring (#142268 ) as polling these endpoints causes too much load on Bring API servers. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #142268
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
