### PR TITLE
Add reconfigure config flow to APCUPSD

### DIFF
--- a/homeassistant/components/apcupsd/config_flow.py
+++ b/homeassistant/components/apcupsd/config_flow.py
@@ -46,11 +46,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             return self.async_show_form(step_id="user", data_schema=_SCHEMA)
 
         host, port = user_input[CONF_HOST], user_input[CONF_PORT]
-
-        # Abort if an entry with same host and port is present.
         self._async_abort_entries_match({CONF_HOST: host, CONF_PORT: port})
-
-        # Test the connection to the host and get the current status for serial number.
         try:
             async with asyncio.timeout(CONNECTION_TIMEOUT):
                 data = APCUPSdData(await aioapcaccess.request_status(host, port))
@@ -67,3 +63,30 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
         title = data.name or data.model or data.serial_no or "APC UPS"
         return self.async_create_entry(title=title, data=user_input)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of an existing entry."""
+
+        if user_input is None:
+            return self.async_show_form(step_id="reconfigure", data_schema=_SCHEMA)
+
+        host, port = user_input[CONF_HOST], user_input[CONF_PORT]
+        self._async_abort_entries_match({CONF_HOST: host, CONF_PORT: port})
+        try:
+            async with asyncio.timeout(CONNECTION_TIMEOUT):
+                data = APCUPSdData(await aioapcaccess.request_status(host, port))
+        except (OSError, asyncio.IncompleteReadError, TimeoutError):
+            errors = {"base": "cannot_connect"}
+            return self.async_show_form(
+                step_id="reconfigure", data_schema=_SCHEMA, errors=errors
+            )
+
+        await self.async_set_unique_id(data.serial_no)
+        self._abort_if_unique_id_mismatch(reason="wrong_apcupsd_daemon")
+
+        return self.async_update_reload_and_abort(
+            self._get_reconfigure_entry(),
+            data_updates=user_input,
+        )

--- a/homeassistant/components/apcupsd/strings.json
+++ b/homeassistant/components/apcupsd/strings.json
@@ -1,7 +1,9 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "wrong_apcupsd_daemon": "The reconfigured APC UPS Daemon is not the same as the one already configured.",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -27,7 +27,9 @@ def _patch_setup():
 
 async def test_config_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Test config flow setup with connection error."""
-    with patch("aioapcaccess.request_status") as mock_get:
+    with patch(
+        "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
+    ) as mock_get:
         mock_get.side_effect = OSError()
 
         result = await hass.config_entries.flow.async_init(
@@ -53,7 +55,9 @@ async def test_config_flow_duplicate(hass: HomeAssistant) -> None:
     mock_entry.add_to_hass(hass)
 
     with (
-        patch("aioapcaccess.request_status") as mock_request_status,
+        patch(
+            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
+        ) as mock_request_status,
         _patch_setup(),
     ):
         mock_request_status.return_value = MOCK_STATUS
@@ -100,7 +104,10 @@ async def test_config_flow_duplicate(hass: HomeAssistant) -> None:
 async def test_flow_works(hass: HomeAssistant) -> None:
     """Test successful creation of config entries via user configuration."""
     with (
-        patch("aioapcaccess.request_status", return_value=MOCK_STATUS),
+        patch(
+            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
+            return_value=MOCK_STATUS,
+        ),
         _patch_setup() as mock_setup,
     ):
         result = await hass.config_entries.flow.async_init(
@@ -140,7 +147,9 @@ async def test_flow_minimal_status(
     integration will vary.
     """
     with (
-        patch("aioapcaccess.request_status") as mock_request_status,
+        patch(
+            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
+        ) as mock_request_status,
         _patch_setup() as mock_setup,
     ):
         status = MOCK_MINIMAL_STATUS | extra_status
@@ -176,7 +185,10 @@ async def test_reconfigure_flow_works(hass: HomeAssistant) -> None:
     new_conf_data = {CONF_HOST: "new_host", CONF_PORT: 4321}
 
     with (
-        patch("aioapcaccess.request_status", return_value=MOCK_STATUS),
+        patch(
+            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
+            return_value=MOCK_STATUS,
+        ),
         _patch_setup() as mock_setup,
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -211,7 +223,10 @@ async def test_reconfigure_flow_cannot_connect(hass: HomeAssistant) -> None:
 
     # New configuration data with different host/port.
     new_conf_data = {CONF_HOST: "new_host", CONF_PORT: 4321}
-    with patch("aioapcaccess.request_status", side_effect=OSError()):
+    with patch(
+        "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
+        side_effect=OSError(),
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=new_conf_data
         )
@@ -251,7 +266,10 @@ async def test_reconfigure_flow_wrong_device(
     # Make a copy of the status and modify the serial number if needed.
     mock_status = {k: v for k, v in MOCK_STATUS.items() if k != "SERIALNO"}
     mock_status["SERIALNO"] = unique_id_after
-    with patch("aioapcaccess.request_status", return_value=mock_status):
+    with patch(
+        "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
+        return_value=mock_status,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=new_conf_data
         )

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -157,7 +157,6 @@ async def test_flow_minimal_status(
 
 async def test_reconfigure_flow_works(hass: HomeAssistant) -> None:
     """Test successful reconfiguration of an existing entry."""
-    # First add an existing config entry to hass.
     mock_entry = MockConfigEntry(
         version=1,
         domain=DOMAIN,
@@ -189,7 +188,7 @@ async def test_reconfigure_flow_works(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "reconfigure"
 
-        # Submit the new configuration
+        # Submit the new configuration.
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=new_conf_data
         )
@@ -207,7 +206,6 @@ async def test_reconfigure_flow_works(hass: HomeAssistant) -> None:
 
 async def test_reconfigure_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Test reconfiguration with connection error."""
-    # First add an existing config entry to hass
     mock_entry = MockConfigEntry(
         version=1,
         domain=DOMAIN,
@@ -241,7 +239,6 @@ async def test_reconfigure_flow_cannot_connect(hass: HomeAssistant) -> None:
 
 async def test_reconfigure_flow_wrong_device(hass: HomeAssistant) -> None:
     """Test reconfiguration with a different device (wrong serial number)."""
-    # First add an existing config entry to hass
     mock_entry = MockConfigEntry(
         version=1,
         domain=DOMAIN,
@@ -252,7 +249,7 @@ async def test_reconfigure_flow_wrong_device(hass: HomeAssistant) -> None:
     )
     mock_entry.add_to_hass(hass)
 
-    # New configuration data with different host/port
+    # New configuration data with different host/port.
     new_conf_data = {CONF_HOST: "new_host", CONF_PORT: 4321}
 
     with patch("aioapcaccess.request_status") as mock_request_status:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds reconfigure config flow to APCUPSD integration such that users can reconfigure their config when they updated the IP address of the same APC UPS Daemon. Tests have been added to ensure the reconfigure flow works, and it aborts if connection fails or is not pointing to the same device as before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
