### PR TITLE
Make proper Z-Wave reconfigure flow

### DIFF
--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -10,7 +10,7 @@
       "addon_stop_failed": "Failed to stop the Z-Wave add-on.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "backup_failed": "Failed to backup network.",
+      "backup_failed": "Failed to back up network.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "different_device": "The connected USB device is not the same as previously configured for this config entry. Please instead create a new config entry for the new device.",
       "discovery_requires_supervisor": "Discovery requires the supervisor.",

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -4,17 +4,22 @@
       "addon_get_discovery_info_failed": "Failed to get Z-Wave add-on discovery info.",
       "addon_info_failed": "Failed to get Z-Wave add-on info.",
       "addon_install_failed": "Failed to install the Z-Wave add-on.",
+      "addon_required": "The Z-Wave migration flow requires the integration to be configured using the Z-Wave Supervisor add-on. You can still use the Backup and Restore buttons to migrate your network manually.",
       "addon_set_config_failed": "Failed to set Z-Wave configuration.",
       "addon_start_failed": "Failed to start the Z-Wave add-on.",
+      "addon_stop_failed": "Failed to stop the Z-Wave add-on.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "backup_failed": "Failed to backup network.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "different_device": "The connected USB device is not the same as previously configured for this config entry. Please instead create a new config entry for the new device.",
       "discovery_requires_supervisor": "Discovery requires the supervisor.",
+      "migration_successful": "Migration successful.",
       "not_zwave_device": "Discovered device is not a Z-Wave device.",
       "not_zwave_js_addon": "Discovered add-on is not the official Z-Wave add-on.",
-      "backup_failed": "Failed to backup network.",
-      "restore_failed": "Failed to restore network.",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "reset_failed": "Failed to reset controller.",
+      "restore_failed": "Failed to restore network.",
       "usb_ports_failed": "Failed to get USB devices."
     },
     "error": {
@@ -42,6 +47,19 @@
         "description": "The add-on will generate security keys if those fields are left empty.",
         "title": "Enter the Z-Wave add-on configuration"
       },
+      "configure_addon_reconfigure": {
+        "data": {
+          "emulate_hardware": "Emulate Hardware",
+          "log_level": "Log level",
+          "s0_legacy_key": "[%key:component::zwave_js::config::step::configure_addon::data::s0_legacy_key%]",
+          "s2_access_control_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_access_control_key%]",
+          "s2_authenticated_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_authenticated_key%]",
+          "s2_unauthenticated_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_unauthenticated_key%]",
+          "usb_path": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "description": "[%key:component::zwave_js::config::step::configure_addon::description%]",
+        "title": "[%key:component::zwave_js::config::step::configure_addon::title%]"
+      },
       "hassio_confirm": {
         "title": "Set up Z-Wave integration with the Z-Wave add-on"
       },
@@ -53,12 +71,24 @@
           "url": "[%key:common::config_flow::data::url%]"
         }
       },
+      "manual_reconfigure": {
+        "data": {
+          "url": "[%key:common::config_flow::data::url%]"
+        }
+      },
       "on_supervisor": {
         "data": {
           "use_addon": "Use the Z-Wave Supervisor add-on"
         },
         "description": "Do you want to use the Z-Wave Supervisor add-on?",
         "title": "Select connection method"
+      },
+      "on_supervisor_reconfigure": {
+        "data": {
+          "use_addon": "[%key:component::zwave_js::config::step::on_supervisor::data::use_addon%]"
+        },
+        "description": "[%key:component::zwave_js::config::step::on_supervisor::description%]",
+        "title": "[%key:component::zwave_js::config::step::on_supervisor::title%]"
       },
       "start_addon": {
         "title": "The Z-Wave add-on is starting."
@@ -69,6 +99,28 @@
       "zeroconf_confirm": {
         "description": "Do you want to add the Z-Wave Server with home ID {home_id} found at {url} to Home Assistant?",
         "title": "Discovered Z-Wave Server"
+      },
+      "reconfigure": {
+        "title": "Migrate or re-configure",
+        "description": "Are you migrating to a new controller or re-configuring the current controller?",
+        "menu_options": {
+          "intent_migrate": "Migrate to a new controller",
+          "intent_reconfigure": "Re-configure the current controller"
+        }
+      },
+      "intent_migrate": {
+        "title": "[%key:component::zwave_js::config::step::reconfigure::menu_options::intent_migrate%]",
+        "description": "Before setting up your new controller, your old controller needs to be reset. A backup will be performed first.\n\nDo you wish to continue?"
+      },
+      "instruct_unplug": {
+        "title": "Unplug your old controller",
+        "description": "Backup saved to \"{file_path}\"\n\nYour old controller has been reset. If the hardware is no longer needed, you can now unplug it.\n\nPlease make sure your new controller is plugged in before continuing."
+      },
+      "choose_serial_port": {
+        "data": {
+          "usb_path": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "title": "Select your Z-Wave device"
       }
     }
   },
@@ -211,90 +263,6 @@
     "invalid_server_version": {
       "description": "The version of Z-Wave Server you are currently running is too old for this version of Home Assistant. Please update the Z-Wave Server to the latest version to fix this issue.",
       "title": "Newer version of Z-Wave Server needed"
-    }
-  },
-  "options": {
-    "abort": {
-      "addon_get_discovery_info_failed": "[%key:component::zwave_js::config::abort::addon_get_discovery_info_failed%]",
-      "addon_info_failed": "[%key:component::zwave_js::config::abort::addon_info_failed%]",
-      "addon_install_failed": "[%key:component::zwave_js::config::abort::addon_install_failed%]",
-      "addon_set_config_failed": "[%key:component::zwave_js::config::abort::addon_set_config_failed%]",
-      "addon_start_failed": "[%key:component::zwave_js::config::abort::addon_start_failed%]",
-      "addon_stop_failed": "Failed to stop the Z-Wave add-on.",
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "different_device": "The connected USB device is not the same as previously configured for this config entry. Please instead create a new config entry for the new device.",
-      "addon_required": "The Z-Wave migration flow requires the integration to be configured using the Z-Wave Supervisor add-on. You can still use the Backup and Restore buttons to migrate your network manually.",
-      "backup_failed": "[%key:component::zwave_js::config::abort::backup_failed%]",
-      "restore_failed": "[%key:component::zwave_js::config::abort::restore_failed%]",
-      "reset_failed": "[%key:component::zwave_js::config::abort::reset_failed%]",
-      "usb_ports_failed": "[%key:component::zwave_js::config::abort::usb_ports_failed%]"
-    },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_ws_url": "[%key:component::zwave_js::config::error::invalid_ws_url%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "progress": {
-      "install_addon": "[%key:component::zwave_js::config::progress::install_addon%]",
-      "start_addon": "[%key:component::zwave_js::config::progress::start_addon%]",
-      "backup_nvm": "[%key:component::zwave_js::config::progress::backup_nvm%]",
-      "restore_nvm": "[%key:component::zwave_js::config::progress::restore_nvm%]"
-    },
-    "step": {
-      "init": {
-        "title": "Migrate or re-configure",
-        "description": "Are you migrating to a new controller or re-configuring the current controller?",
-        "menu_options": {
-          "intent_migrate": "Migrate to a new controller",
-          "intent_reconfigure": "Re-configure the current controller"
-        }
-      },
-      "intent_migrate": {
-        "title": "[%key:component::zwave_js::options::step::init::menu_options::intent_migrate%]",
-        "description": "Before setting up your new controller, your old controller needs to be reset. A backup will be performed first.\n\nDo you wish to continue?"
-      },
-      "instruct_unplug": {
-        "title": "Unplug your old controller",
-        "description": "Backup saved to \"{file_path}\"\n\nYour old controller has been reset. If the hardware is no longer needed, you can now unplug it.\n\nPlease make sure your new controller is plugged in before continuing."
-      },
-      "configure_addon": {
-        "data": {
-          "emulate_hardware": "Emulate Hardware",
-          "log_level": "Log level",
-          "s0_legacy_key": "[%key:component::zwave_js::config::step::configure_addon::data::s0_legacy_key%]",
-          "s2_access_control_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_access_control_key%]",
-          "s2_authenticated_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_authenticated_key%]",
-          "s2_unauthenticated_key": "[%key:component::zwave_js::config::step::configure_addon::data::s2_unauthenticated_key%]",
-          "usb_path": "[%key:common::config_flow::data::usb_path%]"
-        },
-        "description": "[%key:component::zwave_js::config::step::configure_addon::description%]",
-        "title": "[%key:component::zwave_js::config::step::configure_addon::title%]"
-      },
-      "choose_serial_port": {
-        "data": {
-          "usb_path": "[%key:common::config_flow::data::usb_path%]"
-        },
-        "title": "Select your Z-Wave device"
-      },
-      "install_addon": {
-        "title": "[%key:component::zwave_js::config::step::install_addon::title%]"
-      },
-      "manual": {
-        "data": {
-          "url": "[%key:common::config_flow::data::url%]"
-        }
-      },
-      "on_supervisor": {
-        "data": {
-          "use_addon": "[%key:component::zwave_js::config::step::on_supervisor::data::use_addon%]"
-        },
-        "description": "[%key:component::zwave_js::config::step::on_supervisor::description%]",
-        "title": "[%key:component::zwave_js::config::step::on_supervisor::title%]"
-      },
-      "start_addon": {
-        "title": "[%key:component::zwave_js::config::step::start_addon::title%]"
-      }
     }
   },
   "services": {

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -17,11 +17,7 @@ from zwave_js_server.exceptions import FailedCommand
 from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.zwave_js.config_flow import (
-    SERVER_VERSION_TIMEOUT,
-    TITLE,
-    OptionsFlowHandler,
-)
+from homeassistant.components.zwave_js.config_flow import SERVER_VERSION_TIMEOUT, TITLE
 from homeassistant.components.zwave_js.const import ADDON_SLUG, CONF_USB_PATH, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -299,29 +295,30 @@ async def test_manual_errors(hass: HomeAssistant, integration, url, error) -> No
         ),
     ],
 )
-async def test_manual_errors_options_flow(
+async def test_reconfigure_manual_errors(
     hass: HomeAssistant, integration, url, error
 ) -> None:
-    """Test all errors with a manual set up."""
-    result = await hass.config_entries.options.async_init(integration.entry_id)
+    """Test all errors with a manual set up in a reconfigure flow."""
+    entry = integration
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
-    result = await hass.config_entries.options.async_configure(
+    assert result["step_id"] == "reconfigure"
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "manual"
+    assert result["step_id"] == "manual_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             "url": url,
         },
     )
 
-    assert result["step_id"] == "manual"
+    assert result["step_id"] == "manual_reconfigure"
     assert result["errors"] == {"base": error}
 
 
@@ -2027,32 +2024,33 @@ async def test_install_addon_failure(
     assert result["reason"] == "addon_install_failed"
 
 
-async def test_options_manual(hass: HomeAssistant, client, integration) -> None:
-    """Test manual settings in options flow."""
+async def test_reconfigure_manual(hass: HomeAssistant, client, integration) -> None:
+    """Test manual settings in reconfigure flow."""
     entry = integration
     hass.config_entries.async_update_entry(entry, unique_id="1234")
 
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "manual"
+    assert result["step_id"] == "manual_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"url": "ws://1.1.1.1:3001"}
     )
     await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
     assert entry.data["url"] == "ws://1.1.1.1:3001"
     assert entry.data["use_addon"] is False
     assert entry.data["integration_created_addon"] is False
@@ -2060,26 +2058,26 @@ async def test_options_manual(hass: HomeAssistant, client, integration) -> None:
     assert client.disconnect.call_count == 1
 
 
-async def test_options_manual_different_device(
+async def test_reconfigure_manual_different_device(
     hass: HomeAssistant, integration
 ) -> None:
-    """Test options flow manual step connecting to different device."""
+    """Test reconfigure flow manual step connecting to different device."""
     entry = integration
     hass.config_entries.async_update_entry(entry, unique_id="5678")
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "manual"
+    assert result["step_id"] == "manual_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"url": "ws://1.1.1.1:3001"}
     )
     await hass.async_block_till_done()
@@ -2088,36 +2086,36 @@ async def test_options_manual_different_device(
     assert result["reason"] == "different_device"
 
 
-async def test_options_not_addon(
+async def test_reconfigure_not_addon(
     hass: HomeAssistant, client, supervisor, integration
 ) -> None:
-    """Test options flow and opting out of add-on on Supervisor."""
+    """Test reconfigure flow and opting out of add-on on Supervisor."""
     entry = integration
     hass.config_entries.async_update_entry(entry, unique_id="1234")
 
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": False}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "manual"
+    assert result["step_id"] == "manual_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             "url": "ws://localhost:3000",
@@ -2125,7 +2123,8 @@ async def test_options_not_addon(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
     assert entry.data["url"] == "ws://localhost:3000"
     assert entry.data["use_addon"] is False
     assert entry.data["integration_created_addon"] is False
@@ -2134,14 +2133,14 @@ async def test_options_not_addon(
 
 
 @pytest.mark.usefixtures("supervisor")
-async def test_options_not_addon_with_addon(
+async def test_reconfigure_not_addon_with_addon(
     hass: HomeAssistant,
     setup_entry: AsyncMock,
     unload_entry: AsyncMock,
     integration: MockConfigEntry,
     stop_addon: AsyncMock,
 ) -> None:
-    """Test options flow opting out of add-on on Supervisor with add-on."""
+    """Test reconfigure flow opting out of add-on on Supervisor with add-on."""
     entry = integration
     hass.config_entries.async_update_entry(
         entry,
@@ -2153,19 +2152,19 @@ async def test_options_not_addon_with_addon(
     assert unload_entry.call_count == 0
     setup_entry.reset_mock()
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": False}
     )
 
@@ -2176,9 +2175,9 @@ async def test_options_not_addon_with_addon(
     assert stop_addon.call_args == call("core_zwave_js")
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "manual"
+    assert result["step_id"] == "manual_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
             "url": "ws://localhost:3000",
@@ -2186,7 +2185,8 @@ async def test_options_not_addon_with_addon(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
     assert entry.data["url"] == "ws://localhost:3000"
     assert entry.data["use_addon"] is False
     assert entry.data["integration_created_addon"] is False
@@ -2200,14 +2200,14 @@ async def test_options_not_addon_with_addon(
 
 
 @pytest.mark.usefixtures("supervisor")
-async def test_options_not_addon_with_addon_stop_fail(
+async def test_reconfigure_not_addon_with_addon_stop_fail(
     hass: HomeAssistant,
     setup_entry: AsyncMock,
     unload_entry: AsyncMock,
     integration: MockConfigEntry,
     stop_addon: AsyncMock,
 ) -> None:
-    """Test options flow opting out of add-on and add-on stop error."""
+    """Test reconfigure flow opting out of add-on and add-on stop error."""
     stop_addon.side_effect = SupervisorError("Boom!")
     entry = integration
     hass.config_entries.async_update_entry(
@@ -2220,19 +2220,19 @@ async def test_options_not_addon_with_addon_stop_fail(
     assert unload_entry.call_count == 0
     setup_entry.reset_mock()
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": False}
     )
     await hass.async_block_till_done()
@@ -2330,7 +2330,7 @@ async def test_options_not_addon_with_addon_stop_fail(
         ),
     ],
 )
-async def test_options_addon_running(
+async def test_reconfigure_addon_running(
     hass: HomeAssistant,
     client,
     supervisor,
@@ -2346,7 +2346,7 @@ async def test_options_addon_running(
     new_addon_options,
     disconnect_calls,
 ) -> None:
-    """Test options flow and add-on already running on Supervisor."""
+    """Test reconfigure flow and add-on already running on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
     data = {**entry.data, **entry_data}
@@ -2357,26 +2357,26 @@ async def test_options_addon_running(
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": True}
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_addon"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         new_addon_options,
     )
@@ -2392,12 +2392,13 @@ async def test_options_addon_running(
     assert result["step_id"] == "start_addon"
 
     await hass.async_block_till_done()
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
     await hass.async_block_till_done()
 
     assert restart_addon.call_args == call("core_zwave_js")
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
     assert entry.data["url"] == "ws://host1:3001"
     assert entry.data["usb_path"] == new_addon_options["device"]
     assert entry.data["s0_legacy_key"] == new_addon_options["s0_legacy_key"]
@@ -2465,7 +2466,7 @@ async def test_options_addon_running(
         ),
     ],
 )
-async def test_options_addon_running_no_changes(
+async def test_reconfigure_addon_running_no_changes(
     hass: HomeAssistant,
     client,
     supervisor,
@@ -2480,7 +2481,7 @@ async def test_options_addon_running_no_changes(
     old_addon_options,
     new_addon_options,
 ) -> None:
-    """Test options flow without changes, and add-on already running on Supervisor."""
+    """Test reconfigure flow without changes, and add-on already running on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
     data = {**entry.data, **entry_data}
@@ -2491,26 +2492,26 @@ async def test_options_addon_running_no_changes(
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": True}
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_addon"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         new_addon_options,
     )
@@ -2520,7 +2521,8 @@ async def test_options_addon_running_no_changes(
     assert set_addon_options.call_count == 0
     assert restart_addon.call_count == 0
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
     assert entry.data["url"] == "ws://host1:3001"
     assert entry.data["usb_path"] == new_addon_options["device"]
     assert entry.data["s0_legacy_key"] == new_addon_options["s0_legacy_key"]
@@ -2643,7 +2645,7 @@ async def different_device_server_version(*args):
         ),
     ],
 )
-async def test_options_different_device(
+async def test_reconfigure_different_device(
     hass: HomeAssistant,
     client,
     supervisor,
@@ -2660,7 +2662,7 @@ async def test_options_different_device(
     disconnect_calls,
     server_version_side_effect,
 ) -> None:
-    """Test options flow and configuring a different device."""
+    """Test reconfigure flow and configuring a different device."""
     addon_options.update(old_addon_options)
     entry = integration
     data = {**entry.data, **entry_data}
@@ -2671,26 +2673,26 @@ async def test_options_different_device(
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": True}
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_addon"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         new_addon_options,
     )
@@ -2709,7 +2711,7 @@ async def test_options_different_device(
     assert restart_addon.call_count == 1
     assert restart_addon.call_args == call("core_zwave_js")
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
     await hass.async_block_till_done()
 
     # Default emulate_hardware is False.
@@ -2729,7 +2731,7 @@ async def test_options_different_device(
     assert restart_addon.call_count == 2
     assert restart_addon.call_args == call("core_zwave_js")
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
@@ -2826,7 +2828,7 @@ async def test_options_different_device(
         ),
     ],
 )
-async def test_options_addon_restart_failed(
+async def test_reconfigure_addon_restart_failed(
     hass: HomeAssistant,
     client,
     supervisor,
@@ -2843,7 +2845,7 @@ async def test_options_addon_restart_failed(
     disconnect_calls,
     restart_addon_side_effect,
 ) -> None:
-    """Test options flow and add-on restart failure."""
+    """Test reconfigure flow and add-on restart failure."""
     addon_options.update(old_addon_options)
     entry = integration
     data = {**entry.data, **entry_data}
@@ -2854,26 +2856,26 @@ async def test_options_addon_restart_failed(
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": True}
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_addon"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         new_addon_options,
     )
@@ -2892,7 +2894,7 @@ async def test_options_addon_restart_failed(
     assert restart_addon.call_count == 1
     assert restart_addon.call_args == call("core_zwave_js")
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
     await hass.async_block_till_done()
 
     # The legacy network key should not be reset.
@@ -2909,7 +2911,7 @@ async def test_options_addon_restart_failed(
     assert restart_addon.call_count == 2
     assert restart_addon.call_args == call("core_zwave_js")
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
@@ -2967,7 +2969,7 @@ async def test_options_addon_restart_failed(
         ),
     ],
 )
-async def test_options_addon_running_server_info_failure(
+async def test_reconfigure_addon_running_server_info_failure(
     hass: HomeAssistant,
     client,
     supervisor,
@@ -2984,7 +2986,7 @@ async def test_options_addon_running_server_info_failure(
     disconnect_calls,
     server_version_side_effect,
 ) -> None:
-    """Test options flow and add-on already running with server info failure."""
+    """Test reconfigure flow and add-on already running with server info failure."""
     addon_options.update(old_addon_options)
     entry = integration
     data = {**entry.data, **entry_data}
@@ -2995,26 +2997,26 @@ async def test_options_addon_running_server_info_failure(
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": True}
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_addon"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         new_addon_options,
     )
@@ -3104,7 +3106,7 @@ async def test_options_addon_running_server_info_failure(
         ),
     ],
 )
-async def test_options_addon_not_installed(
+async def test_reconfigure_addon_not_installed(
     hass: HomeAssistant,
     client,
     supervisor,
@@ -3121,7 +3123,7 @@ async def test_options_addon_not_installed(
     new_addon_options,
     disconnect_calls,
 ) -> None:
-    """Test options flow and add-on not installed on Supervisor."""
+    """Test reconfigure flow and add-on not installed on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
     data = {**entry.data, **entry_data}
@@ -3132,19 +3134,19 @@ async def test_options_addon_not_installed(
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": True}
     )
 
@@ -3154,14 +3156,14 @@ async def test_options_addon_not_installed(
     # Make sure the flow continues when the progress task is done.
     await hass.async_block_till_done()
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert install_addon.call_args == call("core_zwave_js")
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_addon"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         new_addon_options,
     )
@@ -3180,11 +3182,12 @@ async def test_options_addon_not_installed(
     assert start_addon.call_count == 1
     assert start_addon.call_args == call("core_zwave_js")
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
     await hass.async_block_till_done()
     await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
     assert entry.data["url"] == "ws://host1:3001"
     assert entry.data["usb_path"] == new_addon_options["device"]
     assert entry.data["s0_legacy_key"] == new_addon_options["s0_legacy_key"]
@@ -3244,19 +3247,19 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_options_migrate_no_addon(hass: HomeAssistant, integration) -> None:
+async def test_reconfigure_migrate_no_addon(hass: HomeAssistant, integration) -> None:
     """Test migration flow fails when not using add-on."""
     entry = integration
     hass.config_entries.async_update_entry(
         entry, unique_id="1234", data={**entry.data, "use_addon": False}
     )
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_migrate"}
     )
 
@@ -3277,7 +3280,7 @@ async def test_options_migrate_no_addon(hass: HomeAssistant, integration) -> Non
         ]
     ],
 )
-async def test_options_migrate_with_addon(
+async def test_reconfigure_migrate_with_addon(
     hass: HomeAssistant,
     client,
     supervisor,
@@ -3288,8 +3291,9 @@ async def test_options_migrate_with_addon(
     get_addon_discovery_info,
 ) -> None:
     """Test migration flow with add-on."""
+    entry = integration
     hass.config_entries.async_update_entry(
-        integration,
+        entry,
         unique_id="1234",
         data={
             "url": "ws://localhost:3000",
@@ -3328,19 +3332,19 @@ async def test_options_migrate_with_addon(
         hass, data_entry_flow.EVENT_DATA_ENTRY_FLOW_PROGRESS_UPDATE
     )
 
-    result = await hass.config_entries.options.async_init(integration.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] == FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_migrate"}
     )
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "intent_migrate"
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "backup_nvm"
@@ -3353,18 +3357,18 @@ async def test_options_migrate_with_addon(
         assert events[0].data["progress"] == 0.5
         events.clear()
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "instruct_unplug"
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "choose_serial_port"
     assert result["data_schema"].schema[CONF_USB_PATH]
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
             CONF_USB_PATH: "/test",
@@ -3381,7 +3385,7 @@ async def test_options_migrate_with_addon(
 
     assert restart_addon.call_args == call("core_zwave_js")
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "restore_nvm"
@@ -3393,15 +3397,16 @@ async def test_options_migrate_with_addon(
     assert events[0].data["progress"] == 0.25
     assert events[1].data["progress"] == 0.75
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "migration_successful"
     assert integration.data["url"] == "ws://host1:3001"
     assert integration.data["usb_path"] == "/test"
     assert integration.data["use_addon"] is True
 
 
-async def test_options_migrate_backup_failure(
+async def test_reconfigure_migrate_backup_failure(
     hass: HomeAssistant, integration, client
 ) -> None:
     """Test backup failure."""
@@ -3414,25 +3419,25 @@ async def test_options_migrate_backup_failure(
         side_effect=FailedCommand("test_error", "unknown_error")
     )
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] == FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_migrate"}
     )
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "intent_migrate"
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "backup_failed"
 
 
-async def test_options_migrate_backup_file_failure(
+async def test_reconfigure_migrate_backup_file_failure(
     hass: HomeAssistant, integration, client
 ) -> None:
     """Test backup file failure."""
@@ -3449,19 +3454,19 @@ async def test_options_migrate_backup_file_failure(
         side_effect=mock_backup_nvm_raw
     )
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] == FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_migrate"}
     )
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "intent_migrate"
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "backup_nvm"
@@ -3472,7 +3477,7 @@ async def test_options_migrate_backup_file_failure(
         await hass.async_block_till_done()
         assert client.driver.controller.async_backup_nvm_raw.call_count == 1
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "backup_failed"
@@ -3491,7 +3496,7 @@ async def test_options_migrate_backup_file_failure(
         ]
     ],
 )
-async def test_options_migrate_restore_failure(
+async def test_reconfigure_migrate_restore_failure(
     hass: HomeAssistant,
     client,
     supervisor,
@@ -3502,8 +3507,9 @@ async def test_options_migrate_restore_failure(
     get_addon_discovery_info,
 ) -> None:
     """Test restore failure."""
+    entry = integration
     hass.config_entries.async_update_entry(
-        integration, unique_id="1234", data={**integration.data, "use_addon": True}
+        entry, unique_id="1234", data={**entry.data, "use_addon": True}
     )
 
     async def mock_backup_nvm_raw():
@@ -3517,19 +3523,19 @@ async def test_options_migrate_restore_failure(
         side_effect=FailedCommand("test_error", "unknown_error")
     )
 
-    result = await hass.config_entries.options.async_init(integration.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] == FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_migrate"}
     )
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "intent_migrate"
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "backup_nvm"
@@ -3539,17 +3545,17 @@ async def test_options_migrate_restore_failure(
         assert client.driver.controller.async_backup_nvm_raw.call_count == 1
         assert mock_file.call_count == 1
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "instruct_unplug"
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "choose_serial_port"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
             CONF_USB_PATH: "/test",
@@ -3560,7 +3566,7 @@ async def test_options_migrate_restore_failure(
     assert result["step_id"] == "start_addon"
 
     await hass.async_block_till_done()
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "restore_nvm"
@@ -3569,7 +3575,7 @@ async def test_options_migrate_restore_failure(
 
     assert client.driver.controller.async_restore_nvm.call_count == 1
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "restore_failed"
@@ -3577,18 +3583,32 @@ async def test_options_migrate_restore_failure(
 
 async def test_get_driver_failure(hass: HomeAssistant, integration, client) -> None:
     """Test get driver failure."""
+    entry = integration
+    hass.config_entries.async_update_entry(
+        integration, unique_id="1234", data={**integration.data, "use_addon": True}
+    )
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "reconfigure"
 
-    handler = OptionsFlowHandler()
-    handler.hass = hass
-    handler._config_entry = integration
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "intent_migrate"}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "intent_migrate"
+
     await hass.config_entries.async_unload(integration.entry_id)
 
-    with pytest.raises(data_entry_flow.AbortFlow):
-        await handler._get_driver()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "backup_failed"
 
 
 async def test_hard_reset_failure(hass: HomeAssistant, integration, client) -> None:
     """Test hard reset failure."""
+    entry = integration
     hass.config_entries.async_update_entry(
         integration, unique_id="1234", data={**integration.data, "use_addon": True}
     )
@@ -3604,19 +3624,19 @@ async def test_hard_reset_failure(hass: HomeAssistant, integration, client) -> N
         side_effect=FailedCommand("test_error", "unknown_error")
     )
 
-    result = await hass.config_entries.options.async_init(integration.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] == FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_migrate"}
     )
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "intent_migrate"
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "backup_nvm"
@@ -3626,7 +3646,7 @@ async def test_hard_reset_failure(hass: HomeAssistant, integration, client) -> N
         assert client.driver.controller.async_backup_nvm_raw.call_count == 1
         assert mock_file.call_count == 1
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reset_failed"
@@ -3636,6 +3656,7 @@ async def test_choose_serial_port_usb_ports_failure(
     hass: HomeAssistant, integration, client
 ) -> None:
     """Test choose serial port usb ports failure."""
+    entry = integration
     hass.config_entries.async_update_entry(
         integration, unique_id="1234", data={**integration.data, "use_addon": True}
     )
@@ -3648,19 +3669,19 @@ async def test_choose_serial_port_usb_ports_failure(
         side_effect=mock_backup_nvm_raw
     )
 
-    result = await hass.config_entries.options.async_init(integration.entry_id)
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] == FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_migrate"}
     )
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "intent_migrate"
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "backup_nvm"
@@ -3670,7 +3691,7 @@ async def test_choose_serial_port_usb_ports_failure(
         assert client.driver.controller.async_backup_nvm_raw.call_count == 1
         assert mock_file.call_count == 1
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "instruct_unplug"
@@ -3679,9 +3700,7 @@ async def test_choose_serial_port_usb_ports_failure(
         "homeassistant.components.zwave_js.config_flow.async_get_usb_ports",
         side_effect=OSError("test_error"),
     ):
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], {}
-        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "usb_ports_failed"
 
@@ -3690,23 +3709,24 @@ async def test_configure_addon_usb_ports_failure(
     hass: HomeAssistant, integration, addon_installed, supervisor
 ) -> None:
     """Test configure addon usb ports failure."""
-    result = await hass.config_entries.options.async_init(integration.entry_id)
+    entry = integration
+    result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] == FlowResultType.MENU
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.options.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "intent_reconfigure"}
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "on_supervisor"
+    assert result["step_id"] == "on_supervisor_reconfigure"
 
     with patch(
         "homeassistant.components.zwave_js.config_flow.async_get_usb_ports",
         side_effect=OSError("test_error"),
     ):
-        result = await hass.config_entries.options.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"use_addon": True}
         )
         assert result["type"] == FlowResultType.ABORT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Merge the options flow into the config flow and let the reconfigure step start that part of the flow. The options flow was always only a way to reconfigure the integration. Now that we have a native way to do reconfiguration, use that instead of having a custom way.
- This requires a frontend change since the Z-Wave integration has its own config panel in the frontend that starts the reconfiguration/options flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
