### PR TITLE
Raise on failed switching in devolo Home Network

### DIFF
--- a/homeassistant/components/devolo_home_network/switch.py
+++ b/homeassistant/components/devolo_home_network/switch.py
@@ -114,9 +114,14 @@ class DevoloSwitchEntity[_DataT: _DataType](
                 translation_key="password_protected",
                 translation_placeholders={"title": self.entry.title},
             ) from ex
-        except DeviceUnavailable:
-            pass  # The coordinator will handle this
-        await self.coordinator.async_request_refresh()
+        except DeviceUnavailable as ex:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="no_response",
+                translation_placeholders={"title": self.entry.title},
+            ) from ex
+        finally:
+            await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
@@ -129,6 +134,11 @@ class DevoloSwitchEntity[_DataT: _DataType](
                 translation_key="password_protected",
                 translation_placeholders={"title": self.entry.title},
             ) from ex
-        except DeviceUnavailable:
-            pass  # The coordinator will handle this
-        await self.coordinator.async_request_refresh()
+        except DeviceUnavailable as ex:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="no_response",
+                translation_placeholders={"title": self.entry.title},
+            ) from ex
+        finally:
+            await self.coordinator.async_request_refresh()

--- a/tests/components/devolo_home_network/mock.py
+++ b/tests/components/devolo_home_network/mock.py
@@ -64,6 +64,7 @@ class MockDevice(Device):
             return_value=FIRMWARE_UPDATE_AVAILABLE
         )
         self.device.async_get_led_setting = AsyncMock(return_value=False)
+        self.device.async_set_led_setting = AsyncMock(return_value=True)
         self.device.async_restart = AsyncMock(return_value=True)
         self.device.async_uptime = AsyncMock(return_value=UPTIME)
         self.device.async_start_wps = AsyncMock(return_value=True)
@@ -71,6 +72,7 @@ class MockDevice(Device):
             return_value=CONNECTED_STATIONS
         )
         self.device.async_get_wifi_guest_access = AsyncMock(return_value=GUEST_WIFI)
+        self.device.async_set_wifi_guest_access = AsyncMock(return_value=True)
         self.device.async_get_wifi_neighbor_access_points = AsyncMock(
             return_value=NEIGHBOR_ACCESS_POINTS
         )

--- a/tests/components/devolo_home_network/test_switch.py
+++ b/tests/components/devolo_home_network/test_switch.py
@@ -1,7 +1,7 @@
 """Tests for the devolo Home Network switch."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from devolo_plc_api.device_api import WifiGuestAccessGet
 from devolo_plc_api.exceptions.device import DevicePasswordProtected, DeviceUnavailable
@@ -106,18 +106,15 @@ async def test_update_enable_guest_wifi(
     mock_device.device.async_get_wifi_guest_access.return_value = WifiGuestAccessGet(
         enabled=False
     )
-    with patch(
-        "devolo_plc_api.device_api.deviceapi.DeviceApi.async_set_wifi_guest_access",
-        new=AsyncMock(),
-    ) as turn_off:
-        await hass.services.async_call(
-            PLATFORM, SERVICE_TURN_OFF, {"entity_id": state_key}, blocking=True
-        )
+    await hass.services.async_call(
+        PLATFORM, SERVICE_TURN_OFF, {"entity_id": state_key}, blocking=True
+    )
 
-        state = hass.states.get(state_key)
-        assert state is not None
-        assert state.state == STATE_OFF
-        turn_off.assert_called_once_with(False)
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == STATE_OFF
+    mock_device.device.async_set_wifi_guest_access.assert_called_once_with(False)
+    mock_device.device.async_set_wifi_guest_access.reset_mock()
 
     freezer.tick(REQUEST_REFRESH_DEFAULT_COOLDOWN)
     async_fire_time_changed(hass)
@@ -127,18 +124,15 @@ async def test_update_enable_guest_wifi(
     mock_device.device.async_get_wifi_guest_access.return_value = WifiGuestAccessGet(
         enabled=True
     )
-    with patch(
-        "devolo_plc_api.device_api.deviceapi.DeviceApi.async_set_wifi_guest_access",
-        new=AsyncMock(),
-    ) as turn_on:
-        await hass.services.async_call(
-            PLATFORM, SERVICE_TURN_ON, {"entity_id": state_key}, blocking=True
-        )
+    await hass.services.async_call(
+        PLATFORM, SERVICE_TURN_ON, {"entity_id": state_key}, blocking=True
+    )
 
-        state = hass.states.get(state_key)
-        assert state is not None
-        assert state.state == STATE_ON
-        turn_on.assert_called_once_with(True)
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == STATE_ON
+    mock_device.device.async_set_wifi_guest_access.assert_called_once_with(True)
+    mock_device.device.async_set_wifi_guest_access.reset_mock()
 
     freezer.tick(REQUEST_REFRESH_DEFAULT_COOLDOWN)
     async_fire_time_changed(hass)
@@ -146,17 +140,15 @@ async def test_update_enable_guest_wifi(
 
     # Device unavailable
     mock_device.device.async_get_wifi_guest_access.side_effect = DeviceUnavailable()
-    with patch(
-        "devolo_plc_api.device_api.deviceapi.DeviceApi.async_set_wifi_guest_access",
-        side_effect=DeviceUnavailable,
-    ):
+    mock_device.device.async_set_wifi_guest_access.side_effect = DeviceUnavailable()
+
+    with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             PLATFORM, SERVICE_TURN_ON, {"entity_id": state_key}, blocking=True
         )
-
-        state = hass.states.get(state_key)
-        assert state is not None
-        assert state.state == STATE_UNAVAILABLE
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
     await hass.config_entries.async_unload(entry.entry_id)
 
@@ -191,18 +183,15 @@ async def test_update_enable_leds(
 
     # Switch off
     mock_device.device.async_get_led_setting.return_value = False
-    with patch(
-        "devolo_plc_api.device_api.deviceapi.DeviceApi.async_set_led_setting",
-        new=AsyncMock(),
-    ) as turn_off:
-        await hass.services.async_call(
-            PLATFORM, SERVICE_TURN_OFF, {"entity_id": state_key}, blocking=True
-        )
+    await hass.services.async_call(
+        PLATFORM, SERVICE_TURN_OFF, {"entity_id": state_key}, blocking=True
+    )
 
-        state = hass.states.get(state_key)
-        assert state is not None
-        assert state.state == STATE_OFF
-        turn_off.assert_called_once_with(False)
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == STATE_OFF
+    mock_device.device.async_set_led_setting.assert_called_once_with(False)
+    mock_device.device.async_set_led_setting.reset_mock()
 
     freezer.tick(REQUEST_REFRESH_DEFAULT_COOLDOWN)
     async_fire_time_changed(hass)
@@ -210,18 +199,15 @@ async def test_update_enable_leds(
 
     # Switch on
     mock_device.device.async_get_led_setting.return_value = True
-    with patch(
-        "devolo_plc_api.device_api.deviceapi.DeviceApi.async_set_led_setting",
-        new=AsyncMock(),
-    ) as turn_on:
-        await hass.services.async_call(
-            PLATFORM, SERVICE_TURN_ON, {"entity_id": state_key}, blocking=True
-        )
+    await hass.services.async_call(
+        PLATFORM, SERVICE_TURN_ON, {"entity_id": state_key}, blocking=True
+    )
 
-        state = hass.states.get(state_key)
-        assert state is not None
-        assert state.state == STATE_ON
-        turn_on.assert_called_once_with(True)
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == STATE_ON
+    mock_device.device.async_set_led_setting.assert_called_once_with(True)
+    mock_device.device.async_set_led_setting.reset_mock()
 
     freezer.tick(REQUEST_REFRESH_DEFAULT_COOLDOWN)
     async_fire_time_changed(hass)
@@ -229,17 +215,15 @@ async def test_update_enable_leds(
 
     # Device unavailable
     mock_device.device.async_get_led_setting.side_effect = DeviceUnavailable()
-    with patch(
-        "devolo_plc_api.device_api.deviceapi.DeviceApi.async_set_led_setting",
-        side_effect=DeviceUnavailable,
-    ):
+    mock_device.device.async_set_led_setting.side_effect = DeviceUnavailable()
+
+    with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             PLATFORM, SERVICE_TURN_OFF, {"entity_id": state_key}, blocking=True
         )
-
-        state = hass.states.get(state_key)
-        assert state is not None
-        assert state.state == STATE_UNAVAILABLE
+    state = hass.states.get(state_key)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
     await hass.config_entries.async_unload(entry.entry_id)
 

--- a/tests/components/devolo_home_network/test_switch.py
+++ b/tests/components/devolo_home_network/test_switch.py
@@ -16,6 +16,7 @@ from homeassistant.components.devolo_home_network.const import (
 from homeassistant.components.switch import DOMAIN as PLATFORM
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_OFF,
@@ -107,7 +108,7 @@ async def test_update_enable_guest_wifi(
         enabled=False
     )
     await hass.services.async_call(
-        PLATFORM, SERVICE_TURN_OFF, {"entity_id": state_key}, blocking=True
+        PLATFORM, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: state_key}, blocking=True
     )
 
     state = hass.states.get(state_key)
@@ -125,7 +126,7 @@ async def test_update_enable_guest_wifi(
         enabled=True
     )
     await hass.services.async_call(
-        PLATFORM, SERVICE_TURN_ON, {"entity_id": state_key}, blocking=True
+        PLATFORM, SERVICE_TURN_ON, {ATTR_ENTITY_ID: state_key}, blocking=True
     )
 
     state = hass.states.get(state_key)
@@ -142,9 +143,11 @@ async def test_update_enable_guest_wifi(
     mock_device.device.async_get_wifi_guest_access.side_effect = DeviceUnavailable()
     mock_device.device.async_set_wifi_guest_access.side_effect = DeviceUnavailable()
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError, match=f"Device {entry.title} did not respond"
+    ):
         await hass.services.async_call(
-            PLATFORM, SERVICE_TURN_ON, {"entity_id": state_key}, blocking=True
+            PLATFORM, SERVICE_TURN_ON, {ATTR_ENTITY_ID: state_key}, blocking=True
         )
     state = hass.states.get(state_key)
     assert state is not None
@@ -184,7 +187,7 @@ async def test_update_enable_leds(
     # Switch off
     mock_device.device.async_get_led_setting.return_value = False
     await hass.services.async_call(
-        PLATFORM, SERVICE_TURN_OFF, {"entity_id": state_key}, blocking=True
+        PLATFORM, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: state_key}, blocking=True
     )
 
     state = hass.states.get(state_key)
@@ -200,7 +203,7 @@ async def test_update_enable_leds(
     # Switch on
     mock_device.device.async_get_led_setting.return_value = True
     await hass.services.async_call(
-        PLATFORM, SERVICE_TURN_ON, {"entity_id": state_key}, blocking=True
+        PLATFORM, SERVICE_TURN_ON, {ATTR_ENTITY_ID: state_key}, blocking=True
     )
 
     state = hass.states.get(state_key)
@@ -217,9 +220,11 @@ async def test_update_enable_leds(
     mock_device.device.async_get_led_setting.side_effect = DeviceUnavailable()
     mock_device.device.async_set_led_setting.side_effect = DeviceUnavailable()
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError, match=f"Device {entry.title} did not respond"
+    ):
         await hass.services.async_call(
-            PLATFORM, SERVICE_TURN_OFF, {"entity_id": state_key}, blocking=True
+            PLATFORM, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: state_key}, blocking=True
         )
     state = hass.states.get(state_key)
     assert state is not None
@@ -292,7 +297,7 @@ async def test_auth_failed(
 
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
-            PLATFORM, SERVICE_TURN_ON, {"entity_id": state_key}, blocking=True
+            PLATFORM, SERVICE_TURN_ON, {ATTR_ENTITY_ID: state_key}, blocking=True
         )
 
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In https://github.com/home-assistant/core/pull/131510 @joostlek suggested to raise properly on failed switching. This PR addresses that and because I had to adapt the tests anyhow, I removed patching internals of the library.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
