### PR TITLE
Remove deprecated `hass.helpers`

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -428,9 +428,6 @@ class HomeAssistant:
     def __init__(self, config_dir: str) -> None:
         """Initialize new Home Assistant object."""
         # pylint: disable-next=import-outside-toplevel
-        from . import loader
-
-        # pylint: disable-next=import-outside-toplevel
         from .core_config import Config
 
         # This is a dictionary that any component can store any data on.
@@ -443,7 +440,6 @@ class HomeAssistant:
         self.states = StateMachine(self.bus, self.loop)
         self.config = Config(self, config_dir)
         self.config.async_initialize()
-        self.helpers = loader.Helpers(self)
         self.state: CoreState = CoreState.not_running
         self.exit_code: int = 0
         # If not None, use to signal end-of-loop

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1710,37 +1710,6 @@ class ModuleWrapper:
         return value
 
 
-class Helpers:
-    """Helper to load helpers."""
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the Helpers class."""
-        self._hass = hass
-
-    def __getattr__(self, helper_name: str) -> ModuleWrapper:
-        """Fetch a helper."""
-        helper = importlib.import_module(f"homeassistant.helpers.{helper_name}")
-
-        # Local import to avoid circular dependencies
-        # pylint: disable-next=import-outside-toplevel
-        from .helpers.frame import ReportBehavior, report_usage
-
-        report_usage(
-            (
-                f"accesses hass.helpers.{helper_name}, which"
-                f" should be updated to import functions used from {helper_name} directly"
-            ),
-            core_behavior=ReportBehavior.IGNORE,
-            core_integration_behavior=ReportBehavior.IGNORE,
-            custom_integration_behavior=ReportBehavior.LOG,
-            breaks_in_ha_version="2025.5",
-        )
-
-        wrapped = ModuleWrapper(self._hass, helper)
-        setattr(self, helper_name, wrapped)
-        return wrapped
-
-
 def bind_hass[_CallableT: Callable[..., Any]](func: _CallableT) -> _CallableT:
     """Decorate function to indicate that first argument is hass.
 

--- a/tests/components/flexit_bacnet/test_climate.py
+++ b/tests/components/flexit_bacnet/test_climate.py
@@ -27,7 +27,7 @@ from homeassistant.components.flexit_bacnet.const import PRESET_TO_VENTILATION_M
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_component, entity_registry as er
 
 from . import setup_with_selected_platforms
 
@@ -156,14 +156,14 @@ async def test_hvac_action(
 
     # Simulate electric heater being ON
     mock_flexit_bacnet.electric_heater = True
-    await hass.helpers.entity_component.async_update_entity(ENTITY_ID)
+    await entity_component.async_update_entity(hass, ENTITY_ID)
 
     state = hass.states.get(ENTITY_ID)
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
 
     # Simulate electric heater being OFF
     mock_flexit_bacnet.electric_heater = False
-    await hass.helpers.entity_component.async_update_entity(ENTITY_ID)
+    await entity_component.async_update_entity(hass, ENTITY_ID)
 
     state = hass.states.get(ENTITY_ID)
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.FAN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The deprecated `hass.helpers` has been removed completely.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With HA 2024.3 `hass.helpers` where deprecated and will be removed now.
- https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers
- https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
