### PR TITLE
Remove deprecated state attributes in seventeentrack

### DIFF
--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_LOCATION
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -14,15 +11,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import SeventeenTrackCoordinator
-from .const import (
-    ATTR_INFO_TEXT,
-    ATTR_PACKAGES,
-    ATTR_STATUS,
-    ATTR_TIMESTAMP,
-    ATTR_TRACKING_NUMBER,
-    ATTRIBUTION,
-    DOMAIN,
-)
+from .const import ATTRIBUTION, DOMAIN
 
 
 async def async_setup_entry(
@@ -81,22 +70,3 @@ class SeventeenTrackSummarySensor(SeventeenTrackSensor):
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.coordinator.data.summary[self._status]["quantity"]
-
-    # This has been deprecated in 2024.8, will be removed in 2025.2
-    @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Return the state attributes."""
-        packages = self.coordinator.data.summary[self._status]["packages"]
-        return {
-            ATTR_PACKAGES: [
-                {
-                    ATTR_TRACKING_NUMBER: package.tracking_number,
-                    ATTR_LOCATION: package.location,
-                    ATTR_STATUS: package.status,
-                    ATTR_TIMESTAMP: package.timestamp,
-                    ATTR_INFO_TEXT: package.info_text,
-                    ATTR_FRIENDLY_NAME: package.friendly_name,
-                }
-                for package in packages
-            ]
-        }

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -4,20 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
-from freezegun.api import FrozenDateTimeFactory
 from pyseventeentrack.errors import SeventeenTrackError
 
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
-from . import goto_future, init_integration
-from .conftest import (
-    DEFAULT_SUMMARY,
-    DEFAULT_SUMMARY_LENGTH,
-    NEW_SUMMARY_DATA,
-    VALID_PLATFORM_CONFIG_FULL,
-    get_package,
-)
+from . import init_integration
+from .conftest import DEFAULT_SUMMARY, get_package
 
 from tests.common import MockConfigEntry
 
@@ -78,38 +70,6 @@ async def test_package_error(
     assert hass.states.get("sensor.17track_package_friendly_name_1") is None
 
 
-async def test_summary_correctly_updated(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    mock_seventeentrack: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Ensure summary entities are not duplicated."""
-    package = get_package(status=30)
-    mock_seventeentrack.return_value.profile.packages.return_value = [package]
-
-    await init_integration(hass, mock_config_entry)
-
-    assert len(hass.states.async_entity_ids()) == DEFAULT_SUMMARY_LENGTH
-
-    state_ready_picked = hass.states.get("sensor.17track_ready_to_be_picked_up")
-    assert state_ready_picked is not None
-    assert len(state_ready_picked.attributes["packages"]) == 1
-
-    mock_seventeentrack.return_value.profile.packages.return_value = []
-    mock_seventeentrack.return_value.profile.summary.return_value = NEW_SUMMARY_DATA
-
-    await goto_future(hass, freezer)
-
-    assert len(hass.states.async_entity_ids()) == len(NEW_SUMMARY_DATA)
-    for state in hass.states.async_all():
-        assert state.state == "1"
-
-    state_ready_picked = hass.states.get("sensor.17track_ready_to_be_picked_up")
-    assert state_ready_picked is not None
-    assert len(state_ready_picked.attributes["packages"]) == 0
-
-
 async def test_summary_error(
     hass: HomeAssistant,
     mock_seventeentrack: AsyncMock,
@@ -129,13 +89,3 @@ async def test_summary_error(
     assert (
         hass.states.get("sensor.seventeentrack_packages_ready_to_be_picked_up") is None
     )
-
-
-async def test_non_valid_platform_config(
-    hass: HomeAssistant, mock_seventeentrack: AsyncMock
-) -> None:
-    """Test if login fails."""
-    mock_seventeentrack.return_value.profile.login.return_value = False
-    assert await async_setup_component(hass, "sensor", VALID_PLATFORM_CONFIG_FULL)
-    await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids()) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The deprecated state attributes for seventeentrack have been removed

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated state attributes in seventeentrack

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
