### PR TITLE
Abort Shelly flows if the device is not fully provisioned

### DIFF
--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -198,7 +198,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
                                 CONF_GEN: device_info[CONF_GEN],
                             },
                         )
-                    errors["base"] = "firmware_not_fully_provisioned"
+                    return self.async_abort(reason="firmware_not_fully_provisioned")
 
         return self.async_show_form(
             step_id="user", data_schema=CONFIG_SCHEMA, errors=errors
@@ -238,7 +238,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
                             CONF_GEN: device_info[CONF_GEN],
                         },
                     )
-                errors["base"] = "firmware_not_fully_provisioned"
+                return self.async_abort(reason="firmware_not_fully_provisioned")
         else:
             user_input = {}
 
@@ -333,21 +333,19 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if not self.device_info[CONF_MODEL]:
-            errors["base"] = "firmware_not_fully_provisioned"
-            model = "Shelly"
-        else:
-            model = get_model_name(self.info)
-            if user_input is not None:
-                return self.async_create_entry(
-                    title=self.device_info["title"],
-                    data={
-                        CONF_HOST: self.host,
-                        CONF_SLEEP_PERIOD: self.device_info[CONF_SLEEP_PERIOD],
-                        CONF_MODEL: self.device_info[CONF_MODEL],
-                        CONF_GEN: self.device_info[CONF_GEN],
-                    },
-                )
-            self._set_confirm_only()
+            return self.async_abort(reason="firmware_not_fully_provisioned")
+        model = get_model_name(self.info)
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self.device_info["title"],
+                data={
+                    CONF_HOST: self.host,
+                    CONF_SLEEP_PERIOD: self.device_info[CONF_SLEEP_PERIOD],
+                    CONF_MODEL: self.device_info[CONF_MODEL],
+                    CONF_GEN: self.device_info[CONF_GEN],
+                },
+            )
+        self._set_confirm_only()
 
         return self.async_show_form(
             step_id="confirm_discovery",

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -50,21 +50,21 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "custom_port_not_supported": "Gen1 device does not support custom port.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]",
-      "firmware_not_fully_provisioned": "Device not fully provisioned. Please contact Shelly support",
-      "custom_port_not_supported": "Gen1 device does not support custom port.",
-      "mac_address_mismatch": "The MAC address of the device does not match the one in the configuration, please reboot the device and try again."
+      "mac_address_mismatch": "The MAC address of the device does not match the one in the configuration, please reboot the device and try again.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "another_device": "Re-configuration was unsuccessful, the IP address/hostname of another Shelly device was used.",
+      "firmware_not_fully_provisioned": "Device not fully provisioned. Please contact Shelly support",
+      "ipv6_not_supported": "IPv6 is not supported.",
+      "mac_address_mismatch": "[%key:component::shelly::config::error::mac_address_mismatch%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again.",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "another_device": "Re-configuration was unsuccessful, the IP address/hostname of another Shelly device was used.",
-      "ipv6_not_supported": "IPv6 is not supported.",
-      "mac_address_mismatch": "[%key:component::shelly::config::error::mac_address_mismatch%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "device_automation": {

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -348,8 +348,8 @@ async def test_form_missing_model_key(
             {CONF_HOST: "1.1.1.1"},
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "firmware_not_fully_provisioned"}
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "firmware_not_fully_provisioned"
 
 
 async def test_form_missing_model_key_auth_enabled(
@@ -378,8 +378,8 @@ async def test_form_missing_model_key_auth_enabled(
     result3 = await hass.config_entries.flow.async_configure(
         result2["flow_id"], {CONF_PASSWORD: "1234"}
     )
-    assert result3["type"] is FlowResultType.FORM
-    assert result3["errors"] == {"base": "firmware_not_fully_provisioned"}
+    assert result3["type"] is FlowResultType.ABORT
+    assert result3["reason"] == "firmware_not_fully_provisioned"
 
 
 async def test_form_missing_model_key_zeroconf(
@@ -398,15 +398,8 @@ async def test_form_missing_model_key_zeroconf(
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "firmware_not_fully_provisioned"}
-
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {},
-        )
-        assert result2["type"] is FlowResultType.FORM
-        assert result2["errors"] == {"base": "firmware_not_fully_provisioned"}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "firmware_not_fully_provisioned"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extracted to separate PR from https://github.com/home-assistant/core/pull/143517

The user cannot repair a device that is not fully provisioned, so the flows should be aborted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
