### PR TITLE
Adjust cover reproduce state to prefer setting positions if supported

### DIFF
--- a/homeassistant/components/cover/reproduce_state.py
+++ b/homeassistant/components/cover/reproduce_state.py
@@ -119,16 +119,18 @@ async def _async_close_cover(
     features: CoverEntityFeature,
     set_position: bool,
     set_tilt: bool,
+    current_position: int | None,
+    current_tilt_position: int | None,
 ) -> None:
     """Close the cover if it was not closed by setting the position."""
-    if not set_position:
+    if not set_position and current_position != FULL_CLOSE:
         if CoverEntityFeature.CLOSE in features:
             await service_call(SERVICE_CLOSE_COVER, service_data)
         elif CoverEntityFeature.SET_POSITION in features:
             await service_call(
                 SERVICE_SET_COVER_POSITION, service_data | {ATTR_POSITION: FULL_CLOSE}
             )
-    if not set_tilt:
+    if not set_tilt and current_tilt_position != FULL_CLOSE:
         if CoverEntityFeature.CLOSE_TILT in features:
             await service_call(SERVICE_CLOSE_COVER_TILT, service_data)
         elif CoverEntityFeature.SET_TILT_POSITION in features:
@@ -144,16 +146,18 @@ async def _async_open_cover(
     features: CoverEntityFeature,
     set_position: bool,
     set_tilt: bool,
+    current_position: int | None,
+    current_tilt_position: int | None,
 ) -> None:
     """Open the cover if it was not opened by setting the position."""
-    if not set_position:
+    if not set_position and current_position != FULL_OPEN:
         if CoverEntityFeature.OPEN in features:
             await service_call(SERVICE_OPEN_COVER, service_data)
         elif CoverEntityFeature.SET_POSITION in features:
             await service_call(
                 SERVICE_SET_COVER_POSITION, service_data | {ATTR_POSITION: FULL_OPEN}
             )
-    if not set_tilt:
+    if not set_tilt and current_tilt_position != FULL_OPEN:
         if CoverEntityFeature.OPEN_TILT in features:
             await service_call(SERVICE_OPEN_COVER_TILT, service_data)
         elif CoverEntityFeature.SET_TILT_POSITION in features:
@@ -183,12 +187,12 @@ async def _async_reproduce_state(
     current_attrs = cur_state.attributes
     target_attrs = state.attributes
 
-    current_position = current_attrs.get(ATTR_CURRENT_POSITION)
-    target_position = target_attrs.get(ATTR_CURRENT_POSITION)
+    current_position: int | None = current_attrs.get(ATTR_CURRENT_POSITION)
+    target_position: int | None = target_attrs.get(ATTR_CURRENT_POSITION)
     position_matches = current_position == target_position
 
-    current_tilt_position = current_attrs.get(ATTR_CURRENT_TILT_POSITION)
-    target_tilt_position = target_attrs.get(ATTR_CURRENT_TILT_POSITION)
+    current_tilt_position: int | None = current_attrs.get(ATTR_CURRENT_TILT_POSITION)
+    target_tilt_position: int | None = target_attrs.get(ATTR_CURRENT_TILT_POSITION)
     tilt_position_matches = current_tilt_position == target_tilt_position
 
     state_matches = cur_state.state == target_state
@@ -231,12 +235,24 @@ async def _async_reproduce_state(
 
     if target_state in CLOSING_STATES:
         await _async_close_cover(
-            service_call, service_data, features, set_position, set_tilt
+            service_call,
+            service_data,
+            features,
+            set_position,
+            set_tilt,
+            current_position,
+            current_tilt_position,
         )
 
     elif target_state in OPENING_STATES:
         await _async_open_cover(
-            service_call, service_data, features, set_position, set_tilt
+            service_call,
+            service_data,
+            features,
+            set_position,
+            set_tilt,
+            current_position,
+            current_tilt_position,
         )
 
 

--- a/homeassistant/components/cover/reproduce_state.py
+++ b/homeassistant/components/cover/reproduce_state.py
@@ -73,14 +73,14 @@ async def _async_set_position(
     Returns True if the position was set, False if there is no
     supported method for setting the position.
     """
-    if target_position == FULL_CLOSE and CoverEntityFeature.CLOSE in features:
-        await service_call(SERVICE_CLOSE_COVER, service_data)
-    elif target_position == FULL_OPEN and CoverEntityFeature.OPEN in features:
-        await service_call(SERVICE_OPEN_COVER, service_data)
-    elif CoverEntityFeature.SET_POSITION in features:
+    if CoverEntityFeature.SET_POSITION in features:
         await service_call(
             SERVICE_SET_COVER_POSITION, service_data | {ATTR_POSITION: target_position}
         )
+    elif target_position == FULL_CLOSE and CoverEntityFeature.CLOSE in features:
+        await service_call(SERVICE_CLOSE_COVER, service_data)
+    elif target_position == FULL_OPEN and CoverEntityFeature.OPEN in features:
+        await service_call(SERVICE_OPEN_COVER, service_data)
     else:
         # Requested a position but the cover doesn't support it
         return False
@@ -98,15 +98,17 @@ async def _async_set_tilt_position(
     Returns True if the tilt position was set, False if there is no
     supported method for setting the tilt position.
     """
-    if target_tilt_position == FULL_CLOSE and CoverEntityFeature.CLOSE_TILT in features:
-        await service_call(SERVICE_CLOSE_COVER_TILT, service_data)
-    elif target_tilt_position == FULL_OPEN and CoverEntityFeature.OPEN_TILT in features:
-        await service_call(SERVICE_OPEN_COVER_TILT, service_data)
-    elif CoverEntityFeature.SET_TILT_POSITION in features:
+    if CoverEntityFeature.SET_TILT_POSITION in features:
         await service_call(
             SERVICE_SET_COVER_TILT_POSITION,
             service_data | {ATTR_TILT_POSITION: target_tilt_position},
         )
+    elif (
+        target_tilt_position == FULL_CLOSE and CoverEntityFeature.CLOSE_TILT in features
+    ):
+        await service_call(SERVICE_CLOSE_COVER_TILT, service_data)
+    elif target_tilt_position == FULL_OPEN and CoverEntityFeature.OPEN_TILT in features:
+        await service_call(SERVICE_OPEN_COVER_TILT, service_data)
     else:
         # Requested a tilt position but the cover doesn't support it
         return False
@@ -214,19 +216,11 @@ async def _async_reproduce_state(
     )
     service_data = {ATTR_ENTITY_ID: entity_id}
 
-    set_position = (
-        not position_matches
-        and target_position is not None
-        and await _async_set_position(
-            service_call, service_data, features, target_position
-        )
+    set_position = target_position is not None and await _async_set_position(
+        service_call, service_data, features, target_position
     )
-    set_tilt = (
-        not tilt_position_matches
-        and target_tilt_position is not None
-        and await _async_set_tilt_position(
-            service_call, service_data, features, target_tilt_position
-        )
+    set_tilt = target_tilt_position is not None and await _async_set_tilt_position(
+        service_call, service_data, features, target_tilt_position
     )
 
     if target_state in CLOSING_STATES:

--- a/homeassistant/components/cover/reproduce_state.py
+++ b/homeassistant/components/cover/reproduce_state.py
@@ -119,18 +119,16 @@ async def _async_close_cover(
     features: CoverEntityFeature,
     set_position: bool,
     set_tilt: bool,
-    current_position: int | None,
-    current_tilt_position: int | None,
 ) -> None:
     """Close the cover if it was not closed by setting the position."""
-    if not set_position and current_position != FULL_CLOSE:
+    if not set_position:
         if CoverEntityFeature.CLOSE in features:
             await service_call(SERVICE_CLOSE_COVER, service_data)
         elif CoverEntityFeature.SET_POSITION in features:
             await service_call(
                 SERVICE_SET_COVER_POSITION, service_data | {ATTR_POSITION: FULL_CLOSE}
             )
-    if not set_tilt and current_tilt_position != FULL_CLOSE:
+    if not set_tilt:
         if CoverEntityFeature.CLOSE_TILT in features:
             await service_call(SERVICE_CLOSE_COVER_TILT, service_data)
         elif CoverEntityFeature.SET_TILT_POSITION in features:
@@ -146,18 +144,16 @@ async def _async_open_cover(
     features: CoverEntityFeature,
     set_position: bool,
     set_tilt: bool,
-    current_position: int | None,
-    current_tilt_position: int | None,
 ) -> None:
     """Open the cover if it was not opened by setting the position."""
-    if not set_position and current_position != FULL_OPEN:
+    if not set_position:
         if CoverEntityFeature.OPEN in features:
             await service_call(SERVICE_OPEN_COVER, service_data)
         elif CoverEntityFeature.SET_POSITION in features:
             await service_call(
                 SERVICE_SET_COVER_POSITION, service_data | {ATTR_POSITION: FULL_OPEN}
             )
-    if not set_tilt and current_tilt_position != FULL_OPEN:
+    if not set_tilt:
         if CoverEntityFeature.OPEN_TILT in features:
             await service_call(SERVICE_OPEN_COVER_TILT, service_data)
         elif CoverEntityFeature.SET_TILT_POSITION in features:
@@ -235,24 +231,12 @@ async def _async_reproduce_state(
 
     if target_state in CLOSING_STATES:
         await _async_close_cover(
-            service_call,
-            service_data,
-            features,
-            set_position,
-            set_tilt,
-            current_position,
-            current_tilt_position,
+            service_call, service_data, features, set_position, set_tilt
         )
 
     elif target_state in OPENING_STATES:
         await _async_open_cover(
-            service_call,
-            service_data,
-            features,
-            set_position,
-            set_tilt,
-            current_position,
-            current_tilt_position,
+            service_call, service_data, features, set_position, set_tilt
         )
 
 

--- a/tests/components/cover/test_reproduce_state.py
+++ b/tests/components/cover/test_reproduce_state.py
@@ -265,7 +265,14 @@ async def test_reproducing_states(
     await async_reproduce_state(
         hass,
         [
-            State("cover.closed_supports_all_features", CoverState.CLOSED),
+            State(
+                "cover.closed_supports_all_features",
+                CoverState.CLOSED,
+                {
+                    ATTR_CURRENT_POSITION: 0,
+                    ATTR_CURRENT_TILT_POSITION: 0,
+                },
+            ),
             State("cover.entity_close", CoverState.CLOSED),
             State("cover.closed_only_supports_close_open", CoverState.CLOSED),
             State("cover.closed_only_supports_tilt_close_open", CoverState.CLOSED),
@@ -506,6 +513,7 @@ async def test_reproducing_states(
         {"entity_id": "cover.entity_open_tilt"},
         {"entity_id": "cover.entity_entirely_open"},
         {"entity_id": "cover.tilt_only_open"},
+        {"entity_id": "cover.entity_open_attr"},
         {"entity_id": "cover.tilt_only_tilt_position_100"},
         {"entity_id": "cover.open_only_supports_tilt_close_open"},
     ]

--- a/tests/components/cover/test_reproduce_state.py
+++ b/tests/components/cover/test_reproduce_state.py
@@ -179,6 +179,22 @@ async def test_reproducing_states(
         },
     )
     hass.states.async_set(
+        "cover.closed_supports_all_features",
+        CoverState.CLOSED,
+        {
+            ATTR_CURRENT_POSITION: 0,
+            ATTR_CURRENT_TILT_POSITION: 0,
+            ATTR_SUPPORTED_FEATURES: CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.SET_POSITION
+            | CoverEntityFeature.STOP
+            | CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.STOP_TILT
+            | CoverEntityFeature.SET_TILT_POSITION,
+        },
+    )
+    hass.states.async_set(
         "cover.tilt_only_open",
         CoverState.OPEN,
         {
@@ -249,6 +265,7 @@ async def test_reproducing_states(
     await async_reproduce_state(
         hass,
         [
+            State("cover.closed_supports_all_features", CoverState.CLOSED),
             State("cover.entity_close", CoverState.CLOSED),
             State("cover.closed_only_supports_close_open", CoverState.CLOSED),
             State("cover.closed_only_supports_tilt_close_open", CoverState.CLOSED),
@@ -364,6 +381,11 @@ async def test_reproducing_states(
     await async_reproduce_state(
         hass,
         [
+            State(
+                "cover.closed_supports_all_features",
+                CoverState.CLOSED,
+                {ATTR_CURRENT_POSITION: 0, ATTR_CURRENT_TILT_POSITION: 50},
+            ),
             State("cover.entity_close", CoverState.OPEN),
             State(
                 "cover.closed_only_supports_close_open",
@@ -484,7 +506,6 @@ async def test_reproducing_states(
         {"entity_id": "cover.entity_open_tilt"},
         {"entity_id": "cover.entity_entirely_open"},
         {"entity_id": "cover.tilt_only_open"},
-        {"entity_id": "cover.entity_open_attr"},
         {"entity_id": "cover.tilt_only_tilt_position_100"},
         {"entity_id": "cover.open_only_supports_tilt_close_open"},
     ]
@@ -550,6 +571,10 @@ async def test_reproducing_states(
         {
             "entity_id": "cover.tilt_partial_open_only_supports_tilt_position",
             ATTR_TILT_POSITION: 70,
+        },
+        {
+            "entity_id": "cover.closed_supports_all_features",
+            ATTR_TILT_POSITION: 50,
         },
     ]
     assert len(position_tilt_calls) == len(valid_position_tilt_calls)

--- a/tests/components/cover/test_reproduce_state.py
+++ b/tests/components/cover/test_reproduce_state.py
@@ -487,7 +487,6 @@ async def test_reproducing_states(
     valid_close_calls = [
         {"entity_id": "cover.entity_open"},
         {"entity_id": "cover.entity_open_attr"},
-        {"entity_id": "cover.entity_entirely_open"},
         {"entity_id": "cover.open_only_supports_close_open"},
         {"entity_id": "cover.open_missing_all_features"},
     ]
@@ -510,11 +509,8 @@ async def test_reproducing_states(
         valid_open_calls.remove(call.data)
 
     valid_close_tilt_calls = [
-        {"entity_id": "cover.entity_open_tilt"},
-        {"entity_id": "cover.entity_entirely_open"},
         {"entity_id": "cover.tilt_only_open"},
         {"entity_id": "cover.entity_open_attr"},
-        {"entity_id": "cover.tilt_only_tilt_position_100"},
         {"entity_id": "cover.open_only_supports_tilt_close_open"},
     ]
     assert len(close_tilt_calls) == len(valid_close_tilt_calls)
@@ -524,9 +520,7 @@ async def test_reproducing_states(
         valid_close_tilt_calls.remove(call.data)
 
     valid_open_tilt_calls = [
-        {"entity_id": "cover.entity_close_tilt"},
         {"entity_id": "cover.tilt_only_closed"},
-        {"entity_id": "cover.tilt_only_tilt_position_0"},
         {"entity_id": "cover.closed_only_supports_tilt_close_open"},
     ]
     assert len(open_tilt_calls) == len(valid_open_tilt_calls)
@@ -550,6 +544,14 @@ async def test_reproducing_states(
         },
         {
             "entity_id": "cover.open_only_supports_position",
+            ATTR_POSITION: 0,
+        },
+        {
+            "entity_id": "cover.closed_supports_all_features",
+            ATTR_POSITION: 0,
+        },
+        {
+            "entity_id": "cover.entity_entirely_open",
             ATTR_POSITION: 0,
         },
     ]
@@ -584,7 +586,30 @@ async def test_reproducing_states(
             "entity_id": "cover.closed_supports_all_features",
             ATTR_TILT_POSITION: 50,
         },
+        {
+            "entity_id": "cover.entity_close_tilt",
+            ATTR_TILT_POSITION: 100,
+        },
+        {
+            "entity_id": "cover.entity_open_tilt",
+            ATTR_TILT_POSITION: 0,
+        },
+        {
+            "entity_id": "cover.entity_entirely_open",
+            ATTR_TILT_POSITION: 0,
+        },
+        {
+            "entity_id": "cover.tilt_only_tilt_position_100",
+            ATTR_TILT_POSITION: 0,
+        },
+        {
+            "entity_id": "cover.tilt_only_tilt_position_0",
+            ATTR_TILT_POSITION: 100,
+        },
     ]
+    for call in position_tilt_calls:
+        if ATTR_TILT_POSITION not in call.data:
+            continue
     assert len(position_tilt_calls) == len(valid_position_tilt_calls)
     for call in position_tilt_calls:
         assert call.domain == "cover"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a target position or target tilt position is provided and the entity supports setting the position or setting the target tilt position, prefer that over sending a close/open call when the target (tilt) position is fully open or fully closed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143221
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
