### PR TITLE
Reload websocket after 30 minutes in lamarzocco

### DIFF
--- a/homeassistant/components/lamarzocco/coordinator.py
+++ b/homeassistant/components/lamarzocco/coordinator.py
@@ -120,7 +120,7 @@ class LaMarzoccoConfigUpdateCoordinator(LaMarzoccoUpdateCoordinator):
             await sleep(WS_AUTO_RECONNECT_INTERVAL)
             _LOGGER.debug("Auto reconnecting WebSocket")
             await self.device.websocket.disconnect()
-            await self.async_request_refresh()
+            await self.async_refresh()  # refresh to reconnect
 
         if self._ws_scheduled_reconnect_task is not None:
             self._ws_scheduled_reconnect_task.cancel()

--- a/tests/components/lamarzocco/conftest.py
+++ b/tests/components/lamarzocco/conftest.py
@@ -1,7 +1,7 @@
 """Lamarzocco session fixtures."""
 
 from collections.abc import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from bleak.backends.device import BLEDevice
 from pylamarzocco.const import ModelName
@@ -111,6 +111,7 @@ def mock_lamarzocco(device_fixture: ModelName) -> Generator[MagicMock]:
             "schedule": machine_mock.schedule.to_dict(),
             "settings": machine_mock.settings.to_dict(),
         }
+        machine_mock.websocket.disconnect = AsyncMock()
         yield machine_mock
 
 
@@ -125,3 +126,12 @@ def mock_ble_device() -> BLEDevice:
     return BLEDevice(
         "00:00:00:00:00:00", "GS_GS012345", details={"path": "path"}, rssi=50
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_ws_settle_in() -> Generator:
+    """Auto mock websocket settle in."""
+    with patch(
+        "homeassistant.components.lamarzocco.coordinator.WS_SETTLE_IN_TIME", new=0
+    ):
+        yield

--- a/tests/components/lamarzocco/test_init.py
+++ b/tests/components/lamarzocco/test_init.py
@@ -257,6 +257,16 @@ async def test_websocket_auto_reconnect(
     """Test the websocket gets automatically shut down after a certain time."""
 
     mock_lamarzocco.websocket.connected = False
+    disconnect_counter = 0
+
+    async def dummy_disconnect() -> None:
+        """Disconnect function to change websocket status."""
+        nonlocal disconnect_counter
+        if disconnect_counter > 0:
+            mock_lamarzocco.websocket.connected = True
+        disconnect_counter += 1
+
+    mock_lamarzocco.websocket.disconnect = dummy_disconnect
 
     with patch(
         "homeassistant.components.lamarzocco.coordinator.WS_AUTO_RECONNECT_INTERVAL",
@@ -266,7 +276,7 @@ async def test_websocket_auto_reconnect(
 
     assert mock_lamarzocco.get_dashboard.call_count == 2
     assert mock_lamarzocco.connect_dashboard_websocket.call_count == 2
-    assert mock_lamarzocco.websocket.disconnect.call_count == 2
+    assert disconnect_counter == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/components/lamarzocco/test_init.py
+++ b/tests/components/lamarzocco/test_init.py
@@ -249,6 +249,26 @@ async def test_websocket_closed_on_unload(
     mock_disconnect_callback.assert_called_once()
 
 
+async def test_websocket_auto_reconnect(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_lamarzocco: MagicMock,
+) -> None:
+    """Test the websocket gets automatically shut down after a certain time."""
+
+    mock_lamarzocco.websocket.connected = False
+
+    with patch(
+        "homeassistant.components.lamarzocco.coordinator.WS_AUTO_RECONNECT_INTERVAL",
+        new=0,
+    ):
+        await async_init_integration(hass, mock_config_entry)
+
+    assert mock_lamarzocco.get_dashboard.call_count == 2
+    assert mock_lamarzocco.connect_dashboard_websocket.call_count == 2
+    assert mock_lamarzocco.websocket.disconnect.call_count == 2
+
+
 @pytest.mark.parametrize(
     ("version", "issue_exists"), [("v3.5-rc6", True), ("v5.0.9", False)]
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Auto  disconnect the websocket every 30 minutes to avoid disconnect from remote. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
