### PR TITLE
Add icon translations and missing text translations for select in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/icons.json
+++ b/homeassistant/components/overkiz/icons.json
@@ -8,7 +8,6 @@
               "auto": "mdi:thermostat-auto",
               "comfort-1": "mdi:thermometer",
               "comfort-2": "mdi:thermometer-low",
-              "drying": "mdi:hair-dryer",
               "frost_protection": "mdi:snowflake",
               "prog": "mdi:clock-outline",
               "external": "mdi:remote"

--- a/homeassistant/components/overkiz/icons.json
+++ b/homeassistant/components/overkiz/icons.json
@@ -8,11 +8,21 @@
               "auto": "mdi:thermostat-auto",
               "comfort-1": "mdi:thermometer",
               "comfort-2": "mdi:thermometer-low",
+              "drying": "mdi:hair-dryer",
               "frost_protection": "mdi:snowflake",
               "prog": "mdi:clock-outline",
               "external": "mdi:remote"
             }
           }
+        }
+      }
+    },
+    "select": {
+      "operating_mode": {
+        "default": "mdi:sun-snowflake",
+        "state": {
+          "heating": "mdi:heat-wave",
+          "cooling": "mdi:snowflake"
         }
       }
     }

--- a/homeassistant/components/overkiz/icons.json
+++ b/homeassistant/components/overkiz/icons.json
@@ -18,12 +18,28 @@
       }
     },
     "select": {
+      "open_closed_pedestrian": {
+        "default": "mdi:content-save-cog"
+      },
+      "open_closed_partial": {
+        "default": "mdi:content-save-cog"
+      },
+      "memorized_simple_volume": {
+        "default": "mdi:volume-medium",
+        "state": {
+          "highest": "mdi:volume-high",
+          "standard": "mdi:volume-medium"
+        }
+      },
       "operating_mode": {
         "default": "mdi:sun-snowflake",
         "state": {
           "heating": "mdi:heat-wave",
           "cooling": "mdi:snowflake"
         }
+      },
+      "active_zones": {
+        "default": "mdi:shield-lock"
       }
     }
   }

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -72,7 +72,6 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
     OverkizSelectDescription(
         key=OverkizState.CORE_OPEN_CLOSED_PEDESTRIAN,
         name="Position",
-        icon="mdi:content-save-cog",
         options=[
             OverkizCommandParam.OPEN,
             OverkizCommandParam.PEDESTRIAN,
@@ -84,7 +83,6 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
     OverkizSelectDescription(
         key=OverkizState.CORE_OPEN_CLOSED_PARTIAL,
         name="Position",
-        icon="mdi:content-save-cog",
         options=[
             OverkizCommandParam.OPEN,
             OverkizCommandParam.PARTIAL,
@@ -96,7 +94,6 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
     OverkizSelectDescription(
         key=OverkizState.IO_MEMORIZED_SIMPLE_VOLUME,
         name="Memorized simple volume",
-        icon="mdi:volume-high",
         options=[OverkizCommandParam.STANDARD, OverkizCommandParam.HIGHEST],
         select_option=_select_option_memorized_simple_volume,
         entity_category=EntityCategory.CONFIG,
@@ -106,7 +103,6 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
     OverkizSelectDescription(
         key=OverkizState.OVP_HEATING_TEMPERATURE_INTERFACE_OPERATING_MODE,
         name="Operating mode",
-        icon="mdi:sun-snowflake",
         options=[OverkizCommandParam.HEATING, OverkizCommandParam.COOLING],
         select_option=lambda option, execute_command: execute_command(
             OverkizCommand.SET_OPERATING_MODE, option
@@ -118,9 +114,9 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
     OverkizSelectDescription(
         key=OverkizState.CORE_ACTIVE_ZONES,
         name="Active zones",
-        icon="mdi:shield-lock",
         options=["", "A", "B", "C", "A,B", "B,C", "A,C", "A,B,C"],
         select_option=_select_option_active_zone,
+        translation_key="active_zones",
     ),
 ]
 

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -112,6 +112,7 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
             OverkizCommand.SET_OPERATING_MODE, option
         ),
         entity_category=EntityCategory.CONFIG,
+        translation_key="operating_mode",
     ),
     # StatefulAlarmController
     OverkizSelectDescription(

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -112,6 +112,12 @@
           "highest": "Highest",
           "standard": "Standard"
         }
+      },
+      "operating_mode": {
+        "state": {
+          "heating": "Heating",
+          "cooling": "Cooling"
+        }
       }
     },
     "sensor": {

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -115,8 +115,8 @@
       },
       "operating_mode": {
         "state": {
-          "heating": "Heating",
-          "cooling": "Cooling"
+          "heating": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::heating%]",
+          "cooling": "[%key:component::climate::entity_component::_::state_attributes::hvac_action::state::cooling%]"
         }
       }
     },


### PR DESCRIPTION
## Proposed change
To improve the code quality, supporting text translations for all select entities and moving icon translations to icons.json.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
