### PR TITLE
Fix quality loss for LLM conversation agent question answering

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -72,6 +72,19 @@ NO_ENTITIES_PROMPT = (
     "to their voice assistant in Home Assistant."
 )
 
+DYNAMIC_CONTEXT_PROMPT = """You ARE equipped to answer questions about the current state of
+the home using the `GetLiveContext` tool. This is a primary function. Do not state you lack the
+functionality if the question requires live data.
+If the user asks about device existence/type (e.g., "Do I have lights in the bedroom?"): Answer
+from the static context below.
+If the user asks about the CURRENT state, value, or mode (e.g., "Is the lock locked?",
+"Is the fan on?", "What mode is the thermostat in?", "What is the temperature outside?"):
+    1.  Recognize this requires live data.
+    2.  You MUST call `GetLiveContext`. This tool will provide the needed real-time information (like temperature from the local weather, lock status, etc.).
+    3.  Use the tool's response** to answer the user accurately (e.g., "The temperature outside is [value from tool].").
+For general knowledge questions not about the home: Answer truthfully from internal knowledge.
+"""
+
 
 @callback
 def async_render_no_api_prompt(hass: HomeAssistant) -> str:
@@ -385,6 +398,8 @@ class AssistAPI(API):
         ):
             prompt.append("This device is not able to start timers.")
 
+        prompt.append(DYNAMIC_CONTEXT_PROMPT)
+
         return prompt
 
     @callback
@@ -396,7 +411,7 @@ class AssistAPI(API):
 
         if exposed_entities and exposed_entities["entities"]:
             prompt.append(
-                "An overview of the areas and the devices in this smart home:"
+                "Static Context: An overview of the areas and the devices in this smart home:"
             )
             prompt.append(yaml_util.dump(list(exposed_entities["entities"].values())))
 
@@ -458,7 +473,7 @@ class AssistAPI(API):
             )
 
         if exposed_domains:
-            tools.append(GetHomeStateTool())
+            tools.append(GetLiveContextTool())
 
         return tools
 
@@ -899,7 +914,7 @@ class CalendarGetEventsTool(Tool):
         return {"success": True, "result": events}
 
 
-class GetHomeStateTool(Tool):
+class GetLiveContextTool(Tool):
     """Tool for getting the current state of exposed entities.
 
     This returns state for all entities that have been exposed to
@@ -907,8 +922,13 @@ class GetHomeStateTool(Tool):
     returns state for entities based on intent parameters.
     """
 
-    name = "get_home_state"
-    description = "Get the current state of all devices in the home. "
+    name = "GetLiveContext"
+    description = (
+        "Use this tool when the user asks a question about the CURRENT state, "
+        "value, or mode of a specific device, sensor, entity, or area in the "
+        "smart home, and the answer can be improved with real-time data not "
+        "available in the static device overview list. "
+    )
 
     async def async_call(
         self,

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -946,7 +946,7 @@ class GetLiveContextTool(Tool):
         if not exposed_entities["entities"]:
             return {"success": False, "error": NO_ENTITIES_PROMPT}
         prompt = [
-            "An overview of the areas and the devices in this smart home:",
+            "Live Context: An overview of the areas and the devices in this smart home:",
             yaml_util.dump(list(exposed_entities["entities"].values())),
         ]
         return {

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -166,6 +166,12 @@ def create_tool_use_block(
     ]
 
 
+# DEBUG    RawContentBlockStopEvent(index=0, type='content_block_stop')
+# DEBUG    RawContentBlockStartEvent(content_block=ToolUseBlock(id='toolu_011EhVxV5tV2R4CMZn2N51yr', input={}, name='get_home_state', type='tool_use'), index=1, type='content_block_start')
+# DEBUG    RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='', type='input_json_delta'), index=1, type='content_block_delta')
+# DEBUG    RawContentBlockStopEvent(index=1, type='content_block_stop')
+
+
 async def test_entity(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -166,12 +166,6 @@ def create_tool_use_block(
     ]
 
 
-# DEBUG    RawContentBlockStopEvent(index=0, type='content_block_stop')
-# DEBUG    RawContentBlockStartEvent(content_block=ToolUseBlock(id='toolu_011EhVxV5tV2R4CMZn2N51yr', input={}, name='get_home_state', type='tool_use'), index=1, type='content_block_start')
-# DEBUG    RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='', type='input_json_delta'), index=1, type='content_block_delta')
-# DEBUG    RawContentBlockStopEvent(index=1, type='content_block_stop')
-
-
 async def test_entity(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -181,13 +181,13 @@ async def test_assist_api(
 
     assert len(llm.async_get_apis(hass)) == 1
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert [tool.name for tool in api.tools] == ["get_home_state"]
+    assert [tool.name for tool in api.tools] == ["GetLiveContext"]
 
     # Match all
     intent_handler.platforms = None
 
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert [tool.name for tool in api.tools] == ["test_intent", "get_home_state"]
+    assert [tool.name for tool in api.tools] == ["test_intent", "GetLiveContext"]
 
     # Match specific domain
     intent_handler.platforms = {"light"}
@@ -575,7 +575,7 @@ async def test_assist_api_prompt(
             suggested_area="Test Area 2",
         )
     )
-    exposed_entities_prompt = """An overview of the areas and the devices in this smart home:
+    exposed_entities_prompt = """Live Context: An overview of the areas and the devices in this smart home:
 - names: '1'
   domain: light
   state: unavailable
@@ -623,7 +623,7 @@ async def test_assist_api_prompt(
   state: unavailable
   areas: Test Area 2
 """
-    stateless_exposed_entities_prompt = """An overview of the areas and the devices in this smart home:
+    stateless_exposed_entities_prompt = """Static Context: An overview of the areas and the devices in this smart home:
 - names: '1'
   domain: light
   areas: Test Area 2
@@ -669,17 +669,30 @@ async def test_assist_api_prompt(
         "When a user asks to turn on all devices of a specific type, "
         "ask user to specify an area, unless there is only one device of that type."
     )
+    dynamic_context_prompt = """You ARE equipped to answer questions about the current state of
+the home using the `GetLiveContext` tool. This is a primary function. Do not state you lack the
+functionality if the question requires live data.
+If the user asks about device existence/type (e.g., "Do I have lights in the bedroom?"): Answer
+from the static context below.
+If the user asks about the CURRENT state, value, or mode (e.g., "Is the lock locked?",
+"Is the fan on?", "What mode is the thermostat in?", "What is the temperature outside?"):
+    1.  Recognize this requires live data.
+    2.  You MUST call `GetLiveContext`. This tool will provide the needed real-time information (like temperature from the local weather, lock status, etc.).
+    3.  Use the tool's response** to answer the user accurately (e.g., "The temperature outside is [value from tool].").
+For general knowledge questions not about the home: Answer truthfully from internal knowledge.
+"""
     api = await llm.async_get_api(hass, "assist", llm_context)
     assert api.api_prompt == (
         f"""{first_part_prompt}
 {area_prompt}
 {no_timer_prompt}
+{dynamic_context_prompt}
 {stateless_exposed_entities_prompt}"""
     )
 
-    # Verify that the get_home_state tool returns the same results as the exposed_entities_prompt
+    # Verify that the GetLiveContext tool returns the same results as the exposed_entities_prompt
     result = await api.async_call_tool(
-        llm.ToolInput(tool_name="get_home_state", tool_args={})
+        llm.ToolInput(tool_name="GetLiveContext", tool_args={})
     )
     assert result == {
         "success": True,
@@ -697,6 +710,7 @@ async def test_assist_api_prompt(
         f"""{first_part_prompt}
 {area_prompt}
 {no_timer_prompt}
+{dynamic_context_prompt}
 {stateless_exposed_entities_prompt}"""
     )
 
@@ -712,6 +726,7 @@ async def test_assist_api_prompt(
         f"""{first_part_prompt}
 {area_prompt}
 {no_timer_prompt}
+{dynamic_context_prompt}
 {stateless_exposed_entities_prompt}"""
     )
 
@@ -723,6 +738,7 @@ async def test_assist_api_prompt(
     assert api.api_prompt == (
         f"""{first_part_prompt}
 {area_prompt}
+{dynamic_context_prompt}
 {stateless_exposed_entities_prompt}"""
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix quality loss for LLM conversation agent question answering by improving the prompts for obtaining live  home state.  The loss was primarily introduced by #141034

This fixes a gap where some models would not realize they were able to call a tool to get
realtime home information. This significant iteration on the prompt (both to find what would work, and to slim to reduce token count) and was measured based on the [questions](https://github.com/allenporter/home-assistant-datasets/tree/main/datasets/questions) dataset. The results primarily were targeted as fixing Gemini models which now have scores on par with Claude, and OpenAI models. This also sees significant improvements on Llama 3.1 (though still a little behind the other models)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #142312
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
