### PR TITLE
Add remove device support to NUT

### DIFF
--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -185,6 +185,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: NutConfigEntry) -> bool
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    device_entry: dr.DeviceEntry,
+) -> bool:
+    """Remove NUT config entry from a device."""
+    return True
+
+
 async def _async_update_listener(hass: HomeAssistant, entry: NutConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -191,7 +191,12 @@ async def async_remove_config_entry_device(
     device_entry: dr.DeviceEntry,
 ) -> bool:
     """Remove NUT config entry from a device."""
-    return True
+    return not any(
+        identifier
+        for identifier in device_entry.identifiers
+        if identifier[0] == DOMAIN
+        and identifier[1] in config_entry.runtime_data.unique_id
+    )
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: NutConfigEntry) -> None:

--- a/tests/components/nut/test_init.py
+++ b/tests/components/nut/test_init.py
@@ -86,12 +86,12 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
         assert not hass.data.get(DOMAIN)
 
 
-async def test_remove_device(
+async def test_remove_device_valid(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test remove device through device registry."""
+    """Test that we cannot remove a device that still exists."""
     assert await async_setup_component(hass, "config", {})
 
     mock_serial_number = "A00000000000"
@@ -116,11 +116,44 @@ async def test_remove_device(
 
     client = await hass_ws_client(hass)
     response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
+
+
+async def test_remove_device_stale(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that we can remove a device that no longer exists."""
+    assert await async_setup_component(hass, "config", {})
+
+    mock_serial_number = "A00000000000"
+    config_entry = await async_init_integration(
+        hass,
+        username="someuser",
+        password="somepassword",
+        list_vars={"ups.serial": mock_serial_number},
+        list_ups={"ups1": "UPS 1"},
+        list_commands_return_value=[],
+    )
+
+    device_registry = dr.async_get(hass)
+    assert device_registry is not None
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "remove-device-id")},
+    )
+
+    assert device_entry is not None
+
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
     assert response["success"]
 
-    # Verify that device entry is removed since this is the only config entry
+    # Verify that device entry is removed
     device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_serial_number)}
+        identifiers={(DOMAIN, "remove-device-id")}
     )
     assert device_entry is None
 

--- a/tests/components/nut/test_init.py
+++ b/tests/components/nut/test_init.py
@@ -18,10 +18,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
 
 from .util import _get_mock_nutclient, async_init_integration
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 async def test_config_entry_migrations(hass: HomeAssistant) -> None:
@@ -82,6 +84,45 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
 
         assert entry.state is ConfigEntryState.NOT_LOADED
         assert not hass.data.get(DOMAIN)
+
+
+async def test_remove_device(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test remove device through device registry."""
+    assert await async_setup_component(hass, "config", {})
+
+    mock_serial_number = "A00000000000"
+    config_entry = await async_init_integration(
+        hass,
+        username="someuser",
+        password="somepassword",
+        list_vars={"ups.serial": mock_serial_number},
+        list_ups={"ups1": "UPS 1"},
+        list_commands_return_value=[],
+    )
+
+    device_registry = dr.async_get(hass)
+    assert device_registry is not None
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_serial_number)}
+    )
+
+    assert device_entry is not None
+    assert device_entry.serial_number == mock_serial_number
+
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert response["success"]
+
+    # Verify that device entry is removed since this is the only config entry
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_serial_number)}
+    )
+    assert device_entry is None
 
 
 async def test_config_not_ready(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for the async_remove_config_entry_device() in NUT.  Add test cases for removing when both the device exists and does not exist.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
