### PR TITLE
Correct handling of entities with empty name for ESPHome devices

### DIFF
--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -224,7 +224,16 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self._attr_device_info = DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, device_info.mac_address)}
         )
-        self.entity_id = f"{domain}.{device_info.name}_{entity_info.object_id}"
+        if entity_info.name:
+            self.entity_id = f"{domain}.{device_info.name}_{entity_info.object_id}"
+        else:
+            # https://github.com/home-assistant/core/issues/132532
+            # If name is not set, ESPHome will use the sanitized friendly name
+            # as the name, however we want to use the original object_id
+            # as the entity_id before it is sanitized since the sanitizer
+            # is not utf-8 aware. In this case, its always going to be
+            # an empty string so we drop the object_id.
+            self.entity_id = f"{domain}.{device_info.name}"
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -260,7 +269,12 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self._static_info = static_info
         self._attr_unique_id = build_unique_id(device_info.mac_address, static_info)
         self._attr_entity_registry_enabled_default = not static_info.disabled_by_default
-        self._attr_name = static_info.name
+        # https://github.com/home-assistant/core/issues/132532
+        # If the name is "", we need to set it to None since otherwise
+        # the friendly_name will be "{friendly_name} " with a trailing
+        # space. ESPHome uses protobuf under the hood, and an empty field
+        # gets a default value of "".
+        self._attr_name = static_info.name if static_info.name else None
         if entity_category := static_info.entity_category:
             self._attr_entity_category = ENTITY_CATEGORIES.from_esphome(entity_category)
         else:

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -17,6 +17,7 @@ from aioesphomeapi import (
 )
 
 from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
     ATTR_RESTORED,
     EVENT_HOMEASSISTANT_STOP,
     STATE_OFF,
@@ -503,3 +504,40 @@ async def test_esphome_device_without_friendly_name(
     state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
+
+
+async def test_entity_without_name_device_with_friendly_name(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    hass_storage: dict[str, Any],
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+) -> None:
+    """Test name and entity_id for a device a friendly name and an entity without a name."""
+    entity_info = [
+        BinarySensorInfo(
+            object_id="mybinary_sensor",
+            key=1,
+            name="",
+            unique_id="my_binary_sensor",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+    ]
+    user_service = []
+    await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+        device_info={"friendly_name": "The Best Mixer", "name": "mixer"},
+    )
+    state = hass.states.get("binary_sensor.mixer")
+    assert state is not None
+    assert state.state == STATE_ON
+    # Make sure we have set the name to `None` as otherwise
+    # the friendly_name will be "The Best Mixer "
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "The Best Mixer"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the name was set to `""`, the integration should treat this as if the name was `None`. Since protobuf treats empty fields and defaults as `""` we need to handle this as `None` internally as otherwise it leads to friendly names like `Friendly Name `  with a trailing space and unexpected entity_id formats.

On a side note, it seems things break rather spectacularly if you have two entities in the same domain both named `""` because we end up with a unique id conflict.  We should prevent that in config validation on the ESPHome side as there should only be one entity in each domain named `""`. This is tracked as https://github.com/esphome/issues/issues/6953

fixes #132532


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
