### PR TITLE
Revert "Don't create repairs asking user to remove duplicate flipr config entries"

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2357,12 +2357,7 @@ class ConfigEntries:
         if unique_id is not UNDEFINED and entry.unique_id != unique_id:
             # Deprecated in 2024.11, should fail in 2025.11
             if (
-                # flipr creates duplicates during migration, and asks users to
-                # remove the duplicate. We don't need warn about it here too.
-                # We should remove the special case for "flipr" in HA Core 2025.4,
-                # when the flipr migration period ends
-                entry.domain != "flipr"
-                and unique_id is not None
+                unique_id is not None
                 and self.async_entry_for_domain_unique_id(entry.domain, unique_id)
                 is not None
             ):
@@ -2729,12 +2724,6 @@ class ConfigEntries:
             issues.add(issue.issue_id)
 
         for domain, unique_ids in self._entries._domain_unique_id_index.items():  # noqa: SLF001
-            # flipr creates duplicates during migration, and asks users to
-            # remove the duplicate. We don't need warn about it here too.
-            # We should remove the special case for "flipr" in HA Core 2025.4,
-            # when the flipr migration period ends
-            if domain == "flipr":
-                continue
             for unique_id, entries in unique_ids.items():
                 # We might mutate the list of entries, so we need a copy to not mess up
                 # the index

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -8424,41 +8424,6 @@ async def test_async_update_entry_unique_id_collision(
     assert issue_registry.async_get_issue(HOMEASSISTANT_DOMAIN, issue_id)
 
 
-@pytest.mark.parametrize("domain", ["flipr"])
-async def test_async_update_entry_unique_id_collision_allowed_domain(
-    hass: HomeAssistant,
-    manager: config_entries.ConfigEntries,
-    caplog: pytest.LogCaptureFixture,
-    issue_registry: ir.IssueRegistry,
-    domain: str,
-) -> None:
-    """Test we warn when async_update_entry creates a unique_id collision.
-
-    This tests we don't warn and don't create issues for domains which have
-    their own migration path.
-    """
-    assert len(issue_registry.issues) == 0
-
-    entry1 = MockConfigEntry(domain=domain, unique_id=None)
-    entry2 = MockConfigEntry(domain=domain, unique_id="not none")
-    entry3 = MockConfigEntry(domain=domain, unique_id="very unique")
-    entry4 = MockConfigEntry(domain=domain, unique_id="also very unique")
-    entry1.add_to_manager(manager)
-    entry2.add_to_manager(manager)
-    entry3.add_to_manager(manager)
-    entry4.add_to_manager(manager)
-
-    manager.async_update_entry(entry2, unique_id=None)
-    assert len(issue_registry.issues) == 0
-    assert len(caplog.record_tuples) == 0
-
-    manager.async_update_entry(entry4, unique_id="very unique")
-    assert len(issue_registry.issues) == 0
-    assert len(caplog.record_tuples) == 0
-
-    assert ("already in use") not in caplog.text
-
-
 async def test_unique_id_collision_issues(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,


### PR DESCRIPTION
Reverts home-assistant/core#130058

This is no longer needed because the relevant `flipr` code has been removed by https://github.com/home-assistant/core/pull/142504