### PR TITLE
Add device config parameter to Airzone Cloud

### DIFF
--- a/homeassistant/components/airzone_cloud/config_flow.py
+++ b/homeassistant/components/airzone_cloud/config_flow.py
@@ -97,6 +97,7 @@ class AirZoneCloudConfigFlow(ConfigFlow, domain=DOMAIN):
                     user_input[CONF_USERNAME],
                     user_input[CONF_PASSWORD],
                     False,
+                    False,
                 ),
             )
 

--- a/homeassistant/components/airzone_cloud/config_flow.py
+++ b/homeassistant/components/airzone_cloud/config_flow.py
@@ -20,13 +20,14 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import DOMAIN
+from .const import CONF_DEVICE_CONFIG, DOMAIN
 
 
 class AirZoneCloudConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle config flow for an Airzone Cloud device."""
 
     airzone: AirzoneCloudApi
+    MINOR_VERSION = 2
 
     async def async_step_inst_pick(
         self, user_input: dict[str, Any] | None = None
@@ -74,6 +75,7 @@ class AirZoneCloudConfigFlow(ConfigFlow, domain=DOMAIN):
                             mode=SelectSelectorMode.DROPDOWN,
                         )
                     ),
+                    vol.Required(CONF_DEVICE_CONFIG, default=True): bool,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/airzone_cloud/const.py
+++ b/homeassistant/components/airzone_cloud/const.py
@@ -2,7 +2,10 @@
 
 from typing import Final
 
+CONF_DEVICE_CONFIG: Final[str] = "device_config"
 DOMAIN: Final[str] = "airzone_cloud"
 MANUFACTURER: Final[str] = "Airzone"
 
-AIOAIRZONE_CLOUD_TIMEOUT_SEC: Final[int] = 30
+AIOAIRZONE_CLOUD_TIMEOUT_SEC: Final[int] = 90
+
+DEFAULT_DEVICE_CONFIG: Final[bool] = True

--- a/homeassistant/components/airzone_cloud/strings.json
+++ b/homeassistant/components/airzone_cloud/strings.json
@@ -9,6 +9,7 @@
     "step": {
       "user": {
         "data": {
+          "device_config": "Fetch device config (may cause timeouts on older devices)",
           "id": "Installation",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
+++ b/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
@@ -86,6 +86,7 @@
     }),
     'config_entry': dict({
       'data': dict({
+        'device_config': True,
         'id': 'installation1',
         'password': '**REDACTED**',
         'username': '**REDACTED**',
@@ -95,7 +96,7 @@
       }),
       'domain': 'airzone_cloud',
       'entry_id': 'd186e31edb46d64d14b9b2f11f1ebd9f',
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,

--- a/tests/components/airzone_cloud/test_init.py
+++ b/tests/components/airzone_cloud/test_init.py
@@ -4,8 +4,13 @@ from unittest.mock import patch
 
 from aioairzone_cloud.exceptions import AirzoneTimeout
 
-from homeassistant.components.airzone_cloud.const import DOMAIN
+from homeassistant.components.airzone_cloud.const import (
+    CONF_DEVICE_CONFIG,
+    DEFAULT_DEVICE_CONFIG,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from .util import CONFIG
@@ -69,3 +74,46 @@ async def test_init_api_timeout(hass: HomeAssistant) -> None:
         config_entry.add_to_hass(hass)
 
         assert await hass.config_entries.async_setup(config_entry.entry_id) is False
+
+
+async def test_migrate_entry_v2(hass: HomeAssistant) -> None:
+    """Test entry migration to v2."""
+
+    config_entry = MockConfigEntry(
+        minor_version=1,
+        data={
+            CONF_ID: CONFIG[CONF_ID],
+            CONF_USERNAME: CONFIG[CONF_USERNAME],
+            CONF_PASSWORD: CONFIG[CONF_PASSWORD],
+        },
+        domain=DOMAIN,
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.airzone_cloud.AirzoneCloudApi.login",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.airzone_cloud.AirzoneCloudApi.logout",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.airzone_cloud.AirzoneCloudApi.list_installations",
+            return_value=[],
+        ),
+        patch(
+            "homeassistant.components.airzone_cloud.AirzoneCloudApi.update_installation",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.airzone_cloud.AirzoneCloudApi.update",
+            return_value=None,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.minor_version == 2
+    assert config_entry.data.get(CONF_DEVICE_CONFIG) == DEFAULT_DEVICE_CONFIG

--- a/tests/components/airzone_cloud/util.py
+++ b/tests/components/airzone_cloud/util.py
@@ -113,7 +113,7 @@ from aioairzone_cloud.const import (
 from aioairzone_cloud.device import Device
 from aioairzone_cloud.webserver import WebServer
 
-from homeassistant.components.airzone_cloud.const import DOMAIN
+from homeassistant.components.airzone_cloud.const import CONF_DEVICE_CONFIG, DOMAIN
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
@@ -124,6 +124,7 @@ WS_ID_AIDOO = "11:22:33:44:55:67"
 WS_ID_AIDOO_PRO = "11:22:33:44:55:68"
 
 CONFIG = {
+    CONF_DEVICE_CONFIG: True,
     CONF_ID: "inst1",
     CONF_USERNAME: "user",
     CONF_PASSWORD: "pass",


### PR DESCRIPTION
## Proposed change
Add new device config parameter to Airzone Cloud integration, which allows disabling fetching the device config since it causes timeouts on certain old devices:
https://github.com/home-assistant/core/issues/132523
Also increase AIOAIRZONE_CLOUD_TIMEOUT_SEC to allow older devices to work properly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/132523
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
