### PR TITLE
Record Anthropic token statistics in conversation trace

### DIFF
--- a/homeassistant/components/anthropic/conversation.py
+++ b/homeassistant/components/anthropic/conversation.py
@@ -9,11 +9,13 @@ from anthropic import AsyncStream
 from anthropic._types import NOT_GIVEN
 from anthropic.types import (
     InputJSONDelta,
+    MessageDeltaUsage,
     MessageParam,
     MessageStreamEvent,
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
     RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
     RawMessageStartEvent,
     RawMessageStopEvent,
     RedactedThinkingBlock,
@@ -31,6 +33,7 @@ from anthropic.types import (
     ToolResultBlockParam,
     ToolUseBlock,
     ToolUseBlockParam,
+    Usage,
 )
 from voluptuous_openapi import convert
 
@@ -162,7 +165,8 @@ def _convert_content(
     return messages
 
 
-async def _transform_stream(
+async def _transform_stream(  # noqa: C901 - This is complex, but better to have it in one place
+    chat_log: conversation.ChatLog,
     result: AsyncStream[MessageStreamEvent],
     messages: list[MessageParam],
 ) -> AsyncGenerator[conversation.AssistantContentDeltaDict]:
@@ -207,6 +211,7 @@ async def _transform_stream(
         | None
     ) = None
     current_tool_args: str
+    input_usage: Usage | None = None
 
     async for response in result:
         LOGGER.debug("Received response: %s", response)
@@ -215,6 +220,7 @@ async def _transform_stream(
             if response.message.role != "assistant":
                 raise ValueError("Unexpected message role")
             current_message = MessageParam(role=response.message.role, content=[])
+            input_usage = response.message.usage
         elif isinstance(response, RawContentBlockStartEvent):
             if isinstance(response.content_block, ToolUseBlock):
                 current_block = ToolUseBlockParam(
@@ -285,10 +291,32 @@ async def _transform_stream(
                 raise ValueError("Unexpected stop event without a current message")
             current_message["content"].append(current_block)  # type: ignore[union-attr]
             current_block = None
+        elif isinstance(response, RawMessageDeltaEvent):
+            if (usage := response.usage) is not None:
+                chat_log.async_trace(_create_token_stats(input_usage, usage))
         elif isinstance(response, RawMessageStopEvent):
             if current_message is not None:
                 messages.append(current_message)
                 current_message = None
+
+
+def _create_token_stats(
+    input_usage: Usage | None, response_usage: MessageDeltaUsage
+) -> dict[str, Any]:
+    """Create token stats for conversation agent tracing."""
+    input_tokens = 0
+    cached_input_tokens = 0
+    if input_usage:
+        input_tokens = input_usage.input_tokens
+        cached_input_tokens = input_usage.cache_creation_input_tokens or 0
+    output_tokens = response_usage.output_tokens
+    return {
+        "stats": {
+            "input_tokens": input_tokens,
+            "cached_input_tokens": cached_input_tokens,
+            "output_tokens": output_tokens,
+        }
+    }
 
 
 class AnthropicConversationEntity(
@@ -393,7 +421,8 @@ class AnthropicConversationEntity(
                     [
                         content
                         async for content in chat_log.async_add_delta_content_stream(
-                            user_input.agent_id, _transform_stream(stream, messages)
+                            user_input.agent_id,
+                            _transform_stream(chat_log, stream, messages),
                         )
                         if not isinstance(content, conversation.AssistantContent)
                     ]

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -8,9 +8,11 @@ from anthropic import RateLimitError
 from anthropic.types import (
     InputJSONDelta,
     Message,
+    MessageDeltaUsage,
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
     RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
     RawMessageStartEvent,
     RawMessageStopEvent,
     RawMessageStreamEvent,
@@ -23,6 +25,7 @@ from anthropic.types import (
     ToolUseBlock,
     Usage,
 )
+from anthropic.types.raw_message_delta_event import Delta
 from freezegun import freeze_time
 from httpx import URL, Request, Response
 import pytest
@@ -65,6 +68,11 @@ def create_messages(
             type="message_start",
         ),
         *content_blocks,
+        RawMessageDeltaEvent(
+            type="message_delta",
+            delta=Delta(stop_reason="end_turn", stop_sequence=""),
+            usage=MessageDeltaUsage(output_tokens=0),
+        ),
         RawMessageStopEvent(type="message_stop"),
     ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Record Anthropic token statistics in conversation trace, similar to what is done for other conversation agents. This is currently used to estimate the cost when performing evaluations.

Example output looks something like this: https://github.com/allenporter/home-assistant-datasets/tree/main/reports#gemini-25-flash
```
Assist Eval Performance Metrics
Average Latency: 2262 (ms)
Total Eval Cost: $0.39
Cost breakdown:
- 2092631 input tokens, $0.15/1M tokens
- 126680 output tokens, $0.60/1M tokens
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ]  Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
