### PR TITLE
Migrate climate attributes to own entities in AVM Fritz!SmartHome

### DIFF
--- a/homeassistant/components/fritzbox/binary_sensor.py
+++ b/homeassistant/components/fritzbox/binary_sensor.py
@@ -62,7 +62,6 @@ BINARY_SENSOR_TYPES: Final[tuple[FritzBinarySensorEntityDescription, ...]] = (
     ),
     FritzBinarySensorEntityDescription(
         key="battery_low",
-        translation_key="battery_low",
         device_class=BinarySensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
         suitable=lambda device: device.battery_low is not None,

--- a/homeassistant/components/fritzbox/binary_sensor.py
+++ b/homeassistant/components/fritzbox/binary_sensor.py
@@ -60,6 +60,33 @@ BINARY_SENSOR_TYPES: Final[tuple[FritzBinarySensorEntityDescription, ...]] = (
         suitable=lambda device: device.device_lock is not None,
         is_on=lambda device: not device.device_lock,
     ),
+    FritzBinarySensorEntityDescription(
+        key="battery_low",
+        translation_key="battery_low",
+        device_class=BinarySensorDeviceClass.BATTERY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suitable=lambda device: device.battery_low is not None,
+        is_on=lambda device: device.battery_low,
+        entity_registry_enabled_default=False,
+    ),
+    FritzBinarySensorEntityDescription(
+        key="holiday_active",
+        translation_key="holiday_active",
+        suitable=lambda device: device.holiday_active is not None,
+        is_on=lambda device: device.holiday_active,
+    ),
+    FritzBinarySensorEntityDescription(
+        key="summer_active",
+        translation_key="summer_active",
+        suitable=lambda device: device.summer_active is not None,
+        is_on=lambda device: device.summer_active,
+    ),
+    FritzBinarySensorEntityDescription(
+        key="window_open",
+        translation_key="window_open",
+        suitable=lambda device: device.window_open is not None,
+        is_on=lambda device: device.window_open,
+    ),
 )
 
 

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -220,6 +220,7 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
     @property
     def extra_state_attributes(self) -> ClimateExtraAttributes:
         """Return the device specific state attributes."""
+        # deprecated with #143394, can be removed in 2025.11
         attrs: ClimateExtraAttributes = {
             ATTR_STATE_BATTERY_LOW: self.data.battery_low,
         }

--- a/homeassistant/components/fritzbox/icons.json
+++ b/homeassistant/components/fritzbox/icons.json
@@ -1,5 +1,28 @@
 {
   "entity": {
+    "binary_sensor": {
+      "holiday_active": {
+        "default": "mdi:bag-suitcase-outline",
+        "state": {
+          "on": "mdi:bag-suitcase-outline",
+          "off": "mdi:bag-suitcase-off-outline"
+        }
+      },
+      "summer_active": {
+        "default": "mdi:radiator-off",
+        "state": {
+          "on": "mdi:radiator-off",
+          "off": "mdi:radiator"
+        }
+      },
+      "window_open": {
+        "default": "mdi:window-open",
+        "state": {
+          "on": "mdi:window-open",
+          "off": "mdi:window-closed"
+        }
+      }
+    },
     "climate": {
       "thermostat": {
         "state_attributes": {

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -54,7 +54,6 @@
   "entity": {
     "binary_sensor": {
       "alarm": { "name": "Alarm" },
-      "battery_low": { "name": "Battery low" },
       "device_lock": { "name": "Button lock via UI" },
       "holiday_active": { "name": "Holiday mode" },
       "lock": { "name": "Button lock on device" },

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -54,8 +54,12 @@
   "entity": {
     "binary_sensor": {
       "alarm": { "name": "Alarm" },
+      "battery_low": { "name": "Battery low" },
       "device_lock": { "name": "Button lock via UI" },
-      "lock": { "name": "Button lock on device" }
+      "holiday_active": { "name": "Holiday mode" },
+      "lock": { "name": "Button lock on device" },
+      "summer_active": { "name": "Summer mode" },
+      "window_open": { "name": "Open window detected" }
     },
     "climate": {
       "thermostat": {

--- a/tests/components/fritzbox/snapshots/test_binary_sensor.ambr
+++ b/tests/components/fritzbox/snapshots/test_binary_sensor.ambr
@@ -72,7 +72,7 @@
     }),
     'original_device_class': <BinarySensorDeviceClass.BATTERY: 'battery'>,
     'original_icon': None,
-    'original_name': 'Battery low',
+    'original_name': 'Battery',
     'platform': 'fritzbox',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -85,7 +85,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
-      'friendly_name': 'fake_name Battery low',
+      'friendly_name': 'fake_name Battery',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.fake_name_battery_low',

--- a/tests/components/fritzbox/snapshots/test_binary_sensor.ambr
+++ b/tests/components/fritzbox/snapshots/test_binary_sensor.ambr
@@ -47,7 +47,7 @@
     'state': 'on',
   })
 # ---
-# name: test_setup[binary_sensor.fake_name_battery_low-entry]
+# name: test_setup[binary_sensor.fake_name_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -60,7 +60,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.fake_name_battery_low',
+    'entity_id': 'binary_sensor.fake_name_battery',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -76,19 +76,19 @@
     'platform': 'fritzbox',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'battery_low',
+    'translation_key': None,
     'unique_id': '12345 1234567_battery_low',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[binary_sensor.fake_name_battery_low-state]
+# name: test_setup[binary_sensor.fake_name_battery-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
       'friendly_name': 'fake_name Battery',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.fake_name_battery_low',
+    'entity_id': 'binary_sensor.fake_name_battery',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/fritzbox/snapshots/test_binary_sensor.ambr
+++ b/tests/components/fritzbox/snapshots/test_binary_sensor.ambr
@@ -47,6 +47,54 @@
     'state': 'on',
   })
 # ---
+# name: test_setup[binary_sensor.fake_name_battery_low-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.fake_name_battery_low',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery low',
+    'platform': 'fritzbox',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery_low',
+    'unique_id': '12345 1234567_battery_low',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[binary_sensor.fake_name_battery_low-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'fake_name Battery low',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.fake_name_battery_low',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_setup[binary_sensor.fake_name_button_lock_on_device-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -141,5 +189,146 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_setup[binary_sensor.fake_name_holiday_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.fake_name_holiday_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Holiday mode',
+    'platform': 'fritzbox',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'holiday_active',
+    'unique_id': '12345 1234567_holiday_active',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[binary_sensor.fake_name_holiday_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'fake_name Holiday mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.fake_name_holiday_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup[binary_sensor.fake_name_open_window_detected-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.fake_name_open_window_detected',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Open window detected',
+    'platform': 'fritzbox',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'window_open',
+    'unique_id': '12345 1234567_window_open',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[binary_sensor.fake_name_open_window_detected-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'fake_name Open window detected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.fake_name_open_window_detected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup[binary_sensor.fake_name_summer_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.fake_name_summer_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Summer mode',
+    'platform': 'fritzbox',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'summer_active',
+    'unique_id': '12345 1234567_summer_active',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[binary_sensor.fake_name_summer_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'fake_name Summer mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.fake_name_summer_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---

--- a/tests/components/fritzbox/test_binary_sensor.py
+++ b/tests/components/fritzbox/test_binary_sensor.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest import mock
 from unittest.mock import Mock, patch
 
+import pytest
 from requests.exceptions import HTTPError
 from syrupy import SnapshotAssertion
 
@@ -23,6 +24,7 @@ from tests.common import async_fire_time_changed, snapshot_platform
 ENTITY_ID = f"{BINARY_SENSOR_DOMAIN}.{CONF_FAKE_NAME}"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_setup(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -105,7 +105,7 @@ async def test_coordinator_automatic_registry_cleanup(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 11
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 19
     assert len(dr.async_entries_for_config_entry(device_registry, entry.entry_id)) == 2
 
     fritz().get_devices.return_value = [
@@ -119,5 +119,5 @@ async def test_coordinator_automatic_registry_cleanup(
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 8
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 12
     assert len(dr.async_entries_for_config_entry(device_registry, entry.entry_id)) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
All the extra state attributes of the `climate` entity got migrated to own entities. With this these attributes are deprecated and will be removed in 2025.11.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
