### PR TITLE
Allow post timestamp with state updates

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -270,13 +270,14 @@ class APIEntityStateView(HomeAssistantView):
 
         attributes = data.get("attributes")
         force_update = data.get("force_update", False)
+        timestamp = data.get("timestamp", None)
 
         is_new_state = hass.states.get(entity_id) is None
 
         # Write state
         try:
             hass.states.async_set(
-                entity_id, new_state, attributes, force_update, self.context(request)
+                entity_id, new_state, attributes, force_update, self.context(request), None, timestamp
             )
         except InvalidEntityFormatError:
             return self.json_message(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

This is not a breaking change


## Proposed change

Many sensors can provide state that corresponds to different moments than the current moment. For example, I have a water usage sensor that has its own buffer for when the remote sensor loses connectivity. When it reconnects it can deliver data that was missing. Public utility companies also often have historical data that could be pushed into home assistant. I found a number of feature reqeusts for this type of thing and I can link them here if we need more supporting arguments for doing this.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Some context of requests for ability to insert sensor data at specific timestamps

https://community.home-assistant.io/t/insert-state-at-specific-timestamp/329790
https://community.home-assistant.io/t/offset-date-for-sensor-values/169522/16
https://community.home-assistant.io/t/timestamp-on-sensor-readings/202518
https://community.home-assistant.io/t/loading-sensor-data-from-text-files-with-date-times/108445
https://community.home-assistant.io/t/loading-historical-data-to-ha/738997
https://community.home-assistant.io/t/wth-is-there-no-way-to-add-historical-data-to-energy-dashboard/468748
https://community.home-assistant.io/t/add-historic-data-to-energy-dashboard/423205
https://community.home-assistant.io/t/import-old-energy-readings-for-use-in-energy-dashboard/341406
https://github.com/klausj1/homeassistant-statistics

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

I will work through this checklist, but I'd like to get some feedback before I spend the effort.

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

I am happy to add docs, but let's decide if the community wants this before I add docs.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

I will take a look.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
