### PR TITLE
Add WebSocket API to zeroconf to observe discovery

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -36,6 +36,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_homekit, async_get_zeroconf, bind_hass
 from homeassistant.setup import async_when_setup_or_start
 
+from . import websocket_api
 from .const import DOMAIN, ZEROCONF_TYPE
 from .discovery import (  # noqa: F401
     DATA_DISCOVERY,
@@ -198,6 +199,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
     await discovery.async_setup()
     hass.data[DATA_DISCOVERY] = discovery
+    websocket_api.async_setup(hass)
 
     async def _async_zeroconf_hass_start(hass: HomeAssistant, comp: str) -> None:
         """Expose Home Assistant on zeroconf when it starts.

--- a/homeassistant/components/zeroconf/websocket_api.py
+++ b/homeassistant/components/zeroconf/websocket_api.py
@@ -17,15 +17,13 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.json import json_bytes
 
-from .const import DOMAIN
+from .const import DOMAIN, REQUEST_TIMEOUT
 from .discovery import DATA_DISCOVERY, ZeroconfDiscovery
 from .models import HaAsyncZeroconf
 
 _LOGGER = logging.getLogger(__name__)
 CLASS_IN = 1
 TYPE_PTR = 12
-
-_TIMEOUT_MS = 10000
 
 
 @callback
@@ -131,7 +129,7 @@ class _DiscoverySubscription:
 
     async def _async_handle_service(self, info: AsyncServiceInfo) -> None:
         """Add a device that became visible via zeroconf."""
-        await info.async_request(self.aiozc.zeroconf, _TIMEOUT_MS)
+        await info.async_request(self.aiozc.zeroconf, REQUEST_TIMEOUT)
         self._async_on_update(info)
 
     def _async_event_message(self, message: dict[str, Any]) -> None:

--- a/homeassistant/components/zeroconf/websocket_api.py
+++ b/homeassistant/components/zeroconf/websocket_api.py
@@ -140,7 +140,8 @@ class _DiscoverySubscription:
         )
 
     def _async_on_update(self, info: AsyncServiceInfo) -> None:
-        self._async_event_message({"add": [serialize_service_info(info)]})
+        if info.type in self.discovery.zeroconf_types:
+            self._async_event_message({"add": [serialize_service_info(info)]})
 
     def _async_on_remove(self, name: str) -> None:
         self._async_event_message({"remove": [{"name": name}]})

--- a/homeassistant/components/zeroconf/websocket_api.py
+++ b/homeassistant/components/zeroconf/websocket_api.py
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 CLASS_IN = 1
 TYPE_PTR = 12
 
-_TIMEOUT_MS = 3000
+_TIMEOUT_MS = 10000
 
 
 @callback

--- a/homeassistant/components/zeroconf/websocket_api.py
+++ b/homeassistant/components/zeroconf/websocket_api.py
@@ -1,0 +1,164 @@
+"""The zeroconf integration websocket apis."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from functools import partial
+import logging
+from typing import Any, cast
+
+import voluptuous as vol
+from zeroconf import (
+    BadTypeInNameException,
+    DNSPointer,
+    DNSRecord,
+    Zeroconf,
+    current_time_millis,
+)
+from zeroconf.asyncio import AsyncServiceInfo, IPVersion
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.json import json_bytes
+
+from .const import DOMAIN
+from .discovery import DATA_DISCOVERY, ZeroconfDiscovery
+from .models import HaAsyncZeroconf
+
+_LOGGER = logging.getLogger(__name__)
+CLASS_IN = 1
+TYPE_PTR = 12
+
+_TIMEOUT_MS = 3000
+
+
+@callback
+def async_setup(hass: HomeAssistant) -> None:
+    """Set up the zeroconf websocket API."""
+    websocket_api.async_register_command(hass, ws_subscribe_discovery)
+
+
+def serialize_service_info(service_info: AsyncServiceInfo) -> dict[str, Any]:
+    """Serialize an AsyncServiceInfo object."""
+    return {
+        "name": service_info.name,
+        "type": service_info.type,
+        "port": service_info.port,
+        "properties": service_info.decoded_properties,
+        "ip_addresses": [
+            str(ip) for ip in service_info.ip_addresses_by_version(IPVersion.All)
+        ],
+    }
+
+
+class _DiscoverySubscription:
+    """Class to hold and manage the subscription data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        ws_msg_id: int,
+        aiozc: HaAsyncZeroconf,
+        discovery: ZeroconfDiscovery,
+    ) -> None:
+        """Initialize the subscription data."""
+        self.hass = hass
+        self.discovery = discovery
+        self.aiozc = aiozc
+        self.ws_msg_id = ws_msg_id
+        self.connection = connection
+
+    @callback
+    def _async_unsubscribe(
+        self, cancel_callbacks: tuple[Callable[[], None], ...]
+    ) -> None:
+        """Unsubscribe the callback."""
+        for cancel_callback in cancel_callbacks:
+            cancel_callback()
+
+    async def async_start(self) -> None:
+        """Start the subscription."""
+        connection = self.connection
+        listeners = (
+            self.discovery.async_register_service_update_listener(
+                self._async_on_update
+            ),
+            self.discovery.async_register_service_removed_listener(
+                self._async_on_remove
+            ),
+        )
+        connection.subscriptions[self.ws_msg_id] = partial(
+            self._async_unsubscribe, listeners
+        )
+        self.connection.send_message(
+            json_bytes(websocket_api.result_message(self.ws_msg_id))
+        )
+        await self._async_update_from_cache()
+
+    async def _async_update_from_cache(self) -> None:
+        """Load the records from the cache."""
+        tasks: list[asyncio.Task[None]] = []
+        now = current_time_millis()
+        for record in self._async_get_ptr_records(self.aiozc.zeroconf):
+            try:
+                info = AsyncServiceInfo(record.name, record.alias)
+            except BadTypeInNameException as ex:
+                _LOGGER.debug(
+                    "Ignoring record with bad type in name: %s: %s", record.alias, ex
+                )
+                continue
+            if info.load_from_cache(self.aiozc.zeroconf, now):
+                self._async_on_update(info)
+            else:
+                tasks.append(
+                    self.hass.async_create_background_task(
+                        self._async_handle_service(info),
+                        f"zeroconf resolve {record.alias}",
+                    ),
+                )
+
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    def _async_get_ptr_records(self, zc: Zeroconf) -> list[DNSPointer]:
+        """Return all PTR records for the HAP type."""
+        records: list[DNSRecord] = []
+        for zc_type in self.discovery.zeroconf_types:
+            records.extend(zc.cache.async_all_by_details(zc_type, TYPE_PTR, CLASS_IN))
+        return cast(list[DNSPointer], records)
+
+    async def _async_handle_service(self, info: AsyncServiceInfo) -> None:
+        """Add a device that became visible via zeroconf."""
+        await info.async_request(self.aiozc.zeroconf, _TIMEOUT_MS)
+        self._async_on_update(info)
+
+    def _async_event_message(self, message: dict[str, Any]) -> None:
+        self.connection.send_message(
+            json_bytes(websocket_api.event_message(self.ws_msg_id, message))
+        )
+
+    def _async_on_update(self, info: AsyncServiceInfo) -> None:
+        self._async_event_message({"add": [serialize_service_info(info)]})
+
+    def _async_on_remove(self, name: str) -> None:
+        self._async_event_message({"remove": [{"name": name}]})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "zeroconf/subscribe_discovery",
+    }
+)
+@websocket_api.async_response
+async def ws_subscribe_discovery(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Handle subscribe advertisements websocket command."""
+    discovery = hass.data[DATA_DISCOVERY]
+    aiozc: HaAsyncZeroconf = hass.data[DOMAIN]
+    await _DiscoverySubscription(
+        hass, connection, msg["id"], aiozc, discovery
+    ).async_start()

--- a/tests/components/zeroconf/test_usage.py
+++ b/tests/components/zeroconf/test_usage.py
@@ -3,7 +3,6 @@
 from unittest.mock import Mock, patch
 
 import pytest
-import zeroconf
 
 from homeassistant.components.zeroconf import async_get_instance
 from homeassistant.components.zeroconf.usage import install_multiple_zeroconf_catcher
@@ -15,6 +14,16 @@ from tests.common import extract_stack_to_frame
 DOMAIN = "zeroconf"
 
 
+class MockZeroconf:
+    """Mock Zeroconf class."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize the mock."""
+
+    def __new__(cls, *args, **kwargs) -> "MockZeroconf":
+        """Return the shared instance."""
+
+
 @pytest.mark.usefixtures("mock_async_zeroconf", "mock_zeroconf")
 async def test_multiple_zeroconf_instances(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
@@ -24,12 +33,13 @@ async def test_multiple_zeroconf_instances(
 
     zeroconf_instance = await async_get_instance(hass)
 
-    install_multiple_zeroconf_catcher(zeroconf_instance)
+    with patch("zeroconf.Zeroconf", MockZeroconf):
+        install_multiple_zeroconf_catcher(zeroconf_instance)
 
-    new_zeroconf_instance = zeroconf.Zeroconf()
-    assert new_zeroconf_instance == zeroconf_instance
+        new_zeroconf_instance = MockZeroconf()
+        assert new_zeroconf_instance == zeroconf_instance
 
-    assert "Zeroconf" in caplog.text
+        assert "Zeroconf" in caplog.text
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf", "mock_zeroconf")
@@ -41,44 +51,45 @@ async def test_multiple_zeroconf_instances_gives_shared(
 
     zeroconf_instance = await async_get_instance(hass)
 
-    install_multiple_zeroconf_catcher(zeroconf_instance)
+    with patch("zeroconf.Zeroconf", MockZeroconf):
+        install_multiple_zeroconf_catcher(zeroconf_instance)
 
-    correct_frame = Mock(
-        filename="/config/custom_components/burncpu/light.py",
-        lineno="23",
-        line="self.light.is_on",
-    )
-    with (
-        patch(
-            "homeassistant.helpers.frame.linecache.getline",
-            return_value=correct_frame.line,
-        ),
-        patch(
-            "homeassistant.helpers.frame.get_current_frame",
-            return_value=extract_stack_to_frame(
-                [
-                    Mock(
-                        filename="/home/dev/homeassistant/core.py",
-                        lineno="23",
-                        line="do_something()",
-                    ),
-                    correct_frame,
-                    Mock(
-                        filename="/home/dev/homeassistant/components/zeroconf/usage.py",
-                        lineno="23",
-                        line="self.light.is_on",
-                    ),
-                    Mock(
-                        filename="/home/dev/mdns/lights.py",
-                        lineno="2",
-                        line="something()",
-                    ),
-                ]
+        correct_frame = Mock(
+            filename="/config/custom_components/burncpu/light.py",
+            lineno="23",
+            line="self.light.is_on",
+        )
+        with (
+            patch(
+                "homeassistant.helpers.frame.linecache.getline",
+                return_value=correct_frame.line,
             ),
-        ),
-    ):
-        assert zeroconf.Zeroconf() == zeroconf_instance
+            patch(
+                "homeassistant.helpers.frame.get_current_frame",
+                return_value=extract_stack_to_frame(
+                    [
+                        Mock(
+                            filename="/home/dev/homeassistant/core.py",
+                            lineno="23",
+                            line="do_something()",
+                        ),
+                        correct_frame,
+                        Mock(
+                            filename="/home/dev/homeassistant/components/zeroconf/usage.py",
+                            lineno="23",
+                            line="self.light.is_on",
+                        ),
+                        Mock(
+                            filename="/home/dev/mdns/lights.py",
+                            lineno="2",
+                            line="something()",
+                        ),
+                    ]
+                ),
+            ),
+        ):
+            assert MockZeroconf() == zeroconf_instance
 
-    assert "custom_components/burncpu/light.py" in caplog.text
-    assert "23" in caplog.text
-    assert "self.light.is_on" in caplog.text
+        assert "custom_components/burncpu/light.py" in caplog.text
+        assert "23" in caplog.text
+        assert "self.light.is_on" in caplog.text

--- a/tests/components/zeroconf/test_websocket_api.py
+++ b/tests/components/zeroconf/test_websocket_api.py
@@ -66,7 +66,8 @@ async def test_subscribe_discovery(
                 const._TYPE_TXT,
                 const._CLASS_IN,
                 const._DNS_HOST_TTL,
-                b"\x13md=HASS Bridge W9DN\x06pv=1.0\x14id=11:8E:DB:5B:5C:C5\x05c#=12\x04s#=1",
+                b"\x13md=HASS Bridge W9DN\x06pv=1.0\x14id=11:8E:DB:5B:5C:C5"
+                b"\x05c#=12\x04s#=1",
             ),
             DNSPointer(
                 "_fakeservice._tcp.local.",
@@ -90,7 +91,8 @@ async def test_subscribe_discovery(
                 const._TYPE_TXT,
                 const._CLASS_IN,
                 const._DNS_HOST_TTL,
-                b"\x13md=HASS Bridge W9DN\x06pv=1.0\x14id=11:8E:DB:5B:5C:C5\x05c#=12\x04s#=1",
+                b"\x13md=HASS Bridge W9DN\x06pv=1.0\x14id=11:8E:DB:5B:5C:C5"
+                b"\x05c#=12\x04s#=1",
             ),
         ]
     )
@@ -138,7 +140,8 @@ async def test_subscribe_discovery(
     ]
     instance.zeroconf.cache.async_add_records(records)
     instance.zeroconf.record_manager.async_updates(
-        current_time_millis(), [RecordUpdate(record, None) for record in records]
+        current_time_millis(),
+        [RecordUpdate(record, None) for record in records],
     )
     # Now for the add
     async with asyncio.timeout(1):

--- a/tests/components/zeroconf/test_websocket_api.py
+++ b/tests/components/zeroconf/test_websocket_api.py
@@ -157,14 +157,4 @@ async def test_subscribe_discovery(
     instance.zeroconf.record_manager.async_updates_complete(False)
     async with asyncio.timeout(2):
         response = await client.receive_json()
-    assert response["event"] == {
-        "add": [
-            {
-                "ip_addresses": ["127.0.0.1"],
-                "name": "foo3._http._tcp.local.",
-                "port": 1234,
-                "properties": {},
-                "type": "_http._tcp.local.",
-            }
-        ]
-    }
+    assert response["event"] == {"remove": ["foo2._http._tcp.local."]}

--- a/tests/components/zeroconf/test_websocket_api.py
+++ b/tests/components/zeroconf/test_websocket_api.py
@@ -1,0 +1,130 @@
+"""The tests for the bluetooth WebSocket API."""
+
+import asyncio
+import socket
+
+from zeroconf import DNSAddress, DNSPointer, DNSService, DNSText, const
+
+from homeassistant.components.zeroconf import DOMAIN, async_get_async_instance
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.typing import WebSocketGenerator
+
+
+async def test_subscribe_discovery(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test zeroconf subscribe_discovery."""
+    instance = await async_get_async_instance(hass)
+    instance.zeroconf.cache.async_add_records(
+        [
+            DNSPointer(
+                "_hap._udp.local.",
+                const._TYPE_PTR,
+                const._CLASS_IN,
+                const._DNS_OTHER_TTL,
+                "foo2._hap._udp.local.",
+            ),
+            DNSService(
+                "foo2._hap._udp.local.",
+                const._TYPE_SRV,
+                const._CLASS_IN,
+                const._DNS_OTHER_TTL,
+                0,
+                0,
+                1234,
+                "foo.local.",
+            ),
+            DNSAddress(
+                "foo.local.",
+                const._TYPE_A,
+                const._CLASS_IN,
+                const._DNS_HOST_TTL,
+                socket.inet_aton("127.0.0.1"),
+            ),
+            DNSText(
+                "foo.local.",
+                const._TYPE_TXT,
+                const._CLASS_IN,
+                const._DNS_HOST_TTL,
+                b"\x13md=HASS Bridge W9DN\x06pv=1.0\x14id=11:8E:DB:5B:5C:C5\x05c#=12\x04s#=1",
+            ),
+            DNSPointer(
+                "_hap._udp.local.",
+                const._TYPE_PTR,
+                const._CLASS_IN,
+                const._DNS_OTHER_TTL,
+                "foo3._hap._udp.local.",
+            ),
+            DNSService(
+                "foo3._hap._udp.local.",
+                const._TYPE_SRV,
+                const._CLASS_IN,
+                const._DNS_OTHER_TTL,
+                0,
+                0,
+                1234,
+                "foo3.local.",
+            ),
+            DNSText(
+                "foo3.local.",
+                const._TYPE_TXT,
+                const._CLASS_IN,
+                const._DNS_HOST_TTL,
+                b"\x13md=HASS Bridge W9DN\x06pv=1.0\x14id=11:8E:DB:5B:5C:C5\x05c#=12\x04s#=1",
+            ),
+        ]
+    )
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "zeroconf/subscribe_discovery",
+        }
+    )
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["success"]
+
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["event"] == {
+        "add": [
+            {
+                "ip_addresses": ["127.0.0.1"],
+                "name": "foo2._hap._udp.local.",
+                "port": 1234,
+                "properties": {},
+                "type": "_hap._udp.local.",
+            }
+        ]
+    }
+
+    # now late inject the address record
+    instance.zeroconf.cache.async_add_records(
+        [
+            DNSAddress(
+                "foo.local.",
+                const._TYPE_A,
+                const._CLASS_IN,
+                const._DNS_HOST_TTL,
+                socket.inet_aton("127.0.0.1"),
+            ),
+        ]
+    )
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["event"] == {
+        "add": [
+            {
+                "ip_addresses": ["127.0.0.1"],
+                "name": "foo3._hap._udp.local.",
+                "port": 1234,
+                "properties": {},
+                "type": "_hap._udp.local.",
+            }
+        ]
+    }

--- a/tests/components/zeroconf/test_websocket_api.py
+++ b/tests/components/zeroconf/test_websocket_api.py
@@ -175,18 +175,17 @@ async def test_subscribe_discovery(
     record_updates = [RecordUpdate(record, record) for record in records]
     instance.zeroconf.record_manager.async_updates(future, record_updates)
     instance.zeroconf.record_manager.async_updates_complete(True)
-    removes: set[str] = set()
-    async with asyncio.timeout(1):
-        response = await client.receive_json()
-    assert "remove" in response["event"]
-    removes.add(next(iter(response["event"]["remove"]))["name"])
 
-    async with asyncio.timeout(1):
-        response = await client.receive_json()
-    assert "remove" in response["event"]
-    removes.add(next(iter(response["event"]["remove"]))["name"])
-    assert len(removes) == 2
+    removes: set[str] = set()
+    for _ in range(3):
+        async with asyncio.timeout(1):
+            response = await client.receive_json()
+        assert "remove" in response["event"]
+        removes.add(next(iter(response["event"]["remove"]))["name"])
+
+    assert len(removes) == 3
     assert removes == {
         "foo2._fakeservice._tcp.local.",
         "foo3._fakeservice._tcp.local.",
+        "wrong._wrongservice._tcp.local.",
     }

--- a/tests/components/zeroconf/test_websocket_api.py
+++ b/tests/components/zeroconf/test_websocket_api.py
@@ -1,9 +1,17 @@
-"""The tests for the bluetooth WebSocket API."""
+"""The tests for the zeroconf WebSocket API."""
 
 import asyncio
 import socket
 
-from zeroconf import DNSAddress, DNSPointer, DNSService, DNSText, const
+from zeroconf import (
+    DNSAddress,
+    DNSPointer,
+    DNSService,
+    DNSText,
+    RecordUpdate,
+    const,
+    current_time_millis,
+)
 
 from homeassistant.components.zeroconf import DOMAIN, async_get_async_instance
 from homeassistant.core import HomeAssistant
@@ -21,45 +29,45 @@ async def test_subscribe_discovery(
     instance.zeroconf.cache.async_add_records(
         [
             DNSPointer(
-                "_hap._udp.local.",
+                "_http._tcp.local.",
                 const._TYPE_PTR,
                 const._CLASS_IN,
                 const._DNS_OTHER_TTL,
-                "foo2._hap._udp.local.",
+                "foo2._http._tcp.local.",
             ),
             DNSService(
-                "foo2._hap._udp.local.",
+                "foo2._http._tcp.local.",
                 const._TYPE_SRV,
                 const._CLASS_IN,
                 const._DNS_OTHER_TTL,
                 0,
                 0,
                 1234,
-                "foo.local.",
+                "foo2.local.",
             ),
             DNSAddress(
-                "foo.local.",
+                "foo2.local.",
                 const._TYPE_A,
                 const._CLASS_IN,
                 const._DNS_HOST_TTL,
                 socket.inet_aton("127.0.0.1"),
             ),
             DNSText(
-                "foo.local.",
+                "foo2.local.",
                 const._TYPE_TXT,
                 const._CLASS_IN,
                 const._DNS_HOST_TTL,
                 b"\x13md=HASS Bridge W9DN\x06pv=1.0\x14id=11:8E:DB:5B:5C:C5\x05c#=12\x04s#=1",
             ),
             DNSPointer(
-                "_hap._udp.local.",
+                "_http._tcp.local.",
                 const._TYPE_PTR,
                 const._CLASS_IN,
                 const._DNS_OTHER_TTL,
-                "foo3._hap._udp.local.",
+                "foo3._http._tcp.local.",
             ),
             DNSService(
-                "foo3._hap._udp.local.",
+                "foo3._http._tcp.local.",
                 const._TYPE_SRV,
                 const._CLASS_IN,
                 const._DNS_OTHER_TTL,
@@ -95,25 +103,27 @@ async def test_subscribe_discovery(
         "add": [
             {
                 "ip_addresses": ["127.0.0.1"],
-                "name": "foo2._hap._udp.local.",
+                "name": "foo2._http._tcp.local.",
                 "port": 1234,
                 "properties": {},
-                "type": "_hap._udp.local.",
+                "type": "_http._tcp.local.",
             }
         ]
     }
 
     # now late inject the address record
-    instance.zeroconf.cache.async_add_records(
-        [
-            DNSAddress(
-                "foo.local.",
-                const._TYPE_A,
-                const._CLASS_IN,
-                const._DNS_HOST_TTL,
-                socket.inet_aton("127.0.0.1"),
-            ),
-        ]
+    records = [
+        DNSPointer(
+            "_http._tcp.local.",
+            const._TYPE_PTR,
+            const._CLASS_IN,
+            0,  # TTL = 0
+            "foo2._http._tcp.local.",
+        ),
+    ]
+    instance.zeroconf.cache.async_add_records(records)
+    instance.zeroconf.record_manager.async_updates(
+        current_time_millis(), [RecordUpdate(record, None) for record in records]
     )
     async with asyncio.timeout(1):
         response = await client.receive_json()
@@ -121,10 +131,40 @@ async def test_subscribe_discovery(
         "add": [
             {
                 "ip_addresses": ["127.0.0.1"],
-                "name": "foo3._hap._udp.local.",
+                "name": "foo3._http._tcp.local.",
                 "port": 1234,
                 "properties": {},
-                "type": "_hap._udp.local.",
+                "type": "_http._tcp.local.",
+            }
+        ]
+    }
+
+    # now inject a goodbye
+    records = [
+        DNSPointer(
+            "_http._tcp.local.",
+            const._TYPE_PTR,
+            const._CLASS_IN,
+            0,  # goodbye TTL = 0
+            "foo2._http._tcp.local.",
+        ),
+    ]
+    record_updates = [RecordUpdate(record, record) for record in records]
+    instance.zeroconf.cache.async_add_records(records)
+    instance.zeroconf.record_manager.async_updates(
+        current_time_millis(), record_updates
+    )
+    instance.zeroconf.record_manager.async_updates_complete(False)
+    async with asyncio.timeout(2):
+        response = await client.receive_json()
+    assert response["event"] == {
+        "add": [
+            {
+                "ip_addresses": ["127.0.0.1"],
+                "name": "foo3._http._tcp.local.",
+                "port": 1234,
+                "properties": {},
+                "type": "_http._tcp.local.",
             }
         ]
     }

--- a/tests/components/zeroconf/test_websocket_api.py
+++ b/tests/components/zeroconf/test_websocket_api.py
@@ -35,6 +35,13 @@ async def test_subscribe_discovery(
                 const._TYPE_PTR,
                 const._CLASS_IN,
                 const._DNS_OTHER_TTL,
+                "wrong._wrongservice._tcp.local.",
+            ),
+            DNSPointer(
+                "_fakeservice._tcp.local.",
+                const._TYPE_PTR,
+                const._CLASS_IN,
+                const._DNS_OTHER_TTL,
                 "foo2._fakeservice._tcp.local.",
             ),
             DNSService(


### PR DESCRIPTION
frontend: https://github.com/home-assistant/frontend/pull/25151

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add WebSocket API to zeroconf to observe discovery

This is for a dedicated Zeroconf panel in the UI. This panel will allow users to review discovered devices and help troubleshoot issues that require inspecting mDNS data.

This has already been helpful without even shipping it as it made me realize the timeout that has been that way in zeroconf as well for 15+ years (we use the same default) was too low: https://github.com/home-assistant/core/pull/143541


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
