### PR TITLE
Bump Environment Canada library to 0.10.1

### DIFF
--- a/homeassistant/components/environment_canada/config_flow.py
+++ b/homeassistant/components/environment_canada/config_flow.py
@@ -35,7 +35,7 @@ async def validate_input(data):
         lon = weather_data.lon
 
     return {
-        CONF_TITLE: weather_data.metadata.get("location"),
+        CONF_TITLE: weather_data.metadata.location,
         CONF_STATION: weather_data.station_id,
         CONF_LATITUDE: lat,
         CONF_LONGITUDE: lon,

--- a/homeassistant/components/environment_canada/coordinator.py
+++ b/homeassistant/components/environment_canada/coordinator.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import logging
 import xml.etree.ElementTree as ET
 
-from env_canada import ECAirQuality, ECRadar, ECWeather, ec_exc
+from env_canada import ECAirQuality, ECRadar, ECWeather, ECWeatherUpdateFailed, ec_exc
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -65,6 +65,6 @@ class ECDataUpdateCoordinator[DataT: ECDataType](DataUpdateCoordinator[DataT]):
         """Fetch data from EC."""
         try:
             await self.ec_data.update()
-        except (ET.ParseError, ec_exc.UnknownStationId) as ex:
+        except (ET.ParseError, ECWeatherUpdateFailed, ec_exc.UnknownStationId) as ex:
             raise UpdateFailed(f"Error fetching {self.name} data: {ex}") from ex
         return self.ec_data

--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
   "iot_class": "cloud_polling",
   "loggers": ["env_canada"],
-  "requirements": ["env-canada==0.10.0"]
+  "requirements": ["env-canada==0.10.1"]
 }

--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
   "iot_class": "cloud_polling",
   "loggers": ["env_canada"],
-  "requirements": ["env-canada==0.8.0"]
+  "requirements": ["env-canada==0.10.0"]
 }

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -145,7 +145,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
         key="timestamp",
         translation_key="timestamp",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data: data.metadata.get("timestamp"),
+        value_fn=lambda data: data.metadata.timestamp,
     ),
     ECSensorEntityDescription(
         key="uv_index",
@@ -289,7 +289,7 @@ class ECBaseSensorEntity[DataT: ECDataType](
         super().__init__(coordinator)
         self.entity_description = description
         self._ec_data = coordinator.ec_data
-        self._attr_attribution = self._ec_data.metadata["attribution"]
+        self._attr_attribution = self._ec_data.metadata.attribution
         self._attr_unique_id = f"{coordinator.config_entry.title}-{description.key}"
         self._attr_device_info = coordinator.device_info
 
@@ -313,8 +313,8 @@ class ECSensorEntity[DataT: ECDataType](ECBaseSensorEntity[DataT]):
         """Initialize the sensor."""
         super().__init__(coordinator, description)
         self._attr_extra_state_attributes = {
-            ATTR_LOCATION: self._ec_data.metadata.get("location"),
-            ATTR_STATION: self._ec_data.metadata.get("station"),
+            ATTR_LOCATION: self._ec_data.metadata.location,
+            ATTR_STATION: self._ec_data.metadata.station,
         }
 
 
@@ -329,8 +329,8 @@ class ECAlertSensorEntity(ECBaseSensorEntity[ECWeather]):
             return None
 
         extra_state_attrs = {
-            ATTR_LOCATION: self._ec_data.metadata.get("location"),
-            ATTR_STATION: self._ec_data.metadata.get("station"),
+            ATTR_LOCATION: self._ec_data.metadata.location,
+            ATTR_STATION: self._ec_data.metadata.station,
         }
         for index, alert in enumerate(value, start=1):
             extra_state_attrs[f"alert_{index}"] = alert.get("title")

--- a/homeassistant/components/environment_canada/weather.py
+++ b/homeassistant/components/environment_canada/weather.py
@@ -115,7 +115,7 @@ class ECWeatherEntity(
         """Initialize Environment Canada weather."""
         super().__init__(coordinator)
         self.ec_data = coordinator.ec_data
-        self._attr_attribution = self.ec_data.metadata["attribution"]
+        self._attr_attribution = self.ec_data.metadata.attribution
         self._attr_translation_key = "forecast"
         self._attr_unique_id = _calculate_unique_id(
             coordinator.config_entry.unique_id, False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -871,7 +871,7 @@ enocean==0.50
 enturclient==0.2.4
 
 # homeassistant.components.environment_canada
-env-canada==0.8.0
+env-canada==0.10.0
 
 # homeassistant.components.season
 ephem==4.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -871,7 +871,7 @@ enocean==0.50
 enturclient==0.2.4
 
 # homeassistant.components.environment_canada
-env-canada==0.10.0
+env-canada==0.10.1
 
 # homeassistant.components.season
 ephem==4.1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -741,7 +741,7 @@ energyzero==2.1.1
 enocean==0.50
 
 # homeassistant.components.environment_canada
-env-canada==0.10.0
+env-canada==0.10.1
 
 # homeassistant.components.season
 ephem==4.1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -741,7 +741,7 @@ energyzero==2.1.1
 enocean==0.50
 
 # homeassistant.components.environment_canada
-env-canada==0.8.0
+env-canada==0.10.0
 
 # homeassistant.components.season
 ephem==4.1.6

--- a/tests/components/environment_canada/__init__.py
+++ b/tests/components/environment_canada/__init__.py
@@ -33,7 +33,7 @@ async def init_integration(hass: HomeAssistant, ec_data) -> MockConfigEntry:
     config_entry.add_to_hass(hass)
 
     weather_mock = mock_ec()
-    ec_data["metadata"]["timestamp"] = datetime(2022, 10, 4, tzinfo=UTC)
+    ec_data["metadata"].timestamp = datetime(2022, 10, 4, tzinfo=UTC)
     weather_mock.conditions = ec_data["conditions"]
     weather_mock.alerts = ec_data["alerts"]
     weather_mock.daily_forecasts = ec_data["daily_forecasts"]

--- a/tests/components/environment_canada/conftest.py
+++ b/tests/components/environment_canada/conftest.py
@@ -4,9 +4,9 @@ import contextlib
 from datetime import datetime
 import json
 
+from env_canada.ec_weather import MetaData
 import pytest
 
-from env_canada.ec_weather import MetaData
 from tests.common import load_fixture
 
 

--- a/tests/components/environment_canada/conftest.py
+++ b/tests/components/environment_canada/conftest.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from env_canada.ec_weather import MetaData
 from tests.common import load_fixture
 
 
@@ -13,7 +14,7 @@ from tests.common import load_fixture
 def ec_data():
     """Load Environment Canada data."""
 
-    def date_hook(weather):
+    def data_hook(weather):
         """Convert timestamp string to datetime."""
 
         if t := weather.get("timestamp"):
@@ -22,9 +23,11 @@ def ec_data():
         elif t := weather.get("period"):
             with contextlib.suppress(ValueError):
                 weather["period"] = datetime.fromisoformat(t)
+        if t := weather.get("metadata"):
+            weather["metadata"] = MetaData(**t)
         return weather
 
     return json.loads(
         load_fixture("environment_canada/current_conditions_data.json"),
-        object_hook=date_hook,
+        object_hook=data_hook,
     )

--- a/tests/components/environment_canada/test_config_flow.py
+++ b/tests/components/environment_canada/test_config_flow.py
@@ -30,7 +30,7 @@ def mocked_ec():
     ec_mock.lat = FAKE_CONFIG[CONF_LATITUDE]
     ec_mock.lon = FAKE_CONFIG[CONF_LONGITUDE]
     ec_mock.language = FAKE_CONFIG[CONF_LANGUAGE]
-    ec_mock.metadata = {"location": FAKE_TITLE}
+    ec_mock.metadata.location = FAKE_TITLE
 
     ec_mock.update = AsyncMock()
 

--- a/tests/components/environment_canada/test_diagnostics.py
+++ b/tests/components/environment_canada/test_diagnostics.py
@@ -31,10 +31,6 @@ async def test_entry_diagnostics(
 ) -> None:
     """Test config entry diagnostics."""
 
-    ec_data = json.loads(
-        load_fixture("environment_canada/current_conditions_data.json")
-    )
-
     config_entry = await init_integration(hass, ec_data)
     diagnostics = await get_diagnostics_for_config_entry(
         hass, hass_client, config_entry

--- a/tests/components/environment_canada/test_diagnostics.py
+++ b/tests/components/environment_canada/test_diagnostics.py
@@ -1,6 +1,5 @@
 """Test Environment Canada diagnostics."""
 
-import json
 from typing import Any
 
 from syrupy import SnapshotAssertion
@@ -11,7 +10,6 @@ from homeassistant.core import HomeAssistant
 
 from . import init_integration
 
-from tests.common import load_fixture
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 


### PR DESCRIPTION
## Proposed change
Bump the Environment Canada library to 0.10.1.

There were breaking changes in the library. There are not breaking changes in HA.

https://github.com/michaeldavie/env_canada/compare/v0.8.0...0.10.1

All of the changes except the last 3 commits were around code quality and adding tests.

The last 3 commits (April 13) add a feature for network resiliency as Environment Canada tends to return 404 errors frequently (a number of people are seeing 404s once a day) enough to cause quite a number of discussions. 

The changes to the HA code are because of a breaking change in the env_canada library where the metadata dict was switched to the dataclass. 

This is a bug fix, that was discussed on Discourse here: https://community.home-assistant.io/t/environment-canada-integration-error-404-every-night-at-8-02/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
