### PR TITLE
Add helper method to clear logger overwrites for tests

### DIFF
--- a/homeassistant/components/logger/__init__.py
+++ b/homeassistant/components/logger/__init__.py
@@ -27,6 +27,7 @@ from .helpers import (
     DATA_LOGGER,
     LoggerDomainConfig,
     LoggerSettings,
+    _clear_logger_overwrites,  # noqa: F401
     set_default_log_level,
     set_log_levels,
 )

--- a/homeassistant/components/logger/__init__.py
+++ b/homeassistant/components/logger/__init__.py
@@ -24,6 +24,7 @@ from .const import (
     SERVICE_SET_LEVEL,
 )
 from .helpers import (
+    DATA_LOGGER,
     LoggerDomainConfig,
     LoggerSettings,
     set_default_log_level,
@@ -54,7 +55,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     settings = LoggerSettings(hass, config)
 
-    domain_config = hass.data[DOMAIN] = LoggerDomainConfig({}, settings)
+    domain_config = hass.data[DATA_LOGGER] = LoggerDomainConfig({}, settings)
     logging.setLoggerClass(_get_logger_class(domain_config.overrides))
 
     websocket_api.async_load_websocket_api(hass)

--- a/homeassistant/components/logger/helpers.py
+++ b/homeassistant/components/logger/helpers.py
@@ -9,13 +9,14 @@ from dataclasses import asdict, dataclass
 from enum import StrEnum
 from functools import lru_cache
 import logging
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.const import EVENT_LOGGING_CHANGED
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import IntegrationNotFound, async_get_integration
+from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     DOMAIN,
@@ -27,6 +28,8 @@ from .const import (
     STORAGE_LOG_KEY,
     STORAGE_VERSION,
 )
+
+DATA_LOGGER: HassKey[LoggerDomainConfig] = HassKey(DOMAIN)
 
 SAVE_DELAY = 15.0
 # At startup, we want to save after a long delay to avoid
@@ -40,12 +43,6 @@ SAVE_DELAY_LONG = 180.0
 
 
 @callback
-def async_get_domain_config(hass: HomeAssistant) -> LoggerDomainConfig:
-    """Return the domain config."""
-    return cast(LoggerDomainConfig, hass.data[DOMAIN])
-
-
-@callback
 def set_default_log_level(hass: HomeAssistant, level: int) -> None:
     """Set the default log level for components."""
     _set_log_level(logging.getLogger(""), level)
@@ -55,7 +52,7 @@ def set_default_log_level(hass: HomeAssistant, level: int) -> None:
 @callback
 def set_log_levels(hass: HomeAssistant, logpoints: Mapping[str, int]) -> None:
     """Set the specified log levels."""
-    async_get_domain_config(hass).overrides.update(logpoints)
+    hass.data[DATA_LOGGER].overrides.update(logpoints)
     for key, value in logpoints.items():
         _set_log_level(logging.getLogger(key), value)
     hass.bus.async_fire(EVENT_LOGGING_CHANGED)

--- a/homeassistant/components/logger/helpers.py
+++ b/homeassistant/components/logger/helpers.py
@@ -75,6 +75,12 @@ def _chattiest_log_level(level1: int, level2: int) -> int:
     return min(level1, level2)
 
 
+@callback
+def _clear_logger_overwrites(hass: HomeAssistant) -> None:
+    """Clear logger overwrites. Used for testing."""
+    hass.data[DATA_LOGGER].overrides.clear()
+
+
 async def get_integration_loggers(hass: HomeAssistant, domain: str) -> set[str]:
     """Get loggers for an integration."""
     loggers: set[str] = {f"homeassistant.components.{domain}"}

--- a/homeassistant/components/logger/websocket_api.py
+++ b/homeassistant/components/logger/websocket_api.py
@@ -12,10 +12,10 @@ from homeassistant.setup import async_get_loaded_integrations
 
 from .const import LOGSEVERITY
 from .helpers import (
+    DATA_LOGGER,
     LoggerSetting,
     LogPersistance,
     LogSettingsType,
-    async_get_domain_config,
     get_logger,
 )
 
@@ -68,7 +68,7 @@ async def handle_integration_log_level(
             msg["id"], websocket_api.ERR_NOT_FOUND, "Integration not found"
         )
         return
-    await async_get_domain_config(hass).settings.async_update(
+    await hass.data[DATA_LOGGER].settings.async_update(
         hass,
         msg["integration"],
         LoggerSetting(
@@ -93,7 +93,7 @@ async def handle_module_log_level(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Handle setting integration log level."""
-    await async_get_domain_config(hass).settings.async_update(
+    await hass.data[DATA_LOGGER].settings.async_update(
         hass,
         msg["module"],
         LoggerSetting(

--- a/tests/common.py
+++ b/tests/common.py
@@ -46,7 +46,11 @@ from homeassistant.components import device_automation, persistent_notification 
 from homeassistant.components.device_automation import (  # noqa: F401
     _async_get_device_automation_capabilities as async_get_device_automation_capabilities,
 )
-from homeassistant.components.logger import DOMAIN as LOGGER_DOMAIN, SERVICE_SET_LEVEL
+from homeassistant.components.logger import (
+    DOMAIN as LOGGER_DOMAIN,
+    SERVICE_SET_LEVEL,
+    _clear_logger_overwrites,
+)
 from homeassistant.config import IntegrationConfigInfo, async_process_component_config
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
@@ -1708,7 +1712,7 @@ async def async_call_logger_set_level(
         )
         await hass.async_block_till_done()
         yield
-        hass.data[LOGGER_DOMAIN].overrides.clear()
+        _clear_logger_overwrites(hass)
 
 
 def import_and_test_deprecated_constant_enum(

--- a/tests/components/logger/test_websocket_api.py
+++ b/tests/components/logger/test_websocket_api.py
@@ -4,7 +4,7 @@ import logging
 from unittest.mock import patch
 
 from homeassistant import loader
-from homeassistant.components.logger.helpers import async_get_domain_config
+from homeassistant.components.logger.helpers import DATA_LOGGER
 from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -76,7 +76,7 @@ async def test_integration_log_level(
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
-    assert async_get_domain_config(hass).overrides == {
+    assert hass.data[DATA_LOGGER].overrides == {
         "homeassistant.components.websocket_api": logging.DEBUG
     }
 
@@ -126,7 +126,7 @@ async def test_custom_integration_log_level(
         assert msg["type"] == TYPE_RESULT
         assert msg["success"]
 
-        assert async_get_domain_config(hass).overrides == {
+        assert hass.data[DATA_LOGGER].overrides == {
             "homeassistant.components.hue": logging.DEBUG,
             "custom_components.hue": logging.DEBUG,
             "some_other_logger": logging.DEBUG,
@@ -182,7 +182,7 @@ async def test_module_log_level(
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
-    assert async_get_domain_config(hass).overrides == {
+    assert hass.data[DATA_LOGGER].overrides == {
         "homeassistant.components.websocket_api": logging.DEBUG,
         "homeassistant.components.other_component": logging.WARNING,
     }
@@ -199,7 +199,7 @@ async def test_module_log_level_override(
         {"logger": {"logs": {"homeassistant.components.websocket_api": "warning"}}},
     )
 
-    assert async_get_domain_config(hass).overrides == {
+    assert hass.data[DATA_LOGGER].overrides == {
         "homeassistant.components.websocket_api": logging.WARNING
     }
 
@@ -218,7 +218,7 @@ async def test_module_log_level_override(
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
-    assert async_get_domain_config(hass).overrides == {
+    assert hass.data[DATA_LOGGER].overrides == {
         "homeassistant.components.websocket_api": logging.ERROR
     }
 
@@ -237,7 +237,7 @@ async def test_module_log_level_override(
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
-    assert async_get_domain_config(hass).overrides == {
+    assert hass.data[DATA_LOGGER].overrides == {
         "homeassistant.components.websocket_api": logging.DEBUG
     }
 
@@ -256,6 +256,6 @@ async def test_module_log_level_override(
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
-    assert async_get_domain_config(hass).overrides == {
+    assert hass.data[DATA_LOGGER].overrides == {
         "homeassistant.components.websocket_api": logging.NOTSET
     }


### PR DESCRIPTION
## Proposed change
Followup to https://github.com/home-assistant/core/pull/143295#discussion_r2051603165

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
