### PR TITLE
Add reconfigure flow to ntfy integration

### DIFF
--- a/homeassistant/components/ntfy/config_flow.py
+++ b/homeassistant/components/ntfy/config_flow.py
@@ -90,6 +90,24 @@ STEP_REAUTH_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_RECONFIGURE_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Exclusive(CONF_USERNAME, ATTR_CREDENTIALS): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.TEXT,
+                autocomplete="username",
+            ),
+        ),
+        vol.Optional(CONF_PASSWORD, default=""): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.PASSWORD,
+                autocomplete="current-password",
+            ),
+        ),
+        vol.Exclusive(CONF_TOKEN, ATTR_CREDENTIALS): str,
+    }
+)
+
 STEP_USER_TOPIC_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_TOPIC): str,
@@ -242,6 +260,70 @@ class NtfyConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
             description_placeholders={CONF_USERNAME: entry.data[CONF_USERNAME]},
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfigure flow for ntfy."""
+        errors: dict[str, str] = {}
+
+        entry = self._get_reconfigure_entry()
+
+        if entry.data[CONF_USERNAME]:
+            return self.async_abort(reason="nothing_to_reconfigure")
+
+        if user_input is not None:
+            session = async_get_clientsession(self.hass)
+            if token := user_input.get(CONF_TOKEN):
+                ntfy = Ntfy(
+                    entry.data[CONF_URL],
+                    session,
+                    token=user_input[CONF_TOKEN],
+                )
+            else:
+                ntfy = Ntfy(
+                    entry.data[CONF_URL],
+                    session,
+                    username=user_input[CONF_USERNAME],
+                    password=user_input[CONF_PASSWORD],
+                )
+
+            try:
+                account = await ntfy.account()
+                if not token:
+                    token = (await ntfy.generate_token("Home Assistant")).token
+            except NtfyUnauthorizedAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except NtfyHTTPError as e:
+                _LOGGER.debug("Error %s: %s [%s]", e.code, e.error, e.link)
+                errors["base"] = "cannot_connect"
+            except NtfyException:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                self._async_abort_entries_match(
+                    {
+                        CONF_URL: entry.data[CONF_URL],
+                        CONF_USERNAME: account.username,
+                    }
+                )
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={
+                        CONF_USERNAME: account.username,
+                        CONF_TOKEN: token,
+                    },
+                )
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=STEP_RECONFIGURE_DATA_SCHEMA, suggested_values=user_input
+            ),
+            errors=errors,
+            description_placeholders={CONF_NAME: entry.title},
         )
 
 

--- a/homeassistant/components/ntfy/config_flow.py
+++ b/homeassistant/components/ntfy/config_flow.py
@@ -108,12 +108,6 @@ STEP_RECONFIGURE_DATA_SCHEMA = vol.Schema(
     }
 )
 
-STEP_RECONFIGURE_TOKEN_ONLY_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_TOKEN): str,
-    }
-)
-
 STEP_USER_TOPIC_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_TOPIC): str,

--- a/homeassistant/components/ntfy/quality_scale.yaml
+++ b/homeassistant/components/ntfy/quality_scale.yaml
@@ -72,7 +72,7 @@ rules:
     comment: the notify entity uses the device name as entity name, no translation required
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: exempt
     comment: the integration has no repairs

--- a/homeassistant/components/ntfy/strings.json
+++ b/homeassistant/components/ntfy/strings.json
@@ -53,7 +53,19 @@
         "data_description": {
           "username": "[%key:component::ntfy::config::step::user::sections::auth::data_description::username%]",
           "password": "[%key:component::ntfy::config::step::user::sections::auth::data_description::password%]",
-          "token": "Enter an existing ntfy access token instead of logging in"
+          "token": "Enter a new or existing access token. To create a new access token navigate to Account → Access tokens and click create access token"
+        }
+      },
+      "reconfigure_user": {
+        "title": "[%key:component::ntfy::config::step::reconfigure::title%]",
+        "description": "Enter the password for **{username}** below. Home Assistant will automatically create a new access token to authenticate with **ntfy**. You can also directly provide a valid access token",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "token": "[%key:common::config_flow::data::access_token%]"
+        },
+        "data_description": {
+          "password": "[%key:component::ntfy::config::step::reauth_confirm::data_description::password%]",
+          "token": "[%key:component::ntfy::config::step::reconfigure::data_description::token%]"
         }
       }
     },
@@ -66,7 +78,6 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "account_mismatch": "The provided access token corresponds to the account {wrong_username}. Please re-authenticate with the account **{username}**",
-      "nothing_to_reconfigure": "There are no configuration options available for this entry",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },

--- a/homeassistant/components/ntfy/strings.json
+++ b/homeassistant/components/ntfy/strings.json
@@ -44,7 +44,7 @@
       },
       "reconfigure": {
         "title": "Configuration for {name}",
-        "description": "Log in with your **ntfy** username and password. Home Assistant will automatically generate an access token to authenticate with **ntfy**. You can also enter an existing token manually",
+        "description": "You can either log in with your **ntfy** username and password, and Home Assistant will automatically create an access token to authenticate with **ntfy**, or you can provide an access token directly",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",

--- a/homeassistant/components/ntfy/strings.json
+++ b/homeassistant/components/ntfy/strings.json
@@ -41,6 +41,20 @@
           "password": "Enter the password corresponding to the aforementioned username to automatically create an access token",
           "token": "Enter a new access token. To create a new access token navigate to Account → Access tokens and click create access token"
         }
+      },
+      "reconfigure": {
+        "title": "Configuration for {name}",
+        "description": "Log in with your **ntfy** username and password. Home Assistant will automatically generate an access token to authenticate with **ntfy**. You can also enter an existing token manually",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "token": "[%key:common::config_flow::data::access_token%]"
+        },
+        "data_description": {
+          "username": "[%key:component::ntfy::config::step::user::sections::auth::data_description::username%]",
+          "password": "[%key:component::ntfy::config::step::user::sections::auth::data_description::password%]",
+          "token": "Enter an existing ntfy access token instead of logging in"
+        }
       }
     },
     "error": {
@@ -51,7 +65,9 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "account_mismatch": "The provided access token corresponds to the account {wrong_username}. Please re-authenticate with the account **{username}**"
+      "account_mismatch": "The provided access token corresponds to the account {wrong_username}. Please re-authenticate with the account **{username}**",
+      "nothing_to_reconfigure": "There are no configuration options available for this entry",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "config_subentries": {

--- a/homeassistant/components/ntfy/strings.json
+++ b/homeassistant/components/ntfy/strings.json
@@ -39,7 +39,7 @@
         },
         "data_description": {
           "password": "Enter the password corresponding to the aforementioned username to automatically create an access token",
-          "token": "Enter a new access token. To create a new access token navigate to Account → Access tokens and click create access token"
+          "token": "Enter a new access token. To create a new access token navigate to Account → Access tokens and select 'Create access token'"
         }
       },
       "reconfigure": {
@@ -53,7 +53,7 @@
         "data_description": {
           "username": "[%key:component::ntfy::config::step::user::sections::auth::data_description::username%]",
           "password": "[%key:component::ntfy::config::step::user::sections::auth::data_description::password%]",
-          "token": "Enter a new or existing access token. To create a new access token navigate to Account → Access tokens and click create access token"
+          "token": "Enter a new or existing access token. To create a new access token navigate to Account → Access tokens and select 'Create access token'"
         }
       },
       "reconfigure_user": {

--- a/tests/components/ntfy/test_config_flow.py
+++ b/tests/components/ntfy/test_config_flow.py
@@ -498,3 +498,205 @@ async def test_flow_reauth_account_mismatch(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "account_mismatch"
+
+
+async def test_flow_reconfigure(
+    hass: HomeAssistant,
+    mock_aiontfy: AsyncMock,
+) -> None:
+    """Test reconfigure flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="ntfy.sh",
+        data={
+            CONF_URL: "https://ntfy.sh/",
+            CONF_USERNAME: None,
+            CONF_TOKEN: None,
+        },
+    )
+    mock_aiontfy.generate_token.return_value = AccountTokenResponse(
+        token="newtoken", last_access=datetime.now()
+    )
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "username", CONF_PASSWORD: "password"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_USERNAME] == "username"
+    assert config_entry.data[CONF_TOKEN] == "newtoken"
+
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+async def test_flow_reconfigure_token(
+    hass: HomeAssistant,
+    mock_aiontfy: AsyncMock,
+) -> None:
+    """Test reconfigure flow with access token."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="ntfy.sh",
+        data={
+            CONF_URL: "https://ntfy.sh/",
+            CONF_USERNAME: None,
+            CONF_TOKEN: None,
+        },
+    )
+
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_TOKEN: "access_token"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_USERNAME] == "username"
+    assert config_entry.data[CONF_TOKEN] == "access_token"
+
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (
+            NtfyHTTPError(418001, 418, "I'm a teapot", ""),
+            "cannot_connect",
+        ),
+        (
+            NtfyUnauthorizedAuthenticationError(
+                40101,
+                401,
+                "unauthorized",
+                "https://ntfy.sh/docs/publish/#authentication",
+            ),
+            "invalid_auth",
+        ),
+        (NtfyException, "cannot_connect"),
+        (TypeError, "unknown"),
+    ],
+)
+async def test_flow_reconfigure_errors(
+    hass: HomeAssistant,
+    mock_aiontfy: AsyncMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test reconfigure flow errors."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="ntfy.sh",
+        data={
+            CONF_URL: "https://ntfy.sh/",
+            CONF_USERNAME: None,
+            CONF_TOKEN: None,
+        },
+    )
+    mock_aiontfy.generate_token.return_value = AccountTokenResponse(
+        token="newtoken", last_access=datetime.now()
+    )
+    mock_aiontfy.account.side_effect = exception
+
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "username", CONF_PASSWORD: "password"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_aiontfy.account.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "username", CONF_PASSWORD: "password"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_USERNAME] == "username"
+    assert config_entry.data[CONF_TOKEN] == "newtoken"
+
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.usefixtures("mock_aiontfy")
+async def test_flow_reconfigure_already_configured(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow already configured."""
+    other_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="ntfy.sh",
+        data={
+            CONF_URL: "https://ntfy.sh/",
+            CONF_USERNAME: "username",
+        },
+    )
+    other_config_entry.add_to_hass(hass)
+
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "username", CONF_PASSWORD: "password"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+    assert len(hass.config_entries.async_entries()) == 2
+
+
+@pytest.mark.usefixtures("mock_aiontfy")
+async def test_flow_reconfigure_nothing_to_reconfigure(
+    hass: HomeAssistant,
+) -> None:
+    """Test reconfigure flow abort if nothing to reconfigure."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="ntfy.sh",
+        data={
+            CONF_URL: "https://ntfy.sh/",
+            CONF_USERNAME: "username",
+        },
+    )
+
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reconfigure_flow(hass)
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "nothing_to_reconfigure"
+
+    assert len(hass.config_entries.async_entries()) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a reconfigure flow to the ntfy integration.

There are 2 possible reconfigure flows:
- If a config entry is configured without credentials, reconfigure will allow to add authentication to the config entry. Either by entering credentials, a token will be created automatically, or by entering an existing token directly. 
- If a config entry configured with a username, reconfigure will allow to update the access token, either by entering a password, the new token will be created automatically or by entering the token directly. The username cannot be updated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
