### PR TITLE
Remove legacy format exception for ESPHome entity naming

### DIFF
--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -191,6 +191,7 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     """Define a base esphome entity."""
 
     _attr_should_poll = False
+    _attr_has_entity_name = True
     _static_info: _InfoT
     _state: _StateT
     _has_state: bool
@@ -215,24 +216,6 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self._attr_device_info = DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, device_info.mac_address)}
         )
-        #
-        # If `friendly_name` is set, we use the Friendly naming rules, if
-        # `friendly_name` is not set we make an exception to the naming rules for
-        # backwards compatibility and use the Legacy naming rules.
-        #
-        # Friendly naming
-        # - Friendly name is prepended to entity names
-        # - Device Name is prepended to entity ids
-        # - Entity id is constructed from device name and object id
-        #
-        # Legacy naming
-        # - Device name is not prepended to entity names
-        # - Device name is not prepended to entity ids
-        # - Entity id is constructed from entity name
-        #
-        if not device_info.friendly_name:
-            return
-        self._attr_has_entity_name = True
         self.entity_id = f"{domain}.{device_info.name}_{entity_info.object_id}"
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -760,13 +760,12 @@ def _async_setup_device_registry(
     if device_info.suggested_area:
         suggested_area = device_info.suggested_area
 
-    name = entry_data.friendly_name or entry_data.name
     device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         configuration_url=configuration_url,
         connections={(dr.CONNECTION_NETWORK_MAC, device_info.mac_address)},
-        name=name,
+        name=entry_data.friendly_name or entry_data.name,
         manufacturer=manufacturer,
         model=model,
         sw_version=sw_version,

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -772,11 +772,6 @@ def _async_setup_device_registry(
         sw_version=sw_version,
         suggested_area=suggested_area,
     )
-    if device_entry.name != name:
-        # Update the device name if the name was changed.
-        # we don't overwrite name_by_user in case they
-        # changed it in the UI
-        device_registry.async_update_device(device_entry.id, name=name)
     return device_entry.id
 
 

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -500,6 +500,6 @@ async def test_esphome_device_without_friendly_name(
         states=states,
         device_info={"friendly_name": None},
     )
-    state = hass.states.get("binary_sensor.my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -1517,3 +1517,51 @@ async def test_entry_missing_bluetooth_mac_address(
     )
     await hass.async_block_till_done()
     assert entry.data[CONF_BLUETOOTH_MAC_ADDRESS] == "AA:BB:CC:DD:EE:FC"
+
+
+async def test_device_adds_friendly_name(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a device with user services that change arguments."""
+    entity_info = []
+    states = []
+    device: MockESPHomeDevice = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=[],
+        device_info={"name": "nofriendlyname", "friendly_name": ""},
+        states=states,
+    )
+    await hass.async_block_till_done()
+    dev_reg = dr.async_get(hass)
+    dev = dev_reg.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, device.entry.unique_id)}
+    )
+    assert dev.name == "Nofriendlyname"
+    assert (
+        "No `friendly_name` set in the `esphome:` section of "
+        "the YAML config for device 'nofriendlyname'"
+    ) in caplog.text
+    caplog.clear()
+
+    await device.mock_disconnect(True)
+    await hass.async_block_till_done()
+    device.device_info = DeviceInfo(
+        **{**device.device_info.to_dict(), "friendly_name": "I have a friendly name"}
+    )
+    mock_client.device_info = AsyncMock(return_value=device.device_info)
+    await device.mock_connect()
+    await hass.async_block_till_done()
+    dev = dev_reg.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, device.entry.unique_id)}
+    )
+    assert dev.name == "I have a friendly name"
+    assert (
+        "No `friendly_name` set in the `esphome:` section of the YAML config for device"
+    ) not in caplog.text


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We have had an exception for the legacy naming scheme when friendly name is unset. As ESPHome is working to reach bronze quality scale, remove the exception.

I think a few folks might be a bit frustrated with this change, especially if they’ve been stuck with some odd naming from before we had friendly names. There might be a little transition pain, but once everything’s consistent, it’ll be way easier to understand and keep things tidy moving forward.

quality scale pr: https://github.com/home-assistant/core/pull/143033

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38559
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
