### PR TITLE
Add contextmanager to reset logger after set_level call in tests

### DIFF
--- a/tests/components/bluetooth/test_scanner.py
+++ b/tests/components/bluetooth/test_scanner.py
@@ -29,7 +29,11 @@ from . import (
     patch_bluetooth_time,
 )
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import (
+    MockConfigEntry,
+    async_call_logger_set_level,
+    async_fire_time_changed,
+)
 
 # If the adapter is in a stuck state the following errors are raised:
 NEED_RESET_ERRORS = [
@@ -482,70 +486,67 @@ async def test_adapter_fails_to_start_and_takes_a_bit_to_init(
 ) -> None:
     """Test we can recover the adapter at startup and we wait for Dbus to init."""
     assert await async_setup_component(hass, "logger", {})
-    await hass.services.async_call(
-        "logger",
-        "set_level",
-        {"homeassistant.components.bluetooth": "DEBUG"},
-        blocking=True,
-    )
-    called_start = 0
-    called_stop = 0
-    _callback = None
-    mock_discovered = []
-
-    class MockBleakScanner:
-        async def start(self, *args, **kwargs):
-            """Mock Start."""
-            nonlocal called_start
-            called_start += 1
-            if called_start == 1:
-                raise BleakError("org.freedesktop.DBus.Error.UnknownObject")
-            if called_start == 2:
-                raise BleakError("org.bluez.Error.InProgress")
-            if called_start == 3:
-                raise BleakError("org.bluez.Error.InProgress")
-
-        async def stop(self, *args, **kwargs):
-            """Mock Start."""
-            nonlocal called_stop
-            called_stop += 1
-
-        @property
-        def discovered_devices(self):
-            """Mock discovered_devices."""
-            nonlocal mock_discovered
-            return mock_discovered
-
-        def register_detection_callback(self, callback: AdvertisementDataCallback):
-            """Mock Register Detection Callback."""
-            nonlocal _callback
-            _callback = callback
-
-    scanner = MockBleakScanner()
-    start_time_monotonic = time.monotonic()
-
-    with (
-        patch(
-            "habluetooth.scanner.ADAPTER_INIT_TIME",
-            0,
-        ),
-        patch_bluetooth_time(
-            start_time_monotonic,
-        ),
-        patch(
-            "habluetooth.scanner.OriginalBleakScanner",
-            return_value=scanner,
-        ),
-        patch(
-            "habluetooth.util.recover_adapter", return_value=True
-        ) as mock_recover_adapter,
+    async with async_call_logger_set_level(
+        "homeassistant.components.bluetooth", "DEBUG", hass=hass, caplog=caplog
     ):
-        await async_setup_with_one_adapter(hass)
+        called_start = 0
+        called_stop = 0
+        _callback = None
+        mock_discovered = []
 
-        assert called_start == 4
+        class MockBleakScanner:
+            async def start(self, *args, **kwargs):
+                """Mock Start."""
+                nonlocal called_start
+                called_start += 1
+                if called_start == 1:
+                    raise BleakError("org.freedesktop.DBus.Error.UnknownObject")
+                if called_start == 2:
+                    raise BleakError("org.bluez.Error.InProgress")
+                if called_start == 3:
+                    raise BleakError("org.bluez.Error.InProgress")
 
-    assert len(mock_recover_adapter.mock_calls) == 1
-    assert "Waiting for adapter to initialize" in caplog.text
+            async def stop(self, *args, **kwargs):
+                """Mock Start."""
+                nonlocal called_stop
+                called_stop += 1
+
+            @property
+            def discovered_devices(self):
+                """Mock discovered_devices."""
+                nonlocal mock_discovered
+                return mock_discovered
+
+            def register_detection_callback(self, callback: AdvertisementDataCallback):
+                """Mock Register Detection Callback."""
+                nonlocal _callback
+                _callback = callback
+
+        scanner = MockBleakScanner()
+        start_time_monotonic = time.monotonic()
+
+        with (
+            patch(
+                "habluetooth.scanner.ADAPTER_INIT_TIME",
+                0,
+            ),
+            patch_bluetooth_time(
+                start_time_monotonic,
+            ),
+            patch(
+                "habluetooth.scanner.OriginalBleakScanner",
+                return_value=scanner,
+            ),
+            patch(
+                "habluetooth.util.recover_adapter", return_value=True
+            ) as mock_recover_adapter,
+        ):
+            await async_setup_with_one_adapter(hass)
+
+            assert called_start == 4
+
+        assert len(mock_recover_adapter.mock_calls) == 1
+        assert "Waiting for adapter to initialize" in caplog.text
 
 
 @pytest.mark.usefixtures("one_adapter")

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from tests.common import async_fire_time_changed
+from tests.common import async_call_logger_set_level, async_fire_time_changed
 from tests.typing import MockHAClientWebSocket, WebSocketGenerator
 
 
@@ -533,27 +533,19 @@ async def test_enable_disable_debug_logging(
 ) -> None:
     """Test enabling and disabling debug logging."""
     assert await async_setup_component(hass, "logger", {"logger": {}})
-    await hass.services.async_call(
-        "logger",
-        "set_level",
-        {"homeassistant.components.websocket_api": "DEBUG"},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-    await websocket_client.send_json({"id": 1, "type": "ping"})
-    msg = await websocket_client.receive_json()
-    assert msg["id"] == 1
-    assert msg["type"] == "pong"
-    assert 'Sending b\'{"id":1,"type":"pong"}\'' in caplog.text
-    await hass.services.async_call(
-        "logger",
-        "set_level",
-        {"homeassistant.components.websocket_api": "WARNING"},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-    await websocket_client.send_json({"id": 2, "type": "ping"})
-    msg = await websocket_client.receive_json()
-    assert msg["id"] == 2
-    assert msg["type"] == "pong"
-    assert 'Sending b\'{"id":2,"type":"pong"}\'' not in caplog.text
+    async with async_call_logger_set_level(
+        "homeassistant.components.websocket_api", "DEBUG", hass=hass, caplog=caplog
+    ):
+        await websocket_client.send_json({"id": 1, "type": "ping"})
+        msg = await websocket_client.receive_json()
+        assert msg["id"] == 1
+        assert msg["type"] == "pong"
+        assert 'Sending b\'{"id":1,"type":"pong"}\'' in caplog.text
+    async with async_call_logger_set_level(
+        "homeassistant.components.websocket_api", "WARNING", hass=hass, caplog=caplog
+    ):
+        await websocket_client.send_json({"id": 2, "type": "ping"})
+        msg = await websocket_client.receive_json()
+        assert msg["id"] == 2
+        assert msg["type"] == "pong"
+        assert 'Sending b\'{"id":2,"type":"pong"}\'' not in caplog.text


### PR DESCRIPTION
## Proposed change
The logger integrations sets a custom logger class which prevents resetting the logger after a test case. Add a helper contextmanager to make using it in tests safer and prevent flaky test runs.

This is a followup to #143291.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
