### PR TITLE
Fix homeaticip_cloud RuntimeWarnings

### DIFF
--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -129,10 +129,6 @@ async def test_hap_reset_unloads_entry_if_setup(
     assert hass.data[HMIPC_DOMAIN] == {}
 
 
-@patch(
-    "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
-    return_value=ConnectionContext(),
-)
 async def test_hap_create(
     hass: HomeAssistant, hmip_config_entry: MockConfigEntry, simple_mock_home
 ) -> None:
@@ -140,15 +136,17 @@ async def test_hap_create(
     hass.config.components.add(HMIPC_DOMAIN)
     hap = HomematicipHAP(hass, hmip_config_entry)
     assert hap
-    with patch.object(hap, "async_connect"):
+    with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
+            return_value=ConnectionContext(),
+        ),
+        patch.object(hap, "async_connect"),
+    ):
         async with hmip_config_entry.setup_lock:
             assert await hap.async_setup()
 
 
-@patch(
-    "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
-    return_value=ConnectionContext(),
-)
 async def test_hap_create_exception(
     hass: HomeAssistant, hmip_config_entry: MockConfigEntry, mock_connection_init
 ) -> None:
@@ -158,13 +156,23 @@ async def test_hap_create_exception(
     hap = HomematicipHAP(hass, hmip_config_entry)
     assert hap
 
-    with patch(
-        "homeassistant.components.homematicip_cloud.hap.AsyncHome.get_current_state_async",
-        side_effect=Exception,
+    with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
+            return_value=ConnectionContext(),
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.AsyncHome.get_current_state_async",
+            side_effect=Exception,
+        ),
     ):
         assert not await hap.async_setup()
 
     with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
+            return_value=ConnectionContext(),
+        ),
         patch(
             "homeassistant.components.homematicip_cloud.hap.AsyncHome.get_current_state_async",
             side_effect=HmipConnectionError,


### PR DESCRIPTION
## Proposed change
Fixes RuntimeWarnings introduced in #139081. In particular the `@patch` decorator was added to two functions without a corresponding argument. Thus the pytest fixtures failed to match causing the warnings. I'd recommend to just stick to the patch contextmanager instead, even if slightly longer, as for that it's at least obvious which argument it binds to.


```py
tests/components/homematicip_cloud/test_hap.py::test_hap_create
  /home/runner/work/ha-core/ha-core/tests/components/homematicip_cloud/test_hap.py:140: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/home/runner/work/ha-core/ha-core/tests/components/homematicip_cloud/test_hap.py", line 140, in test_hap_create
      hass.config.components.add(HMIPC_DOMAIN)

tests/components/homematicip_cloud/test_hap.py::test_hap_create
  /home/runner/work/ha-core/ha-core/homeassistant/components/homematicip_cloud/hap.py:289: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/homematicip_cloud/hap.py", line 120, in async_setup
      self.home = await self.get_hap(
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/homematicip_cloud/hap.py", line 289, in get_hap
      hass.loop.create_task(self.async_connect())

tests/components/homematicip_cloud/test_hap.py::test_hap_create_exception
  /home/runner/work/ha-core/ha-core/tests/components/homematicip_cloud/test_hap.py:156: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/home/runner/work/ha-core/ha-core/tests/components/homematicip_cloud/test_hap.py", line 156, in test_hap_create_exception
      hass.config.components.add(HMIPC_DOMAIN)

tests/components/homematicip_cloud/test_hap.py::test_hap_create_exception
  /home/runner/work/ha-core/ha-core/tests/components/homematicip_cloud/test_hap.py:172: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/homematicip_cloud/hap.py", line 283, in get_hap
      home.init_with_context(context, True, get_async_client(hass))
    File "/home/runner/work/ha-core/ha-core/homeassistant/helpers/httpx_client.py", line 52, in get_async_client
      if (client := hass.data.get(key)) is None:

tests/components/homematicip_cloud/test_hap.py::test_hap_create_exception
  /home/runner/work/ha-core/ha-core/venv/lib/python3.13/site-packages/_pytest/stash.py:108: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/homematicip_cloud/hap.py", line 283, in get_hap
      home.init_with_context(context, True, get_async_client(hass))
    File "/home/runner/work/ha-core/ha-core/homeassistant/helpers/httpx_client.py", line 52, in get_async_client
      if (client := hass.data.get(key)) is None:

tests/components/broadlink/test_sensor.py::test_a1_sensor_setup
  /home/runner/work/ha-core/ha-core/tests/conftest.py:314: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/homematicip_cloud/hap.py", line 283, in get_hap
      home.init_with_context(context, True, get_async_client(hass))
    File "/home/runner/work/ha-core/ha-core/homeassistant/helpers/httpx_client.py", line 52, in get_async_client
      if (client := hass.data.get(key)) is None:
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
