### PR TITLE
Fix hassio mocking in ESPHome dashboard tests

### DIFF
--- a/tests/components/esphome/test_dashboard.py
+++ b/tests/components/esphome/test_dashboard.py
@@ -81,6 +81,7 @@ async def test_restore_dashboard_storage_end_to_end(
         assert mock_dashboard_api.mock_calls[0][1][0] == "http://new-host:6052"
 
 
+@pytest.mark.usefixtures("hassio_stubs")
 async def test_restore_dashboard_storage_skipped_if_addon_uninstalled(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
@@ -105,9 +106,7 @@ async def test_restore_dashboard_storage_skipped_if_addon_uninstalled(
             return_value={},
         ),
     ):
-        await async_setup_component(hass, "hassio", {})
-        await hass.async_block_till_done()
-        await async_setup_component(hass, DOMAIN, {})
+        assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         assert "test-slug is no longer installed" in caplog.text
         assert not mock_dashboard_api.called

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -3,17 +3,16 @@
 from collections.abc import Generator
 import os
 import re
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 from aiohasupervisor.models import AddonsStats, AddonState
 from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant.auth.models import RefreshToken
-from homeassistant.components.hassio.handler import HassIO, HassioAPIError
+from homeassistant.components.hassio.handler import HassIO
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.setup import async_setup_component
 
 from . import SUPERVISOR_TOKEN
 
@@ -29,55 +28,6 @@ def disable_security_filter() -> Generator[None]:
         re.compile("not-matching-anything"),
     ):
         yield
-
-
-@pytest.fixture
-def hassio_env(supervisor_is_connected: AsyncMock) -> Generator[None]:
-    """Fixture to inject hassio env."""
-    with (
-        patch.dict(os.environ, {"SUPERVISOR": "127.0.0.1"}),
-        patch.dict(os.environ, {"SUPERVISOR_TOKEN": SUPERVISOR_TOKEN}),
-        patch(
-            "homeassistant.components.hassio.HassIO.get_info",
-            Mock(side_effect=HassioAPIError()),
-        ),
-    ):
-        yield
-
-
-@pytest.fixture
-async def hassio_stubs(
-    hassio_env: None,
-    hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    aioclient_mock: AiohttpClientMocker,
-    supervisor_client: AsyncMock,
-) -> RefreshToken:
-    """Create mock hassio http client."""
-    with (
-        patch(
-            "homeassistant.components.hassio.HassIO.update_hass_api",
-            return_value={"result": "ok"},
-        ) as hass_api,
-        patch(
-            "homeassistant.components.hassio.HassIO.update_hass_timezone",
-            return_value={"result": "ok"},
-        ),
-        patch(
-            "homeassistant.components.hassio.HassIO.get_info",
-            side_effect=HassioAPIError(),
-        ),
-        patch(
-            "homeassistant.components.hassio.HassIO.get_ingress_panels",
-            return_value={"panels": []},
-        ),
-        patch(
-            "homeassistant.components.hassio.issues.SupervisorIssues.setup",
-        ),
-    ):
-        await async_setup_component(hass, "hassio", {})
-
-    return hass_api.call_args[0][1]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,9 @@ from .typing import (
 if TYPE_CHECKING:
     # Local import to avoid processing recorder and SQLite modules when running a
     # testcase which does not use the recorder.
+    from homeassistant.auth.models import RefreshToken
     from homeassistant.components import recorder
+
 
 pytest.register_assert_rewrite("tests.common")
 
@@ -1892,6 +1894,67 @@ def mock_bleak_scanner_start() -> Generator[MagicMock]:
         patch.object(bluetooth_scanner, "HaScanner"),
     ):
         yield mock_bleak_scanner_start
+
+
+@pytest.fixture
+def hassio_env(supervisor_is_connected: AsyncMock) -> Generator[None]:
+    """Fixture to inject hassio env."""
+    from homeassistant.components.hassio import (  # pylint: disable=import-outside-toplevel
+        HassioAPIError,
+    )
+
+    from .components.hassio import (  # pylint: disable=import-outside-toplevel
+        SUPERVISOR_TOKEN,
+    )
+
+    with (
+        patch.dict(os.environ, {"SUPERVISOR": "127.0.0.1"}),
+        patch.dict(os.environ, {"SUPERVISOR_TOKEN": SUPERVISOR_TOKEN}),
+        patch(
+            "homeassistant.components.hassio.HassIO.get_info",
+            Mock(side_effect=HassioAPIError()),
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+async def hassio_stubs(
+    hassio_env: None,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    supervisor_client: AsyncMock,
+) -> RefreshToken:
+    """Create mock hassio http client."""
+    from homeassistant.components.hassio import (  # pylint: disable=import-outside-toplevel
+        HassioAPIError,
+    )
+
+    with (
+        patch(
+            "homeassistant.components.hassio.HassIO.update_hass_api",
+            return_value={"result": "ok"},
+        ) as hass_api,
+        patch(
+            "homeassistant.components.hassio.HassIO.update_hass_timezone",
+            return_value={"result": "ok"},
+        ),
+        patch(
+            "homeassistant.components.hassio.HassIO.get_info",
+            side_effect=HassioAPIError(),
+        ),
+        patch(
+            "homeassistant.components.hassio.HassIO.get_ingress_panels",
+            return_value={"panels": []},
+        ),
+        patch(
+            "homeassistant.components.hassio.issues.SupervisorIssues.setup",
+        ),
+    ):
+        await async_setup_component(hass, "hassio", {})
+
+    return hass_api.call_args[0][1]
 
 
 @pytest.fixture


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have tried to fix the test_restore_dashboard_storage_skipped_if_addon_uninstalled test a few times and it never fails locally since the problem depends on order of test execution. The last failure showed hassio was not being mocked out properly so for the 3rd attempt to fix it, make sure hassio is mocked out

https://app.codecov.io/gh/home-assistant/core/tests/dev?parameter=FLAKY_TESTS


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
