### PR TITLE
add `verify_ssl` config flow option to ntfy integration

### DIFF
--- a/homeassistant/components/ntfy/__init__.py
+++ b/homeassistant/components/ntfy/__init__.py
@@ -30,7 +30,7 @@ type NtfyConfigEntry = ConfigEntry[Ntfy]
 async def async_setup_entry(hass: HomeAssistant, entry: NtfyConfigEntry) -> bool:
     """Set up ntfy from a config entry."""
 
-    session = async_get_clientsession(hass, entry.data[CONF_VERIFY_SSL])
+    session = async_get_clientsession(hass, entry.data.get(CONF_VERIFY_SSL, True))
     ntfy = Ntfy(entry.data[CONF_URL], session, token=entry.data.get(CONF_TOKEN))
 
     try:

--- a/homeassistant/components/ntfy/__init__.py
+++ b/homeassistant/components/ntfy/__init__.py
@@ -13,7 +13,7 @@ from aiontfy.exceptions import (
 )
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_TOKEN, CONF_URL, Platform
+from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -30,7 +30,7 @@ type NtfyConfigEntry = ConfigEntry[Ntfy]
 async def async_setup_entry(hass: HomeAssistant, entry: NtfyConfigEntry) -> bool:
     """Set up ntfy from a config entry."""
 
-    session = async_get_clientsession(hass)
+    session = async_get_clientsession(hass, entry.data[CONF_VERIFY_SSL])
     ntfy = Ntfy(entry.data[CONF_URL], session, token=entry.data.get(CONF_TOKEN))
 
     try:

--- a/homeassistant/components/ntfy/config_flow.py
+++ b/homeassistant/components/ntfy/config_flow.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     CONF_TOKEN,
     CONF_URL,
     CONF_USERNAME,
+    CONF_VERIFY_SSL,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -54,6 +55,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
                 autocomplete="url",
             ),
         ),
+        vol.Required(CONF_VERIFY_SSL, default=True): bool,
         vol.Required(SECTION_AUTH): data_entry_flow.section(
             vol.Schema(
                 {
@@ -123,7 +125,7 @@ class NtfyConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_USERNAME: username,
                 }
             )
-            session = async_get_clientsession(self.hass)
+            session = async_get_clientsession(self.hass, user_input[CONF_VERIFY_SSL])
             if username:
                 ntfy = Ntfy(
                     user_input[CONF_URL],
@@ -160,6 +162,7 @@ class NtfyConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_URL: url.human_repr(),
                         CONF_USERNAME: username,
                         CONF_TOKEN: token,
+                        CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
                     },
                 )
 

--- a/homeassistant/components/ntfy/strings.json
+++ b/homeassistant/components/ntfy/strings.json
@@ -8,10 +8,12 @@
       "user": {
         "description": "Set up **ntfy** push notification service",
         "data": {
-          "url": "Service URL"
+          "url": "Service URL",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "url": "Address of the ntfy service. Modify this if you want to use a different server"
+          "url": "Address of the ntfy service. Modify this if you want to use a different server",
+          "verify_ssl": "Enable SSL certificate verification for secure connections. Disable only if connecting to a ntfy instance using a self-signed certificate"
         },
         "sections": {
           "auth": {

--- a/tests/components/ntfy/conftest.py
+++ b/tests/components/ntfy/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 from homeassistant.components.ntfy.const import CONF_TOPIC, DOMAIN
 from homeassistant.config_entries import ConfigSubentryData
-from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_USERNAME
+from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -64,6 +64,7 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_URL: "https://ntfy.sh/",
             CONF_USERNAME: None,
             CONF_TOKEN: "token",
+            CONF_VERIFY_SSL: True,
         },
         entry_id="123456789",
         subentries_data=[

--- a/tests/components/ntfy/test_config_flow.py
+++ b/tests/components/ntfy/test_config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     CONF_TOKEN,
     CONF_URL,
     CONF_USERNAME,
+    CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -33,17 +34,24 @@ from tests.common import MockConfigEntry
         (
             {
                 CONF_URL: "https://ntfy.sh",
+                CONF_VERIFY_SSL: True,
                 SECTION_AUTH: {CONF_USERNAME: "username", CONF_PASSWORD: "password"},
             },
             {
                 CONF_URL: "https://ntfy.sh/",
+                CONF_VERIFY_SSL: True,
                 CONF_USERNAME: "username",
                 CONF_TOKEN: "token",
             },
         ),
         (
-            {CONF_URL: "https://ntfy.sh", SECTION_AUTH: {}},
-            {CONF_URL: "https://ntfy.sh/", CONF_USERNAME: None, CONF_TOKEN: "token"},
+            {CONF_URL: "https://ntfy.sh", CONF_VERIFY_SSL: True, SECTION_AUTH: {}},
+            {
+                CONF_URL: "https://ntfy.sh/",
+                CONF_VERIFY_SSL: True,
+                CONF_USERNAME: None,
+                CONF_TOKEN: "token",
+            },
         ),
     ],
 )
@@ -109,6 +117,7 @@ async def test_form_errors(
         result["flow_id"],
         {
             CONF_URL: "https://ntfy.sh",
+            CONF_VERIFY_SSL: True,
             SECTION_AUTH: {CONF_USERNAME: "username", CONF_PASSWORD: "password"},
         },
     )
@@ -121,6 +130,7 @@ async def test_form_errors(
         result["flow_id"],
         {
             CONF_URL: "https://ntfy.sh",
+            CONF_VERIFY_SSL: True,
             SECTION_AUTH: {CONF_USERNAME: "username", CONF_PASSWORD: "password"},
         },
     )
@@ -130,6 +140,7 @@ async def test_form_errors(
     assert result["title"] == "ntfy.sh"
     assert result["data"] == {
         CONF_URL: "https://ntfy.sh/",
+        CONF_VERIFY_SSL: True,
         CONF_USERNAME: "username",
         CONF_TOKEN: "token",
     }
@@ -151,7 +162,11 @@ async def test_form_already_configured(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_URL: "https://ntfy.sh", SECTION_AUTH: {}},
+        user_input={
+            CONF_URL: "https://ntfy.sh",
+            CONF_VERIFY_SSL: True,
+            SECTION_AUTH: {},
+        },
     )
 
     assert result["type"] is FlowResultType.ABORT
@@ -163,7 +178,7 @@ async def test_add_topic_flow(hass: HomeAssistant) -> None:
     """Test add topic subentry flow."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_URL: "https://ntfy.sh/", CONF_USERNAME: None},
+        data={CONF_URL: "https://ntfy.sh/", CONF_VERIFY_SSL: True, CONF_USERNAME: None},
     )
     config_entry.add_to_hass(hass)
 
@@ -211,7 +226,7 @@ async def test_generated_topic(hass: HomeAssistant, mock_random: AsyncMock) -> N
     """Test add topic subentry flow with generated topic name."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_URL: "https://ntfy.sh/"},
+        data={CONF_URL: "https://ntfy.sh/", CONF_VERIFY_SSL: True},
     )
     config_entry.add_to_hass(hass)
 
@@ -265,7 +280,7 @@ async def test_invalid_topic(hass: HomeAssistant, mock_random: AsyncMock) -> Non
     """Test add topic subentry flow with invalid topic name."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_URL: "https://ntfy.sh/"},
+        data={CONF_URL: "https://ntfy.sh/", CONF_VERIFY_SSL: True},
     )
     config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the option to disable SSL verification as ntfy can be self-hosted and users may use it with a self-signed certificate.
This is a breaking change but as the integration is new a config entry migration is not required if this is merged before the 2025.5 release


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
