### PR TITLE
Add non-shared ssl client_context

### DIFF
--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -82,10 +82,10 @@ def _client_context_no_verify(ssl_cipher_list: SSLCipherList) -> ssl.SSLContext:
     return sslcontext
 
 
-@cache
-def _client_context(
+def _create_client_context(
     ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
 ) -> ssl.SSLContext:
+    """Return an independent SSL context for making requests."""
     # Reuse environment variable definition from requests, since it's already a
     # requirement. If the environment variable has no value, fall back to using
     # certs from certifi package.
@@ -98,6 +98,14 @@ def _client_context(
         sslcontext.set_ciphers(SSL_CIPHER_LISTS[ssl_cipher_list])
 
     return sslcontext
+
+
+@cache
+def _client_context(
+    ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
+) -> ssl.SSLContext:
+    # Cached version of _create_client_context
+    return _create_client_context(ssl_cipher_list)
 
 
 # Create this only once and reuse it
@@ -137,6 +145,14 @@ def client_context(
 ) -> ssl.SSLContext:
     """Return an SSL context for making requests."""
     return _SSL_CONTEXTS.get(ssl_cipher_list, _DEFAULT_SSL_CONTEXT)
+
+
+def create_client_context(
+    ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
+) -> ssl.SSLContext:
+    """Return an independent SSL context for making requests."""
+    # This explicitly uses the non-cached version to create a client context
+    return _create_client_context(ssl_cipher_list)
 
 
 def create_no_verify_ssl_context(

--- a/tests/util/test_ssl.py
+++ b/tests/util/test_ssl.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.util.ssl import (
     SSLCipherList,
     client_context,
+    create_client_context,
     create_no_verify_ssl_context,
 )
 
@@ -56,3 +57,28 @@ def test_ssl_context_caching() -> None:
     assert create_no_verify_ssl_context() is create_no_verify_ssl_context(
         SSLCipherList.PYTHON_DEFAULT
     )
+
+
+def test_cteate_client_context(mock_sslcontext) -> None:
+    """Test create client context."""
+    with patch("homeassistant.util.ssl.ssl.SSLContext", return_value=mock_sslcontext):
+        client_context()
+        mock_sslcontext.set_ciphers.assert_not_called()
+
+        client_context(SSLCipherList.MODERN)
+        mock_sslcontext.set_ciphers.assert_not_called()
+
+        client_context(SSLCipherList.INTERMEDIATE)
+        mock_sslcontext.set_ciphers.assert_not_called()
+
+        client_context(SSLCipherList.INSECURE)
+        mock_sslcontext.set_ciphers.assert_not_called()
+
+
+def test_create_client_context_independent() -> None:
+    """Test create_client_context independence."""
+    shared_context = client_context()
+    independent_context_1 = create_client_context()
+    independent_context_2 = create_client_context()
+    assert shared_context is not independent_context_1
+    assert independent_context_1 is not independent_context_2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

All calls to util.ssl.client_context create an SSLContext which is reused / cached. This can create problems when this context is modified in such a way which create incompatibilities between usages. For example: helpers.httpx_client adds the http/1.1 ALPN, which would make setting up a connection to an SMTP server to fail.

This change adds a new function to create a fresh SSLContext, for cases where separation is required.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #138573, #142296
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
