### PR TITLE
Handle Tailscale hosts without client connectivity details

### DIFF
--- a/homeassistant/components/tailscale/binary_sensor.py
+++ b/homeassistant/components/tailscale/binary_sensor.py
@@ -46,37 +46,61 @@ BINARY_SENSORS: tuple[TailscaleBinarySensorEntityDescription, ...] = (
         key="client_supports_hair_pinning",
         translation_key="client_supports_hair_pinning",
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda device: device.client_connectivity.client_supports.hair_pinning,
+        is_on_fn=lambda device: (
+            device.client_connectivity.client_supports.hair_pinning
+            if device.client_connectivity is not None
+            else None
+        ),
     ),
     TailscaleBinarySensorEntityDescription(
         key="client_supports_ipv6",
         translation_key="client_supports_ipv6",
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda device: device.client_connectivity.client_supports.ipv6,
+        is_on_fn=lambda device: (
+            device.client_connectivity.client_supports.ipv6
+            if device.client_connectivity is not None
+            else None
+        ),
     ),
     TailscaleBinarySensorEntityDescription(
         key="client_supports_pcp",
         translation_key="client_supports_pcp",
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda device: device.client_connectivity.client_supports.pcp,
+        is_on_fn=lambda device: (
+            device.client_connectivity.client_supports.pcp
+            if device.client_connectivity is not None
+            else None
+        ),
     ),
     TailscaleBinarySensorEntityDescription(
         key="client_supports_pmp",
         translation_key="client_supports_pmp",
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda device: device.client_connectivity.client_supports.pmp,
+        is_on_fn=lambda device: (
+            device.client_connectivity.client_supports.pmp
+            if device.client_connectivity is not None
+            else None
+        ),
     ),
     TailscaleBinarySensorEntityDescription(
         key="client_supports_udp",
         translation_key="client_supports_udp",
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda device: device.client_connectivity.client_supports.udp,
+        is_on_fn=lambda device: (
+            device.client_connectivity.client_supports.udp
+            if device.client_connectivity is not None
+            else None
+        ),
     ),
     TailscaleBinarySensorEntityDescription(
         key="client_supports_upnp",
         translation_key="client_supports_upnp",
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda device: device.client_connectivity.client_supports.upnp,
+        is_on_fn=lambda device: (
+            device.client_connectivity.client_supports.upnp
+            if device.client_connectivity is not None
+            else None
+        ),
     ),
 )
 

--- a/homeassistant/components/tailscale/manifest.json
+++ b/homeassistant/components/tailscale/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tailscale",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["tailscale==0.6.1"]
+  "requirements": ["tailscale==0.6.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2855,7 +2855,7 @@ systembridgeconnector==4.1.5
 systembridgemodels==4.2.4
 
 # homeassistant.components.tailscale
-tailscale==0.6.1
+tailscale==0.6.2
 
 # homeassistant.components.tank_utility
 tank-utility==1.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2311,7 +2311,7 @@ systembridgeconnector==4.1.5
 systembridgemodels==4.2.4
 
 # homeassistant.components.tailscale
-tailscale==0.6.1
+tailscale==0.6.2
 
 # homeassistant.components.tellduslive
 tellduslive==0.10.12

--- a/tests/components/tailscale/fixtures/devices.json
+++ b/tests/components/tailscale/fixtures/devices.json
@@ -104,6 +104,28 @@
           "upnp": false
         }
       }
+    },
+    {
+      "addresses": ["100.11.11.113"],
+      "id": "123458",
+      "user": "frenck",
+      "name": "host-no-connectivity.homeassistant.github",
+      "hostname": "host-no-connectivity",
+      "clientVersion": "1.14.0-t5cff36945-g809e87bba",
+      "updateAvailable": true,
+      "os": "linux",
+      "created": "2021-08-29T09:49:06Z",
+      "lastSeen": "2021-11-15T20:37:03Z",
+      "keyExpiryDisabled": false,
+      "expires": "2022-02-25T09:49:06Z",
+      "authorized": true,
+      "isExternal": false,
+      "machineKey": "mkey:mock",
+      "nodeKey": "nodekey:mock",
+      "blocksIncomingConnections": false,
+      "enabledRoutes": ["0.0.0.0/0", "10.10.10.0/23", "::/0"],
+      "advertisedRoutes": ["0.0.0.0/0", "10.10.10.0/23", "::/0"],
+      "clientConnectivity": null
     }
   ]
 }

--- a/tests/components/tailscale/snapshots/test_diagnostics.ambr
+++ b/tests/components/tailscale/snapshots/test_diagnostics.ambr
@@ -82,6 +82,38 @@
         'update_available': True,
         'user': '**REDACTED**',
       }),
+      dict({
+        'addresses': '**REDACTED**',
+        'advertised_routes': list([
+          '0.0.0.0/0',
+          '10.10.10.0/23',
+          '::/0',
+        ]),
+        'authorized': True,
+        'blocks_incoming_connections': False,
+        'client_connectivity': None,
+        'client_version': '1.14.0-t5cff36945-g809e87bba',
+        'created': '2021-08-29T09:49:06+00:00',
+        'device_id': '**REDACTED**',
+        'enabled_routes': list([
+          '0.0.0.0/0',
+          '10.10.10.0/23',
+          '::/0',
+        ]),
+        'expires': '2022-02-25T09:49:06+00:00',
+        'hostname': '**REDACTED**',
+        'is_external': False,
+        'key_expiry_disabled': False,
+        'last_seen': '2021-11-15T20:37:03+00:00',
+        'machine_key': '**REDACTED**',
+        'name': '**REDACTED**',
+        'node_key': '**REDACTED**',
+        'os': 'linux',
+        'tags': list([
+        ]),
+        'update_available': True,
+        'user': '**REDACTED**',
+      }),
     ]),
   })
 # ---

--- a/tests/components/tailscale/test_binary_sensor.py
+++ b/tests/components/tailscale/test_binary_sensor.py
@@ -6,7 +6,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
 )
 from homeassistant.components.tailscale.const import DOMAIN
-from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME, EntityCategory
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    STATE_UNKNOWN,
+    EntityCategory,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -122,3 +127,19 @@ async def test_tailscale_binary_sensors(
         device_entry.configuration_url
         == "https://login.tailscale.com/admin/machines/100.11.11.111"
     )
+
+    # Check host without client connectivity attribute
+    state = hass.states.get("binary_sensor.host_no_connectivity_supports_hairpinning")
+    entry = entity_registry.async_get(
+        "binary_sensor.host_no_connectivity_supports_hairpinning"
+    )
+    assert entry
+    assert state
+    assert entry.unique_id == "123458_client_supports_hair_pinning"
+    assert entry.entity_category == EntityCategory.DIAGNOSTIC
+    assert state.state == STATE_UNKNOWN
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == "host-no-connectivity Supports hairpinning"
+    )
+    assert ATTR_DEVICE_CLASS not in state.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
It seems that the Tailscale API does not provide client connectivity details for all hosts. Make sure to handle this case gracefully by bumping the tailscale library and returning None for the affected entities if the client connectivity is missing.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130462
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
