### PR TITLE
Fix device creation in fibaro integration

### DIFF
--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -176,18 +176,18 @@ class FibaroController:
             platform = Platform.LIGHT
         return platform
 
-    def _create_device_info(self, master_device: DeviceModel) -> None:
-        """Create the device info for a master device."""
+    def _create_device_info(self, main_device: DeviceModel) -> None:
+        """Create the device info for a main device."""
 
-        if "zwaveCompany" in master_device.properties:
-            manufacturer = master_device.properties.get("zwaveCompany")
+        if "zwaveCompany" in main_device.properties:
+            manufacturer = main_device.properties.get("zwaveCompany")
         else:
             manufacturer = None
 
-        self._device_infos[master_device.fibaro_id] = DeviceInfo(
-            identifiers={(DOMAIN, master_device.fibaro_id)},
+        self._device_infos[main_device.fibaro_id] = DeviceInfo(
+            identifiers={(DOMAIN, main_device.fibaro_id)},
             manufacturer=manufacturer,
-            name=master_device.name,
+            name=main_device.name,
             via_device=(DOMAIN, self.hub_serial),
         )
 
@@ -223,8 +223,8 @@ class FibaroController:
         """Read and process the device list."""
         devices = self._fibaro_device_manager.get_devices()
 
-        for master_device in find_master_devices(devices):
-            self._create_device_info(master_device)
+        for main_device in find_master_devices(devices):
+            self._create_device_info(main_device)
 
         self._device_map = {}
         last_climate_parent = None

--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -12,7 +12,7 @@ from pyfibaro.fibaro_client import (
     FibaroClient,
     FibaroConnectFailed,
 )
-from pyfibaro.fibaro_data_helper import read_rooms
+from pyfibaro.fibaro_data_helper import find_master_devices, read_rooms
 from pyfibaro.fibaro_device import DeviceModel
 from pyfibaro.fibaro_device_manager import FibaroDeviceManager
 from pyfibaro.fibaro_info import InfoModel
@@ -176,35 +176,18 @@ class FibaroController:
             platform = Platform.LIGHT
         return platform
 
-    def _create_device_info(
-        self, device: DeviceModel, devices: list[DeviceModel]
-    ) -> None:
-        """Create the device info. Unrooted entities are directly shown below the home center."""
+    def _create_device_info(self, master_device: DeviceModel) -> None:
+        """Create the device info for a master device."""
 
-        # The home center is always id 1 (z-wave primary controller)
-        if device.parent_fibaro_id <= 1:
-            return
-
-        master_entity: DeviceModel | None = None
-        if device.parent_fibaro_id == 1:
-            master_entity = device
-        else:
-            for parent in devices:
-                if parent.fibaro_id == device.parent_fibaro_id:
-                    master_entity = parent
-        if master_entity is None:
-            _LOGGER.error("Parent with id %s not found", device.parent_fibaro_id)
-            return
-
-        if "zwaveCompany" in master_entity.properties:
-            manufacturer = master_entity.properties.get("zwaveCompany")
+        if "zwaveCompany" in master_device.properties:
+            manufacturer = master_device.properties.get("zwaveCompany")
         else:
             manufacturer = None
 
-        self._device_infos[master_entity.fibaro_id] = DeviceInfo(
-            identifiers={(DOMAIN, master_entity.fibaro_id)},
+        self._device_infos[master_device.fibaro_id] = DeviceInfo(
+            identifiers={(DOMAIN, master_device.fibaro_id)},
             manufacturer=manufacturer,
-            name=master_entity.name,
+            name=master_device.name,
             via_device=(DOMAIN, self.hub_serial),
         )
 
@@ -239,6 +222,10 @@ class FibaroController:
     def _read_devices(self) -> None:
         """Read and process the device list."""
         devices = self._fibaro_device_manager.get_devices()
+
+        for master_device in find_master_devices(devices):
+            self._create_device_info(master_device)
+
         self._device_map = {}
         last_climate_parent = None
         last_endpoint = None
@@ -258,7 +245,6 @@ class FibaroController:
                 if platform is None:
                     continue
                 device.unique_id_str = f"{slugify(self.hub_serial)}.{device.fibaro_id}"
-                self._create_device_info(device, devices)
                 self._device_map[device.fibaro_id] = device
                 _LOGGER.debug(
                     "%s (%s, %s) -> %s %s",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Properly create `DeviceInfo` for special devices in the fibaro integration. This does not affect standard z-wave devices which have the logic on the child endpoints. But it moves virtual devices and other non-standard devices to it's own device instead of showing all entities directly as part of the Fibaro Home Center Hub device.

**Example**
_Before this change:_
Fibaro Home Center Hub -> [Entity] My thermostat
_After this change:_
[Device] Fibaro Home Cener Hub -> [Device] My thermostat -> [Entity] My thermostat

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #142419
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
