### PR TITLE
Rework platform setup tests for devolo Home Network

### DIFF
--- a/tests/components/devolo_home_network/test_binary_sensor.py
+++ b/tests/components/devolo_home_network/test_binary_sensor.py
@@ -37,9 +37,6 @@ async def test_binary_sensor_setup(
         f"{PLATFORM}.{device_name}_connected_to_router"
     ).disabled
 
-    await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state is ConfigEntryState.NOT_LOADED
-
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_update_attached_to_router(

--- a/tests/components/devolo_home_network/test_binary_sensor.py
+++ b/tests/components/devolo_home_network/test_binary_sensor.py
@@ -7,11 +7,9 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.devolo_home_network.const import (
-    CONNECTED_TO_ROUTER,
-    LONG_UPDATE_INTERVAL,
-)
+from homeassistant.components.binary_sensor import DOMAIN as PLATFORM
+from homeassistant.components.devolo_home_network.const import LONG_UPDATE_INTERVAL
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -24,19 +22,23 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
+async def test_binary_sensor_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test default setup of the binary sensor component."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
 
-    assert (
-        hass.states.get(f"{BINARY_SENSOR_DOMAIN}.{device_name}_{CONNECTED_TO_ROUTER}")
-        is None
-    )
+    assert entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_connected_to_router"
+    ).disabled
 
     await hass.config_entries.async_unload(entry.entry_id)
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -50,7 +52,7 @@ async def test_update_attached_to_router(
     """Test state change of a attached_to_router binary sensor device."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
-    state_key = f"{BINARY_SENSOR_DOMAIN}.{device_name}_{CONNECTED_TO_ROUTER}"
+    state_key = f"{PLATFORM}.{device_name}_connected_to_router"
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -81,5 +83,3 @@ async def test_update_attached_to_router(
     state = hass.states.get(state_key)
     assert state is not None
     assert state.state == STATE_ON
-
-    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/devolo_home_network/test_button.py
+++ b/tests/components/devolo_home_network/test_button.py
@@ -41,9 +41,6 @@ async def test_button_setup(
     ).disabled
     assert not entity_registry.async_get(f"{PLATFORM}.{device_name}_start_wps").disabled
 
-    await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state is ConfigEntryState.NOT_LOADED
-
 
 @pytest.mark.parametrize(
     ("name", "api_name", "trigger_method"),

--- a/tests/components/devolo_home_network/test_button.py
+++ b/tests/components/devolo_home_network/test_button.py
@@ -8,7 +8,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as PLATFORM, SERVICE_PRESS
 from homeassistant.components.devolo_home_network.const import DOMAIN
-from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -19,22 +19,30 @@ from .mock import MockDevice
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_button_setup(hass: HomeAssistant) -> None:
+async def test_button_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test default setup of the button component."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
 
-    assert (
-        hass.states.get(f"{PLATFORM}.{device_name}_identify_device_with_a_blinking_led")
-        is not None
-    )
-    assert hass.states.get(f"{PLATFORM}.{device_name}_start_plc_pairing") is not None
-    assert hass.states.get(f"{PLATFORM}.{device_name}_restart_device") is not None
-    assert hass.states.get(f"{PLATFORM}.{device_name}_start_wps") is not None
+    assert not entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_identify_device_with_a_blinking_led"
+    ).disabled
+    assert not entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_start_plc_pairing"
+    ).disabled
+    assert not entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_restart_device"
+    ).disabled
+    assert not entity_registry.async_get(f"{PLATFORM}.{device_name}_start_wps").disabled
 
     await hass.config_entries.async_unload(entry.entry_id)
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(
@@ -107,8 +115,6 @@ async def test_button(
             blocking=True,
         )
 
-    await hass.config_entries.async_unload(entry.entry_id)
-
 
 async def test_auth_failed(hass: HomeAssistant, mock_device: MockDevice) -> None:
     """Test setting unautherized triggers the reauth flow."""
@@ -139,5 +145,3 @@ async def test_auth_failed(hass: HomeAssistant, mock_device: MockDevice) -> None
     assert "context" in flow
     assert flow["context"]["source"] == SOURCE_REAUTH
     assert flow["context"]["entry_id"] == entry.entry_id
-
-    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/devolo_home_network/test_device_tracker.py
+++ b/tests/components/devolo_home_network/test_device_tracker.py
@@ -70,8 +70,6 @@ async def test_device_tracker(
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_unload(entry.entry_id)
-
 
 async def test_restoring_clients(
     hass: HomeAssistant,

--- a/tests/components/devolo_home_network/test_image.py
+++ b/tests/components/devolo_home_network/test_image.py
@@ -40,9 +40,6 @@ async def test_image_setup(
         f"{PLATFORM}.{device_name}_guest_wi_fi_credentials_as_qr_code"
     ).disabled
 
-    await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state is ConfigEntryState.NOT_LOADED
-
 
 @pytest.mark.freeze_time("2023-01-13 12:00:00+00:00")
 async def test_guest_wifi_qr(

--- a/tests/components/devolo_home_network/test_image.py
+++ b/tests/components/devolo_home_network/test_image.py
@@ -9,7 +9,8 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.devolo_home_network.const import SHORT_UPDATE_INTERVAL
-from homeassistant.components.image import DOMAIN as IMAGE_DOMAIN
+from homeassistant.components.image import DOMAIN as PLATFORM
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -24,21 +25,23 @@ from tests.typing import ClientSessionGenerator
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_image_setup(hass: HomeAssistant) -> None:
+async def test_image_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test default setup of the image component."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
 
-    assert (
-        hass.states.get(
-            f"{IMAGE_DOMAIN}.{device_name}_guest_wi_fi_credentials_as_qr_code"
-        )
-        is not None
-    )
+    assert not entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_guest_wi_fi_credentials_as_qr_code"
+    ).disabled
 
     await hass.config_entries.async_unload(entry.entry_id)
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.freeze_time("2023-01-13 12:00:00+00:00")
@@ -53,7 +56,7 @@ async def test_guest_wifi_qr(
     """Test showing a QR code of the guest wifi credentials."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
-    state_key = f"{IMAGE_DOMAIN}.{device_name}_guest_wi_fi_credentials_as_qr_code"
+    state_key = f"{PLATFORM}.{device_name}_guest_wi_fi_credentials_as_qr_code"
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -95,5 +98,3 @@ async def test_guest_wifi_qr(
     resp = await client.get(f"/api/image_proxy/{state_key}")
     assert resp.status == HTTPStatus.OK
     assert await resp.read() != body
-
-    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -63,9 +63,6 @@ async def test_sensor_setup(
         f"{PLATFORM}.{device_name}_last_restart_of_the_device"
     ).disabled
 
-    await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state is ConfigEntryState.NOT_LOADED
-
 
 @pytest.mark.parametrize(
     ("name", "get_method", "interval", "expected_state"),

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -27,49 +27,44 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_sensor_setup(hass: HomeAssistant) -> None:
+async def test_sensor_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test default setup of the sensor component."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
 
-    assert (
-        hass.states.get(f"{PLATFORM}.{device_name}_connected_wi_fi_clients") is not None
-    )
-    assert hass.states.get(f"{PLATFORM}.{device_name}_connected_plc_devices") is None
-    assert (
-        hass.states.get(f"{PLATFORM}.{device_name}_neighboring_wi_fi_networks") is None
-    )
-    assert (
-        hass.states.get(
-            f"{PLATFORM}.{device_name}_plc_downlink_phy_rate_{PLCNET.devices[1].user_device_name}"
-        )
-        is not None
-    )
-    assert (
-        hass.states.get(
-            f"{PLATFORM}.{device_name}_plc_uplink_phy_rate_{PLCNET.devices[1].user_device_name}"
-        )
-        is not None
-    )
-    assert (
-        hass.states.get(
-            f"{PLATFORM}.{device_name}_plc_downlink_phyrate_{PLCNET.devices[2].user_device_name}"
-        )
-        is None
-    )
-    assert (
-        hass.states.get(
-            f"{PLATFORM}.{device_name}_plc_uplink_phyrate_{PLCNET.devices[2].user_device_name}"
-        )
-        is None
-    )
-    assert (
-        hass.states.get(f"{PLATFORM}.{device_name}_last_restart_of_the_device") is None
-    )
+    assert not entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_connected_wi_fi_clients"
+    ).disabled
+    assert entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_connected_plc_devices"
+    ).disabled
+    assert entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_neighboring_wi_fi_networks"
+    ).disabled
+    assert not entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_plc_downlink_phy_rate_{PLCNET.devices[1].user_device_name}"
+    ).disabled
+    assert not entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_plc_uplink_phy_rate_{PLCNET.devices[1].user_device_name}"
+    ).disabled
+    assert entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_plc_downlink_phyrate_{PLCNET.devices[2].user_device_name}"
+    ).disabled
+    assert entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_plc_uplink_phyrate_{PLCNET.devices[2].user_device_name}"
+    ).disabled
+    assert entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_last_restart_of_the_device"
+    ).disabled
 
     await hass.config_entries.async_unload(entry.entry_id)
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(
@@ -145,8 +140,6 @@ async def test_sensor(
     assert state is not None
     assert state.state == expected_state
 
-    await hass.config_entries.async_unload(entry.entry_id)
-
 
 async def test_update_plc_phyrates(
     hass: HomeAssistant,
@@ -198,8 +191,6 @@ async def test_update_plc_phyrates(
     assert state is not None
     assert state.state == str(PLCNET.data_rates[0].tx_rate)
 
-    await hass.config_entries.async_unload(entry.entry_id)
-
 
 async def test_update_last_update_auth_failed(
     hass: HomeAssistant, mock_device: MockDevice
@@ -222,5 +213,3 @@ async def test_update_last_update_auth_failed(
     assert "context" in flow
     assert flow["context"]["source"] == SOURCE_REAUTH
     assert flow["context"]["entry_id"] == entry.entry_id
-
-    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -54,10 +54,10 @@ async def test_sensor_setup(
         f"{PLATFORM}.{device_name}_plc_uplink_phy_rate_{PLCNET.devices[1].user_device_name}"
     ).disabled
     assert entity_registry.async_get(
-        f"{PLATFORM}.{device_name}_plc_downlink_phyrate_{PLCNET.devices[2].user_device_name}"
+        f"{PLATFORM}.{device_name}_plc_downlink_phy_rate_{PLCNET.devices[2].user_device_name}"
     ).disabled
     assert entity_registry.async_get(
-        f"{PLATFORM}.{device_name}_plc_uplink_phyrate_{PLCNET.devices[2].user_device_name}"
+        f"{PLATFORM}.{device_name}_plc_uplink_phy_rate_{PLCNET.devices[2].user_device_name}"
     ).disabled
     assert entity_registry.async_get(
         f"{PLATFORM}.{device_name}_last_restart_of_the_device"

--- a/tests/components/devolo_home_network/test_switch.py
+++ b/tests/components/devolo_home_network/test_switch.py
@@ -53,9 +53,6 @@ async def test_switch_setup(
         f"{PLATFORM}.{device_name}_enable_leds"
     ).disabled
 
-    await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state is ConfigEntryState.NOT_LOADED
-
 
 async def test_update_guest_wifi_status_auth_failed(
     hass: HomeAssistant, mock_device: MockDevice

--- a/tests/components/devolo_home_network/test_switch.py
+++ b/tests/components/devolo_home_network/test_switch.py
@@ -35,17 +35,26 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_switch_setup(hass: HomeAssistant) -> None:
+async def test_switch_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test default setup of the switch component."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
 
-    assert hass.states.get(f"{PLATFORM}.{device_name}_enable_guest_wi_fi") is not None
-    assert hass.states.get(f"{PLATFORM}.{device_name}_enable_leds") is not None
+    assert not entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_enable_guest_wi_fi"
+    ).disabled
+    assert not entity_registry.async_get(
+        f"{PLATFORM}.{device_name}_enable_leds"
+    ).disabled
 
     await hass.config_entries.async_unload(entry.entry_id)
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_update_guest_wifi_status_auth_failed(
@@ -69,8 +78,6 @@ async def test_update_guest_wifi_status_auth_failed(
     assert "context" in flow
     assert flow["context"]["source"] == SOURCE_REAUTH
     assert flow["context"]["entry_id"] == entry.entry_id
-
-    await hass.config_entries.async_unload(entry.entry_id)
 
 
 async def test_update_enable_guest_wifi(
@@ -153,8 +160,6 @@ async def test_update_enable_guest_wifi(
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_unload(entry.entry_id)
-
 
 async def test_update_enable_leds(
     hass: HomeAssistant,
@@ -229,8 +234,6 @@ async def test_update_enable_leds(
     state = hass.states.get(state_key)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
-
-    await hass.config_entries.async_unload(entry.entry_id)
 
 
 @pytest.mark.parametrize(
@@ -325,5 +328,3 @@ async def test_auth_failed(
     assert "context" in flow
     assert flow["context"]["source"] == SOURCE_REAUTH
     assert flow["context"]["entry_id"] == entry.entry_id
-
-    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/devolo_home_network/test_update.py
+++ b/tests/components/devolo_home_network/test_update.py
@@ -38,9 +38,6 @@ async def test_update_setup(
 
     assert not entity_registry.async_get(f"{PLATFORM}.{device_name}_firmware").disabled
 
-    await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state is ConfigEntryState.NOT_LOADED
-
 
 async def test_update_firmware(
     hass: HomeAssistant,

--- a/tests/components/devolo_home_network/test_update.py
+++ b/tests/components/devolo_home_network/test_update.py
@@ -11,7 +11,7 @@ from homeassistant.components.devolo_home_network.const import (
     FIRMWARE_UPDATE_INTERVAL,
 )
 from homeassistant.components.update import DOMAIN as PLATFORM, SERVICE_INSTALL
-from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -25,16 +25,21 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_device")
-async def test_update_setup(hass: HomeAssistant) -> None:
+async def test_update_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test default setup of the update component."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
 
-    assert hass.states.get(f"{PLATFORM}.{device_name}_firmware") is not None
+    assert not entity_registry.async_get(f"{PLATFORM}.{device_name}_firmware").disabled
 
     await hass.config_entries.async_unload(entry.entry_id)
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_update_firmware(
@@ -84,8 +89,6 @@ async def test_update_firmware(
     )
     assert device_info is not None
     assert device_info.sw_version == mock_device.firmware_version
-
-    await hass.config_entries.async_unload(entry.entry_id)
 
 
 async def test_device_failure_check(
@@ -137,8 +140,6 @@ async def test_device_failure_update(
             blocking=True,
         )
 
-    await hass.config_entries.async_unload(entry.entry_id)
-
 
 async def test_auth_failed(hass: HomeAssistant, mock_device: MockDevice) -> None:
     """Test updating unauthorized triggers the reauth flow."""
@@ -168,5 +169,3 @@ async def test_auth_failed(hass: HomeAssistant, mock_device: MockDevice) -> None
     assert "context" in flow
     assert flow["context"]["source"] == SOURCE_REAUTH
     assert flow["context"]["entry_id"] == entry.entry_id
-
-    await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In https://github.com/home-assistant/core/pull/131510 @joostlek discovered, that my platform setup tests don't do, what I desired them to do. I wanted to verify, that disabled entities show up disabled and enabled entities show up enabled. But instead I only tested for the state and if a entity was removed by accident, the test would have still passed.

I used the opportunity to streamline a few things that differed between the tests and to remove reoccurring calls of async_unload.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
