### PR TITLE
Fix lg_thinq RuntimeWarning in tests

### DIFF
--- a/tests/components/lg_thinq/conftest.py
+++ b/tests/components/lg_thinq/conftest.py
@@ -94,7 +94,7 @@ def mock_invalid_thinq_api(mock_config_thinq_api: AsyncMock) -> AsyncMock:
 
 
 @pytest.fixture
-def mock_thinq_api() -> Generator[AsyncMock]:
+def mock_thinq_api(mock_thinq_mqtt_client: None) -> Generator[AsyncMock]:
     """Mock a thinq api."""
     with patch("homeassistant.components.lg_thinq.ThinQApi", autospec=True) as mock_api:
         thinq_api = mock_api.return_value
@@ -111,7 +111,7 @@ def mock_thinq_api() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_thinq_mqtt_client() -> Generator[AsyncMock]:
+def mock_thinq_mqtt_client() -> Generator[None]:
     """Mock a thinq mqtt client."""
     with patch(
         "homeassistant.components.lg_thinq.mqtt.ThinQMQTTClient",

--- a/tests/components/lg_thinq/test_init.py
+++ b/tests/components/lg_thinq/test_init.py
@@ -15,7 +15,6 @@ from tests.common import MockConfigEntry
 async def test_load_unload_entry(
     hass: HomeAssistant,
     mock_thinq_api: AsyncMock,
-    mock_thinq_mqtt_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test load and unload entry."""
@@ -37,7 +36,6 @@ async def test_load_unload_entry(
 async def test_config_not_ready(
     hass: HomeAssistant,
     mock_thinq_api: AsyncMock,
-    mock_thinq_mqtt_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     exception: Exception,
 ) -> None:


### PR DESCRIPTION
## Proposed change
```
tests/components/lg_thinq/test_climate.py::test_all_entities
tests/components/lg_thinq/test_event.py::test_all_entities
tests/components/lg_thinq/test_number.py::test_all_entities
tests/components/lg_thinq/test_sensor.py::test_all_entities
  /home/runner/work/ha-core/ha-core/homeassistant/config_entries.py:827: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/lg_thinq/__init__.py", line 141, in async_setup_mqtt
      result = await mqtt_client.async_connect()
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/lg_thinq/mqtt.py", line 47, in async_connect
      self.client = await ThinQMQTTClient(
    File "/home/runner/work/ha-core/ha-core/venv/lib/python3.13/site-packages/thinqconnect/mqtt_client.py", line 65, in __await__
      yield from self.async_init().__await__()
    ...
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
