### PR TITLE
Encourage to use UID instead of name for update and delete todos

### DIFF
--- a/homeassistant/components/todo/services.yaml
+++ b/homeassistant/components/todo/services.yaml
@@ -55,7 +55,7 @@ update_item:
   fields:
     item:
       required: true
-      example: "Submit income tax return"
+      example: "62df5ffa78e84f90a0f7ff38aa28ff9d"
       selector:
         text:
     rename:
@@ -100,6 +100,7 @@ remove_item:
   fields:
     item:
       required: true
+      example: "62df5ffa78e84f90a0f7ff38aa28ff9d"
       selector:
         text:
 

--- a/homeassistant/components/todo/services.yaml
+++ b/homeassistant/components/todo/services.yaml
@@ -55,7 +55,7 @@ update_item:
   fields:
     item:
       required: true
-      example: "62df5ffa78e84f90a0f7ff38aa28ff9d"
+      example: "Submit income tax return"
       selector:
         text:
     rename:
@@ -100,7 +100,7 @@ remove_item:
   fields:
     item:
       required: true
-      example: "62df5ffa78e84f90a0f7ff38aa28ff9d"
+      example: "Submit income tax return"
       selector:
         text:
 

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -44,7 +44,7 @@
       "fields": {
         "item": {
           "name": "Item name or UID",
-          "description": "The name/summary of the to-do item. In some cases, for example if you have items with the same name, it can make sense to use the UID instead of the name. To find the UID of an item, perform a `get_items` action on the to-do list."
+          "description": "The name/summary of the to-do item. If you have items with duplicate names, you can reference specific ones using their UID instead."
         },
         "rename": {
           "name": "Rename item",
@@ -77,8 +77,8 @@
       "description": "Removes an existing to-do list item by its name or UID.",
       "fields": {
         "item": {
-          "name": "Item name or UID",
-          "description": "The name/summary of the to-do item. In some cases, for example if you have items with the same name, it can make sense to use the UID instead of the name. To find the UID of an item, perform a `get_items` action on the to-do list."
+          "name": "[%key:component::todo::services::update_item::fields::item::name%]",
+          "description": "[%key:component::todo::services::update_item::fields::item::description%]"
         }
       }
     }

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -40,11 +40,11 @@
     },
     "update_item": {
       "name": "Update item",
-      "description": "Updates an existing to-do list item based on its UID or name.",
+      "description": "Updates an existing to-do list item based on its name or UID.",
       "fields": {
         "item": {
-          "name": "Item UID or name",
-          "description": "The UID of the to-do item. Using the name is discouraged as it may not be unique."
+          "name": "Item name or UID",
+          "description": "The name/summary of the to-do item. In some cases, for example if you have items with the same name, it can make sense to use the UID instead of the name. To find the UID of an item, perform a `get_items` action on the to-do list."
         },
         "rename": {
           "name": "Rename item",
@@ -74,11 +74,11 @@
     },
     "remove_item": {
       "name": "Remove item",
-      "description": "Removes an existing to-do list item by its UID or name.",
+      "description": "Removes an existing to-do list item by its name or UID.",
       "fields": {
         "item": {
-          "name": "Item UID or name",
-          "description": "The UID of the to-do item. Using the name is discouraged as it may not be unique."
+          "name": "Item name or UID",
+          "description": "The name/summary of the to-do item. In some cases, for example if you have items with the same name, it can make sense to use the UID instead of the name. To find the UID of an item, perform a `get_items` action on the to-do list."
         }
       }
     }

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -40,11 +40,11 @@
     },
     "update_item": {
       "name": "Update item",
-      "description": "Updates an existing to-do list item based on its name.",
+      "description": "Updates an existing to-do list item based on its UID or name.",
       "fields": {
         "item": {
-          "name": "Item name",
-          "description": "The current name of the to-do item."
+          "name": "Item UID or name",
+          "description": "The UID of the to-do item. Using the name is discouraged as it may not be unique."
         },
         "rename": {
           "name": "Rename item",
@@ -74,11 +74,11 @@
     },
     "remove_item": {
       "name": "Remove item",
-      "description": "Removes an existing to-do list item by its name.",
+      "description": "Removes an existing to-do list item by its UID or name.",
       "fields": {
         "item": {
-          "name": "Item name",
-          "description": "The name for the to-do list item."
+          "name": "Item UID or name",
+          "description": "The UID of the to-do item. Using the name is discouraged as it may not be unique."
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While using the API to update TODO items I was mislead by the documentation and used the name of the item to `update` and `delete`. When doing more testing with my code I found a weird behavior when I had multiple items in the list with the same name. I was not able to complete all the items. I then switch to UID and it fixed my issue. This PR is simply updating the documentation to clarify that the UID can be use instead of the name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38704

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
