### PR TITLE
Fix display issues with ESPHome encryption key steps

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -662,10 +662,11 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             return ERROR_REQUIRES_ENCRYPTION_KEY
         except InvalidEncryptionKeyAPIError as ex:
             if ex.received_name:
+                device_name_changed = self._device_name != ex.received_name
                 self._device_name = ex.received_name
                 if ex.received_mac:
                     self._device_mac = format_mac(ex.received_mac)
-                if not self._name:
+                if not self._name or device_name_changed:
                     self._name = ex.received_name
             return ERROR_INVALID_ENCRYPTION_KEY
         except ResolveAPIError:

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -665,7 +665,8 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 self._device_name = ex.received_name
                 if ex.received_mac:
                     self._device_mac = format_mac(ex.received_mac)
-                self._name = ex.received_name
+                if not self._name:
+                    self._name = ex.received_name
             return ERROR_INVALID_ENCRYPTION_KEY
         except ResolveAPIError:
             return "resolve_error"

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -19,11 +19,11 @@
       "reconfigure_unique_id_changed": "**Reconfiguration of `{name}` was aborted** because the address `{host}` points to a different device: `{unexpected_device_name}` (MAC: `{unexpected_mac}`) instead of the expected one (MAC: `{expected_mac}`)."
     },
     "error": {
-      "resolve_error": "Can't resolve address of the ESP. If this error persists, please set a static IP address",
-      "connection_error": "Can't connect to ESP. Please make sure your YAML file contains an 'api:' line.",
-      "requires_encryption_key": "This ESPHome device requires an encryption key to connect. Please enter the key configured in the device’s YAML file under `api.encryption.key`",
+      "resolve_error": "Unable to resolve the address of the ESPHome device. If this issue continues, consider setting a static IP address.",
+      "connection_error": "Unable to connect to the ESPHome device. Make sure the device’s YAML configuration includes an `api` section.",
+      "requires_encryption_key": "The ESPHome device requires an encryption key. Enter the key defined in the device’s YAML configuration under `api -> encryption -> key`.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_psk": "The transport encryption key is invalid. Please ensure it matches the device’s YAML file under `api.encryption.key`"
+      "invalid_psk": "The encryption key is invalid. Make sure it matches the value in the device’s YAML configuration under `api -> encryption -> key`."
     },
     "step": {
       "user": {

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -21,6 +21,7 @@
     "error": {
       "resolve_error": "Can't resolve address of the ESP. If this error persists, please set a static IP address",
       "connection_error": "Can't connect to ESP. Please make sure your YAML file contains an 'api:' line.",
+      "requires_encryption_key": "This ESPHome device requires an encryption key to connect. Please enter the key configured in the device’s YAML file under `api.encryption.key`",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_psk": "The transport encryption key is invalid. Please ensure it matches what you have in your configuration"
     },

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -23,7 +23,7 @@
       "connection_error": "Can't connect to ESP. Please make sure your YAML file contains an 'api:' line.",
       "requires_encryption_key": "This ESPHome device requires an encryption key to connect. Please enter the key configured in the device’s YAML file under `api.encryption.key`",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_psk": "The transport encryption key is invalid. Please ensure it matches what you have in your configuration"
+      "invalid_psk": "The transport encryption key is invalid. Please ensure it matches the device’s YAML file under `api.encryption.key`"
     },
     "step": {
       "user": {

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -440,7 +440,7 @@ async def test_user_dashboard_has_wrong_key(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encryption_key"
-    assert result["description_placeholders"] == {"name": "test"}
+    assert result["description_placeholders"] == {"name": "ESPHome (test)"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}
@@ -547,7 +547,7 @@ async def test_user_discovers_name_and_gets_key_from_dashboard_fails(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encryption_key"
-    assert result["description_placeholders"] == {"name": "test"}
+    assert result["description_placeholders"] == {"name": "ESPHome (test)"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}
@@ -602,7 +602,7 @@ async def test_user_discovers_name_and_dashboard_is_unavailable(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encryption_key"
-    assert result["description_placeholders"] == {"name": "test"}
+    assert result["description_placeholders"] == {"name": "ESPHome (test)"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}
@@ -1775,7 +1775,7 @@ async def test_user_discovers_name_no_dashboard(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encryption_key"
-    assert result["description_placeholders"] == {"name": "test"}
+    assert result["description_placeholders"] == {"name": "ESPHome (test)"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -440,7 +440,7 @@ async def test_user_dashboard_has_wrong_key(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encryption_key"
-    assert result["description_placeholders"] == {"name": "ESPHome (test)"}
+    assert result["description_placeholders"] == {"name": "test"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}
@@ -547,7 +547,7 @@ async def test_user_discovers_name_and_gets_key_from_dashboard_fails(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encryption_key"
-    assert result["description_placeholders"] == {"name": "ESPHome (test)"}
+    assert result["description_placeholders"] == {"name": "test"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}
@@ -602,7 +602,7 @@ async def test_user_discovers_name_and_dashboard_is_unavailable(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encryption_key"
-    assert result["description_placeholders"] == {"name": "ESPHome (test)"}
+    assert result["description_placeholders"] == {"name": "test"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}
@@ -1775,7 +1775,7 @@ async def test_user_discovers_name_no_dashboard(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encryption_key"
-    assert result["description_placeholders"] == {"name": "ESPHome (test)"}
+    assert result["description_placeholders"] == {"name": "test"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I noticed this when I checked all the config flow tests to make sure they reach and abort or create entry state that `requires_encryption_key` was missing a string.

- Fix missing `requires_encryption_key` error string for ESPHome
- Small cleanups to align the strings so all errors use the same terms.
- Make sure the friendly name is displayed on the encryption step as it would get overwritten from the invalid encryption error.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
