### PR TITLE
Add Netatmo person switches

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -43,6 +43,7 @@ from .const import (
     DATA_PERSONS,
     DATA_SCHEDULES,
     DOMAIN,
+    PERSONS_DEVICE_IDENTIFIER_SUFFIX,
     PLATFORMS,
     WEBHOOK_DEACTIVATION,
     WEBHOOK_PUSH_TYPE,
@@ -253,10 +254,15 @@ async def async_remove_config_entry_device(
     data = hass.data[DOMAIN][config_entry.entry_id][DATA_HANDLER]
     modules = [m for h in data.account.homes.values() for m in h.modules]
     rooms = [r for h in data.account.homes.values() for r in h.rooms]
+    persons = [
+        f"{h.entity_id}-{PERSONS_DEVICE_IDENTIFIER_SUFFIX}"
+        for h in data.account.homes.values()
+    ]
 
     return not any(
         identifier
         for identifier in device_entry.identifiers
         if (identifier[0] == DOMAIN and identifier[1] in modules)
         or identifier[1] in rooms
+        or identifier[1] in persons
     )

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import aiohttp
 from pyatmo import ApiError as NetatmoApiError, modules as NaModules
 from pyatmo.event import Event as NaEvent
+from pyatmo.person import Person as NaPerson
 import voluptuous as vol
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
@@ -103,13 +104,14 @@ class NetatmoCamera(NetatmoModuleEntity, Camera):
 
         self._attr_unique_id = f"{netatmo_device.device.entity_id}-{self.device_type}"
         self._light_state = None
+        self._signal_name_home = f"{HOME}-{self.home.entity_id}"
 
         self._publishers.extend(
             [
                 {
                     "name": HOME,
                     "home_id": self.home.entity_id,
-                    SIGNAL_NAME: f"{HOME}-{self.home.entity_id}",
+                    SIGNAL_NAME: self._signal_name_home,
                 },
                 {
                     "name": EVENT,
@@ -254,49 +256,58 @@ class NetatmoCamera(NetatmoModuleEntity, Camera):
             return f"{self.device.local_url}/vod/{video_id}/files/{self._quality}/index.m3u8"
         return f"{self.device.vpn_url}/vod/{video_id}/files/{self._quality}/index.m3u8"
 
-    def fetch_person_ids(self, persons: list[str | None]) -> list[str]:
+    def fetch_persons(self, person_names: list[str | None]) -> list[NaPerson]:
         """Fetch matching person ids for given list of persons."""
-        person_ids = []
+        persons: list[NaPerson] = []
         person_id_errors = []
 
-        for person in persons:
+        for person_name in person_names:
             person_id = None
-            for pid, data in self.home.persons.items():
-                if data.pseudo == person:
-                    person_ids.append(pid)
+            for pid, person in self.home.persons.items():
+                if person.pseudo == person_name:
+                    persons.append(person)
                     person_id = pid
                     break
 
             if person_id is None:
-                person_id_errors.append(person)
+                person_id_errors.append(person_name)
 
         if person_id_errors:
             raise HomeAssistantError(f"Person(s) not registered {person_id_errors}")
 
-        return person_ids
+        return persons
 
     async def _service_set_persons_home(self, **kwargs: Any) -> None:
         """Service to change current home schedule."""
-        persons = kwargs.get(ATTR_PERSONS, [])
-        person_ids = self.fetch_person_ids(persons)
+        person_names = kwargs.get(ATTR_PERSONS, [])
+        persons = self.fetch_persons(person_names)
+        person_ids = [person.entity_id for person in persons]
 
         await self.home.async_set_persons_home(person_ids=person_ids)
-        _LOGGER.debug("Set %s as at home", persons)
+        for person in persons:
+            person.out_of_sight = False
+        _LOGGER.debug("Set %s as at home", person_names)
+        self.data_handler.notify(self._signal_name_home)
 
     async def _service_set_person_away(self, **kwargs: Any) -> None:
         """Service to mark a person as away or set the home as empty."""
-        person = kwargs.get(ATTR_PERSON)
-        person_ids = self.fetch_person_ids([person] if person else [])
-        person_id = next(iter(person_ids), None)
+        person_name = kwargs.get(ATTR_PERSON)
+        persons = self.fetch_persons([person_name] if person_name else [])
+        person = next(iter(persons), None)
 
-        await self.home.async_set_persons_away(
-            person_id=person_id,
-        )
-
-        if person_id:
-            _LOGGER.debug("Set %s as away %s", person, person_id)
+        if person is not None:
+            await self.home.async_set_persons_away(
+                person_id=person.entity_id,
+            )
+            person.out_of_sight = True
+            _LOGGER.debug("Set %s as away %s", person.pseudo, person.entity_id)
         else:
+            await self.home.async_set_persons_away(person_id=None)
+            for person in self.home.persons.values():
+                person.out_of_sight = True
             _LOGGER.debug("Set home as empty")
+
+        self.data_handler.notify(self._signal_name_home)
 
     async def _service_set_camera_light(self, **kwargs: Any) -> None:
         """Service to set light mode."""

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -34,6 +34,9 @@ HOME_DATA = "netatmo_home_data"
 DATA_HANDLER = "netatmo_data_handler"
 SIGNAL_NAME = "signal_name"
 
+PERSONS_DEVICE_NAME_SUFFIX = "Persons"
+PERSONS_DEVICE_IDENTIFIER_SUFFIX = "persons"
+
 API_SCOPES_EXCLUDED_FROM_CLOUD = [
     "access_doorbell",
     "read_doorbell",
@@ -49,6 +52,7 @@ NETATMO_CREATE_COVER = "netatmo_create_cover"
 NETATMO_CREATE_BUTTON = "netatmo_create_button"
 NETATMO_CREATE_FAN = "netatmo_create_fan"
 NETATMO_CREATE_LIGHT = "netatmo_create_light"
+NETATMO_CREATE_PERSON_SWITCHES = "netatmo_create_person_switch"
 NETATMO_CREATE_ROOM_SENSOR = "netatmo_create_room_sensor"
 NETATMO_CREATE_SELECT = "netatmo_create_select"
 NETATMO_CREATE_SENSOR = "netatmo_create_sensor"

--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -256,11 +256,15 @@ class NetatmoDataHandler:
             _LOGGER.debug(err)
             return True
 
+        self.notify(signal_name)
+
+        return has_error
+
+    def notify(self, signal_name: str) -> None:
+        """Notify signal subscribers."""
         for update_callback in self.publisher[signal_name].subscriptions:
             if update_callback:
                 update_callback()
-
-        return has_error
 
     async def subscribe(
         self,

--- a/homeassistant/components/netatmo/switch.py
+++ b/homeassistant/components/netatmo/switch.py
@@ -165,9 +165,11 @@ class NetatmoPersonHomeSwitch(NetatmoDeviceEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Set person home."""
         await self.home.async_set_persons_home([self.person.entity_id])
-        self._attr_is_on = True
+        self.person.out_of_sight = False
+        self.data_handler.notify(self._signal_name)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Set person away."""
         await self.home.async_set_persons_away(self.person.entity_id)
-        self._attr_is_on = False
+        self.person.out_of_sight = True
+        self.data_handler.notify(self._signal_name)

--- a/homeassistant/components/netatmo/switch.py
+++ b/homeassistant/components/netatmo/switch.py
@@ -111,6 +111,7 @@ class NetatmoPersonHomeSwitch(NetatmoDeviceEntity, SwitchEntity):
     """Representation of a Netatmo person home/away switch."""
 
     person: Person
+    entity_registry_enabled_default = False
     _attr_configuration_url = CONF_URL_SECURITY
 
     def __init__(self, netatmo_person: NetatmoPerson) -> None:

--- a/homeassistant/components/netatmo/switch.py
+++ b/homeassistant/components/netatmo/switch.py
@@ -5,17 +5,31 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pyatmo import modules as NaModules
+from pyatmo import DeviceType, modules as NaModules
+from pyatmo.person import Person
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_URL_CONTROL, NETATMO_CREATE_SWITCH
-from .data_handler import HOME, SIGNAL_NAME, NetatmoDevice
-from .entity import NetatmoModuleEntity
+from .const import (
+    CONF_URL_CONTROL,
+    CONF_URL_SECURITY,
+    DOMAIN,
+    NETATMO_CREATE_PERSON_SWITCHES,
+    NETATMO_CREATE_SWITCH,
+    PERSONS_DEVICE_IDENTIFIER_SUFFIX,
+    PERSONS_DEVICE_NAME_SUFFIX,
+)
+from .data_handler import HOME, SIGNAL_NAME, NetatmoDevice, NetatmoPerson
+from .entity import NetatmoDeviceEntity, NetatmoModuleEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,6 +49,18 @@ async def async_setup_entry(
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, NETATMO_CREATE_SWITCH, _create_entity)
+    )
+
+    @callback
+    def _create_person_switch_entities(persons: list[NetatmoPerson]) -> None:
+        entities = [NetatmoPersonHomeSwitch(person) for person in persons]
+        _LOGGER.debug("Adding person home switches %s", entities)
+        async_add_entities(entities)
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, NETATMO_CREATE_PERSON_SWITCHES, _create_person_switch_entities
+        )
     )
 
 
@@ -80,3 +106,68 @@ class NetatmoSwitch(NetatmoModuleEntity, SwitchEntity):
         await self.device.async_off()
         self._attr_is_on = False
         self.async_write_ha_state()
+
+
+PERSONS_ENTITY_DESCRIPTION_KEY = "presence"
+
+
+class NetatmoPersonHomeSwitch(NetatmoDeviceEntity, SwitchEntity):
+    """Representation of a Netatmo person home/away switch."""
+
+    person: Person
+    _attr_configuration_url = CONF_URL_SECURITY
+
+    def __init__(self, person: NetatmoPerson) -> None:
+        """Initialize the Netatmo device."""
+        super().__init__(person.data_handler, person.person)
+        self.person = person.person
+        self._signal_name = f"{HOME}-{self.home.entity_id}"
+        self._publishers.extend(
+            [
+                {
+                    "name": HOME,
+                    "home_id": self.home.entity_id,
+                    SIGNAL_NAME: self._signal_name,
+                },
+            ]
+        )
+        self.entity_description = SwitchEntityDescription(
+            key=PERSONS_ENTITY_DESCRIPTION_KEY, device_class=SwitchDeviceClass.SWITCH
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, f"{person.parent_id}-{PERSONS_DEVICE_IDENTIFIER_SUFFIX}")
+            },
+            name=f"{self.home.name} {PERSONS_DEVICE_NAME_SUFFIX}",
+            manufacturer=self.device_description[0],
+            model=self.device_description[1],
+            configuration_url=self._attr_configuration_url,
+        )
+        self._attr_name = self.person.pseudo
+        self._attr_unique_id = (
+            f"{self.person.entity_id}-{PERSONS_ENTITY_DESCRIPTION_KEY}"
+        )
+        self._attr_is_on = not self.person.out_of_sight
+
+    @property
+    def device_type(self) -> DeviceType:
+        """Return the device type."""
+        return DeviceType.NACamera
+
+    @callback
+    def async_update_callback(self) -> None:
+        """Update the entity's state."""
+
+        self._attr_is_on = not self.person.out_of_sight
+        self._attr_available = True
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Set person home."""
+        await self.home.async_set_persons_home([self.person.entity_id])
+        self._attr_is_on = True
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Set person away."""
+        await self.home.async_set_persons_away(self.person.entity_id)
+        self._attr_is_on = False

--- a/tests/components/netatmo/snapshots/test_init.ambr
+++ b/tests/components/netatmo/snapshots/test_init.ambr
@@ -1290,6 +1290,7 @@
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
     'configuration_url': 'https://home.netatmo.com/security',
     'connections': set({
     }),

--- a/tests/components/netatmo/snapshots/test_init.ambr
+++ b/tests/components/netatmo/snapshots/test_init.ambr
@@ -1286,3 +1286,35 @@
     'via_device_id': None,
   })
 # ---
+# name: test_devices[netatmo-91763b24c43d3e344f424e8b-persons]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': 'https://home.netatmo.com/security',
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'netatmo',
+        '91763b24c43d3e344f424e8b-persons',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Netatmo',
+    'model': 'Smart Indoor Camera',
+    'model_id': None,
+    'name': 'MYHOME Persons',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/netatmo/snapshots/test_switch.ambr
+++ b/tests/components/netatmo/snapshots/test_switch.ambr
@@ -57,7 +57,7 @@
     'config_subentry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
-    'disabled_by': None,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
     'domain': 'switch',
     'entity_category': None,
     'entity_id': 'switch.myhome_persons_john_doe',
@@ -82,18 +82,7 @@
   })
 # ---
 # name: test_entity[switch.myhome_persons_john_doe-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'MYHOME Persons John Doe',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.myhome_persons_john_doe',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
+  None
 # ---
 # name: test_entity[switch.myhome_persons_jane_doe-entry]
   EntityRegistryEntrySnapshot({
@@ -105,7 +94,7 @@
     'config_subentry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
-    'disabled_by': None,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
     'domain': 'switch',
     'entity_category': None,
     'entity_id': 'switch.myhome_persons_jane_doe',
@@ -130,18 +119,7 @@
   })
 # ---
 # name: test_entity[switch.myhome_persons_jane_doe-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'MYHOME Persons Jane Doe',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.myhome_persons_jane_doe',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
+  None
 # ---
 # name: test_entity[switch.myhome_persons_richard_doe-entry]
   EntityRegistryEntrySnapshot({
@@ -153,7 +131,7 @@
     'config_subentry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
-    'disabled_by': None,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
     'domain': 'switch',
     'entity_category': None,
     'entity_id': 'switch.myhome_persons_richard_doe',
@@ -178,16 +156,5 @@
   })
 # ---
 # name: test_entity[switch.myhome_persons_richard_doe-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by Netatmo',
-      'friendly_name': 'MYHOME Persons Richard Doe',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.myhome_persons_richard_doe',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
+  None
 # ---

--- a/tests/components/netatmo/snapshots/test_switch.ambr
+++ b/tests/components/netatmo/snapshots/test_switch.ambr
@@ -47,3 +47,147 @@
     'state': 'on',
   })
 # ---
+# name: test_entity[switch.myhome_persons_john_doe-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.myhome_persons_john_doe',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'John Doe',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '91827374-7e04-5298-83ad-a0cb8372dff1-presence',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[switch.myhome_persons_john_doe-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'switch',
+      'friendly_name': 'MYHOME Persons John Doe',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.myhome_persons_john_doe',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entity[switch.myhome_persons_jane_doe-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.myhome_persons_jane_doe',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'Jane Doe',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '91827375-7e04-5298-83ae-a0cb8372dff2-presence',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[switch.myhome_persons_jane_doe-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'switch',
+      'friendly_name': 'MYHOME Persons Jane Doe',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.myhome_persons_jane_doe',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entity[switch.myhome_persons_richard_doe-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.myhome_persons_richard_doe',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'Richard Doe',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '91827376-7e04-5298-83af-a0cb8372dff3-presence',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[switch.myhome_persons_richard_doe-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'switch',
+      'friendly_name': 'MYHOME Persons Richard Doe',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.myhome_persons_richard_doe',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/netatmo/snapshots/test_switch.ambr
+++ b/tests/components/netatmo/snapshots/test_switch.ambr
@@ -54,6 +54,7 @@
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
     'disabled_by': None,
@@ -69,7 +70,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'John Doe',
     'platform': 'netatmo',
@@ -84,7 +85,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'device_class': 'switch',
       'friendly_name': 'MYHOME Persons John Doe',
     }),
     'context': <ANY>,
@@ -102,6 +102,7 @@
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
     'disabled_by': None,
@@ -117,7 +118,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Jane Doe',
     'platform': 'netatmo',
@@ -132,7 +133,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'device_class': 'switch',
       'friendly_name': 'MYHOME Persons Jane Doe',
     }),
     'context': <ANY>,
@@ -150,6 +150,7 @@
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
     'disabled_by': None,
@@ -165,7 +166,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Richard Doe',
     'platform': 'netatmo',
@@ -180,7 +181,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'device_class': 'switch',
       'friendly_name': 'MYHOME Persons Richard Doe',
     }),
     'context': <ANY>,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Netatmo Indoor Camera (or NIC or Welcome) can identify people home. Netatmo API provides list of persons with `out_of_sight` and `last_seen` attributes.
This PR exposes those persons as switch entities, to mimic what user can do in Netatmo Security App.

- turn on sets person home
- turn off sets person away
Switches are entities of a new `{{home_name}} Persons` device.

Also, because existing action/service already exist, 2nd commit (truly debatable) allows sync with entities without fetch call.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
