### PR TITLE
Use None for Unknown state in Whirlpool sensor

### DIFF
--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -25,7 +25,7 @@ from .entity import WhirlpoolEntity
 SCAN_INTERVAL = timedelta(minutes=5)
 
 WASHER_TANK_FILL = {
-    0: "unknown",
+    0: None,
     1: "empty",
     2: "25",
     3: "50",
@@ -120,7 +120,7 @@ WASHER_SENSORS: tuple[WhirlpoolSensorEntityDescription, ...] = (
         translation_key="whirlpool_tank",
         entity_registry_enabled_default=False,
         device_class=SensorDeviceClass.ENUM,
-        options=list(WASHER_TANK_FILL.values()),
+        options=[value for value in WASHER_TANK_FILL.values() if value],
         value_fn=lambda washer: WASHER_TANK_FILL.get(washer.get_dispense_1_level()),
     ),
 )

--- a/tests/components/whirlpool/snapshots/test_sensor.ambr
+++ b/tests/components/whirlpool/snapshots/test_sensor.ambr
@@ -160,7 +160,6 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'unknown',
         'empty',
         '25',
         '50',
@@ -202,7 +201,6 @@
       'device_class': 'enum',
       'friendly_name': 'Washer Detergent level',
       'options': list([
-        'unknown',
         'empty',
         '25',
         '50',

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -299,3 +299,44 @@ async def test_washer_dryer_door_open_state(
     await trigger_attr_callback(hass, mock_instance)
     state = hass.states.get(entity_id)
     assert state.state == "running_maincycle"
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "mock_fixture", "mock_method_name", "values"),
+    [
+        (
+            "sensor.washer_detergent_level",
+            "mock_washer_api",
+            "get_dispense_1_level",
+            [
+                (0, STATE_UNKNOWN),
+                (1, "empty"),
+                (2, "25"),
+                (3, "50"),
+                (4, "100"),
+                (5, "active"),
+            ],
+        ),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_simple_enum_sensors(
+    hass: HomeAssistant,
+    entity_id: str,
+    mock_fixture: str,
+    mock_method_name: str,
+    values: list[tuple[int, str]],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test simple enum sensors where state maps directly from a single API value."""
+    await init_integration(hass)
+
+    mock_instance = request.getfixturevalue(mock_fixture)
+    mock_method = getattr(mock_instance, mock_method_name)
+    for raw_value, expected_state in values:
+        mock_method.return_value = raw_value
+
+        await trigger_attr_callback(hass, mock_instance)
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == expected_state


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
