### PR TITLE
Add fan platform to miele integration

### DIFF
--- a/homeassistant/components/miele/__init__.py
+++ b/homeassistant/components/miele/__init__.py
@@ -21,6 +21,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CLIMATE,
+    Platform.FAN,
     Platform.LIGHT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/miele/const.py
+++ b/homeassistant/components/miele/const.py
@@ -9,6 +9,7 @@ ACTIONS = "actions"
 POWER_ON = "powerOn"
 POWER_OFF = "powerOff"
 PROCESS_ACTION = "processAction"
+VENTILATION_STEP = "ventilationStep"
 DISABLED_TEMP_ENTITIES = (
     -32768 / 100,
     -32766 / 100,

--- a/homeassistant/components/miele/fan.py
+++ b/homeassistant/components/miele/fan.py
@@ -88,7 +88,7 @@ class MieleFan(MieleEntity, FanEntity):
     )
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self) -> bool:
         """Return current on/off state."""
         assert self.device.state_ventilation_step is not None
         return self.device.state_ventilation_step > 0

--- a/homeassistant/components/miele/fan.py
+++ b/homeassistant/components/miele/fan.py
@@ -31,8 +31,6 @@ _LOGGER = logging.getLogger(__name__)
 
 SPEED_RANGE = (1, 4)
 
-# FAN_READ_ONLY = [MieleAppliance.HOB_INDUCT_EXTR]
-
 
 @dataclass(frozen=True, kw_only=True)
 class MieleFanDefinition:

--- a/homeassistant/components/miele/fan.py
+++ b/homeassistant/components/miele/fan.py
@@ -1,0 +1,179 @@
+"""Platform for Miele fan entity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import math
+from typing import Any, Final
+
+from aiohttp import ClientResponseError
+
+from homeassistant.components.fan import (
+    FanEntity,
+    FanEntityDescription,
+    FanEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.percentage import (
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
+from homeassistant.util.scaling import int_states_in_range
+
+from .const import DOMAIN, POWER_OFF, POWER_ON, VENTILATION_STEP, MieleAppliance
+from .coordinator import MieleConfigEntry
+from .entity import MieleEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+SPEED_RANGE = (1, 4)
+
+FAN_READ_ONLY = [MieleAppliance.HOB_INDUCT_EXTR]
+
+
+@dataclass(frozen=True, kw_only=True)
+class MieleFanDescription(FanEntityDescription):
+    """Class describing Miele fan entities."""
+
+
+@dataclass
+class MieleFanDefinition:
+    """Class for defining fan entities."""
+
+    types: tuple[MieleAppliance, ...]
+    description: MieleFanDescription
+
+
+FAN_TYPES: Final[tuple[MieleFanDefinition, ...]] = (
+    MieleFanDefinition(
+        types=(
+            MieleAppliance.HOOD,
+            MieleAppliance.HOB_INDUCT_EXTR,
+        ),
+        description=MieleFanDescription(
+            key="fan",
+            translation_key="fan",
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: MieleConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the fan platform."""
+    coordinator = config_entry.runtime_data
+
+    async_add_entities(
+        MieleFan(coordinator, device_id, definition.description)
+        for device_id, device in coordinator.data.devices.items()
+        for definition in FAN_TYPES
+        if device.device_type in definition.types
+    )
+
+
+class MieleFan(MieleEntity, FanEntity):
+    """Representation of a Fan."""
+
+    entity_description: MieleFanDescription
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return current on/off state."""
+        assert self.device.state_ventilation_step is not None
+        return self.device.state_ventilation_step > 0
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
+
+    @property
+    def percentage(self) -> int | None:
+        """Return the current speed percentage."""
+        return ranged_value_to_percentage(
+            SPEED_RANGE,
+            (self.device.state_ventilation_step or 0),
+        )
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""
+        if self.device.device_type in FAN_READ_ONLY:
+            return
+        _LOGGER.debug("Set_percentage: %s", percentage)
+        ventilation_step = math.ceil(
+            percentage_to_ranged_value(SPEED_RANGE, percentage)
+        )
+        _LOGGER.debug("Calc ventilation_step: %s", ventilation_step)
+        if ventilation_step == 0:
+            await self.async_turn_off()
+        else:
+            try:
+                await self.api.send_action(
+                    self._device_id, {VENTILATION_STEP: ventilation_step}
+                )
+            except ClientResponseError as ex:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="set_state_error",
+                    translation_placeholders={
+                        "entity": self.entity_id,
+                    },
+                ) from ex
+            self.device.state_ventilation_step = ventilation_step
+            self.async_write_ha_state()
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan."""
+        if self.device.device_type in FAN_READ_ONLY:
+            return
+        _LOGGER.debug(
+            "Turn_on -> percentage: %s, preset_mode: %s", percentage, preset_mode
+        )
+        try:
+            await self.api.send_action(self._device_id, {POWER_ON: True})
+        except ClientResponseError as ex:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_state_error",
+                translation_placeholders={
+                    "entity": self.entity_id,
+                },
+            ) from ex
+
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+            return
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the fan off."""
+        if self.device.device_type in FAN_READ_ONLY:
+            return
+        try:
+            await self.api.send_action(self._device_id, {POWER_OFF: True})
+        except ClientResponseError as ex:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_state_error",
+                translation_placeholders={
+                    "entity": self.entity_id,
+                },
+            ) from ex
+
+        self.device.state_ventilation_step = 0
+        self.async_write_ha_state()

--- a/homeassistant/components/miele/strings.json
+++ b/homeassistant/components/miele/strings.json
@@ -139,6 +139,11 @@
         "name": "[%key:common::action::pause%]"
       }
     },
+    "fan": {
+      "fan": {
+        "name": "Fan"
+      }
+    },
     "light": {
       "ambient_light": {
         "name": "Ambient light"

--- a/homeassistant/components/miele/strings.json
+++ b/homeassistant/components/miele/strings.json
@@ -141,7 +141,7 @@
     },
     "fan": {
       "fan": {
-        "name": "Fan"
+        "name": "[%key:component::fan::title%]"
       }
     },
     "light": {

--- a/tests/components/miele/fixtures/fan_devices.json
+++ b/tests/components/miele/fixtures/fan_devices.json
@@ -1,0 +1,214 @@
+{
+  "DummyAppliance_18": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 18,
+        "value_localized": "Cooker Hood"
+      },
+      "deviceName": "",
+      "protocolVersion": 2,
+      "deviceIdentLabel": {
+        "fabNumber": "<fabNumber3>",
+        "fabIndex": "64",
+        "techType": "Fläkt",
+        "matNumber": "<matNumber3>",
+        "swids": ["<swid1>", "<swid2>", "<swid3>", "<...>"]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK039W",
+        "releaseVersion": "02.72"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 1,
+        "value_localized": "Off",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 1,
+        "value_localized": "Off",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 0,
+        "value_localized": "Program",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 4608,
+        "value_localized": "",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 0],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": false,
+        "mobileStart": false
+      },
+      "ambientLight": 2,
+      "light": 1,
+      "elapsedTime": {},
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": null,
+        "value_localized": null,
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": 0,
+        "value_localized": "0",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": null,
+      "batteryLevel": null
+    }
+  },
+  "DummyAppliance_74": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 74,
+        "value_localized": "Hob w extraction"
+      },
+      "deviceName": "",
+      "protocolVersion": 203,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "00",
+        "techType": "KMDA7634",
+        "matNumber": "",
+        "swids": ["000"]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK039W",
+        "releaseVersion": "02.72"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 5,
+        "value_localized": "In use",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 0,
+        "value_localized": "Program",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 0],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        { "value_raw": -32768, "value_localized": null, "unit": "Celsius" },
+        { "value_raw": -32768, "value_localized": null, "unit": "Celsius" },
+        { "value_raw": -32768, "value_localized": null, "unit": "Celsius" }
+      ],
+      "temperature": [
+        { "value_raw": -32768, "value_localized": null, "unit": "Celsius" },
+        { "value_raw": -32768, "value_localized": null, "unit": "Celsius" },
+        { "value_raw": -32768, "value_localized": null, "unit": "Celsius" }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": false,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": 1,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [
+        {
+          "value_raw": 0,
+          "value_localized": 0,
+          "key_localized": "Power level"
+        },
+        {
+          "value_raw": 3,
+          "value_localized": 2,
+          "key_localized": "Power level"
+        },
+        {
+          "value_raw": 7,
+          "value_localized": 4,
+          "key_localized": "Power level"
+        },
+        {
+          "value_raw": 15,
+          "value_localized": 8,
+          "key_localized": "Power level"
+        },
+        {
+          "value_raw": 117,
+          "value_localized": 10,
+          "key_localized": "Power level"
+        }
+      ],
+      "ecoFeedback": null,
+      "batteryLevel": null
+    }
+  }
+}

--- a/tests/components/miele/snapshots/test_fan.ambr
+++ b/tests/components/miele/snapshots/test_fan.ambr
@@ -1,0 +1,55 @@
+# serializer version: 1
+# name: test_fan_states[platforms0][fan.hood_fan-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'preset_modes': None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.hood_fan',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fan',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'supported_features': <FanEntityFeature: 49>,
+    'translation_key': 'fan',
+    'unique_id': 'DummyAppliance_18-fan',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_fan_states[platforms0][fan.hood_fan-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Hood Fan',
+      'percentage': 0,
+      'percentage_step': 25.0,
+      'preset_mode': None,
+      'preset_modes': None,
+      'supported_features': <FanEntityFeature: 49>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.hood_fan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/miele/snapshots/test_fan.ambr
+++ b/tests/components/miele/snapshots/test_fan.ambr
@@ -1,5 +1,54 @@
 # serializer version: 1
-# name: test_fan_states[platforms0][fan.hood_fan-entry]
+# name: test_fan_states[fan_devices.json-platforms0][fan.hob_with_extraction_fan-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.hob_with_extraction_fan',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fan',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'fan',
+    'unique_id': 'DummyAppliance_74-fan_readonly',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_fan_states[fan_devices.json-platforms0][fan.hob_with_extraction_fan-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Hob with extraction Fan',
+      'supported_features': <FanEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.hob_with_extraction_fan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_fan_states[fan_devices.json-platforms0][fan.hood_fan-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -35,7 +84,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fan_states[platforms0][fan.hood_fan-state]
+# name: test_fan_states[fan_devices.json-platforms0][fan.hood_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Hood Fan',

--- a/tests/components/miele/test_fan.py
+++ b/tests/components/miele/test_fan.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.parametrize("platforms", [(TEST_PLATFORM,)])
 ENTITY_ID = "fan.hood_fan"
 
 
+@pytest.mark.parametrize("load_device_file", ["fan_devices.json"])
 async def test_fan_states(
     hass: HomeAssistant,
     mock_miele_client: MagicMock,
@@ -34,6 +35,7 @@ async def test_fan_states(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+@pytest.mark.parametrize("load_device_file", ["fan_devices.json"])
 @pytest.mark.parametrize(
     ("service", "expected_argument"),
     [
@@ -51,7 +53,10 @@ async def test_fan_control(
     """Test the fan can be turned on/off."""
 
     await hass.services.async_call(
-        TEST_PLATFORM, service, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+        TEST_PLATFORM,
+        service,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     mock_miele_client.send_action.assert_called_once_with(
         "DummyAppliance_18", expected_argument

--- a/tests/components/miele/test_fan.py
+++ b/tests/components/miele/test_fan.py
@@ -1,0 +1,110 @@
+"""Tests for miele fan module."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from aiohttp import ClientResponseError
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+TEST_PLATFORM = FAN_DOMAIN
+pytestmark = pytest.mark.parametrize("platforms", [(TEST_PLATFORM,)])
+
+ENTITY_ID = "fan.hood_fan"
+
+
+async def test_fan_states(
+    hass: HomeAssistant,
+    mock_miele_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    setup_platform: None,
+) -> None:
+    """Test fan entity state."""
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_argument"),
+    [
+        (SERVICE_TURN_ON, {"powerOn": True}),
+        (SERVICE_TURN_OFF, {"powerOff": True}),
+    ],
+)
+async def test_fan_control(
+    hass: HomeAssistant,
+    mock_miele_client: MagicMock,
+    setup_platform: None,
+    service: str,
+    expected_argument: dict[str, Any],
+) -> None:
+    """Test the fan can be turned on/off."""
+
+    await hass.services.async_call(
+        TEST_PLATFORM, service, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+    )
+    mock_miele_client.send_action.assert_called_once_with(
+        "DummyAppliance_18", expected_argument
+    )
+
+
+@pytest.mark.parametrize(
+    ("service", "percentage", "expected_argument"),
+    [
+        ("set_percentage", 0, {"powerOff": True}),
+        ("set_percentage", 20, {"ventilationStep": 1}),
+        ("set_percentage", 100, {"ventilationStep": 4}),
+    ],
+)
+async def test_fan_set_speed(
+    hass: HomeAssistant,
+    mock_miele_client: MagicMock,
+    setup_platform: None,
+    service: str,
+    percentage: int,
+    expected_argument: dict[str, Any],
+) -> None:
+    """Test the fan can be turned on/off."""
+
+    await hass.services.async_call(
+        TEST_PLATFORM,
+        service,
+        {ATTR_ENTITY_ID: ENTITY_ID, "percentage": percentage},
+        blocking=True,
+    )
+    mock_miele_client.send_action.assert_called_once_with(
+        "DummyAppliance_18", expected_argument
+    )
+
+
+@pytest.mark.parametrize(
+    ("service"),
+    [
+        (SERVICE_TURN_ON),
+        (SERVICE_TURN_OFF),
+    ],
+)
+async def test_api_failure(
+    hass: HomeAssistant,
+    mock_miele_client: MagicMock,
+    setup_platform: None,
+    service: str,
+) -> None:
+    """Test handling of exception from API."""
+    mock_miele_client.send_action.side_effect = ClientResponseError("test", "Test")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            TEST_PLATFORM, service, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+        )
+    mock_miele_client.send_action.assert_called_once()

--- a/tests/components/miele/test_fan.py
+++ b/tests/components/miele/test_fan.py
@@ -7,7 +7,7 @@ from aiohttp import ClientResponseError
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.fan import ATTR_PERCENTAGE, DOMAIN as FAN_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -84,7 +84,7 @@ async def test_fan_set_speed(
     await hass.services.async_call(
         TEST_PLATFORM,
         service,
-        {ATTR_ENTITY_ID: ENTITY_ID, "percentage": percentage},
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_PERCENTAGE: percentage},
         blocking=True,
     )
     mock_miele_client.send_action.assert_called_once_with(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add fan platform to miele integration
Cooker hoods are exposing the fan entity that allows control of the speed of the evacuation fan. There are also exstraction fan included in certain induction hobs but these fans are not possible to control due to lack of support in the API

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38769
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
