### PR TITLE
Handle name conflicts in ESPHome config flow

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -370,7 +370,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             description_placeholders={
                 "existing_mac": format_mac(self._entry_with_name_conflict.unique_id),
                 "existing_title": self._entry_with_name_conflict.title,
-                "new_mac": format_mac(self.unique_id),
+                "mac": format_mac(self.unique_id),
                 "name": self._device_name,
             },
         )
@@ -386,6 +386,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         assert self._host is not None
         old_mac = format_mac(self._entry_with_name_conflict.unique_id)
         new_mac = format_mac(self.unique_id)
+        entry_id = self._entry_with_name_conflict.entry_id
         self.hass.config_entries.async_update_entry(
             self._entry_with_name_conflict,
             data={
@@ -396,9 +397,8 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_NOISE_PSK: self._noise_psk or "",
             },
         )
-        await async_replace_device(
-            self.hass, self._entry_with_name_conflict.entry_id, old_mac, new_mac
-        )
+        await async_replace_device(self.hass, entry_id, old_mac, new_mac)
+        self.hass.config_entries.async_schedule_reload(entry_id)
         return self.async_abort(
             reason="name_conflict_migrated",
             description_placeholders={

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -47,6 +47,7 @@ from .const import (
     DOMAIN,
 )
 from .dashboard import async_get_or_create_dashboard_manager, async_set_dashboard_info
+from .manager import async_replace_device
 
 ERROR_REQUIRES_ENCRYPTION_KEY = "requires_encryption_key"
 ERROR_INVALID_ENCRYPTION_KEY = "invalid_psk"
@@ -74,6 +75,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         # The ESPHome name as per its config
         self._device_name: str | None = None
         self._device_mac: str | None = None
+        self._entry_with_name_conflict: ConfigEntry | None = None
 
     async def _async_step_user_base(
         self, user_input: dict[str, Any] | None = None, error: str | None = None
@@ -137,7 +139,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle reauthorization flow when encryption was removed."""
         if user_input is not None:
             self._noise_psk = None
-            return self._async_get_entry()
+            return await self._async_get_entry_or_resolve_conflict()
 
         return self.async_show_form(
             step_id="reauth_encryption_removed_confirm",
@@ -227,7 +229,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self.async_step_authenticate()
 
         self._password = ""
-        return self._async_get_entry()
+        return await self._async_get_entry_or_resolve_conflict()
 
     async def async_step_discovery_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -354,6 +356,66 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         )
         return self.async_abort(reason="service_received")
 
+    async def async_step_name_conflict(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle name conflict resolution."""
+        assert self._entry_with_name_conflict is not None
+        assert self._entry_with_name_conflict.unique_id is not None
+        assert self.unique_id is not None
+        assert self._device_name is not None
+        return self.async_show_menu(
+            step_id="name_conflict",
+            menu_options=["migrate", "create"],
+            description_placeholders={
+                "existing_mac": format_mac(self._entry_with_name_conflict.unique_id),
+                "existing_title": self._entry_with_name_conflict.title,
+                "new_mac": format_mac(self.unique_id),
+                "name": self._device_name,
+            },
+        )
+
+    async def async_step_name_conflict_migrate(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle migration of existing entry."""
+        assert self._entry_with_name_conflict is not None
+        assert self._entry_with_name_conflict.unique_id is not None
+        assert self.unique_id is not None
+        assert self._device_name is not None
+        old_mac = format_mac(self._entry_with_name_conflict.unique_id)
+        new_mac = format_mac(self.unique_id)
+        await async_replace_device(
+            self.hass, self._entry_with_name_conflict.entry_id, old_mac, new_mac
+        )
+        return self.async_abort(
+            reason="name_conflict_migrated",
+            description_placeholders={
+                "existing_mac": old_mac,
+                "mac": new_mac,
+                "name": self._device_name,
+            },
+        )
+
+    async def async_step_name_conflict_create(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle creating a new entry."""
+        assert self._entry_with_name_conflict is not None
+        await self.hass.config_entries.async_remove(
+            self._entry_with_name_conflict.entry_id
+        )
+        return self._async_get_entry()
+
+    async def _async_get_entry_or_resolve_conflict(self) -> ConfigFlowResult:
+        """Return the entry or resolve a conflict."""
+        if self.source != SOURCE_REAUTH:
+            for entry in self._async_current_entries(include_ignore=False):
+                if entry.data.get(CONF_DEVICE_NAME) == self._device_name:
+                    self._entry_with_name_conflict = entry
+                    return await self.async_step_name_conflict()
+        return self._async_get_entry()
+
     @callback
     def _async_get_entry(self) -> ConfigFlowResult:
         config_data = {
@@ -371,7 +433,6 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             return self.async_update_reload_and_abort(
                 self._reauth_entry, data=self._reauth_entry.data | config_data
             )
-
         assert self._name is not None
         return self.async_create_entry(
             title=self._name,
@@ -407,7 +468,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             error = await self.try_login()
             if error:
                 return await self.async_step_authenticate(error=error)
-            return self._async_get_entry()
+            return await self._async_get_entry_or_resolve_conflict()
 
         errors = {}
         if error is not None:

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -434,7 +434,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 self._reauth_entry, data=self._reauth_entry.data | config_data
             )
 
-        assert self._name is not None       
+        assert self._name is not None
         return self.async_create_entry(
             title=self._name,
             data=config_data,

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -433,7 +433,8 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             return self.async_update_reload_and_abort(
                 self._reauth_entry, data=self._reauth_entry.data | config_data
             )
-        assert self._name is not None
+
+        assert self._name is not None       
         return self.async_create_entry(
             title=self._name,
             data=config_data,

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -9,7 +9,8 @@
       "mqtt_missing_mac": "Missing MAC address in MQTT properties.",
       "mqtt_missing_api": "Missing API port in MQTT properties.",
       "mqtt_missing_ip": "Missing IP address in MQTT properties.",
-      "mqtt_missing_payload": "Missing MQTT Payload."
+      "mqtt_missing_payload": "Missing MQTT Payload.",
+      "name_conflict_migrated": "The device `{name}` has been migrated to a new device with MAC address `{mac}` from `{existing_mac}`."
     },
     "error": {
       "resolve_error": "Can't resolve address of the ESP. If this error persists, please set a static IP address",
@@ -49,6 +50,14 @@
       "discovery_confirm": {
         "description": "Do you want to add the device `{name}` to Home Assistant?",
         "title": "Discovered ESPHome device"
+      },
+      "name_conflict": {
+        "title": "Name conflict for {name}",
+        "description": "**The name `{name}` is already being used by another device, {existing_title} with MAC address `{existing_mac}`.**\n\nIf you have multiple devices with the same name, please rename or remove the one with MAC address `{mac}` to avoid conflicts.\n\nIf this is a hardware replacement, please confirm that you would like to migrate the Home Assistant configuration to the new device with MAC address `{mac}`.\n\nIf the new device is not a replacement, and you want to delete the existing configuration, select the option to replace the existing configuration.",
+        "menu_options": {
+          "name_conflict_migrate": "Migrate configuration to new device",
+          "name_conflict_replace": "Replace the existing configuration"
+        }
       }
     },
     "flow_title": "{name}"

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -53,7 +53,7 @@
       },
       "name_conflict": {
         "title": "Name conflict",
-        "description": "**The name `{name}` (MAC address: `{mac}`) is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n**Migrate Configuration to New Device:** If this is a replacement, migrate the existing settings to the new device (`{mac}`).\n**Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
+        "description": "**The name `{name}` is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n**Migrate Configuration to New Device:** If this is a replacement, migrate the existing settings to the new device (`{mac}`).\n**Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration for `{existing_mac}` and use the new device instead.",
         "menu_options": {
           "name_conflict_migrate": "Migrate configuration to new device",
           "name_conflict_overwrite": "Overwrite the existing configuration"

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -10,7 +10,7 @@
       "mqtt_missing_api": "Missing API port in MQTT properties.",
       "mqtt_missing_ip": "Missing IP address in MQTT properties.",
       "mqtt_missing_payload": "Missing MQTT Payload.",
-      "name_conflict_migrated": "The device `{name}` has been migrated to a new device with MAC address `{mac}` from `{existing_mac}`."
+      "name_conflict_migrated": "The configuration for `{name}` has been migrated to a new device with MAC address `{mac}` from `{existing_mac}`."
     },
     "error": {
       "resolve_error": "Can't resolve address of the ESP. If this error persists, please set a static IP address",

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -53,10 +53,10 @@
       },
       "name_conflict": {
         "title": "Name conflict for {name}",
-        "description": "**The name `{name}` is already being used by another device, {existing_title} with MAC address `{existing_mac}`.**\n\nIf you have multiple devices with the same name, please rename or remove the one with MAC address `{mac}` to avoid conflicts.\n\nIf this is a hardware replacement, please confirm that you would like to migrate the Home Assistant configuration to the new device with MAC address `{mac}`.\n\nIf the new device is not a replacement, and you want to delete the existing configuration, select the option to replace the existing configuration.",
+        "description": "**The name **`{name}`** is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n- **Migrate Configuration to New Device:** If this is a replacement, transfer the existing settings to the new device (`{mac}`).\n- **Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
         "menu_options": {
           "name_conflict_migrate": "Migrate configuration to new device",
-          "name_conflict_replace": "Replace the existing configuration"
+          "name_conflict_overwrite": "Overwrite the existing configuration"
         }
       }
     },

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -53,7 +53,7 @@
       },
       "name_conflict": {
         "title": "Name conflict",
-        "description": "**The name `{name}` is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n**Migrate Configuration to New Device:** If this is a replacement, migrate the existing settings to the new device (`{mac}`).\n**Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
+        "description": "**The name `{name}` (MAC address: `{mac}`) is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n**Migrate Configuration to New Device:** If this is a replacement, migrate the existing settings to the new device (`{mac}`).\n**Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
         "menu_options": {
           "name_conflict_migrate": "Migrate configuration to new device",
           "name_conflict_overwrite": "Overwrite the existing configuration"

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -53,7 +53,7 @@
       },
       "name_conflict": {
         "title": "Name conflict",
-        "description": "**The name `{name}` is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n**Migrate Configuration to New Device:** If this is a replacement, transfer the existing settings to the new device (`{mac}`).\n**Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
+        "description": "**The name `{name}` is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n**Migrate Configuration to New Device:** If this is a replacement, migrate the existing settings to the new device (`{mac}`).\n**Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
         "menu_options": {
           "name_conflict_migrate": "Migrate configuration to new device",
           "name_conflict_overwrite": "Overwrite the existing configuration"

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -52,8 +52,8 @@
         "title": "Discovered ESPHome device"
       },
       "name_conflict": {
-        "title": "Name conflict for {name}",
-        "description": "**The name `{name}` is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n- **Migrate Configuration to New Device:** If this is a replacement, transfer the existing settings to the new device (`{mac}`).\n- **Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
+        "title": "Name conflict",
+        "description": "**The name `{name}` is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n**Migrate Configuration to New Device:** If this is a replacement, transfer the existing settings to the new device (`{mac}`).\n**Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
         "menu_options": {
           "name_conflict_migrate": "Migrate configuration to new device",
           "name_conflict_overwrite": "Overwrite the existing configuration"

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -53,7 +53,7 @@
       },
       "name_conflict": {
         "title": "Name conflict for {name}",
-        "description": "**The name **`{name}`** is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n- **Migrate Configuration to New Device:** If this is a replacement, transfer the existing settings to the new device (`{mac}`).\n- **Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
+        "description": "**The name `{name}` is already being used by another device: {existing_title} (MAC address: `{existing_mac}`)**\n\nTo continue, please choose one of the following options:\n\n- **Migrate Configuration to New Device:** If this is a replacement, transfer the existing settings to the new device (`{mac}`).\n- **Overwrite the Existing Configuration:** If this is not a replacement, delete the old configuration and use the new device instead.",
         "menu_options": {
           "name_conflict_migrate": "Migrate configuration to new device",
           "name_conflict_overwrite": "Overwrite the existing configuration"

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -1622,3 +1622,95 @@ async def test_discovery_mqtt_initiation(
 
     assert result["result"]
     assert result["result"].unique_id == "11:22:33:44:55:aa"
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_user_flow_name_conflict_migrate(
+    hass: HomeAssistant,
+    mock_client,
+    mock_setup_entry: None,
+) -> None:
+    """Test handle migration on name conflict."""
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DEVICE_NAME: "test"},
+        unique_id="11:22:33:44:55:cc",
+    )
+    existing_entry.add_to_hass(hass)
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(
+            uses_password=False,
+            name="test",
+            mac_address="11:22:33:44:55:AA",
+        )
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        "esphome",
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "name_conflict"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "name_conflict_migrate"}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_conflict_migrated"
+
+    assert existing_entry.data == {
+        CONF_HOST: "127.0.0.1",
+        CONF_PORT: 6053,
+        CONF_PASSWORD: "",
+        CONF_NOISE_PSK: "",
+        CONF_DEVICE_NAME: "test",
+    }
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_user_flow_name_conflict_overwrite(
+    hass: HomeAssistant,
+    mock_client,
+    mock_setup_entry: None,
+) -> None:
+    """Test handle overwrite on name conflict."""
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DEVICE_NAME: "test"},
+        unique_id="11:22:33:44:55:cc",
+    )
+    existing_entry.add_to_hass(hass)
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(
+            uses_password=False,
+            name="test",
+            mac_address="11:22:33:44:55:AA",
+        )
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        "esphome",
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "name_conflict"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "name_conflict_replace"}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    assert result["data"] == {
+        CONF_HOST: "127.0.0.1",
+        CONF_PORT: 6053,
+        CONF_PASSWORD: "",
+        CONF_NOISE_PSK: "",
+        CONF_DEVICE_NAME: "test",
+    }
+    assert result["context"]["unique_id"] == "11:22:33:44:55:aa"

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -1668,6 +1668,7 @@ async def test_user_flow_name_conflict_migrate(
         CONF_NOISE_PSK: "",
         CONF_DEVICE_NAME: "test",
     }
+    assert existing_entry.unique_id == "11:22:33:44:55:aa"
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
@@ -1702,7 +1703,7 @@ async def test_user_flow_name_conflict_overwrite(
     assert result["step_id"] == "name_conflict"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={"next_step_id": "name_conflict_replace"}
+        result["flow_id"], user_input={"next_step_id": "name_conflict_overwrite"}
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the system allows users to create configuration entries for devices that share the same name. This can lead to inconsistent and confusing behavior, since the dashboard retrieves device data, along with update information such as the noise PSK, based solely on the device's `name`.

To address this, update the configuration flow to detect and handle name conflicts when creating a new config entry, prompting the user to resolve duplicates appropriately.


Name conflict resolution step
<img width="585" alt="Screenshot 2025-04-14 at 3 57 12 PM" src="https://github.com/user-attachments/assets/d84f1d83-37eb-4498-b036-7bb4d42723ca" />


Migration path
<img width="595" alt="Screenshot 2025-04-14 at 3 44 47 PM" src="https://github.com/user-attachments/assets/be19d468-3d5c-40ea-8d5f-52bcbfcdd9ee" />

Overwrite path
<img width="382" alt="Screenshot 2025-04-14 at 3 48 44 PM" src="https://github.com/user-attachments/assets/1e17d842-44ff-4893-a0e7-dc34a582e971" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
