### PR TITLE
Add support for identify buttons to WMS WebControl pro

### DIFF
--- a/homeassistant/components/wmspro/__init__.py
+++ b/homeassistant/components/wmspro/__init__.py
@@ -15,7 +15,12 @@ from homeassistant.helpers.typing import UNDEFINED
 
 from .const import DOMAIN, MANUFACTURER
 
-PLATFORMS: list[Platform] = [Platform.COVER, Platform.LIGHT, Platform.SCENE]
+PLATFORMS: list[Platform] = [
+    Platform.BUTTON,
+    Platform.COVER,
+    Platform.LIGHT,
+    Platform.SCENE,
+]
 
 type WebControlProConfigEntry = ConfigEntry[WebControlPro]
 

--- a/homeassistant/components/wmspro/button.py
+++ b/homeassistant/components/wmspro/button.py
@@ -1,0 +1,39 @@
+"""Identify support for WMS WebControl pro."""
+
+from __future__ import annotations
+
+from wmspro.const import WMS_WebControl_pro_API_actionDescription
+
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import WebControlProConfigEntry
+from .entity import WebControlProGenericEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: WebControlProConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the WMS based identify buttons from a config entry."""
+    hub = config_entry.runtime_data
+
+    entities: list[WebControlProGenericEntity] = []
+    for dest in hub.dests.values():
+        if dest.action(WMS_WebControl_pro_API_actionDescription.Identify):
+            entities.append(WebControlProIdentifyButton(config_entry.entry_id, dest))  # noqa: PERF401
+
+    async_add_entities(entities)
+
+
+class WebControlProIdentifyButton(WebControlProGenericEntity, ButtonEntity):
+    """Representation of a WMS based identify button."""
+
+    _attr_device_class = ButtonDeviceClass.IDENTIFY
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        action = self._dest.action(WMS_WebControl_pro_API_actionDescription.Identify)
+        await action()

--- a/homeassistant/components/wmspro/button.py
+++ b/homeassistant/components/wmspro/button.py
@@ -20,10 +20,11 @@ async def async_setup_entry(
     """Set up the WMS based identify buttons from a config entry."""
     hub = config_entry.runtime_data
 
-    entities: list[WebControlProGenericEntity] = []
-    for dest in hub.dests.values():
-        if dest.action(WMS_WebControl_pro_API_actionDescription.Identify):
-            entities.append(WebControlProIdentifyButton(config_entry.entry_id, dest))  # noqa: PERF401
+    entities: list[WebControlProGenericEntity] = [
+        WebControlProIdentifyButton(config_entry.entry_id, dest)
+        for dest in hub.dests.values()
+        if dest.action(WMS_WebControl_pro_API_actionDescription.Identify)
+    ]
 
     async_add_entities(entities)
 

--- a/homeassistant/components/wmspro/cover.py
+++ b/homeassistant/components/wmspro/cover.py
@@ -45,6 +45,7 @@ class WebControlProCover(WebControlProGenericEntity, CoverEntity):
     """Base representation of a WMS based cover."""
 
     _drive_action_desc: WMS_WebControl_pro_API_actionDescription
+    _attr_name = None
 
     @property
     def current_cover_position(self) -> int | None:

--- a/homeassistant/components/wmspro/entity.py
+++ b/homeassistant/components/wmspro/entity.py
@@ -15,7 +15,6 @@ class WebControlProGenericEntity(Entity):
 
     _attr_attribution = ATTRIBUTION
     _attr_has_entity_name = True
-    _attr_name = None
 
     def __init__(self, config_entry_id: str, dest: Destination) -> None:
         """Initialize the entity with destination channel."""

--- a/homeassistant/components/wmspro/light.py
+++ b/homeassistant/components/wmspro/light.py
@@ -42,6 +42,7 @@ class WebControlProLight(WebControlProGenericEntity, LightEntity):
     """Representation of a WMS based light."""
 
     _attr_color_mode = ColorMode.ONOFF
+    _attr_name = None
     _attr_supported_color_modes = {ColorMode.ONOFF}
 
     @property

--- a/tests/components/wmspro/snapshots/test_button.ambr
+++ b/tests/components/wmspro/snapshots/test_button.ambr
@@ -1,0 +1,16 @@
+# serializer version: 1
+# name: test_button_update
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by WMS WebControl pro API',
+      'device_class': 'identify',
+      'friendly_name': 'Markise Identify',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.markise_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/wmspro/test_button.py
+++ b/tests/components/wmspro/test_button.py
@@ -17,7 +17,7 @@ async def test_button_update(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_hub_ping: AsyncMock,
-    mock_hub_configuration_prod: AsyncMock,
+    mock_hub_configuration_prod_awning_dimmer: AsyncMock,
     mock_hub_status_prod_awning: AsyncMock,
     mock_action_call: AsyncMock,
     snapshot: SnapshotAssertion,
@@ -25,7 +25,7 @@ async def test_button_update(
     """Test that a button entity is created and updated correctly."""
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
-    assert len(mock_hub_configuration_prod.mock_calls) == 1
+    assert len(mock_hub_configuration_prod_awning_dimmer.mock_calls) == 1
     assert len(mock_hub_status_prod_awning.mock_calls) == 2
 
     entity = hass.states.get("button.markise_identify")

--- a/tests/components/wmspro/test_button.py
+++ b/tests/components/wmspro/test_button.py
@@ -4,8 +4,8 @@ from unittest.mock import AsyncMock, patch
 
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.button import SERVICE_PRESS
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 from . import setup_config_entry
@@ -32,15 +32,29 @@ async def test_button_update(
     assert entity is not None
     assert entity == snapshot
 
+
+async def test_button_press(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hub_ping: AsyncMock,
+    mock_hub_configuration_prod_awning_dimmer: AsyncMock,
+    mock_hub_status_prod_awning: AsyncMock,
+    mock_action_call: AsyncMock,
+) -> None:
+    """Test that a button entity is pressed correctly."""
+
+    assert await setup_config_entry(hass, mock_config_entry)
+
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
         before = len(mock_hub_status_prod_awning.mock_calls)
+        entity = hass.states.get("button.markise_identify")
         before_state = entity.state
 
         await hass.services.async_call(
-            Platform.BUTTON,
+            BUTTON_DOMAIN,
             SERVICE_PRESS,
             {ATTR_ENTITY_ID: entity.entity_id},
             blocking=True,

--- a/tests/components/wmspro/test_button.py
+++ b/tests/components/wmspro/test_button.py
@@ -1,0 +1,52 @@
+"""Test the wmspro button support."""
+
+from unittest.mock import AsyncMock, patch
+
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.button import SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+
+from . import setup_config_entry
+
+from tests.common import MockConfigEntry
+
+
+async def test_button_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hub_ping: AsyncMock,
+    mock_hub_configuration_prod: AsyncMock,
+    mock_hub_status_prod_awning: AsyncMock,
+    mock_action_call: AsyncMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that a button entity is created and updated correctly."""
+    assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_configuration_prod.mock_calls) == 1
+    assert len(mock_hub_status_prod_awning.mock_calls) == 2
+
+    entity = hass.states.get("button.markise_identify")
+    assert entity is not None
+    assert entity == snapshot
+
+    with patch(
+        "wmspro.destination.Destination.refresh",
+        return_value=True,
+    ):
+        before = len(mock_hub_status_prod_awning.mock_calls)
+        before_state = entity.state
+
+        await hass.services.async_call(
+            Platform.BUTTON,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity.entity_id},
+            blocking=True,
+        )
+
+        entity = hass.states.get("button.markise_identify")
+        assert entity is not None
+        assert entity.state != before_state
+        assert len(mock_hub_status_prod_awning.mock_calls) == before


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support for identification buttons to all devices that support them provided by WMS WebControl pro.

Example screenshots:

<img width="328" alt="image" src="https://github.com/user-attachments/assets/216eff8c-c46a-4f34-8917-0a1bd0f4a77f" />
<img width="328" alt="image" src="https://github.com/user-attachments/assets/b8f8c792-d23a-4bb5-914f-9bba11c12111" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38857
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
