### PR TITLE
Use common state for "Fault", add recommended hyphen in `fronius`

### DIFF
--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -317,11 +317,11 @@
       "state_message": {
         "name": "State message",
         "state": {
+          "fault": "[%key:common::state::fault%]",
+          "critical_fault": "Critical fault",
           "up_and_running": "Up and running",
           "keep_minimum_temperature": "Keep minimum temperature",
           "legionella_protection": "Legionella protection",
-          "critical_fault": "Critical fault",
-          "fault": "Fault",
           "boost_mode": "Boost mode"
         }
       },
@@ -362,7 +362,7 @@
         "name": "Relative autonomy"
       },
       "relative_self_consumption": {
-        "name": "Relative self consumption"
+        "name": "Relative self-consumption"
       },
       "capacity_maximum": {
         "name": "Maximum capacity"

--- a/tests/components/fronius/snapshots/test_sensor.ambr
+++ b/tests/components/fronius/snapshots/test_sensor.ambr
@@ -3179,7 +3179,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Relative self consumption',
+    'original_name': 'Relative self-consumption',
     'platform': 'fronius',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -3191,7 +3191,7 @@
 # name: test_gen24[sensor.solarnet_relative_self_consumption-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'SolarNet Relative self consumption',
+      'friendly_name': 'SolarNet Relative self-consumption',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
@@ -7163,7 +7163,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Relative self consumption',
+    'original_name': 'Relative self-consumption',
     'platform': 'fronius',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -7175,7 +7175,7 @@
 # name: test_gen24_storage[sensor.solarnet_relative_self_consumption-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'SolarNet Relative self consumption',
+      'friendly_name': 'SolarNet Relative self-consumption',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
@@ -10087,7 +10087,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Relative self consumption',
+    'original_name': 'Relative self-consumption',
     'platform': 'fronius',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -10099,7 +10099,7 @@
 # name: test_primo_s0[sensor.solarnet_relative_self_consumption-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'SolarNet Relative self consumption',
+      'friendly_name': 'SolarNet Relative self-consumption',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Use the new common state for "Fault", also reordering the states a bit for clarity
- Add a recommended hyphen to "self-consumption" to improve readability
[See Wiktionary](https://en.wiktionary.org/wiki/self-#Usage_notes): "Words derived from self- are usually formed with a hyphen. Using a hyphen is recommended by the U.S. Government Printing Office Style Manual."


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
