### PR TITLE
Add support for HVAC mode "OFF" in Somfy Heating Temperature Interface in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/climate/somfy_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate/somfy_heating_temperature_interface.py
@@ -77,7 +77,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
         | ClimateEntityFeature.TURN_OFF
         | ClimateEntityFeature.TURN_ON
     )
-    _attr_hvac_modes = [*HVAC_MODES_TO_OVERKIZ]
+    _attr_hvac_modes = [*HVAC_MODES_TO_OVERKIZ, HVACMode.OFF]
     _attr_preset_modes = [*PRESET_MODES_TO_OVERKIZ]
     # Both min and max temp values have been retrieved from the Somfy Application.
     _attr_min_temp = 15.0
@@ -110,9 +110,12 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        await self.executor.async_execute_command(
-            OverkizCommand.SET_ACTIVE_MODE, HVAC_MODES_TO_OVERKIZ[hvac_mode]
-        )
+        if hvac_mode == HVACMode.OFF:
+            await self.executor.async_execute_command("setOnOff", "off")
+        else:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_ACTIVE_MODE, HVAC_MODES_TO_OVERKIZ[hvac_mode]
+            )
 
     @property
     def preset_mode(self) -> str | None:

--- a/homeassistant/components/overkiz/climate/somfy_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate/somfy_heating_temperature_interface.py
@@ -110,7 +110,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode is HVACMode.OFF:
             await self.executor.async_execute_command(
                 OverkizCommand.SET_ON_OFF, OverkizCommandParam.OFF
             )

--- a/homeassistant/components/overkiz/climate/somfy_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate/somfy_heating_temperature_interface.py
@@ -111,7 +111,9 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.OFF:
-            await self.executor.async_execute_command("setOnOff", "off")
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_ON_OFF, OverkizCommandParam.OFF
+            )
         else:
             await self.executor.async_execute_command(
                 OverkizCommand.SET_ACTIVE_MODE, HVAC_MODES_TO_OVERKIZ[hvac_mode]


### PR DESCRIPTION
## Proposed change

Fixes #130102
`HVACMode.off` was not implemented, but `ClimateEntityFeature.TURN_OFF` was set. This PR implements the off commands for this device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130102
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
