### PR TITLE
Update beautifulsoup4 to 4.13.3

### DIFF
--- a/homeassistant/components/scrape/manifest.json
+++ b/homeassistant/components/scrape/manifest.json
@@ -6,5 +6,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/scrape",
   "iot_class": "cloud_polling",
-  "requirements": ["beautifulsoup4==4.12.3", "lxml==5.3.0"]
+  "requirements": ["beautifulsoup4==4.13.3", "lxml==5.3.0"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -527,8 +527,6 @@ filterwarnings = [
   "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:meteofrance_api.model.forecast",
 
   # -- fixed, waiting for release / update
-  # https://bugs.launchpad.net/beautifulsoup/+bug/2076897 - >4.12.3
-  "ignore:The 'strip_cdata' option of HTMLParser\\(\\) has never done anything and will eventually be removed:DeprecationWarning:bs4.builder._lxml",
   # https://github.com/DataDog/datadogpy/pull/290 - >=0.23.0
   "ignore:invalid escape sequence:SyntaxWarning:.*datadog.dogstatsd.base",
   # https://github.com/DataDog/datadogpy/pull/566/files - >=0.37.0
@@ -584,9 +582,6 @@ filterwarnings = [
   "ignore:Callback API version 1 is deprecated, update to latest version:DeprecationWarning:roborock.cloud_api",
   # https://github.com/briis/pyweatherflowudp/blob/v1.4.5/pyweatherflowudp/const.py#L20 - v1.4.5 - 2023-10-10
   "ignore:This function will be removed in future versions of pint:DeprecationWarning:pyweatherflowudp.const",
-  # Wrong stacklevel
-  # https://bugs.launchpad.net/beautifulsoup/+bug/2034451 fixed in >4.12.3
-  "ignore:It looks like you're parsing an XML document using an HTML parser:UserWarning:html.parser",
   # New in aiohttp - v3.9.0
   "ignore:It is recommended to use web.AppKey instances for keys:UserWarning:(homeassistant|tests|aiohttp_cors)",
   # - SyntaxWarnings
@@ -645,6 +640,8 @@ filterwarnings = [
   # https://pypi.org/project/directv/ - v0.4.0 - 2020-09-12
   "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:directv.directv",
   "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:directv.models",
+  # https://pypi.org/project/enocean/ - v0.50.1 (installed) -> v0.60.1 - 2021-06-18
+  "ignore:It looks like you're using an HTML parser to parse an XML document:UserWarning:enocean.protocol.eep",
   # https://pypi.org/project/httpsig/ - v1.3.0 - 2018-11-28
   "ignore:pkg_resources is deprecated as an API:DeprecationWarning:httpsig",
   # https://pypi.org/project/influxdb/ - v5.3.2 - 2024-04-18 (archived)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -590,7 +590,7 @@ batinfo==0.4.2
 # beacontools[scan]==2.1.0
 
 # homeassistant.components.scrape
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
 
 # homeassistant.components.beewi_smartclim
 # beewi-smartclim==0.0.10

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -37,7 +37,6 @@ tqdm==4.67.1
 types-aiofiles==24.1.0.20241221
 types-atomicwrites==1.4.5.1
 types-croniter==5.0.1.20241205
-types-beautifulsoup4==4.12.0.20250204
 types-caldav==1.3.0.20241107
 types-chardet==0.1.5
 types-decorator==5.1.8.20250121

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -527,7 +527,7 @@ babel==2.15.0
 base36==0.1.1
 
 # homeassistant.components.scrape
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.17.2


### PR DESCRIPTION
## Proposed change
https://git.launchpad.net/beautifulsoup/tree/CHANGELOG?h=4.13
Remove `types-beautifulsoup4` since `v4.13` now includes a `py.typed` file.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
