### PR TITLE
Sfirat Omer for "now" ("date" becomes optional)

### DIFF
--- a/homeassistant/components/jewish_calendar/service.py
+++ b/homeassistant/components/jewish_calendar/service.py
@@ -8,7 +8,7 @@ from hdate.omer import Nusach, Omer
 from hdate.translator import Language
 import voluptuous as vol
 
-from homeassistant.const import CONF_LANGUAGE
+from homeassistant.const import CONF_LANGUAGE, SUN_EVENT_SUNSET
 from homeassistant.core import (
     HomeAssistant,
     ServiceCall,
@@ -17,13 +17,15 @@ from homeassistant.core import (
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import LanguageSelector, LanguageSelectorConfig
+from homeassistant.helpers.sun import get_astral_event_date
+from homeassistant.util import dt as dt_util
 
 from .const import ATTR_DATE, ATTR_NUSACH, DOMAIN, SERVICE_COUNT_OMER
 
 SUPPORTED_LANGUAGES = {"en": "english", "fr": "french", "he": "hebrew"}
 OMER_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_DATE, default=datetime.date.today): cv.date,
+        vol.Optional(ATTR_DATE): cv.date,
         vol.Required(ATTR_NUSACH, default="sfarad"): vol.In(
             [nusach.name.lower() for nusach in Nusach]
         ),
@@ -39,7 +41,18 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
     async def get_omer_count(call: ServiceCall) -> ServiceResponse:
         """Return the Omer blessing for a given date."""
-        hebrew_date = HebrewDate.from_gdate(call.data["date"])
+        if "date" in call.data:
+            hebrew_date = HebrewDate.from_gdate(call.data["date"])
+        else:
+            now = dt_util.now()
+            today = now.date()
+            if (
+                sunset := get_astral_event_date(hass, SUN_EVENT_SUNSET, today)
+            ) is not None and now > dt_util.as_local(sunset):
+                hebrew_date = HebrewDate.from_gdate(today + datetime.timedelta(days=1))
+            else:
+                hebrew_date = HebrewDate.from_gdate(today)
+
         nusach = Nusach[call.data["nusach"].upper()]
 
         # Currently Omer only supports Hebrew, English, and French and requires

--- a/homeassistant/components/jewish_calendar/services.yaml
+++ b/homeassistant/components/jewish_calendar/services.yaml
@@ -1,7 +1,6 @@
 count_omer:
   fields:
     date:
-      required: true
       example: "2025-04-14"
       selector:
         date:

--- a/tests/components/jewish_calendar/test_service.py
+++ b/tests/components/jewish_calendar/test_service.py
@@ -1,7 +1,10 @@
 """Test jewish calendar service."""
 
 import datetime as dt
+from datetime import UTC
+from unittest import mock
 
+from freezegun.api import FrozenDateTimeFactory
 from hdate.translator import Language
 import pytest
 
@@ -48,6 +51,52 @@ async def test_get_omer_blessing(
         DOMAIN,
         "count_omer",
         {"date": test_date, "nusach": nusach, "language": language},
+        blocking=True,
+        return_response=True,
+    )
+
+    assert result["message"] == expected
+
+
+@pytest.mark.parametrize(
+    ("test_time", "sunset", "expected"),
+    [
+        pytest.param(
+            dt.datetime(2025, 4, 20, 19, 10, tzinfo=UTC),
+            dt.datetime(2025, 4, 20, 19, 15, tzinfo=UTC),
+            "היום שבעה ימים שהם שבוע אחד לעומר",
+            id="before-sunset",
+        ),
+        pytest.param(
+            dt.datetime(2025, 4, 20, 19, 20, tzinfo=UTC),
+            dt.datetime(2025, 4, 20, 19, 15, tzinfo=UTC),
+            "היום שמונה ימים שהם שבוע אחד ויום אחד לעומר",
+            id="after-sunset",
+        ),
+    ],
+)
+@mock.patch("homeassistant.components.jewish_calendar.service.get_astral_event_date")
+async def test_get_current_omer_blessing(
+    mock_get_astral_event_date: mock.MagicMock,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    test_time: dt.datetime,
+    sunset: dt.datetime,
+    expected: str,
+) -> None:
+    """Test get omer blessing of current time."""
+    hass.config.time_zone = "UTC"
+    freezer.move_to(test_time)
+    mock_get_astral_event_date.return_value = sunset
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        "count_omer",
+        {"nusach": "sfarad", "language": "he"},
         blocking=True,
         return_response=True,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A common use-case for Sfirat HaOmer is to do it "now". This is not straightforward today since the Hebrew date changes after sunset, while the regular date is not. This change makes the date optional, and adds the Hebrew date logic in the server side.
There is no change if the date parameter is provided explicitly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
