### PR TITLE
Bump devolo_plc_api to 1.5.1

### DIFF
--- a/homeassistant/components/devolo_home_network/manifest.json
+++ b/homeassistant/components/devolo_home_network/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["devolo_plc_api"],
-  "requirements": ["devolo-plc-api==1.4.1"],
+  "requirements": ["devolo-plc-api==1.5.0"],
   "zeroconf": [
     {
       "type": "_dvl-deviceapi._tcp.local.",

--- a/homeassistant/components/devolo_home_network/manifest.json
+++ b/homeassistant/components/devolo_home_network/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["devolo_plc_api"],
-  "requirements": ["devolo-plc-api==1.5.0"],
+  "requirements": ["devolo-plc-api==1.5.1"],
   "zeroconf": [
     {
       "type": "_dvl-deviceapi._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -781,7 +781,7 @@ devialet==1.5.7
 devolo-home-control-api==0.18.3
 
 # homeassistant.components.devolo_home_network
-devolo-plc-api==1.5.0
+devolo-plc-api==1.5.1
 
 # homeassistant.components.chacon_dio
 dio-chacon-wifi-api==1.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -781,7 +781,7 @@ devialet==1.5.7
 devolo-home-control-api==0.18.3
 
 # homeassistant.components.devolo_home_network
-devolo-plc-api==1.4.1
+devolo-plc-api==1.5.0
 
 # homeassistant.components.chacon_dio
 dio-chacon-wifi-api==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -672,7 +672,7 @@ devialet==1.5.7
 devolo-home-control-api==0.18.3
 
 # homeassistant.components.devolo_home_network
-devolo-plc-api==1.4.1
+devolo-plc-api==1.5.0
 
 # homeassistant.components.chacon_dio
 dio-chacon-wifi-api==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -672,7 +672,7 @@ devialet==1.5.7
 devolo-home-control-api==0.18.3
 
 # homeassistant.components.devolo_home_network
-devolo-plc-api==1.5.0
+devolo-plc-api==1.5.1
 
 # homeassistant.components.chacon_dio
 dio-chacon-wifi-api==1.2.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump devolo_plc_api to 1.5.1. It introduced the SPDX license identifier and a retry mechanism to hopefully reduce the probability to see https://github.com/home-assistant/core/issues/134805. 

However, there is a sub-dependency conflict with linear-garage-door that I don't know how to resolve easily. linear-garage-door depends on tenacity<9.0.0 while I not being aware of that constraint only tested with tenacity>=9.0.0. Linear Garage Door is marked for removal in 2025.8.0 and has 0 users according to analytics. Please advice how to handle this.

Changelog: https://github.com/2Fake/devolo_plc_api/releases/tag/v1.5.0, https://github.com/2Fake/devolo_plc_api/releases/tag/v1.5.1
Git diff: https://github.com/2Fake/devolo_plc_api/compare/v1.4.1...v1.5.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #134805
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
