### PR TITLE
Remove state attributes in Totalconnect

### DIFF
--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -97,22 +97,6 @@ class TotalConnectAlarm(TotalConnectLocationEntity, AlarmControlPanelEntity):
     @property
     def alarm_state(self) -> AlarmControlPanelState | None:
         """Return the state of the device."""
-        # State attributes can be removed in 2025.3
-        attr = {
-            "location_id": self._location.location_id,
-            "partition": self._partition_id,
-            "ac_loss": self._location.ac_loss,
-            "low_battery": self._location.low_battery,
-            "cover_tampered": self._location.is_cover_tampered(),
-            "triggered_source": None,
-            "triggered_zone": None,
-        }
-
-        if self._partition_id == 1:
-            attr["location_name"] = self.device.name
-        else:
-            attr["location_name"] = f"{self.device.name} partition {self._partition_id}"
-
         state: AlarmControlPanelState | None = None
         if self._partition.arming_state.is_disarmed():
             state = AlarmControlPanelState.DISARMED
@@ -128,17 +112,12 @@ class TotalConnectAlarm(TotalConnectLocationEntity, AlarmControlPanelEntity):
             state = AlarmControlPanelState.ARMING
         elif self._partition.arming_state.is_disarming():
             state = AlarmControlPanelState.DISARMING
-        elif self._partition.arming_state.is_triggered_police():
+        elif (
+            self._partition.arming_state.is_triggered_police()
+            or self._partition.arming_state.is_triggered_fire()
+            or self._partition.arming_state.is_triggered_gas()
+        ):
             state = AlarmControlPanelState.TRIGGERED
-            attr["triggered_source"] = "Police/Medical"
-        elif self._partition.arming_state.is_triggered_fire():
-            state = AlarmControlPanelState.TRIGGERED
-            attr["triggered_source"] = "Fire/Smoke"
-        elif self._partition.arming_state.is_triggered_gas():
-            state = AlarmControlPanelState.TRIGGERED
-            attr["triggered_source"] = "Carbon Monoxide"
-
-        self._attr_extra_state_attributes = attr
 
         return state
 

--- a/tests/components/totalconnect/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/totalconnect/snapshots/test_alarm_control_panel.ambr
@@ -36,19 +36,11 @@
 # name: test_attributes[alarm_control_panel.test-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'ac_loss': False,
       'changed_by': None,
       'code_arm_required': False,
       'code_format': None,
-      'cover_tampered': False,
       'friendly_name': 'test',
-      'location_id': 123456,
-      'location_name': 'test',
-      'low_battery': False,
-      'partition': 1,
       'supported_features': <AlarmControlPanelEntityFeature: 7>,
-      'triggered_source': None,
-      'triggered_zone': None,
     }),
     'context': <ANY>,
     'entity_id': 'alarm_control_panel.test',
@@ -95,19 +87,11 @@
 # name: test_attributes[alarm_control_panel.test_partition_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'ac_loss': False,
       'changed_by': None,
       'code_arm_required': False,
       'code_format': None,
-      'cover_tampered': False,
       'friendly_name': 'test Partition 2',
-      'location_id': 123456,
-      'location_name': 'test partition 2',
-      'low_battery': False,
-      'partition': 2,
       'supported_features': <AlarmControlPanelEntityFeature: 7>,
-      'triggered_source': None,
-      'triggered_zone': None,
     }),
     'context': <ANY>,
     'entity_id': 'alarm_control_panel.test_partition_2',

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -192,7 +192,7 @@ async def test_arm_home_instant_failure(hass: HomeAssistant) -> None:
                 DOMAIN, SERVICE_ALARM_ARM_HOME_INSTANT, DATA, blocking=True
             )
         await hass.async_block_till_done()
-        assert f"{err.value}" == "Usercode is invalid, did not arm home instant"
+        assert str(err.value) == "Usercode is invalid, did not arm home instant"
         assert hass.states.get(ENTITY_ID).state == AlarmControlPanelState.DISARMED
         # should have started a re-auth flow
         assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -50,9 +50,6 @@ from .common import (
     RESPONSE_DISARMED,
     RESPONSE_DISARMING,
     RESPONSE_SUCCESS,
-    RESPONSE_TRIGGERED_CARBON_MONOXIDE,
-    RESPONSE_TRIGGERED_FIRE,
-    RESPONSE_TRIGGERED_POLICE,
     RESPONSE_UNKNOWN,
     RESPONSE_USER_CODE_INVALID,
     TOTALCONNECT_REQUEST,
@@ -511,45 +508,6 @@ async def test_disarming(hass: HomeAssistant, freezer: FrozenDateTimeFactory) ->
         await hass.async_block_till_done()
         assert mock_request.call_count == 3
         assert hass.states.get(ENTITY_ID).state == AlarmControlPanelState.DISARMING
-
-
-async def test_triggered_fire(hass: HomeAssistant) -> None:
-    """Test triggered by fire."""
-    responses = [RESPONSE_TRIGGERED_FIRE]
-    await setup_platform(hass, ALARM_DOMAIN)
-    with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await async_update_entity(hass, ENTITY_ID)
-        await hass.async_block_till_done()
-        state = hass.states.get(ENTITY_ID)
-        assert state.state == AlarmControlPanelState.TRIGGERED
-        assert state.attributes.get("triggered_source") == "Fire/Smoke"
-        assert mock_request.call_count == 1
-
-
-async def test_triggered_police(hass: HomeAssistant) -> None:
-    """Test triggered by police."""
-    responses = [RESPONSE_TRIGGERED_POLICE]
-    await setup_platform(hass, ALARM_DOMAIN)
-    with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await async_update_entity(hass, ENTITY_ID)
-        await hass.async_block_till_done()
-        state = hass.states.get(ENTITY_ID)
-        assert state.state == AlarmControlPanelState.TRIGGERED
-        assert state.attributes.get("triggered_source") == "Police/Medical"
-        assert mock_request.call_count == 1
-
-
-async def test_triggered_carbon_monoxide(hass: HomeAssistant) -> None:
-    """Test triggered by carbon monoxide."""
-    responses = [RESPONSE_TRIGGERED_CARBON_MONOXIDE]
-    await setup_platform(hass, ALARM_DOMAIN)
-    with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
-        await async_update_entity(hass, ENTITY_ID)
-        await hass.async_block_till_done()
-        state = hass.states.get(ENTITY_ID)
-        assert state.state == AlarmControlPanelState.TRIGGERED
-        assert state.attributes.get("triggered_source") == "Carbon Monoxide"
-        assert mock_request.call_count == 1
 
 
 async def test_armed_custom(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The deprecated state attributes for the total connect alarm panel have been removed

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove state attributes in Totalconnect

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
