### PR TITLE
Fix hassfest type hints for ConfigSubentryFlow

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -597,6 +597,16 @@ _CLASS_MATCH: dict[str, list[ClassTypeHintMatch]] = {
                 ),
             ],
         ),
+        ClassTypeHintMatch(
+            base_class="ConfigSubentryFlow",
+            matches=[
+                TypeHintMatch(
+                    function_name="async_step_*",
+                    arg_types={},
+                    return_type="SubentryFlowResult",
+                ),
+            ],
+        ),
     ],
 }
 # Overriding properties and functions are normally checked by mypy, and will only

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import re
 from types import ModuleType
 from unittest.mock import patch
@@ -375,12 +376,11 @@ def test_invalid_config_flow_step(
         type_hint_checker.visit_classdef(class_node)
 
 
-def test_invalid_custom_config_flow_step(
-    linter: UnittestLinter, type_hint_checker: BaseChecker
-) -> None:
-    """Ensure invalid hints are rejected for ConfigFlow step."""
-    class_node, func_node, arg_node = astroid.extract_node(
-        """
+@pytest.mark.parametrize(
+    ("code", "expected_messages_fn"),
+    [
+        (
+            """
     class FlowHandler():
         pass
 
@@ -392,34 +392,79 @@ def test_invalid_custom_config_flow_step(
     ):
         async def async_step_axis_specific( #@
             self,
-            device_config: dict #@
+            device_config: dict
         ):
             pass
-    """,
+""",
+            lambda func_node: [
+                pylint.testutils.MessageTest(
+                    msg_id="hass-return-type",
+                    node=func_node,
+                    args=("ConfigFlowResult", "async_step_axis_specific"),
+                    line=11,
+                    col_offset=4,
+                    end_line=11,
+                    end_col_offset=38,
+                ),
+            ],
+        ),
+        (
+            """
+    class FlowHandler():
+        pass
+
+    class ConfigSubentryFlow(FlowHandler):
+        pass
+
+    class CustomSubentryFlowHandler(ConfigSubentryFlow): #@
+        async def async_step_user( #@
+            self, user_input: dict[str, Any] | None = None
+        ) -> FlowResult:
+            pass
+""",
+            lambda func_node: [
+                pylint.testutils.MessageTest(
+                    msg_id="hass-return-type",
+                    node=func_node,
+                    args=("SubentryFlowResult", "async_step_user"),
+                    line=9,
+                    col_offset=4,
+                    end_line=9,
+                    end_col_offset=29,
+                ),
+            ],
+        ),
+    ],
+    ids=[
+        "Config flow",
+        "Config subentry flow",
+    ],
+)
+def test_invalid_flow_step(
+    linter: UnittestLinter,
+    type_hint_checker: BaseChecker,
+    code: str,
+    expected_messages_fn: Callable[
+        [astroid.NodeNG], tuple[pylint.testutils.MessageTest, ...]
+    ],
+) -> None:
+    """Ensure invalid hints are rejected for flow step."""
+    class_node, func_node = astroid.extract_node(
+        code,
         "homeassistant.components.pylint_test.config_flow",
     )
     type_hint_checker.visit_module(class_node.parent)
 
     with assert_adds_messages(
         linter,
-        pylint.testutils.MessageTest(
-            msg_id="hass-return-type",
-            node=func_node,
-            args=("ConfigFlowResult", "async_step_axis_specific"),
-            line=11,
-            col_offset=4,
-            end_line=11,
-            end_col_offset=38,
-        ),
+        *expected_messages_fn(func_node),
     ):
         type_hint_checker.visit_classdef(class_node)
 
 
-def test_valid_config_flow_step(
-    linter: UnittestLinter, type_hint_checker: BaseChecker
-) -> None:
-    """Ensure valid hints are accepted for ConfigFlow step."""
-    class_node = astroid.extract_node(
+@pytest.mark.parametrize(
+    "code",
+    [
         """
     class FlowHandler():
         pass
@@ -436,6 +481,33 @@ def test_valid_config_flow_step(
         ) -> ConfigFlowResult:
             pass
     """,
+        """
+    class FlowHandler():
+        pass
+
+    class ConfigSubentryFlow(FlowHandler):
+        pass
+
+    class CustomSubentryFlowHandler(ConfigSubentryFlow): #@
+        async def async_step_user(
+            self, user_input: dict[str, Any] | None = None
+        ) -> SubentryFlowResult:
+            pass
+""",
+    ],
+    ids=[
+        "Config flow",
+        "Config subentry flow",
+    ],
+)
+def test_valid_flow_step(
+    linter: UnittestLinter,
+    type_hint_checker: BaseChecker,
+    code: str,
+) -> None:
+    """Ensure valid hints are accepted for flow step."""
+    class_node = astroid.extract_node(
+        code,
         "homeassistant.components.pylint_test.config_flow",
     )
     type_hint_checker.visit_module(class_node.parent)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix hassfest type hints for ConfigSubentryFlow.
Noticed problems on:
- https://github.com/home-assistant/core/pull/135152#discussion_r2030639337
- https://github.com/home-assistant/core/actions/runs/13885460151/job/38849593182?pr=139857
- https://github.com/home-assistant/core/actions/runs/14599676718/job/40954567332?pr=135152

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143470
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
