### PR TITLE
Add translated UoM for non-standard sensor measures in NUT

### DIFF
--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -108,6 +108,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "battery.capacity": SensorEntityDescription(
         key="battery.capacity",
         translation_key="battery_capacity",
+        native_unit_of_measurement="Ah",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -108,7 +108,6 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "battery.capacity": SensorEntityDescription(
         key="battery.capacity",
         translation_key="battery_capacity",
-        native_unit_of_measurement="Ah",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -132,7 +132,10 @@
         }
       },
       "battery_alarm_threshold": { "name": "Battery alarm threshold" },
-      "battery_capacity": { "name": "Battery capacity" },
+      "battery_capacity": {
+        "name": "Battery capacity",
+        "unit_of_measurement": "Ah"
+      },
       "battery_charge": { "name": "Battery charge" },
       "battery_charge_low": { "name": "Low battery setpoint" },
       "battery_charge_restart": { "name": "Minimum battery to start" },
@@ -153,8 +156,14 @@
       "battery_current_total": { "name": "Total battery current" },
       "battery_date": { "name": "Battery date" },
       "battery_mfr_date": { "name": "Battery manuf. date" },
-      "battery_packs": { "name": "Number of batteries" },
-      "battery_packs_bad": { "name": "Number of bad batteries" },
+      "battery_packs": {
+        "name": "Number of batteries",
+        "unit_of_measurement": "packs"
+      },
+      "battery_packs_bad": {
+        "name": "Number of bad batteries",
+        "unit_of_measurement": "packs"
+      },
       "battery_runtime": { "name": "Battery runtime" },
       "battery_runtime_low": { "name": "Low battery runtime" },
       "battery_runtime_restart": { "name": "Minimum battery runtime to start" },
@@ -175,7 +184,10 @@
       "input_bypass_l3_current": { "name": "Input bypass L3 current" },
       "input_bypass_l3_n_voltage": { "name": "Input bypass L3-N voltage" },
       "input_bypass_l3_realpower": { "name": "Input bypass L3 real power" },
-      "input_bypass_phases": { "name": "Input bypass phases" },
+      "input_bypass_phases": {
+        "name": "Input bypass phases",
+        "unit_of_measurement": "phase"
+      },
       "input_bypass_realpower": { "name": "Input bypass real power" },
       "input_bypass_voltage": { "name": "Input bypass voltage" },
       "input_current": { "name": "Input current" },
@@ -211,7 +223,10 @@
       "input_l3_n_voltage": { "name": "Input L3 voltage" },
       "input_l3_realpower": { "name": "Input L3 real power" },
       "input_load": { "name": "Input load" },
-      "input_phases": { "name": "Input phases" },
+      "input_phases": {
+        "name": "Input phases",
+        "unit_of_measurement": "phase"
+      },
       "input_power": { "name": "Input power" },
       "input_realpower": { "name": "Input real power" },
       "input_sensitivity": { "name": "Input power sensitivity" },
@@ -245,7 +260,10 @@
       "output_l3_n_voltage": { "name": "Output L3-N voltage" },
       "output_l3_power_percent": { "name": "Output L3 power usage" },
       "output_l3_realpower": { "name": "Output L3 real power" },
-      "output_phases": { "name": "Output phases" },
+      "output_phases": {
+        "name": "Output phases",
+        "unit_of_measurement": "phase"
+      },
       "output_power": { "name": "Output apparent power" },
       "output_power_nominal": { "name": "Nominal output power" },
       "output_realpower": { "name": "Output real power" },

--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -132,10 +132,7 @@
         }
       },
       "battery_alarm_threshold": { "name": "Battery alarm threshold" },
-      "battery_capacity": {
-        "name": "Battery capacity",
-        "unit_of_measurement": "Ah"
-      },
+      "battery_capacity": { "name": "Battery capacity" },
       "battery_charge": { "name": "Battery charge" },
       "battery_charge_low": { "name": "Low battery setpoint" },
       "battery_charge_restart": { "name": "Minimum battery to start" },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Several NUT sensors return consistent units of measure across manufacturers but that do not map to standard device classes or units in Home Assistant.  Add translated units-of-measurement to `strings.json` for these sensors for easier readability.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
