### PR TITLE
Move state length validation to StateMachine APIs

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -2357,7 +2357,7 @@ class StateMachine:
                 assert old_state is not None
             attributes = old_state.attributes
 
-        if len(new_state) > MAX_LENGTH_STATE_STATE:
+        if not same_state and len(new_state) > MAX_LENGTH_STATE_STATE:
             _LOGGER.error(
                 "State %s for %s is longer than %s, falling back to %s",
                 new_state,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -72,6 +72,7 @@ from .const import (
     MAX_EXPECTED_ENTITY_IDS,
     MAX_LENGTH_EVENT_EVENT_TYPE,
     MAX_LENGTH_STATE_STATE,
+    STATE_UNKNOWN,
     __version__,
 )
 from .exceptions import (
@@ -2297,7 +2298,6 @@ class StateMachine:
         should not be used in integrations.
 
         Callers are responsible for ensuring the entity_id is lower case.
-        Callers are responsible for ensuring the state is a valid state.
 
         This method must be run in the event loop.
         """
@@ -2356,6 +2356,16 @@ class StateMachine:
             if TYPE_CHECKING:
                 assert old_state is not None
             attributes = old_state.attributes
+
+        if len(new_state) > MAX_LENGTH_STATE_STATE:
+            _LOGGER.error(
+                "State %s for %s is longer than %s, falling back to %s",
+                new_state,
+                entity_id,
+                MAX_LENGTH_STATE_STATE,
+                STATE_UNKNOWN,
+            )
+            new_state = STATE_UNKNOWN
 
         # This is intentionally called with positional only arguments for performance
         # reasons

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1794,18 +1794,13 @@ class State:
     ) -> None:
         """Initialize a new state."""
         self._cache: dict[str, Any] = {}
-        state = str(state)
-
         if validate_entity_id and not valid_entity_id(entity_id):
             raise InvalidEntityFormatError(
                 f"Invalid entity id encountered: {entity_id}. "
                 "Format should be <domain>.<object_id>"
             )
-
-        validate_state(state)
-
         self.entity_id = entity_id
-        self.state = state
+        self.state = state if type(state) is str else str(state)
         # State only creates and expects a ReadOnlyDict so
         # there is no need to check for subclassing with
         # isinstance here so we can use the faster type check.
@@ -2271,9 +2266,11 @@ class StateMachine:
 
         This method must be run in the event loop.
         """
+        state = str(new_state)
+        validate_state(state)
         self.async_set_internal(
             entity_id.lower(),
-            str(new_state),
+            state,
             attributes or {},
             force_update,
             context,
@@ -2298,6 +2295,9 @@ class StateMachine:
         and should not be considered a stable API. We will make
         breaking changes to this function in the future and it
         should not be used in integrations.
+
+        Callers are responsible for ensuring the entity_id is lower case.
+        Callers are responsible for ensuring the state is a valid state.
 
         This method must be run in the event loop.
         """

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -31,7 +31,6 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     ATTR_UNIT_OF_MEASUREMENT,
     DEVICE_DEFAULT_NAME,
-    MAX_LENGTH_STATE_STATE,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -1216,16 +1215,6 @@ class Entity(
         ):
             self._context = None
             self._context_set = None
-
-        if len(state) > MAX_LENGTH_STATE_STATE:
-            _LOGGER.error(
-                "State %s for %s is longer than %s, falling back to %s",
-                state,
-                self.entity_id,
-                MAX_LENGTH_STATE_STATE,
-                STATE_UNKNOWN,
-            )
-            state = STATE_UNKNOWN
 
         # Intentionally called with positional args for performance reasons
         self.hass.states.async_set_internal(

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1711,7 +1711,7 @@ async def test_invalid_state(
     ent.async_write_ha_state()
     assert hass.states.get("test.test").state == STATE_UNKNOWN
     assert (
-        "homeassistant.helpers.entity",
+        "homeassistant.core",
         logging.ERROR,
         f"State {long_state} for test.test is longer than 255, "
         f"falling back to {STATE_UNKNOWN}",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1368,9 +1368,6 @@ def test_state_init() -> None:
     with pytest.raises(InvalidEntityFormatError):
         ha.State("invalid_entity_format", "test_state")
 
-    with pytest.raises(InvalidStateError):
-        ha.State("domain.long_state", "t" * 256)
-
 
 def test_state_domain() -> None:
     """Test domain."""
@@ -1438,6 +1435,15 @@ def test_state_repr() -> None:
         )
         == "<state happy.happy=on; brightness=144 @ 1984-12-08T12:00:00+00:00>"
     )
+
+
+async def test_statemachine_async_set_invalid_state(hass: HomeAssistant) -> None:
+    """Test setting an invalid state with the async_set method."""
+    with pytest.raises(
+        InvalidStateError,
+        match="Invalid state with length 256. State max length is 255 characters.",
+    ):
+        hass.states.async_set("light.bowl", "o" * 256, {})
 
 
 async def test_statemachine_is_state(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We call `validate_state` to make sure we do not allow any states into the state machine that have a length>255 so we do not break the recorder (added in #9696).  We can guard against these state getting into the state machine in the set calls (`async_set` - public API, and `async_set_internal` - internal API).

Move the `STATE_UNKNOWN` check from `_async_write_ha_state` to the internal API `states.async_set_internal` and move the `validate_state` check to the public API `states.async_set` instead of at `State` object creation time to avoid needing to check it twice in the hot path.  If the state doesn't change, we can avoid checking it at all.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
