### PR TITLE
Optimize sliding window history_stats to not re-query the database every interval

### DIFF
--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -246,5 +246,5 @@ class HistoryStats:
             history_state.last_changed = start_timestamp
             if i > 0:
                 trim_count += 1
-        if trim_count: # Don't slice if no data was removed
+        if trim_count:  # Don't slice if no data was removed
             self._history_current_period = self._history_current_period[trim_count:]

--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -88,20 +88,20 @@ class HistoryStats:
         if current_period_start_timestamp > now_timestamp:
             # History cannot tell the future
             self._history_current_period = []
-            self._previous_run_before_start = True
+            self._previous_run_before_start = False
             self._state = HistoryStatsState(None, None, self._period)
             return self._state
         #
         # We avoid querying the database if the below did NOT happen:
         #
-        # - The previous run happened before the start time
-        # - The start time changed
-        # - The period shrank in size
+        # - No previous run occurred (uninitialized)
+        # - The start time moved back in time
+        # - The end time moved back in time
         # - The previous period ended before now
         #
         if (
-            not self._previous_run_before_start
-            and current_period_start_timestamp == previous_period_start_timestamp
+            self._previous_run_before_start
+            and current_period_start_timestamp >= previous_period_start_timestamp
             and (
                 current_period_end_timestamp == previous_period_end_timestamp
                 or (
@@ -110,6 +110,21 @@ class HistoryStats:
                 )
             )
         ):
+            start_changed = (
+                current_period_start_timestamp != previous_period_start_timestamp
+            )
+            if start_changed:
+                # Trim the start of the _history_current_period to the new period start
+                trim_count = 0
+                for i, state in enumerate(self._history_current_period):
+                    if state.last_changed < current_period_start_timestamp:
+                        state.last_changed = current_period_start_timestamp
+                        if i > 0:
+                            trim_count += 1
+                    else:
+                        break
+                self._history_current_period = self._history_current_period[trim_count:]
+
             new_data = False
             if event and (new_state := event.data["new_state"]) is not None:
                 if (
@@ -121,7 +136,11 @@ class HistoryStats:
                         HistoryState(new_state.state, new_state.last_changed_timestamp)
                     )
                     new_data = True
-            if not new_data and current_period_end_timestamp < now_timestamp:
+            if (
+                not new_data
+                and current_period_end_timestamp < now_timestamp
+                and not start_changed
+            ):
                 # If period has not changed and current time after the period end...
                 # Don't compute anything as the value cannot have changed
                 return self._state
@@ -139,7 +158,7 @@ class HistoryStats:
                         HistoryState(new_state.state, new_state.last_changed_timestamp)
                     )
 
-            self._previous_run_before_start = False
+            self._previous_run_before_start = True
 
         seconds_matched, match_count = self._async_compute_seconds_and_changes(
             now_timestamp,

--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -241,10 +241,10 @@ class HistoryStats:
         """
         trim_count = 0
         for i, history_state in enumerate(self._history_current_period):
-            if history_state.last_changed < start_timestamp:
-                history_state.last_changed = start_timestamp
-                if i > 0:
-                    trim_count += 1
-            else:
+            if history_state.last_changed >= start_timestamp:
                 break
-        self._history_current_period = self._history_current_period[trim_count:]
+            history_state.last_changed = start_timestamp
+            if i > 0:
+                trim_count += 1
+        if trim_count: # Don't slice if no data was removed
+            self._history_current_period = self._history_current_period[trim_count:]

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -969,11 +969,14 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
     assert hass.states.get("sensor.sensor4").state == "87.5"
 
 
-async def test_async_start_from_history_and_switch_to_watching_state_changes_sliding_window(
+async def test_start_from_history_then_watch_state_changes_sliding(
     recorder_mock: Recorder,
     hass: HomeAssistant,
 ) -> None:
-    """Test we startup from history and switch to watching state changes, with a sliding window, and history_stats does not requery the recorder."""
+    """Test we startup from history and switch to watching state changes.
+
+    With a sliding window, and history_stats does not requery the recorder.
+    """
     await hass.config.async_set_time_zone("UTC")
     utcnow = dt_util.utcnow()
     start_time = utcnow.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -1633,13 +1633,10 @@ async def test_state_change_during_window_rollover(
 
     assert hass.states.get("sensor.sensor1").state == "11.98"
 
-    # One minute has passed and the time has now rolled over into a new day, resetting the recorder window. The sensor will then query the database for updates,
-    # and will see that the sensor is ON starting from midnight.
+    # One minute has passed and the time has now rolled over into a new day, resetting the recorder window.
+    # The sensor will be ON since midnight.
     t3 = t2 + timedelta(minutes=1)
-
-    with (
-        freeze_time(t3),
-    ):
+    with freeze_time(t3):
         # The sensor turns off around this time, before the sensor does its normal polled update.
         hass.states.async_set("binary_sensor.state", "off")
         await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -975,7 +975,7 @@ async def test_start_from_history_then_watch_state_changes_sliding(
 ) -> None:
     """Test we startup from history and switch to watching state changes.
 
-    With a sliding window, and history_stats does not requery the recorder.
+    With a sliding window, history_stats does not requery the recorder.
     """
     await hass.config.async_set_time_zone("UTC")
     utcnow = dt_util.utcnow()
@@ -1477,10 +1477,6 @@ async def test_measure_from_end_going_backwards(
 
     past_next_update = start_time + timedelta(minutes=30)
     with (
-        patch(
-            "homeassistant.components.recorder.history.state_changes_during_period",
-            _fake_states,
-        ),
         freeze_time(past_next_update),
     ):
         async_fire_time_changed(hass, past_next_update)
@@ -1641,23 +1637,7 @@ async def test_state_change_during_window_rollover(
     # and will see that the sensor is ON starting from midnight.
     t3 = t2 + timedelta(minutes=1)
 
-    def _fake_states_t3(*args, **kwargs):
-        return {
-            "binary_sensor.state": [
-                ha.State(
-                    "binary_sensor.state",
-                    "on",
-                    last_changed=t3.replace(hour=0, minute=0, second=0, microsecond=0),
-                    last_updated=t3.replace(hour=0, minute=0, second=0, microsecond=0),
-                ),
-            ]
-        }
-
     with (
-        patch(
-            "homeassistant.components.recorder.history.state_changes_during_period",
-            _fake_states_t3,
-        ),
         freeze_time(t3),
     ):
         # The sensor turns off around this time, before the sensor does its normal polled update.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When using a history_stats with a sliding interval (e.g. end=now(), duration =30m), every minute the sensor ignores all its previous data and requeries from the recorder. 

I think this is unnecessary and we can optimize to just reuse the data we already have cached, discarding any stale data that has expired. 

This also mitigates some issues with longer commit_intervals as history stats starts to not return correct results when querying from the database with longer commit intervals, as it starts missing past events.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #141886 fixes #140007
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
