### PR TITLE
Wake On Lan: Add support for magic packet source Interface IP address

### DIFF
--- a/homeassistant/components/wake_on_lan/__init__.py
+++ b/homeassistant/components/wake_on_lan/__init__.py
@@ -7,7 +7,12 @@ import voluptuous as vol
 import wakeonlan
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
+from homeassistant.const import (
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_IF,
+    CONF_MAC,
+)
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -23,6 +28,7 @@ WAKE_ON_LAN_SEND_MAGIC_PACKET_SCHEMA = vol.Schema(
         vol.Required(CONF_MAC): cv.string,
         vol.Optional(CONF_BROADCAST_ADDRESS): cv.string,
         vol.Optional(CONF_BROADCAST_PORT): cv.port,
+        vol.Optional(CONF_IF): cv.string,
     }
 )
 
@@ -37,18 +43,22 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         mac_address = call.data.get(CONF_MAC)
         broadcast_address = call.data.get(CONF_BROADCAST_ADDRESS)
         broadcast_port = call.data.get(CONF_BROADCAST_PORT)
+        interface = call.data.get(CONF_IF)
 
         service_kwargs = {}
         if broadcast_address is not None:
             service_kwargs["ip_address"] = broadcast_address
         if broadcast_port is not None:
             service_kwargs["port"] = broadcast_port
+        if interface is not None:
+            service_kwargs["interface"] = interface
 
         _LOGGER.debug(
-            "Send magic packet to mac %s (broadcast: %s, port: %s)",
+            "Send magic packet to mac %s (broadcast: %s, port: %s, interface: %s)",
             mac_address,
             broadcast_address,
             broadcast_port,
+            interface,
         )
 
         await hass.async_add_executor_job(

--- a/homeassistant/components/wake_on_lan/config_flow.py
+++ b/homeassistant/components/wake_on_lan/config_flow.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
+from homeassistant.const import (
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_IF,
+    CONF_MAC,
+)
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
@@ -52,6 +57,7 @@ OPTIONS_SCHEMA = {
     vol.Optional(CONF_BROADCAST_PORT): NumberSelector(
         NumberSelectorConfig(min=0, max=65535, step=1, mode=NumberSelectorMode.BOX)
     ),
+    vol.Optional(CONF_IF): TextSelector(),
 }
 
 

--- a/homeassistant/components/wake_on_lan/services.yaml
+++ b/homeassistant/components/wake_on_lan/services.yaml
@@ -16,3 +16,7 @@ send_magic_packet:
           min: 1
           max: 65535
           mode: "box"
+    if:
+      example: "192.168.10.4"
+      selector:
+        text:

--- a/homeassistant/components/wake_on_lan/strings.json
+++ b/homeassistant/components/wake_on_lan/strings.json
@@ -8,12 +8,14 @@
         "data": {
           "mac": "MAC address",
           "broadcast_address": "Broadcast address",
-          "broadcast_port": "Broadcast port"
+          "broadcast_port": "Broadcast port",
+          "if": "Interface IP address"
         },
         "data_description": {
           "mac": "MAC address of the device to wake up.",
           "broadcast_address": "The IP address of the host to send the magic packet to. Defaults to `255.255.255.255` and is normally not changed.",
-          "broadcast_port": "The port to send the magic packet to. Defaults to `9` and is normally not changed."
+          "broadcast_port": "The port to send the magic packet to. Defaults to `9` and is normally not changed.",
+          "if": "The ip address of the network adapter to route the magic packet through. Defaults to None"
         }
       }
     }
@@ -26,11 +28,13 @@
       "init": {
         "data": {
           "broadcast_address": "[%key:component::wake_on_lan::config::step::user::data::broadcast_address%]",
-          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data::broadcast_port%]"
+          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data::broadcast_port%]",
+          "if": "[%key:component::wake_on_lan::config::step::user::data::if%]"
         },
         "data_description": {
           "broadcast_address": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_address%]",
-          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_port%]"
+          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_port%]",
+          "if": "[%key:component::wake_on_lan::config::step::user::data_description::if%]"
         }
       }
     }
@@ -51,6 +55,10 @@
         "broadcast_port": {
           "name": "[%key:component::wake_on_lan::config::step::user::data::broadcast_port%]",
           "description": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_port%]"
+        },
+        "if": {
+          "name": "[%key:component::wake_on_lan::config::step::user::data::if%]",
+          "description": "[%key:component::wake_on_lan::config::step::user::data_description::if%]"
         }
       }
     }

--- a/homeassistant/components/wake_on_lan/strings.json
+++ b/homeassistant/components/wake_on_lan/strings.json
@@ -15,7 +15,7 @@
           "mac": "MAC address of the device to wake up.",
           "broadcast_address": "The IP address of the host to send the magic packet to. Defaults to `255.255.255.255` and is normally not changed.",
           "broadcast_port": "The port to send the magic packet to. Defaults to `9` and is normally not changed.",
-          "if": "The ip address of the network adapter to route the magic packet through. Defaults to None"
+          "if": "The IP address of the network adapter to route the magic packet through. Defaults to None"
         }
       }
     }

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -117,7 +117,6 @@ class WolSwitch(SwitchEntity):
             service_kwargs["ip_address"] = self._broadcast_address
         if self._broadcast_port is not None:
             service_kwargs["port"] = self._broadcast_port
-            service_kwargs["ip_address"] = self._broadcast_address
         if self._interface is not None:
             service_kwargs["interface"] = self._interface
 

--- a/tests/components/wake_on_lan/conftest.py
+++ b/tests/components/wake_on_lan/conftest.py
@@ -10,12 +10,18 @@ import pytest
 
 from homeassistant.components.wake_on_lan.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
+from homeassistant.const import (
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_IF,
+    CONF_MAC,
+)
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 DEFAULT_MAC = "00:01:02:03:04:05"
+DEFAULT_IF = "192.168.0.10"
 
 
 @pytest.fixture
@@ -60,6 +66,7 @@ async def get_config_to_integration_load() -> dict[str, Any]:
         CONF_MAC: DEFAULT_MAC,
         CONF_BROADCAST_ADDRESS: "255.255.255.255",
         CONF_BROADCAST_PORT: 9,
+        CONF_IF: DEFAULT_IF,
     }
 
 

--- a/tests/components/wake_on_lan/test_config_flow.py
+++ b/tests/components/wake_on_lan/test_config_flow.py
@@ -6,11 +6,16 @@ from unittest.mock import AsyncMock
 
 from homeassistant import config_entries
 from homeassistant.components.wake_on_lan.const import DOMAIN
-from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
+from homeassistant.const import (
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_IF,
+    CONF_MAC,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import DEFAULT_MAC
+from .conftest import DEFAULT_IF, DEFAULT_MAC
 
 from tests.common import MockConfigEntry
 
@@ -30,6 +35,7 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
             CONF_MAC: DEFAULT_MAC,
             CONF_BROADCAST_ADDRESS: "255.255.255.255",
             CONF_BROADCAST_PORT: 9,
+            CONF_IF: DEFAULT_IF,
         },
     )
     await hass.async_block_till_done(wait_background_tasks=True)
@@ -40,6 +46,7 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
         CONF_MAC: DEFAULT_MAC,
         CONF_BROADCAST_ADDRESS: "255.255.255.255",
         CONF_BROADCAST_PORT: 9,
+        CONF_IF: DEFAULT_IF,
     }
 
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/wake_on_lan/test_init.py
+++ b/tests/components/wake_on_lan/test_init.py
@@ -30,8 +30,25 @@ async def test_send_magic_packet(hass: HomeAssistant) -> None:
         mac = "aa:bb:cc:dd:ee:ff"
         bc_ip = "192.168.255.255"
         bc_port = 999
+        interface_ip = "192.168.0.10"
 
         await async_setup_component(hass, DOMAIN, {})
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SEND_MAGIC_PACKET,
+            {
+                "mac": mac,
+                "broadcast_address": bc_ip,
+                "broadcast_port": bc_port,
+                "if": interface_ip,
+            },
+            blocking=True,
+        )
+        assert len(mocked_wakeonlan.mock_calls) == 1
+        assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
+        assert mocked_wakeonlan.mock_calls[-1][2]["ip_address"] == bc_ip
+        assert mocked_wakeonlan.mock_calls[-1][2]["port"] == bc_port
+        assert mocked_wakeonlan.mock_calls[-1][2]["interface"] == interface_ip
 
         await hass.services.async_call(
             DOMAIN,
@@ -39,10 +56,11 @@ async def test_send_magic_packet(hass: HomeAssistant) -> None:
             {"mac": mac, "broadcast_address": bc_ip, "broadcast_port": bc_port},
             blocking=True,
         )
-        assert len(mocked_wakeonlan.mock_calls) == 1
+        assert len(mocked_wakeonlan.mock_calls) == 2
         assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
         assert mocked_wakeonlan.mock_calls[-1][2]["ip_address"] == bc_ip
         assert mocked_wakeonlan.mock_calls[-1][2]["port"] == bc_port
+        assert "interface" not in mocked_wakeonlan.mock_calls[-1][2]
 
         await hass.services.async_call(
             DOMAIN,
@@ -50,7 +68,7 @@ async def test_send_magic_packet(hass: HomeAssistant) -> None:
             {"mac": mac, "broadcast_address": bc_ip},
             blocking=True,
         )
-        assert len(mocked_wakeonlan.mock_calls) == 2
+        assert len(mocked_wakeonlan.mock_calls) == 3
         assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
         assert mocked_wakeonlan.mock_calls[-1][2]["ip_address"] == bc_ip
         assert "port" not in mocked_wakeonlan.mock_calls[-1][2]
@@ -61,7 +79,7 @@ async def test_send_magic_packet(hass: HomeAssistant) -> None:
             {"mac": mac, "broadcast_port": bc_port},
             blocking=True,
         )
-        assert len(mocked_wakeonlan.mock_calls) == 3
+        assert len(mocked_wakeonlan.mock_calls) == 4
         assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
         assert mocked_wakeonlan.mock_calls[-1][2]["port"] == bc_port
         assert "ip_address" not in mocked_wakeonlan.mock_calls[-1][2]
@@ -73,11 +91,11 @@ async def test_send_magic_packet(hass: HomeAssistant) -> None:
                 {"broadcast_address": bc_ip},
                 blocking=True,
             )
-        assert len(mocked_wakeonlan.mock_calls) == 3
+        assert len(mocked_wakeonlan.mock_calls) == 4
 
         await hass.services.async_call(
             DOMAIN, SERVICE_SEND_MAGIC_PACKET, {"mac": mac}, blocking=True
         )
-        assert len(mocked_wakeonlan.mock_calls) == 4
+        assert len(mocked_wakeonlan.mock_calls) == 5
         assert mocked_wakeonlan.mock_calls[-1][1][0] == mac
         assert not mocked_wakeonlan.mock_calls[-1][2]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
Add support for specifying optional interface ip address where the WOL packet will be send. This is useful when HA has multiple interface. underlying python module (wakeonlan) already has the support. This PR add this option to HA integration. 

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [#38717](https://github.com/home-assistant/home-assistant.io/pull/38717)
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
