### PR TITLE
Dont add location entities without location scope in Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/device_tracker.py
+++ b/homeassistant/components/teslemetry/device_tracker.py
@@ -76,22 +76,21 @@ async def async_setup_entry(
     entities: list[
         TeslemetryPollingDeviceTrackerEntity | TeslemetryStreamingDeviceTrackerEntity
     ] = []
+    # Only add vehicle location entities if the user has granted vehicle location scope.
+    if Scope.VEHICLE_LOCATION not in entry.runtime_data.scopes:
+        return
+
     for vehicle in entry.runtime_data.vehicles:
-        # Only add vehicle location entities if the user has granted vehicle location scope.
-        if Scope.VEHICLE_LOCATION in entry.runtime_data.scopes:
-            for description in DESCRIPTIONS:
-                if (
-                    vehicle.api.pre2021
-                    or vehicle.firmware < description.streaming_firmware
-                ):
-                    if description.polling_prefix:
-                        entities.append(
-                            TeslemetryPollingDeviceTrackerEntity(vehicle, description)
-                        )
-                else:
+        for description in DESCRIPTIONS:
+            if vehicle.api.pre2021 or vehicle.firmware < description.streaming_firmware:
+                if description.polling_prefix:
                     entities.append(
-                        TeslemetryStreamingDeviceTrackerEntity(vehicle, description)
+                        TeslemetryPollingDeviceTrackerEntity(vehicle, description)
                     )
+            else:
+                entities.append(
+                    TeslemetryStreamingDeviceTrackerEntity(vehicle, description)
+                )
 
     async_add_entities(entities)
 

--- a/tests/components/teslemetry/const.py
+++ b/tests/components/teslemetry/const.py
@@ -45,6 +45,7 @@ METADATA = {
         "vehicle_device_data",
         "vehicle_cmds",
         "vehicle_charging_cmds",
+        "vehicle_location",
         "energy_device_data",
         "energy_cmds",
     ],

--- a/tests/components/teslemetry/snapshots/test_diagnostics.ambr
+++ b/tests/components/teslemetry/snapshots/test_diagnostics.ambr
@@ -191,6 +191,7 @@
       'vehicle_device_data',
       'vehicle_cmds',
       'vehicle_charging_cmds',
+      'vehicle_location',
       'energy_device_data',
       'energy_cmds',
     ]),

--- a/tests/components/teslemetry/test_device_tracker.py
+++ b/tests/components/teslemetry/test_device_tracker.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import assert_entities, assert_entities_alt, setup_platform
-from .const import VEHICLE_DATA_ALT
+from .const import METADATA_NOSCOPE, VEHICLE_DATA_ALT
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -40,6 +40,23 @@ async def test_device_tracker_alt(
     mock_vehicle_data.return_value = VEHICLE_DATA_ALT
     entry = await setup_platform(hass, [Platform.DEVICE_TRACKER])
     assert_entities_alt(hass, entry.entry_id, entity_registry, snapshot)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_device_tracker_noscope(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_metadata: AsyncMock,
+    mock_vehicle_data: AsyncMock,
+    mock_legacy: AsyncMock,
+) -> None:
+    """Tests that the device tracker entities are correct."""
+
+    mock_metadata.return_value = METADATA_NOSCOPE
+    entry = await setup_platform(hass, [Platform.DEVICE_TRACKER])
+    entity_entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    assert len(entity_entries) == 0
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tesla has announced that the new `vehicle_location` scope is going to be enforced from 1 May 2025. Teslemetry is handling this on the server-side, but this PR makes the entities that require the scope unavaliable (rather than unknown) if the scope has not been provided.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38764
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
