### PR TITLE
Fix utility_meter wrong/old value on reset

### DIFF
--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -577,9 +577,9 @@ class UtilityMeterSensor(RestoreSensor):
     async def _async_reset_meter(self, event):
         """Reset the utility meter status."""
 
-        await self._program_reset()
-
         await self.async_reset_meter(self._tariff_entity)
+
+        await self._program_reset()
 
     async def async_reset_meter(self, entity_id):
         """Reset meter."""

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -41,7 +41,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfVolume,
 )
-from homeassistant.core import CoreState, HomeAssistant, State, callback
+from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
@@ -1640,19 +1640,16 @@ async def _test_self_reset(
     with freeze_time(now):
         # Listen for events and check that state in the first event after reset is actually 0, issue #142053
         events = []
-async def handle_energy_bill_event(event):
-    events.append(event)
 
-unsub = async_track_state_change_event(
-    hass,
-    "sensor.energy_bill",
-    handle_energy_bill_event,
-)
+        async def handle_energy_bill_event(event):
+            events.append(event)
+
+        unsub = async_track_state_change_event(
             hass,
             "sensor.energy_bill",
-            # pylint: disable-next=unnecessary-lambda
-            callback(lambda event: events.append(event)),
+            handle_energy_bill_event,
         )
+
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()
         unsub()

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -1671,7 +1671,7 @@ unsub = async_track_state_change_event(
             state.attributes.get("last_reset") == dt_util.as_utc(now).isoformat()
         )  # last_reset is kept in UTC
         assert state.state == "3"
-        # In first event state should be 0, issue #142053
+        # In first event state should be 0
         assert len(events) == 2
         assert events[0].data.get("new_state").state == "0"
         assert events[1].data.get("new_state").state == "0"

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -1638,6 +1638,7 @@ async def _test_self_reset(
 
     now += timedelta(seconds=30)
     with freeze_time(now):
+        # Listen for events and check that state in the first event after reset is actually 0, issue #142053
         events = []
         unsub = async_track_state_change_event(
             hass,
@@ -1663,6 +1664,7 @@ async def _test_self_reset(
             state.attributes.get("last_reset") == dt_util.as_utc(now).isoformat()
         )  # last_reset is kept in UTC
         assert state.state == "3"
+        # In first event state should be 0, issue #142053
         assert len(events) == 2
         assert events[0].data.get("new_state").state == "0"
         assert events[1].data.get("new_state").state == "0"

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -1640,7 +1640,14 @@ async def _test_self_reset(
     with freeze_time(now):
         # Listen for events and check that state in the first event after reset is actually 0, issue #142053
         events = []
-        unsub = async_track_state_change_event(
+async def handle_energy_bill_event(event):
+    events.append(event)
+
+unsub = async_track_state_change_event(
+    hass,
+    "sensor.energy_bill",
+    handle_energy_bill_event,
+)
             hass,
             "sensor.energy_bill",
             # pylint: disable-next=unnecessary-lambda


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix utility_meter wrong/old value on reset (#142053)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #142053
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
