### PR TITLE
Improve websocket_api command typing

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -1,4 +1,4 @@
-"""Commands part of Websocket API."""
+"""Commands of the Websocket API."""
 
 from __future__ import annotations
 

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Hashable
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from aiohttp import web
 import voluptuous as vol
@@ -71,9 +71,7 @@ class ActiveConnection:
         self.last_id = 0
         self.can_coalesce = False
         self.supported_features: dict[str, float] = {}
-        self.handlers: dict[str, tuple[MessageHandler, vol.Schema | Literal[False]]] = (
-            self.hass.data[const.DOMAIN]
-        )
+        self.handlers = self.hass.data[const.DATA_DOMAIN]
         self.binary_handlers: list[BinaryHandler | None] = []
         current_connection.set(self)
 

--- a/homeassistant/components/websocket_api/const.py
+++ b/homeassistant/components/websocket_api/const.py
@@ -3,22 +3,40 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, Literal, Protocol
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import VolSchemaType
+from homeassistant.util.hass_dict import HassKey
 
 if TYPE_CHECKING:
     from .connection import ActiveConnection
 
 
-type WebSocketCommandHandler = Callable[
-    [HomeAssistant, ActiveConnection, dict[str, Any]], None
-]
+class WebSocketCommandHandler(Protocol):
+    """Protocol for websocket command handler."""
+
+    def __call__(
+        self, hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+    ) -> None:
+        """Handle a websocket command."""
+
+
+class WebSocketCommandHandlerWithCommandSchema(WebSocketCommandHandler):
+    """Protocol for websocket command handler with internal attributes."""
+
+    _ws_command: str
+    _ws_schema: VolSchemaType | Literal[False]
+
+
 type AsyncWebSocketCommandHandler = Callable[
     [HomeAssistant, ActiveConnection, dict[str, Any]], Awaitable[None]
 ]
 
 DOMAIN: Final = "websocket_api"
+DATA_DOMAIN: HassKey[
+    dict[str, tuple[WebSocketCommandHandler, VolSchemaType | Literal[False]]]
+] = HassKey(DOMAIN)
 URL: Final = "/api/websocket"
 PENDING_MSG_PEAK: Final = 1024
 PENDING_MSG_PEAK_TIME: Final = 10

--- a/homeassistant/components/websocket_api/const.py
+++ b/homeassistant/components/websocket_api/const.py
@@ -35,7 +35,10 @@ type AsyncWebSocketCommandHandler = Callable[
 
 DOMAIN: Final = "websocket_api"
 DATA_DOMAIN: HassKey[
-    dict[str, tuple[WebSocketCommandHandler, VolSchemaType | Literal[False]]]
+    dict[
+        str,
+        tuple[WebSocketCommandHandlerWithCommandSchema, VolSchemaType | Literal[False]],
+    ]
 ] = HassKey(DOMAIN)
 URL: Final = "/api/websocket"
 PENDING_MSG_PEAK: Final = 1024

--- a/homeassistant/components/websocket_api/decorators.py
+++ b/homeassistant/components/websocket_api/decorators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import voluptuous as vol
 
@@ -133,7 +133,7 @@ def ws_require_user(
 def websocket_command(
     schema: VolDictType | vol.All,
 ) -> Callable[
-    [const.WebSocketCommandHandlerWithCommandSchema],
+    [const.WebSocketCommandHandler],
     const.WebSocketCommandHandlerWithCommandSchema,
 ]:
     """Tag a function as a websocket command.
@@ -147,9 +147,10 @@ def websocket_command(
         command = schema.validators[0].schema["type"]
 
     def decorate(
-        func: const.WebSocketCommandHandlerWithCommandSchema,
+        func: const.WebSocketCommandHandler,
     ) -> const.WebSocketCommandHandlerWithCommandSchema:
         """Decorate ws command function."""
+        func = cast(const.WebSocketCommandHandlerWithCommandSchema, func)
         if is_dict and len(schema) == 1:  # type: ignore[arg-type]  # type only empty schema
             func._ws_schema = False  # noqa: SLF001
         elif is_dict:


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve websocket_api command typing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
