### PR TITLE
Remove redundant entity_id collision check in entity registry

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -883,7 +883,6 @@ class EntityPlatform:
                 get_initial_options=entity.get_initial_entity_options,
                 has_entity_name=entity.has_entity_name,
                 hidden_by=hidden_by,
-                known_object_ids=self.entities,
                 original_device_class=entity.device_class,
                 original_icon=entity.icon,
                 original_name=entity_name,
@@ -927,7 +926,7 @@ class EntityPlatform:
                         f"{self.entity_namespace} {suggested_object_id}"
                     )
                 entity.entity_id = entity_registry.async_generate_entity_id(
-                    self.domain, suggested_object_id, self.entities
+                    self.domain, suggested_object_id
                 )
 
             # Make sure it is valid in case an entity set the value themselves

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -11,7 +11,7 @@ timer.
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Container, Hashable, KeysView, Mapping
+from collections.abc import Callable, Hashable, KeysView, Mapping
 from datetime import datetime, timedelta
 from enum import StrEnum
 import logging
@@ -787,26 +787,18 @@ class EntityRegistry(BaseRegistry):
         """Return known device ids."""
         return list(self.entities.get_device_ids())
 
-    def _entity_id_available(
-        self, entity_id: str, known_object_ids: Container[str] | None
-    ) -> bool:
+    def _entity_id_available(self, entity_id: str) -> bool:
         """Return True if the entity_id is available.
 
         An entity_id is available if:
         - It's not registered
-        - It's not known by the entity component adding the entity
-        - It's not in the state machine
+        - It's available (not in the state machine and not reserved)
 
         Note that an entity_id which belongs to a deleted entity is considered
         available.
         """
-        if known_object_ids is None:
-            known_object_ids = {}
-
-        return (
-            entity_id not in self.entities
-            and entity_id not in known_object_ids
-            and self.hass.states.async_available(entity_id)
+        return entity_id not in self.entities and self.hass.states.async_available(
+            entity_id
         )
 
     @callback
@@ -814,7 +806,6 @@ class EntityRegistry(BaseRegistry):
         self,
         domain: str,
         suggested_object_id: str,
-        known_object_ids: Container[str] | None = None,
     ) -> str:
         """Generate an entity ID that does not conflict.
 
@@ -826,11 +817,9 @@ class EntityRegistry(BaseRegistry):
             raise MaxLengthExceeded(domain, "domain", MAX_LENGTH_STATE_DOMAIN)
 
         test_string = preferred_string[:MAX_LENGTH_STATE_ENTITY_ID]
-        if known_object_ids is None:
-            known_object_ids = set()
 
         tries = 1
-        while not self._entity_id_available(test_string, known_object_ids):
+        while not self._entity_id_available(test_string):
             tries += 1
             len_suffix = len(str(tries)) + 1
             test_string = (
@@ -847,7 +836,6 @@ class EntityRegistry(BaseRegistry):
         unique_id: str,
         *,
         # To influence entity ID generation
-        known_object_ids: Container[str] | None = None,
         suggested_object_id: str | None = None,
         # To disable or hide an entity if it gets created
         disabled_by: RegistryEntryDisabler | None = None,
@@ -921,7 +909,6 @@ class EntityRegistry(BaseRegistry):
         entity_id = self.async_generate_entity_id(
             domain,
             suggested_object_id or f"{platform}_{unique_id}",
-            known_object_ids,
         )
 
         if (
@@ -1164,7 +1151,7 @@ class EntityRegistry(BaseRegistry):
             )
 
         if new_entity_id is not UNDEFINED and new_entity_id != old.entity_id:
-            if not self._entity_id_available(new_entity_id, None):
+            if not self._entity_id_available(new_entity_id):
                 raise ValueError("Entity with this ID is already registered")
 
             if not valid_entity_id(new_entity_id):

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -2017,7 +2017,9 @@ async def test_disabled_entities_excluded_from_entity_list(
     ) == [entry1, entry2]
 
 
-async def test_entity_max_length_exceeded(entity_registry: er.EntityRegistry) -> None:
+async def test_entity_max_length_exceeded(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that an exception is raised when the max character length is exceeded."""
 
     long_domain_name = (
@@ -2042,20 +2044,13 @@ async def test_entity_max_length_exceeded(entity_registry: er.EntityRegistry) ->
         "1234567890123456789012345678901234567"
     )
 
-    known = []
-    new_id = entity_registry.async_generate_entity_id(
-        "sensor", long_entity_id_name, known
-    )
+    new_id = entity_registry.async_generate_entity_id("sensor", long_entity_id_name)
     assert new_id == "sensor." + long_entity_id_name[: 255 - 7]
-    known.append(new_id)
-    new_id = entity_registry.async_generate_entity_id(
-        "sensor", long_entity_id_name, known
-    )
+    hass.states.async_reserve(new_id)
+    new_id = entity_registry.async_generate_entity_id("sensor", long_entity_id_name)
     assert new_id == "sensor." + long_entity_id_name[: 255 - 7 - 2] + "_2"
-    known.append(new_id)
-    new_id = entity_registry.async_generate_entity_id(
-        "sensor", long_entity_id_name, known
-    )
+    hass.states.async_reserve(new_id)
+    new_id = entity_registry.async_generate_entity_id("sensor", long_entity_id_name)
     assert new_id == "sensor." + long_entity_id_name[: 255 - 7 - 2] + "_3"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove redundant entity_id collision check in entity registry

This PR essentially reverts the collision check introduced by https://github.com/home-assistant/core/pull/19222 which is no longer needed thanks to the more extensive collision check introduced by https://github.com/home-assistant/core/pull/42151 

The collision check in https://github.com/home-assistant/core/pull/19222 only detected collisions within a single entity component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
