### PR TITLE
Remove boost and off temperature workaround from AVM Fritz!SmartHome

### DIFF
--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -94,7 +94,7 @@ async def test_target_temperature_on(hass: HomeAssistant, fritz: Mock) -> None:
 
     state = hass.states.get(ENTITY_ID)
     assert state
-    assert state.attributes[ATTR_TEMPERATURE] == 30
+    assert state.attributes[ATTR_TEMPERATURE] is None
 
 
 async def test_target_temperature_off(hass: HomeAssistant, fritz: Mock) -> None:
@@ -107,7 +107,7 @@ async def test_target_temperature_off(hass: HomeAssistant, fritz: Mock) -> None:
 
     state = hass.states.get(ENTITY_ID)
     assert state
-    assert state.attributes[ATTR_TEMPERATURE] == 0
+    assert state.attributes[ATTR_TEMPERATURE] is None
 
 
 async def test_update(hass: HomeAssistant, fritz: Mock) -> None:
@@ -177,15 +177,20 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
 
 
 @pytest.mark.parametrize(
-    ("service_data", "expected_call_args"),
+    (
+        "service_data",
+        "expected_set_target_temperature_call_args",
+        "expected_set_hkr_state_call_args",
+    ),
     [
-        ({ATTR_TEMPERATURE: 23}, [call(23, True)]),
+        ({ATTR_TEMPERATURE: 23}, [call(23, True)], []),
         (
             {
                 ATTR_HVAC_MODE: HVACMode.OFF,
                 ATTR_TEMPERATURE: 23,
             },
-            [call(0, True)],
+            [],
+            [call("off", True)],
         ),
         (
             {
@@ -193,6 +198,7 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
                 ATTR_TEMPERATURE: 23,
             },
             [call(23, True)],
+            [],
         ),
     ],
 )
@@ -200,7 +206,8 @@ async def test_set_temperature(
     hass: HomeAssistant,
     fritz: Mock,
     service_data: dict,
-    expected_call_args: list[_Call],
+    expected_set_target_temperature_call_args: list[_Call],
+    expected_set_hkr_state_call_args: list[_Call],
 ) -> None:
     """Test setting temperature."""
     device = FritzDeviceClimateMock()
@@ -214,29 +221,60 @@ async def test_set_temperature(
         {ATTR_ENTITY_ID: ENTITY_ID, **service_data},
         True,
     )
-    assert device.set_target_temperature.call_count == len(expected_call_args)
-    assert device.set_target_temperature.call_args_list == expected_call_args
+    assert device.set_target_temperature.call_count == len(
+        expected_set_target_temperature_call_args
+    )
+    assert (
+        device.set_target_temperature.call_args_list
+        == expected_set_target_temperature_call_args
+    )
+    assert device.set_hkr_state.call_count == len(expected_set_hkr_state_call_args)
+    assert device.set_hkr_state.call_args_list == expected_set_hkr_state_call_args
 
 
 @pytest.mark.parametrize(
-    ("service_data", "target_temperature", "current_preset", "expected_call_args"),
+    (
+        "service_data",
+        "target_temperature",
+        "current_preset",
+        "expected_set_target_temperature_call_args",
+        "expected_set_hkr_state_call_args",
+    ),
     [
-        # mode off always sets target temperature to 0
-        ({ATTR_HVAC_MODE: HVACMode.OFF}, 22, PRESET_COMFORT, [call(0, True)]),
-        ({ATTR_HVAC_MODE: HVACMode.OFF}, 16, PRESET_ECO, [call(0, True)]),
-        ({ATTR_HVAC_MODE: HVACMode.OFF}, 16, None, [call(0, True)]),
+        # mode off always sets hkr state off
+        ({ATTR_HVAC_MODE: HVACMode.OFF}, 22, PRESET_COMFORT, [], [call("off", True)]),
+        ({ATTR_HVAC_MODE: HVACMode.OFF}, 16, PRESET_ECO, [], [call("off", True)]),
+        ({ATTR_HVAC_MODE: HVACMode.OFF}, 16, None, [], [call("off", True)]),
         # mode heat sets target temperature based on current scheduled preset,
         # when not already in mode heat
-        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 0.0, PRESET_COMFORT, [call(22, True)]),
-        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 0.0, PRESET_ECO, [call(16, True)]),
-        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 0.0, None, [call(22, True)]),
+        (
+            {ATTR_HVAC_MODE: HVACMode.HEAT},
+            OFF_API_TEMPERATURE,
+            PRESET_COMFORT,
+            [call(22, True)],
+            [],
+        ),
+        (
+            {ATTR_HVAC_MODE: HVACMode.HEAT},
+            OFF_API_TEMPERATURE,
+            PRESET_ECO,
+            [call(16, True)],
+            [],
+        ),
+        (
+            {ATTR_HVAC_MODE: HVACMode.HEAT},
+            OFF_API_TEMPERATURE,
+            None,
+            [call(22, True)],
+            [],
+        ),
         # mode heat does not set target temperature, when already in mode heat
-        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 16, PRESET_COMFORT, []),
-        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 16, PRESET_ECO, []),
-        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 16, None, []),
-        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 22, PRESET_COMFORT, []),
-        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 22, PRESET_ECO, []),
-        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 22, None, []),
+        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 16, PRESET_COMFORT, [], []),
+        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 16, PRESET_ECO, [], []),
+        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 16, None, [], []),
+        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 22, PRESET_COMFORT, [], []),
+        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 22, PRESET_ECO, [], []),
+        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 22, None, [], []),
     ],
 )
 async def test_set_hvac_mode(
@@ -245,7 +283,8 @@ async def test_set_hvac_mode(
     service_data: dict,
     target_temperature: float,
     current_preset: str,
-    expected_call_args: list[_Call],
+    expected_set_target_temperature_call_args: list[_Call],
+    expected_set_hkr_state_call_args: list[_Call],
 ) -> None:
     """Test setting hvac mode."""
     device = FritzDeviceClimateMock()
@@ -269,16 +308,23 @@ async def test_set_hvac_mode(
         True,
     )
 
-    assert device.set_target_temperature.call_count == len(expected_call_args)
-    assert device.set_target_temperature.call_args_list == expected_call_args
+    assert device.set_target_temperature.call_count == len(
+        expected_set_target_temperature_call_args
+    )
+    assert (
+        device.set_target_temperature.call_args_list
+        == expected_set_target_temperature_call_args
+    )
+    assert device.set_hkr_state.call_count == len(expected_set_hkr_state_call_args)
+    assert device.set_hkr_state.call_args_list == expected_set_hkr_state_call_args
 
 
 @pytest.mark.parametrize(
     ("comfort_temperature", "expected_call_args"),
     [
-        (20, [call(20, True)]),
-        (28, [call(28, True)]),
-        (ON_API_TEMPERATURE, [call(30, True)]),
+        (20, [call("comfort", True)]),
+        (28, [call("comfort", True)]),
+        (ON_API_TEMPERATURE, [call("comfort", True)]),
     ],
 )
 async def test_set_preset_mode_comfort(
@@ -300,16 +346,16 @@ async def test_set_preset_mode_comfort(
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_PRESET_MODE: PRESET_COMFORT},
         True,
     )
-    assert device.set_target_temperature.call_count == len(expected_call_args)
-    assert device.set_target_temperature.call_args_list == expected_call_args
+    assert device.set_hkr_state.call_count == len(expected_call_args)
+    assert device.set_hkr_state.call_args_list == expected_call_args
 
 
 @pytest.mark.parametrize(
     ("eco_temperature", "expected_call_args"),
     [
-        (20, [call(20, True)]),
-        (16, [call(16, True)]),
-        (OFF_API_TEMPERATURE, [call(0, True)]),
+        (20, [call("eco", True)]),
+        (16, [call("eco", True)]),
+        (OFF_API_TEMPERATURE, [call("eco", True)]),
     ],
 )
 async def test_set_preset_mode_eco(
@@ -331,8 +377,8 @@ async def test_set_preset_mode_eco(
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_PRESET_MODE: PRESET_ECO},
         True,
     )
-    assert device.set_target_temperature.call_count == len(expected_call_args)
-    assert device.set_target_temperature.call_args_list == expected_call_args
+    assert device.set_hkr_state.call_count == len(expected_call_args)
+    assert device.set_hkr_state.call_args_list == expected_call_args
 
 
 async def test_set_preset_mode_boost(
@@ -351,8 +397,8 @@ async def test_set_preset_mode_boost(
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_PRESET_MODE: PRESET_BOOST},
         True,
     )
-    assert device.set_target_temperature.call_count == 1
-    assert device.set_target_temperature.call_args_list == [call(30, True)]
+    assert device.set_hkr_state.call_count == 1
+    assert device.set_hkr_state.call_args_list == [call("on", True)]
 
 
 async def test_preset_mode_update(hass: HomeAssistant, fritz: Mock) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With this we set the `target_temperature` to `None` when the thermostat is off or in boost mode, instead of translating them to 0 for off and 30 for boost. Further we now make use of the `set_hkr_state()` from the lib, those we don't need to have this logic in our code anymore.

I'm not 100% sure, if this could be considered as bugfix - I'm open for suggestions :slightly_smiling_face: 

### Results

#### off

![Image](https://github.com/user-attachments/assets/8221fbf3-feec-49f5-a7b2-08dd014d5162)

#### eco

![Image](https://github.com/user-attachments/assets/8b1461d3-6517-495c-afbd-8be3bdf7b29d)

#### comfort

![Image](https://github.com/user-attachments/assets/38e00022-3c33-4632-9ac2-731d064ef5bf)

#### boost

![Image](https://github.com/user-attachments/assets/edc8053b-8612-4c2a-a176-9d78b65fc388)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #142426
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
