### PR TITLE
Météo-France: Additional states and change weather condition for "Ciel clair"

### DIFF
--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -48,6 +48,7 @@ CONDITION_CLASSES: dict[str, list[str]] = {
         "Brouillard",
         "Brouillard givrant",
         "Bancs de Brouillard",
+        "Brouillard dense",
     ],
     ATTR_CONDITION_HAIL: ["Risque de grêle", "Risque de grèle"],
     ATTR_CONDITION_LIGHTNING: ["Risque d'orages", "Orages", "Orage avec grêle"],

--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -40,7 +40,7 @@ ATTR_NEXT_RAIN_DT_REF = "forecast_time_ref"
 
 
 CONDITION_CLASSES: dict[str, list[str]] = {
-    ATTR_CONDITION_CLEAR_NIGHT: ["Nuit Claire", "Nuit claire"],
+    ATTR_CONDITION_CLEAR_NIGHT: ["Nuit Claire", "Nuit claire", "Ciel clair"],
     ATTR_CONDITION_CLOUDY: ["Très nuageux", "Couvert"],
     ATTR_CONDITION_FOG: [
         "Brume ou bancs de brouillard",
@@ -62,6 +62,7 @@ CONDITION_CLASSES: dict[str, list[str]] = {
         "Éclaircies",
         "Eclaircies",
         "Peu nuageux",
+        "Variable",
     ],
     ATTR_CONDITION_POURING: ["Pluie forte"],
     ATTR_CONDITION_RAINY: [
@@ -83,10 +84,11 @@ CONDITION_CLASSES: dict[str, list[str]] = {
         "Averses de neige",
         "Neige forte",
         "Neige faible",
+        "Averses de neige faible",
         "Quelques flocons",
     ],
     ATTR_CONDITION_SNOWY_RAINY: ["Pluie et neige", "Pluie verglaçante"],
-    ATTR_CONDITION_SUNNY: ["Ensoleillé", "Ciel clair"],
+    ATTR_CONDITION_SUNNY: ["Ensoleillé"],
     ATTR_CONDITION_WINDY: [],
     ATTR_CONDITION_WINDY_VARIANT: [],
     ATTR_CONDITION_EXCEPTIONAL: [],

--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -50,7 +50,7 @@ CONDITION_CLASSES: dict[str, list[str]] = {
         "Bancs de Brouillard",
     ],
     ATTR_CONDITION_HAIL: ["Risque de grêle", "Risque de grèle"],
-    ATTR_CONDITION_LIGHTNING: ["Risque d'orages", "Orages"],
+    ATTR_CONDITION_LIGHTNING: ["Risque d'orages", "Orages", "Orage avec grêle"],
     ATTR_CONDITION_LIGHTNING_RAINY: [
         "Pluie orageuses",
         "Pluies orageuses",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MF API has added or replaced weather conditions, this PR adds to a previous PR
New:
- Variable -> partlycloudy (no good alternative in HA)
- Averses de neige faible -> snowy
- Brouillard dense -> fog
- Orage avec grêle -> lightning

Changed:
- Ciel clair -> clear_night (from: sunny)

Additional comment: I spent roughly 2 hours trying to find a definitive list of MeteoFrance's weather conditions but cannot find it. As a result there may be more conditions that require to be added and I also am not sure if existing conditions have been replaced with the recently updated API, e.g. "Nuit claire" and "Nuit Claire"...are these replaced by "Ciel clair"? If someone manages to finds such a list (if existing) then I am happy to rework all.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143137
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
