### PR TITLE
Add support for device sub units in AVM Fritz!SmartHome

### DIFF
--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -77,12 +77,11 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
         self.configuration_url = self.fritz.get_prefixed_host()
 
         await self.async_config_entry_first_refresh()
-        self.cleanup_removed_devices(
-            list(self.data.devices) + list(self.data.templates)
-        )
+        self.cleanup_removed_devices(self.data)
 
-    def cleanup_removed_devices(self, available_ains: list[str]) -> None:
+    def cleanup_removed_devices(self, data: FritzboxCoordinatorData) -> None:
         """Cleanup entity and device registry from removed devices."""
+        available_ains = list(data.devices) + list(data.templates)
         entity_reg = er.async_get(self.hass)
         for entity in er.async_entries_for_config_entry(
             entity_reg, self.config_entry.entry_id
@@ -91,8 +90,13 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
                 LOGGER.debug("Removing obsolete entity entry %s", entity.entity_id)
                 entity_reg.async_remove(entity.entity_id)
 
+        available_main_ains = [
+            ain
+            for ain, dev in data.devices.items()
+            if dev.device_and_unit_id[1] is None
+        ]
         device_reg = dr.async_get(self.hass)
-        identifiers = {(DOMAIN, ain) for ain in available_ains}
+        identifiers = {(DOMAIN, ain) for ain in available_main_ains}
         for device in dr.async_entries_for_config_entry(
             device_reg, self.config_entry.entry_id
         ):
@@ -185,8 +189,6 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
             self.data.devices.keys() - new_data.devices.keys()
             or self.data.templates.keys() - new_data.templates.keys()
         ):
-            self.cleanup_removed_devices(
-                list(new_data.devices) + list(new_data.templates)
-            )
+            self.cleanup_removed_devices(new_data)
 
         return new_data

--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -165,6 +165,22 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
         """Fetch all device data."""
         new_data = await self.hass.async_add_executor_job(self._update_fritz_devices)
 
+        for device in new_data.devices.values():
+            # create device registry entry for new main devices
+            if (
+                device.ain not in self.data.devices
+                and device.device_and_unit_id[1] is None
+            ):
+                dr.async_get(self.hass).async_get_or_create(
+                    config_entry_id=self.config_entry.entry_id,
+                    name=device.name,
+                    identifiers={(DOMAIN, device.ain)},
+                    manufacturer=device.manufacturer,
+                    model=device.productname,
+                    sw_version=device.fw_version,
+                    configuration_url=self.configuration_url,
+                )
+
         if (
             self.data.devices.keys() - new_data.devices.keys()
             or self.data.templates.keys() - new_data.templates.keys()

--- a/homeassistant/components/fritzbox/entity.py
+++ b/homeassistant/components/fritzbox/entity.py
@@ -58,11 +58,4 @@ class FritzBoxDeviceEntity(FritzBoxEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
-        return DeviceInfo(
-            name=self.data.name,
-            identifiers={(DOMAIN, self.ain)},
-            manufacturer=self.data.manufacturer,
-            model=self.data.productname,
-            sw_version=self.data.fw_version,
-            configuration_url=self.coordinator.configuration_url,
-        )
+        return DeviceInfo(identifiers={(DOMAIN, self.data.device_and_unit_id[0])})

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -60,6 +60,7 @@ class FritzEntityBaseMock(Mock):
     """base mock of a AVM Fritz!Box binary sensor device."""
 
     ain = CONF_FAKE_AIN
+    device_and_unit_id = (CONF_FAKE_AIN, None)
     manufacturer = CONF_FAKE_MANUFACTURER
     name = CONF_FAKE_NAME
     productname = CONF_FAKE_PRODUCTNAME

--- a/tests/components/fritzbox/test_binary_sensor.py
+++ b/tests/components/fritzbox/test_binary_sensor.py
@@ -110,6 +110,7 @@ async def test_discover_new_device(hass: HomeAssistant, fritz: Mock) -> None:
 
     new_device = FritzDeviceBinarySensorMock()
     new_device.ain = "7890 1234"
+    new_device.device_and_unit_id = ("7890 1234", None)
     new_device.name = "new_device"
     set_devices(fritz, devices=[device, new_device])
 

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -85,8 +85,16 @@ async def test_coordinator_automatic_registry_cleanup(
 ) -> None:
     """Test automatic registry cleanup."""
     fritz().get_devices.return_value = [
-        FritzDeviceSwitchMock(ain="fake ain switch", name="fake_switch"),
-        FritzDeviceCoverMock(ain="fake ain cover", name="fake_cover"),
+        FritzDeviceSwitchMock(
+            ain="fake ain switch",
+            device_and_unit_id=("fake ain switch", None),
+            name="fake_switch",
+        ),
+        FritzDeviceCoverMock(
+            ain="fake ain cover",
+            device_and_unit_id=("fake ain cover", None),
+            name="fake_cover",
+        ),
     ]
     entry = MockConfigEntry(
         domain=FB_DOMAIN,
@@ -101,7 +109,11 @@ async def test_coordinator_automatic_registry_cleanup(
     assert len(dr.async_entries_for_config_entry(device_registry, entry.entry_id)) == 2
 
     fritz().get_devices.return_value = [
-        FritzDeviceSwitchMock(ain="fake ain switch", name="fake_switch")
+        FritzDeviceSwitchMock(
+            ain="fake ain switch",
+            device_and_unit_id=("fake ain switch", None),
+            name="fake_switch",
+        )
     ]
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))

--- a/tests/components/fritzbox/test_sensor.py
+++ b/tests/components/fritzbox/test_sensor.py
@@ -108,6 +108,7 @@ async def test_discover_new_device(hass: HomeAssistant, fritz: Mock) -> None:
 
     new_device = FritzDeviceSensorMock()
     new_device.ain = "7890 1234"
+    new_device.device_and_unit_id = ("7890 1234", None)
     new_device.name = "new_device"
     set_devices(fritz, devices=[device, new_device])
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The AVM Fritz!Smarthome has a concept of devices and units. A device can have multiple units with different features. We now merge all units of a device into one entry representing the physical device. As this might remove existing devices and create new ones, you should check your automations and scripts, if they need to be adjusted to the new device registry entries.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The AVM Fritz!Box smarthome api has a concept of devices and units. A device can have multiple units with different features. (_see section 1.2 of [aha-http-api](https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AHA-HTTP-Interface.pdf) docs from AVM - only available in German_). The (_main_) device holds the information about the manufacturer, model and firmware, while the units can have own names and represent the actionable entities. Each device an unit is identified by an ain (_actor identifier_), where the ain of the unit is the ain of the device with an unit-identifier added.

With this change we link all units to their related main device, by their base ain. This allows us to proper support zigbee devices connected via a [AVM Fritz!Smart Gateway](https://en.fritz.com/products/smart-home/fritzsmart-gateway/)

It is considered as a breaking change, since it might change the `device_id` and I would like to have a beta test phase for this.

**conclusion**
- device registry entries are now always identified by the ain of the main device
- device units are linked to the device registry entry of the main device

---

Below some screenshots to show how it works

### current behavior

#### device overview

![image](https://github.com/user-attachments/assets/9894f747-a92f-48b1-a044-02d0534dda36)

#### example unit 1 of device "2023 Adventskranz"

![image](https://github.com/user-attachments/assets/9f7d4502-8052-4089-b1ed-5ae1f2b854d5)

### new behavior

#### device overview

![image](https://github.com/user-attachments/assets/ac469c52-af6f-4d8f-8dec-019bc31cae43)

#### example device "2023 Adventskranz"

![image](https://github.com/user-attachments/assets/ec7f3325-e1b0-41f6-92eb-f48d22b766cf)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #106767
  - fixes #142506
  - fixes https://github.com/hthiery/python-fritzhome/issues/90
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
