### PR TITLE
Bump aiovodafone  to 0.10.0 to use async_create_clientsession in Vodafone Station integration

### DIFF
--- a/homeassistant/components/vodafone_station/__init__.py
+++ b/homeassistant/components/vodafone_station/__init__.py
@@ -4,14 +4,14 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platfor
 from homeassistant.core import HomeAssistant
 
 from .coordinator import VodafoneConfigEntry, VodafoneStationRouter
-from .utils import client_session
+from .utils import async_client_session
 
 PLATFORMS = [Platform.BUTTON, Platform.DEVICE_TRACKER, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: VodafoneConfigEntry) -> bool:
     """Set up Vodafone Station platform."""
-    session = await client_session(hass)
+    session = await async_client_session(hass)
     coordinator = VodafoneStationRouter(
         hass,
         entry.data[CONF_HOST],

--- a/homeassistant/components/vodafone_station/__init__.py
+++ b/homeassistant/components/vodafone_station/__init__.py
@@ -4,18 +4,21 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platfor
 from homeassistant.core import HomeAssistant
 
 from .coordinator import VodafoneConfigEntry, VodafoneStationRouter
+from .utils import client_session
 
 PLATFORMS = [Platform.BUTTON, Platform.DEVICE_TRACKER, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: VodafoneConfigEntry) -> bool:
     """Set up Vodafone Station platform."""
+    session = await client_session(hass)
     coordinator = VodafoneStationRouter(
         hass,
         entry.data[CONF_HOST],
         entry.data[CONF_USERNAME],
         entry.data[CONF_PASSWORD],
         entry,
+        session,
     )
 
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/vodafone_station/config_flow.py
+++ b/homeassistant/components/vodafone_station/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 
 from .const import _LOGGER, DEFAULT_HOST, DEFAULT_USERNAME, DOMAIN
 from .coordinator import VodafoneConfigEntry
-from .utils import client_session
+from .utils import async_client_session
 
 
 def user_form_schema(user_input: dict[str, Any] | None) -> vol.Schema:
@@ -39,7 +39,7 @@ STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, str]:
     """Validate the user input allows us to connect."""
 
-    session = await client_session(hass)
+    session = await async_client_session(hass)
     api = VodafoneStationSercommApi(
         data[CONF_HOST], data[CONF_USERNAME], data[CONF_PASSWORD], session
     )

--- a/homeassistant/components/vodafone_station/config_flow.py
+++ b/homeassistant/components/vodafone_station/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 
 from .const import _LOGGER, DEFAULT_HOST, DEFAULT_USERNAME, DOMAIN
 from .coordinator import VodafoneConfigEntry
+from .utils import client_session
 
 
 def user_form_schema(user_input: dict[str, Any] | None) -> vol.Schema:
@@ -38,8 +39,9 @@ STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, str]:
     """Validate the user input allows us to connect."""
 
+    session = await client_session(hass)
     api = VodafoneStationSercommApi(
-        data[CONF_HOST], data[CONF_USERNAME], data[CONF_PASSWORD]
+        data[CONF_HOST], data[CONF_USERNAME], data[CONF_PASSWORD], session
     )
 
     try:

--- a/homeassistant/components/vodafone_station/coordinator.py
+++ b/homeassistant/components/vodafone_station/coordinator.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from json.decoder import JSONDecodeError
 from typing import Any, cast
 
+from aiohttp import ClientSession
 from aiovodafone import VodafoneStationDevice, VodafoneStationSercommApi, exceptions
 
 from homeassistant.components.device_tracker import DEFAULT_CONSIDER_HOME
@@ -53,11 +54,12 @@ class VodafoneStationRouter(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         username: str,
         password: str,
         config_entry: VodafoneConfigEntry,
+        session: ClientSession,
     ) -> None:
         """Initialize the scanner."""
 
         self._host = host
-        self.api = VodafoneStationSercommApi(host, username, password)
+        self.api = VodafoneStationSercommApi(host, username, password, session)
 
         # Last resort as no MAC or S/N can be retrieved via API
         self._id = config_entry.unique_id

--- a/homeassistant/components/vodafone_station/manifest.json
+++ b/homeassistant/components/vodafone_station/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["aiovodafone"],
   "quality_scale": "platinum",
-  "requirements": ["aiovodafone==0.6.1"]
+  "requirements": ["aiovodafone==0.10.0"]
 }

--- a/homeassistant/components/vodafone_station/utils.py
+++ b/homeassistant/components/vodafone_station/utils.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 
 
-async def client_session(hass: HomeAssistant) -> ClientSession:
+async def async_client_session(hass: HomeAssistant) -> ClientSession:
     """Return a new aiohttp session."""
     return aiohttp_client.async_create_clientsession(
         hass, verify_ssl=False, cookie_jar=CookieJar(unsafe=True)

--- a/homeassistant/components/vodafone_station/utils.py
+++ b/homeassistant/components/vodafone_station/utils.py
@@ -1,0 +1,13 @@
+"""Utils for Vodafone Station."""
+
+from aiohttp import ClientSession, CookieJar
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+
+
+async def client_session(hass: HomeAssistant) -> ClientSession:
+    """Return a new aiohttp session."""
+    return aiohttp_client.async_create_clientsession(
+        hass, verify_ssl=False, cookie_jar=CookieJar(unsafe=True)
+    )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -416,7 +416,7 @@ aiousbwatcher==1.1.1
 aiovlc==0.5.1
 
 # homeassistant.components.vodafone_station
-aiovodafone==0.6.1
+aiovodafone==0.10.0
 
 # homeassistant.components.waqi
 aiowaqi==3.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -398,7 +398,7 @@ aiousbwatcher==1.1.1
 aiovlc==0.5.1
 
 # homeassistant.components.vodafone_station
-aiovodafone==0.6.1
+aiovodafone==0.10.0
 
 # homeassistant.components.waqi
 aiowaqi==3.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
HomeAssistant will create the aiohttp ClientSession instead of creating it inside the library

Needs `aiovodafone` v0.10.0 because of a breaking change

changelog: https://github.com/chemelli74/aiovodafone/releases/tag/v0.10.0
diff: https://github.com/chemelli74/aiovodafone/compare/v0.6.1...v0.10.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
