### PR TITLE
Fix for media content type case in Squeezebox

### DIFF
--- a/homeassistant/components/squeezebox/browse_media.py
+++ b/homeassistant/components/squeezebox/browse_media.py
@@ -22,34 +22,34 @@ from homeassistant.helpers.network import is_internal_request
 from .const import UNPLAYABLE_TYPES
 
 LIBRARY = [
-    "Favorites",
-    "Artists",
-    "Albums",
-    "Tracks",
-    "Playlists",
-    "Genres",
-    "New Music",
-    "Album Artists",
-    "Apps",
-    "Radios",
+    "favorites",
+    "artists",
+    "albums",
+    "tracks",
+    "playlists",
+    "genres",
+    "new music",
+    "album artists",
+    "apps",
+    "radios",
 ]
 
 MEDIA_TYPE_TO_SQUEEZEBOX: dict[str | MediaType, str] = {
-    "Favorites": "favorites",
-    "Artists": "artists",
-    "Albums": "albums",
-    "Tracks": "titles",
-    "Playlists": "playlists",
-    "Genres": "genres",
-    "New Music": "new music",
-    "Album Artists": "album artists",
+    "favorites": "favorites",
+    "artists": "artists",
+    "albums": "albums",
+    "tracks": "titles",
+    "playlists": "playlists",
+    "genres": "genres",
+    "new music": "new music",
+    "album artists": "album artists",
     MediaType.ALBUM: "album",
     MediaType.ARTIST: "artist",
     MediaType.TRACK: "title",
     MediaType.PLAYLIST: "playlist",
     MediaType.GENRE: "genre",
-    "Apps": "apps",
-    "Radios": "radios",
+    MediaType.APPS: "apps",
+    "radios": "radios",
 }
 
 SQUEEZEBOX_ID_BY_TYPE: dict[str | MediaType, str] = {
@@ -58,22 +58,20 @@ SQUEEZEBOX_ID_BY_TYPE: dict[str | MediaType, str] = {
     MediaType.TRACK: "track_id",
     MediaType.PLAYLIST: "playlist_id",
     MediaType.GENRE: "genre_id",
-    "Favorites": "item_id",
+    "favorites": "item_id",
     MediaType.APPS: "item_id",
 }
 
 CONTENT_TYPE_MEDIA_CLASS: dict[str | MediaType, dict[str, MediaClass | str]] = {
-    "Favorites": {"item": MediaClass.DIRECTORY, "children": MediaClass.TRACK},
-    "Apps": {"item": MediaClass.DIRECTORY, "children": MediaClass.APP},
-    "Radios": {"item": MediaClass.DIRECTORY, "children": MediaClass.APP},
-    "App": {"item": MediaClass.DIRECTORY, "children": MediaClass.TRACK},
-    "Artists": {"item": MediaClass.DIRECTORY, "children": MediaClass.ARTIST},
-    "Albums": {"item": MediaClass.DIRECTORY, "children": MediaClass.ALBUM},
-    "Tracks": {"item": MediaClass.DIRECTORY, "children": MediaClass.TRACK},
-    "Playlists": {"item": MediaClass.DIRECTORY, "children": MediaClass.PLAYLIST},
-    "Genres": {"item": MediaClass.DIRECTORY, "children": MediaClass.GENRE},
-    "New Music": {"item": MediaClass.DIRECTORY, "children": MediaClass.ALBUM},
-    "Album Artists": {"item": MediaClass.DIRECTORY, "children": MediaClass.ARTIST},
+    "favorites": {"item": MediaClass.DIRECTORY, "children": MediaClass.TRACK},
+    "radios": {"item": MediaClass.DIRECTORY, "children": MediaClass.APP},
+    "artists": {"item": MediaClass.DIRECTORY, "children": MediaClass.ARTIST},
+    "albums": {"item": MediaClass.DIRECTORY, "children": MediaClass.ALBUM},
+    "tracks": {"item": MediaClass.DIRECTORY, "children": MediaClass.TRACK},
+    "playlists": {"item": MediaClass.DIRECTORY, "children": MediaClass.PLAYLIST},
+    "genres": {"item": MediaClass.DIRECTORY, "children": MediaClass.GENRE},
+    "new music": {"item": MediaClass.DIRECTORY, "children": MediaClass.ALBUM},
+    "album artists": {"item": MediaClass.DIRECTORY, "children": MediaClass.ARTIST},
     MediaType.ALBUM: {"item": MediaClass.ALBUM, "children": MediaClass.TRACK},
     MediaType.ARTIST: {"item": MediaClass.ARTIST, "children": MediaClass.ALBUM},
     MediaType.TRACK: {"item": MediaClass.TRACK, "children": ""},
@@ -91,17 +89,16 @@ CONTENT_TYPE_TO_CHILD_TYPE: dict[
     MediaType.PLAYLIST: MediaType.PLAYLIST,
     MediaType.ARTIST: MediaType.ALBUM,
     MediaType.GENRE: MediaType.ARTIST,
-    "Artists": MediaType.ARTIST,
-    "Albums": MediaType.ALBUM,
-    "Tracks": MediaType.TRACK,
-    "Playlists": MediaType.PLAYLIST,
-    "Genres": MediaType.GENRE,
-    "Favorites": None,  # can only be determined after inspecting the item
-    "Apps": MediaClass.APP,
-    "Radios": MediaClass.APP,
-    "App": None,  # can only be determined after inspecting the item
-    "New Music": MediaType.ALBUM,
-    "Album Artists": MediaType.ARTIST,
+    "artists": MediaType.ARTIST,
+    "albums": MediaType.ALBUM,
+    "tracks": MediaType.TRACK,
+    "playlists": MediaType.PLAYLIST,
+    "genres": MediaType.GENRE,
+    "favorites": None,  # can only be determined after inspecting the item
+    "radios": MediaClass.APP,
+    # "app": None,  # can only be determined after inspecting the item
+    "new music": MediaType.ALBUM,
+    "album artists": MediaType.ARTIST,
     MediaType.APPS: MediaType.APP,
     MediaType.APP: MediaType.TRACK,
 }
@@ -173,7 +170,7 @@ def _build_response_known_app(
 
 
 def _build_response_favorites(item: dict[str, Any]) -> BrowseMedia:
-    """Build item for Favorites."""
+    """Build item for favorites."""
     if "album_id" in item:
         return BrowseMedia(
             media_content_id=str(item["album_id"]),
@@ -183,21 +180,21 @@ def _build_response_favorites(item: dict[str, Any]) -> BrowseMedia:
             can_expand=True,
             can_play=True,
         )
-    if item["hasitems"] and not item["isaudio"]:
+    if item.get("hasitems") and not item.get("isaudio"):
         return BrowseMedia(
             media_content_id=item["id"],
             title=item["title"],
-            media_content_type="Favorites",
-            media_class=CONTENT_TYPE_MEDIA_CLASS["Favorites"]["item"],
+            media_content_type="favorites",
+            media_class=CONTENT_TYPE_MEDIA_CLASS["favorites"]["item"],
             can_expand=True,
             can_play=False,
         )
     return BrowseMedia(
         media_content_id=item["id"],
         title=item["title"],
-        media_content_type="Favorites",
+        media_content_type="favorites",
         media_class=CONTENT_TYPE_MEDIA_CLASS[MediaType.TRACK]["item"],
-        can_expand=item["hasitems"],
+        can_expand=bool(item.get("hasitems")),
         can_play=bool(item["isaudio"] and item.get("url")),
     )
 
@@ -220,7 +217,7 @@ def _get_item_thumbnail(
                 item_type, item["id"], artwork_track_id
             )
 
-    elif search_type in ["Apps", "Radios"]:
+    elif search_type in ["apps", "radios"]:
         item_thumbnail = player.generate_image_url(item["icon"])
     if item_thumbnail is None:
         item_thumbnail = item.get("image_url")  # will not be proxied by HA
@@ -265,10 +262,10 @@ async def build_item_response(
         for item in result["items"]:
             # Force the item id to a string in case it's numeric from some lms
             item["id"] = str(item.get("id", ""))
-            if search_type == "Favorites":
+            if search_type == "favorites":
                 child_media = _build_response_favorites(item)
 
-            elif search_type in ["Apps", "Radios"]:
+            elif search_type in ["apps", "radios"]:
                 # item["cmd"] contains the name of the command to use with the cli for the app
                 # add the command to the dictionaries
                 if item["title"] == "Search" or item.get("type") in UNPLAYABLE_TYPES:
@@ -364,11 +361,11 @@ async def library_payload(
             assert media_class["children"] is not None
             library_info["children"].append(
                 BrowseMedia(
-                    title=item,
+                    title=item.title(),
                     media_class=media_class["children"],
                     media_content_id=item,
                     media_content_type=item,
-                    can_play=item not in ["Favorites", "Apps", "Radios"],
+                    can_play=item not in ["favorites", "apps", "radios"],
                     can_expand=True,
                 )
             )

--- a/homeassistant/components/squeezebox/browse_media.py
+++ b/homeassistant/components/squeezebox/browse_media.py
@@ -96,7 +96,6 @@ CONTENT_TYPE_TO_CHILD_TYPE: dict[
     "genres": MediaType.GENRE,
     "favorites": None,  # can only be determined after inspecting the item
     "radios": MediaClass.APP,
-    # "app": None,  # can only be determined after inspecting the item
     "new music": MediaType.ALBUM,
     "album artists": MediaType.ARTIST,
     MediaType.APPS: MediaType.APP,

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -446,6 +446,9 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         """Send the play_media command to the media player."""
         index = None
 
+        if media_type:
+            media_type = media_type.lower()
+
         enqueue: MediaPlayerEnqueue | None = kwargs.get(ATTR_MEDIA_ENQUEUE)
 
         if enqueue == MediaPlayerEnqueue.ADD:
@@ -616,6 +619,9 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             media_content_type,
             media_content_id,
         )
+
+        if media_content_type:
+            media_content_type = media_content_type.lower()
 
         if media_content_type in [None, "library"]:
             return await library_payload(self.hass, self._player, self._browse_data)

--- a/tests/components/squeezebox/test_media_browser.py
+++ b/tests/components/squeezebox/test_media_browser.py
@@ -65,21 +65,21 @@ async def test_async_browse_media_root(
     assert response["success"]
     result = response["result"]
     for idx, item in enumerate(result["children"]):
-        assert item["title"] == LIBRARY[idx]
+        assert item["title"].lower() == LIBRARY[idx]
 
 
 @pytest.mark.parametrize(
     ("category", "child_count"),
     [
-        ("Favorites", 4),
-        ("Artists", 4),
-        ("Albums", 4),
-        ("Playlists", 4),
-        ("Genres", 4),
-        ("New Music", 4),
-        ("Album Artists", 4),
-        ("Apps", 3),
-        ("Radios", 3),
+        ("favorites", 4),
+        ("artists", 4),
+        ("albums", 4),
+        ("playlists", 4),
+        ("genres", 4),
+        ("new music", 4),
+        ("album artists", 4),
+        ("apps", 3),
+        ("radios", 3),
     ],
 )
 async def test_async_browse_media_with_subitems(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
The definitions of media content types within the squeezebox integration use a mixture of locally defined variables and the MediaType enum from media_player.  The enum uses lower case, whereas the locally defined variables use Title case - e.g. the enum uses album, whereas the local variables for multiple albums is Albums.  The new action media_player.browse_media expects the user to manually input the content type, and having this mixed case is confusing with no way for the user to actually know they should enter album or Albums, leading to "media_player.browse_media. Unknown error" if the wrong content type is entered.

This PR changes all of the internal variables to lower case, and forces the user input to lower case, so that albums, Albums or ALBUMS are all valid inputs.  It also corrects an error which may occur when the browse_media action was called .

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
