### PR TITLE
Update Music Assistant browse media types

### DIFF
--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -65,6 +65,7 @@ LIBRARY_MEDIA_CLASS_MAP = {
 
 MEDIA_CONTENT_TYPE_FLAC = "audio/flac"
 THUMB_SIZE = 200
+SORT_NAME_DESC = "sort_name_desc"
 
 
 def media_source_filter(item: BrowseMedia) -> bool:
@@ -161,16 +162,15 @@ async def build_playlists_listing(mass: MusicAssistantClient) -> BrowseMedia:
         can_play=False,
         can_expand=True,
         children_media_class=media_class,
-        children=sorted(
-            [
-                build_item(mass, item, can_expand=True)
-                # we only grab the first page here because the
-                # HA media browser does not support paging
-                for item in await mass.music.get_library_playlists(limit=500)
-                if item.available
-            ],
-            key=lambda x: x.title,
-        ),
+        children=[
+            build_item(mass, item, can_expand=True)
+            # we only grab the first page here because the
+            # HA media browser does not support paging
+            for item in await mass.music.get_library_playlists(
+                limit=500, order_by=SORT_NAME_DESC
+            )
+            if item.available
+        ],
     )
 
 
@@ -214,16 +214,15 @@ async def build_artists_listing(mass: MusicAssistantClient) -> BrowseMedia:
         can_play=False,
         can_expand=True,
         children_media_class=media_class,
-        children=sorted(
-            [
-                build_item(mass, artist, can_expand=True)
-                # we only grab the first page here because the
-                # HA media browser does not support paging
-                for artist in await mass.music.get_library_artists(limit=500)
-                if artist.available
-            ],
-            key=lambda x: x.title,
-        ),
+        children=[
+            build_item(mass, artist, can_expand=True)
+            # we only grab the first page here because the
+            # HA media browser does not support paging
+            for artist in await mass.music.get_library_artists(
+                limit=500, order_by=SORT_NAME_DESC
+            )
+            if artist.available
+        ],
     )
 
 
@@ -265,16 +264,15 @@ async def build_albums_listing(mass: MusicAssistantClient) -> BrowseMedia:
         can_play=False,
         can_expand=True,
         children_media_class=media_class,
-        children=sorted(
-            [
-                build_item(mass, album, can_expand=True)
-                # we only grab the first page here because the
-                # HA media browser does not support paging
-                for album in await mass.music.get_library_albums(limit=500)
-                if album.available
-            ],
-            key=lambda x: x.title,
-        ),
+        children=[
+            build_item(mass, album, can_expand=True)
+            # we only grab the first page here because the
+            # HA media browser does not support paging
+            for album in await mass.music.get_library_albums(
+                limit=500, order_by=SORT_NAME_DESC
+            )
+            if album.available
+        ],
     )
 
 
@@ -314,16 +312,15 @@ async def build_tracks_listing(mass: MusicAssistantClient) -> BrowseMedia:
         can_play=False,
         can_expand=True,
         children_media_class=media_class,
-        children=sorted(
-            [
-                build_item(mass, track, can_expand=False)
-                # we only grab the first page here because the
-                # HA media browser does not support paging
-                for track in await mass.music.get_library_tracks(limit=500)
-                if track.available
-            ],
-            key=lambda x: x.title,
-        ),
+        children=[
+            build_item(mass, track, can_expand=False)
+            # we only grab the first page here because the
+            # HA media browser does not support paging
+            for track in await mass.music.get_library_tracks(
+                limit=500, order_by=SORT_NAME_DESC
+            )
+            if track.available
+        ],
     )
 
 
@@ -338,16 +335,15 @@ async def build_podcasts_listing(mass: MusicAssistantClient) -> BrowseMedia:
         can_play=False,
         can_expand=True,
         children_media_class=media_class,
-        children=sorted(
-            [
-                build_item(mass, podcast, can_expand=False)
-                # we only grab the first page here because the
-                # HA media browser does not support paging
-                for podcast in await mass.music.get_library_podcasts(limit=500)
-                if podcast.available
-            ],
-            key=lambda x: x.title,
-        ),
+        children=[
+            build_item(mass, podcast, can_expand=False)
+            # we only grab the first page here because the
+            # HA media browser does not support paging
+            for podcast in await mass.music.get_library_podcasts(
+                limit=500, order_by=SORT_NAME_DESC
+            )
+            if podcast.available
+        ],
     )
 
 
@@ -362,16 +358,15 @@ async def build_audiobooks_listing(mass: MusicAssistantClient) -> BrowseMedia:
         can_play=False,
         can_expand=True,
         children_media_class=media_class,
-        children=sorted(
-            [
-                build_item(mass, audiobook, can_expand=False)
-                # we only grab the first page here because the
-                # HA media browser does not support paging
-                for audiobook in await mass.music.get_library_audiobooks(limit=500)
-                if audiobook.available
-            ],
-            key=lambda x: x.title,
-        ),
+        children=[
+            build_item(mass, audiobook, can_expand=False)
+            # we only grab the first page here because the
+            # HA media browser does not support paging
+            for audiobook in await mass.music.get_library_audiobooks(
+                limit=500, order_by=SORT_NAME_DESC
+            )
+            if audiobook.available
+        ],
     )
 
 
@@ -386,16 +381,15 @@ async def build_radio_listing(mass: MusicAssistantClient) -> BrowseMedia:
         can_play=False,
         can_expand=True,
         children_media_class=media_class,
-        children=sorted(
-            [
-                build_item(mass, track, can_expand=False, media_class=media_class)
-                # we only grab the first page here because the
-                # HA media browser does not support paging
-                for track in await mass.music.get_library_radios(limit=500)
-                if track.available
-            ],
-            key=lambda x: x.title,
-        ),
+        children=[
+            build_item(mass, track, can_expand=False, media_class=media_class)
+            # we only grab the first page here because the
+            # HA media browser does not support paging
+            for track in await mass.music.get_library_radios(
+                limit=500, order_by=SORT_NAME_DESC
+            )
+            if track.available
+        ],
     )
 
 

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -9,7 +9,9 @@ from homeassistant.components.music_assistant.const import DOMAIN
 from homeassistant.components.music_assistant.media_browser import (
     LIBRARY_ALBUMS,
     LIBRARY_ARTISTS,
+    LIBRARY_AUDIOBOOKS,
     LIBRARY_PLAYLISTS,
+    LIBRARY_PODCASTS,
     LIBRARY_RADIO,
     LIBRARY_TRACKS,
     async_browse_media,
@@ -27,6 +29,8 @@ from .common import setup_integration_from_fixtures
         (LIBRARY_ALBUMS, MediaType.ALBUM, "library://album/396"),
         (LIBRARY_TRACKS, MediaType.TRACK, "library://track/486"),
         (LIBRARY_RADIO, DOMAIN, "library://radio/1"),
+        (LIBRARY_PODCASTS, MediaType.PODCAST, "library://podcast/6"),
+        (LIBRARY_AUDIOBOOKS, DOMAIN, "library://audiobook/1"),
         ("artist", MediaType.ARTIST, "library://album/115"),
         ("album", MediaType.ALBUM, "library://track/247"),
         ("playlist", DOMAIN, "tidal--Ah76MuMg://track/77616130"),

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -27,7 +27,7 @@ from .common import setup_integration_from_fixtures
         (LIBRARY_PLAYLISTS, MediaType.PLAYLIST, "library://playlist/40"),
         (LIBRARY_ARTISTS, MediaType.ARTIST, "library://artist/127"),
         (LIBRARY_ALBUMS, MediaType.ALBUM, "library://album/396"),
-        (LIBRARY_TRACKS, MediaType.TRACK, "library://track/486"),
+        (LIBRARY_TRACKS, MediaType.TRACK, "library://track/456"),
         (LIBRARY_RADIO, DOMAIN, "library://radio/1"),
         (LIBRARY_PODCASTS, MediaType.PODCAST, "library://podcast/6"),
         (LIBRARY_AUDIOBOOKS, DOMAIN, "library://audiobook/1"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR extends the media browser functionality of the Music Assistant integration with support for library podcasts and audiobooks. As audiobooks do not exist in the HA `MediaType` enum, I have mapped them to `MediaType.DIRECTORY`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
