### PR TITLE
Replace literals with consts in Govee Light Local tests

### DIFF
--- a/tests/components/govee_light_local/test_light.py
+++ b/tests/components/govee_light_local/test_light.py
@@ -8,14 +8,17 @@ import pytest
 
 from homeassistant.components.govee_light_local.const import DOMAIN
 from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
     ATTR_BRIGHTNESS_PCT,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_RGB_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
+    DOMAIN as LIGHT_DOMAIN,
     ColorMode,
 )
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 
 from .conftest import DEFAULT_CAPABILITIES, SCENE_CAPABILITIES
@@ -205,8 +208,8 @@ async def test_light_on_off(hass: HomeAssistant, mock_govee_api: MagicMock) -> N
     assert light.state == "off"
 
     await hass.services.async_call(
-        "light",
-        "turn_on",
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
         {"entity_id": light.entity_id},
         blocking=True,
     )
@@ -219,8 +222,8 @@ async def test_light_on_off(hass: HomeAssistant, mock_govee_api: MagicMock) -> N
 
     # Turn off
     await hass.services.async_call(
-        "light",
-        "turn_off",
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
         {"entity_id": light.entity_id},
         blocking=True,
     )
@@ -285,8 +288,8 @@ async def test_turn_on_call_order(
     assert light.state == "off"
 
     await hass.services.async_call(
-        "light",
-        "turn_on",
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
         {"entity_id": light.entity_id, ATTR_BRIGHTNESS_PCT: 50, attribute: value},
         blocking=True,
     )
@@ -328,8 +331,8 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: MagicMock) 
     assert light.state == "off"
 
     await hass.services.async_call(
-        "light",
-        "turn_on",
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
         {"entity_id": light.entity_id, "brightness_pct": 50},
         blocking=True,
     )
@@ -339,12 +342,12 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: MagicMock) 
     assert light is not None
     assert light.state == "on"
     mock_govee_api.set_brightness.assert_awaited_with(mock_govee_api.devices[0], 50)
-    assert light.attributes["brightness"] == 127
+    assert light.attributes[ATTR_BRIGHTNESS] == 127
 
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "brightness": 255},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_BRIGHTNESS: 255},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -352,13 +355,13 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: MagicMock) 
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["brightness"] == 255
+    assert light.attributes[ATTR_BRIGHTNESS] == 255
     mock_govee_api.set_brightness.assert_awaited_with(mock_govee_api.devices[0], 100)
 
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "brightness": 255},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_BRIGHTNESS: 255},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -366,7 +369,7 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: MagicMock) 
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["brightness"] == 255
+    assert light.attributes[ATTR_BRIGHTNESS] == 255
     mock_govee_api.set_brightness.assert_awaited_with(mock_govee_api.devices[0], 100)
 
 
@@ -395,9 +398,9 @@ async def test_light_color(hass: HomeAssistant, mock_govee_api: MagicMock) -> No
     assert light.state == "off"
 
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "rgb_color": [100, 255, 50]},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_RGB_COLOR: [100, 255, 50]},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -405,7 +408,7 @@ async def test_light_color(hass: HomeAssistant, mock_govee_api: MagicMock) -> No
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["rgb_color"] == (100, 255, 50)
+    assert light.attributes[ATTR_RGB_COLOR] == (100, 255, 50)
     assert light.attributes["color_mode"] == ColorMode.RGB
 
     mock_govee_api.set_color.assert_awaited_with(
@@ -413,8 +416,8 @@ async def test_light_color(hass: HomeAssistant, mock_govee_api: MagicMock) -> No
     )
 
     await hass.services.async_call(
-        "light",
-        "turn_on",
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
         {"entity_id": light.entity_id, "kelvin": 4400},
         blocking=True,
     )
@@ -457,9 +460,9 @@ async def test_scene_on(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
     assert light.state == "off"
 
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "effect": "sunrise"},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_EFFECT: "sunrise"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -467,7 +470,7 @@ async def test_scene_on(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["effect"] == "sunrise"
+    assert light.attributes[ATTR_EFFECT] == "sunrise"
     mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
 
 
@@ -501,16 +504,16 @@ async def test_scene_restore_rgb(
 
     # Set initial color
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "rgb_color": initial_color},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_RGB_COLOR: initial_color},
         blocking=True,
     )
     await hass.async_block_till_done()
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "brightness": 255},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_BRIGHTNESS: 255},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -518,15 +521,15 @@ async def test_scene_restore_rgb(
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["rgb_color"] == initial_color
-    assert light.attributes["brightness"] == 255
+    assert light.attributes[ATTR_RGB_COLOR] == initial_color
+    assert light.attributes[ATTR_BRIGHTNESS] == 255
     mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
 
     # Activate scene
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "effect": "sunrise"},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_EFFECT: "sunrise"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -534,14 +537,14 @@ async def test_scene_restore_rgb(
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["effect"] == "sunrise"
+    assert light.attributes[ATTR_EFFECT] == "sunrise"
     mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
 
     # Deactivate scene
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "effect": "none"},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_EFFECT: "none"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -549,9 +552,9 @@ async def test_scene_restore_rgb(
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["effect"] is None
-    assert light.attributes["rgb_color"] == initial_color
-    assert light.attributes["brightness"] == 255
+    assert light.attributes[ATTR_EFFECT] is None
+    assert light.attributes[ATTR_RGB_COLOR] == initial_color
+    assert light.attributes[ATTR_BRIGHTNESS] == 255
 
 
 async def test_scene_restore_temperature(
@@ -584,8 +587,8 @@ async def test_scene_restore_temperature(
 
     # Set initial color
     await hass.services.async_call(
-        "light",
-        "turn_on",
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
         {"entity_id": light.entity_id, "color_temp_kelvin": initial_color},
         blocking=True,
     )
@@ -599,9 +602,9 @@ async def test_scene_restore_temperature(
 
     # Activate scene
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "effect": "sunrise"},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_EFFECT: "sunrise"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -609,14 +612,14 @@ async def test_scene_restore_temperature(
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["effect"] == "sunrise"
+    assert light.attributes[ATTR_EFFECT] == "sunrise"
     mock_govee_api.set_scene.assert_awaited_with(mock_govee_api.devices[0], "sunrise")
 
     # Deactivate scene
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "effect": "none"},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_EFFECT: "none"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -624,7 +627,7 @@ async def test_scene_restore_temperature(
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["effect"] is None
+    assert light.attributes[ATTR_EFFECT] is None
     assert light.attributes["color_temp_kelvin"] == initial_color
 
 
@@ -656,16 +659,16 @@ async def test_scene_none(hass: HomeAssistant, mock_govee_api: MagicMock) -> Non
 
     # Set initial color
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "rgb_color": initial_color},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_RGB_COLOR: initial_color},
         blocking=True,
     )
     await hass.async_block_till_done()
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "brightness": 255},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_BRIGHTNESS: 255},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -673,21 +676,20 @@ async def test_scene_none(hass: HomeAssistant, mock_govee_api: MagicMock) -> Non
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["rgb_color"] == initial_color
-    assert light.attributes["brightness"] == 255
+    assert light.attributes[ATTR_RGB_COLOR] == initial_color
+    assert light.attributes[ATTR_BRIGHTNESS] == 255
     mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], True)
 
     # Activate scene
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {"entity_id": light.entity_id, "effect": "none"},
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": light.entity_id, ATTR_EFFECT: "none"},
         blocking=True,
     )
     await hass.async_block_till_done()
-
     light = hass.states.get("light.H615A")
     assert light is not None
     assert light.state == "on"
-    assert light.attributes["effect"] is None
+    assert light.attributes[ATTR_EFFECT] is None
     mock_govee_api.set_scene.assert_not_called()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
