### PR TITLE
Fix flakey Bluetooth options flow tests

### DIFF
--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -23,8 +23,7 @@ from . import (
 @pytest.fixture(name="disable_bluez_manager_socket", autouse=True, scope="package")
 def disable_bluez_manager_socket():
     """Mock the bluez manager socket."""
-    with patch.object(bleak_manager, "get_global_bluez_manager_with_timeout"):
-        yield
+    bleak_manager.get_global_bluez_manager_with_timeout._has_dbus_socket = False
 
 
 @pytest.fixture(name="disable_dbus_socket", autouse=True, scope="package")

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -1,7 +1,6 @@
 """Tests for the bluetooth component."""
 
 from collections.abc import Generator
-import sys
 from unittest.mock import patch
 
 from bleak_retry_connector import bleak_manager
@@ -25,13 +24,7 @@ from . import (
 def disable_bluez_manager_socket():
     """Mock the bluez manager socket."""
     with patch.object(bleak_manager, "get_global_bluez_manager_with_timeout"):
-        if (
-            "bleak.backends.bluezdbus" in sys.modules
-        ):  # only on Linux will this be imported
-            with patch("bleak.backends.bluezdbus.manager.get_global_bluez_manager"):
-                yield
-        else:
-            yield
+        yield
 
 
 @pytest.fixture(name="disable_dbus_socket", autouse=True, scope="package")

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -1,6 +1,7 @@
 """Tests for the bluetooth component."""
 
 from collections.abc import Generator
+import sys
 from unittest.mock import patch
 
 from bleak_retry_connector import bleak_manager
@@ -24,7 +25,13 @@ from . import (
 def disable_bluez_manager_socket():
     """Mock the bluez manager socket."""
     with patch.object(bleak_manager, "get_global_bluez_manager_with_timeout"):
-        yield
+        if (
+            "bleak.backends.bluezdbus" in sys.modules
+        ):  # only on Linux will this be imported
+            with patch("bleak.backends.bluezdbus.manager.get_global_bluez_manager"):
+                yield
+        else:
+            yield
 
 
 @pytest.fixture(name="disable_dbus_socket", autouse=True, scope="package")

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -30,10 +30,7 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.mark.usefixtures(
-    "disable_bluez_manager_socket",
-    "macos_adapter",
-    "mock_bleak_scanner_start",
-    "mock_bluetooth_adapters",
+    "macos_adapter", "mock_bleak_scanner_start", "mock_bluetooth_adapters"
 )
 async def test_options_flow_disabled_not_setup(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -30,7 +30,10 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.mark.usefixtures(
-    "macos_adapter", "mock_bleak_scanner_start", "mock_bluetooth_adapters"
+    "disable_bluez_manager_socket",
+    "macos_adapter",
+    "mock_bleak_scanner_start",
+    "mock_bluetooth_adapters",
 )
 async def test_options_flow_disabled_not_setup(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/actions/runs/14533572605/job/40778137565?pr=143208
`FAILED tests/components/bluetooth/test_config_flow.py::test_options_flow_disabled_not_setup - Failed: Timeout >9.0s`
https://app.codecov.io/gh/home-assistant/core/tests/dev?parameter=FLAKY_TESTS


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
