### PR TITLE
Add single shot timer for nexia integration

### DIFF
--- a/homeassistant/components/nexia/util.py
+++ b/homeassistant/components/nexia/util.py
@@ -41,7 +41,9 @@ class SingleShot:
         """Initialize this single shot timer."""
         self._hass = hass
         self._delay = delay
-        self._delayed_call = delayed_call
+        self._delayed_call: Callable[[], Coroutine[Any, Any, None]] | None = (
+            delayed_call
+        )
         self._cancel_delayed_action: Callable[[], None] | None = None
         self._execute_lock = asyncio.Lock()
         self._shutting_down = False

--- a/homeassistant/components/nexia/util.py
+++ b/homeassistant/components/nexia/util.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from http import HTTPStatus
 from typing import Any
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HassJob, HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
 
@@ -30,6 +29,7 @@ class SingleShot:
     """Provides a single shot timer that can be reset.
 
     Fires a while following the *last* call to `reset_delayed_action_trigger`.
+    Caller should use `async_shutdown` to clean up when done.
     """
 
     def __init__(
@@ -49,7 +49,6 @@ class SingleShot:
             self._delayed_action,
             f"resettable single shot action {self._delay}",
         )
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_shutdown)
 
     async def _delayed_action(self, now: Any) -> None:
         """Perform the action now that the delay has completed."""
@@ -78,8 +77,8 @@ class SingleShot:
         )
 
     @callback
-    def _async_shutdown(self, event: Any) -> None:
-        """Handle Home Assistant stopping."""
+    def async_shutdown(self) -> None:
+        """Clean up."""
         self._shutting_down = True
         if self._cancel_delayed_action:
             self._cancel_delayed_action()

--- a/homeassistant/components/nexia/util.py
+++ b/homeassistant/components/nexia/util.py
@@ -1,6 +1,14 @@
 """Utils for Nexia / Trane XL Thermostats."""
 
+import asyncio
+from collections.abc import Callable, Coroutine
+from datetime import timedelta
 from http import HTTPStatus
+from typing import Any
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HassJob, HomeAssistant, callback
+from homeassistant.helpers.event import async_call_later
 
 
 def is_invalid_auth_code(http_status_code):
@@ -16,3 +24,64 @@ def percent_conv(val):
     if val is None:
         return None
     return round(val * 100.0, 1)
+
+
+class SingleShot:
+    """Provides a single shot timer that can be reset.
+
+    Fires a while following the *last* call to `reset_delayed_action_trigger`.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        delay: timedelta,
+        delayed_call: Callable[[], Coroutine[Any, Any, None]],
+    ) -> None:
+        """Initialize this single shot timer."""
+        self._hass = hass
+        self._delay = delay
+        self._delayed_call = delayed_call
+        self._cancel_delayed_action: Callable[[], None] | None = None
+        self._execute_lock = asyncio.Lock()
+        self._shutting_down = False
+        self._job = HassJob(
+            self._delayed_action,
+            f"resettable single shot action {self._delay}",
+        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_shutdown)
+
+    async def _delayed_action(self, now: Any) -> None:
+        """Perform the action now that the delay has completed."""
+        self._cancel_delayed_action = None
+
+        async with self._execute_lock:
+            # Abort if rescheduled while waiting for the lock or shutting down.
+            if self._cancel_delayed_action or self._shutting_down:
+                return
+
+            # Perform the primary action for this timer.
+            await self._delayed_call()
+
+    def reset_delayed_action_trigger(self) -> None:
+        """Set or reset the delayed action trigger.
+
+        Perform the action a while after this call.
+        """
+        if self._shutting_down:
+            return
+        if self._cancel_delayed_action:
+            self._cancel_delayed_action()
+
+        self._cancel_delayed_action = async_call_later(
+            self._hass, self._delay, self._job
+        )
+
+    @callback
+    def _async_shutdown(self, event: Any) -> None:
+        """Handle Home Assistant stopping."""
+        self._shutting_down = True
+        if self._cancel_delayed_action:
+            self._cancel_delayed_action()
+            self._cancel_delayed_action = None
+        self._delayed_call = None

--- a/homeassistant/components/nexia/util.py
+++ b/homeassistant/components/nexia/util.py
@@ -41,9 +41,7 @@ class SingleShot:
         """Initialize this single shot timer."""
         self._hass = hass
         self._delay = delay
-        self._delayed_call: Callable[[], Coroutine[Any, Any, None]] | None = (
-            delayed_call
-        )
+        self._delayed_call = delayed_call
         self._cancel_delayed_action: Callable[[], None] | None = None
         self._execute_lock = asyncio.Lock()
         self._shutting_down = False
@@ -86,4 +84,4 @@ class SingleShot:
         if self._cancel_delayed_action:
             self._cancel_delayed_action()
             self._cancel_delayed_action = None
-        self._delayed_call = None
+        self._delayed_call = None  # type: ignore[assignment]

--- a/tests/components/nexia/test_util.py
+++ b/tests/components/nexia/test_util.py
@@ -54,5 +54,6 @@ async def test_resettable_single_shot(hass: HomeAssistant) -> None:
     assert len(calls) == 1
     assert single_shot._cancel_delayed_action is not None
     single_shot.async_shutdown()
+    single_shot.reset_delayed_action_trigger()
     assert len(calls) == 1
     assert single_shot._cancel_delayed_action is None

--- a/tests/components/nexia/test_util.py
+++ b/tests/components/nexia/test_util.py
@@ -49,7 +49,10 @@ async def test_resettable_single_shot(hass: HomeAssistant) -> None:
     assert len(calls) == 1
     assert single_shot._cancel_delayed_action is None
 
-    # Fire again, then exit to exercise shutdown path.
+    # Fire again, then exercise shutdown path.
     single_shot.reset_delayed_action_trigger()
     assert len(calls) == 1
     assert single_shot._cancel_delayed_action is not None
+    single_shot.async_shutdown()
+    assert len(calls) == 1
+    assert single_shot._cancel_delayed_action is None

--- a/tests/components/nexia/test_util.py
+++ b/tests/components/nexia/test_util.py
@@ -1,8 +1,14 @@
 """The sensor tests for the nexia platform."""
 
+from datetime import timedelta
 from http import HTTPStatus
+from unittest.mock import AsyncMock
 
 from homeassistant.components.nexia import util
+from homeassistant.core import HomeAssistant
+from homeassistant.util import utcnow
+
+from tests.common import async_fire_time_changed
 
 
 async def test_is_invalid_auth_code() -> None:
@@ -18,3 +24,32 @@ async def test_percent_conv() -> None:
 
     assert util.percent_conv(0.12) == 12.0
     assert util.percent_conv(0.123) == 12.3
+
+
+async def test_resettable_single_shot(hass: HomeAssistant) -> None:
+    """Test class SingleShot."""
+    calls = []
+    single_shot = util.SingleShot(
+        hass, timedelta(seconds=0.01), AsyncMock(side_effect=lambda: calls.append(None))
+    )
+
+    # Fire once.
+    single_shot.reset_delayed_action_trigger()
+    assert len(calls) == 0
+    assert single_shot._cancel_delayed_action is not None
+
+    # Fire again while pending.
+    single_shot.reset_delayed_action_trigger()
+    assert len(calls) == 0
+    assert single_shot._cancel_delayed_action is not None
+
+    # Wait for time to run.
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert single_shot._cancel_delayed_action is None
+
+    # Fire again, then exit to exercise shutdown path.
+    single_shot.reset_delayed_action_trigger()
+    assert len(calls) == 1
+    assert single_shot._cancel_delayed_action is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a single shot timer, that can be reset, to the nexia integration. This will be used in a subsequent PR to select RoomIQ sensors. I split this out to make smaller PRs.

Selecting RoomIQ sensors consists of choosing a combination of sensors to include in a zone's average. Since [multiselect entities are not available](https://github.com/home-assistant/architecture/discussions/927), the subsequent PR will use this single shot timer to fire a request following the user's last change to switches controlling included sensors.

I tried using homeassistant.helpers.debounce.Debouncer but needed to act a while following the *last* trigger call -- not the *first*. I considered enhancing Debouncer for this use, but decided it already has a lot of conditional code and such a change would make it hard to maintain.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

This change is not visible to users, but will be used in a subsequent PR.
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
