### PR TITLE
Handle router initialization, connection errors, and missing interfaces in options flow

### DIFF
--- a/homeassistant/components/keenetic_ndms2/config_flow.py
+++ b/homeassistant/components/keenetic_ndms2/config_flow.py
@@ -192,9 +192,13 @@ class KeeneticOptionsFlowHandler(OptionsFlow):
                 ): int,
                 vol.Required(
                     CONF_INTERFACES,
-                    default=self.config_entry.options.get(
-                        CONF_INTERFACES, [DEFAULT_INTERFACE]
-                    ),
+                    default=[
+                        item
+                        for item in self.config_entry.options.get(
+                            CONF_INTERFACES, [DEFAULT_INTERFACE]
+                        )
+                        if item in self._interface_options
+                    ],
                 ): cv.multi_select(self._interface_options),
                 vol.Optional(
                     CONF_TRY_HOTSPOT,

--- a/homeassistant/components/keenetic_ndms2/strings.json
+++ b/homeassistant/components/keenetic_ndms2/strings.json
@@ -36,6 +36,10 @@
           "include_associated": "Use Wi-Fi AP associations data (ignored if hotspot data used)"
         }
       }
+    },
+    "abort": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "not_initialized": "The integration is not initialized yet. Can't display available options."
     }
   }
 }

--- a/tests/components/keenetic_ndms2/test_config_flow.py
+++ b/tests/components/keenetic_ndms2/test_config_flow.py
@@ -6,10 +6,11 @@ from unittest.mock import Mock, patch
 from ndms2_client import ConnectionException
 from ndms2_client.client import InterfaceInfo, RouterInfo
 import pytest
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import keenetic_ndms2 as keenetic
-from homeassistant.components.keenetic_ndms2 import const
+from homeassistant.components.keenetic_ndms2 import CONF_INTERFACES, const
 from homeassistant.const import CONF_HOST, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -177,6 +178,36 @@ async def test_options_connection_error(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
+
+
+async def test_options_interface_filter(hass: HomeAssistant) -> None:
+    """Test the case when the default Home interface is missing on the router."""
+
+    entry = MockConfigEntry(domain=keenetic.DOMAIN, data=MOCK_DATA)
+    entry.add_to_hass(hass)
+
+    # fake interfaces
+    entry.runtime_data = Mock(
+        client=Mock(
+            get_interfaces=Mock(
+                return_value=[
+                    InterfaceInfo.from_dict({"id": name, "type": "bridge"})
+                    for name in ("not_a_home", "also_not_home")
+                ]
+            )
+        )
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    interfaces_schema = next(
+        i
+        for i, s in result["data_schema"].schema.items()
+        if i.schema == CONF_INTERFACES
+    )
+    assert isinstance(interfaces_schema, vol.Required)
+    assert interfaces_schema.default() == []
 
 
 async def test_ssdp_works(hass: HomeAssistant, connect) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added checks in the Keenetic NDMS2 options flow to handle cases where the integration is not initialized or there are connection errors. Relevant user feedback and abort reasons are now provided to ensure a better user experience.

Also added filtering out unavailable options for the config flow, since the frontent does not do that


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #142267 #145970
- This PR is related to issue: home-assistant/frontend#24890
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
