### PR TITLE
Simplify backup retention filtering

### DIFF
--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -2027,29 +2027,33 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2069,29 +2073,33 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2111,17 +2119,19 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2141,50 +2151,55 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-1",
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-2",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-3",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-5": MagicMock(
+                "backup-5": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-5",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2207,49 +2222,54 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-1",
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-2",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-3",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-5": MagicMock(
+                "backup-5": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-5",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2261,7 +2281,6 @@ async def test_config_schedule_logic(
             1,
             {
                 "test.test-agent": [call("backup-1")],
-                "test.test-agent2": [call("backup-1")],
             },
         ),
         (
@@ -2272,35 +2291,40 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-5": MagicMock(
+                "backup-5": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-5",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2320,29 +2344,33 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {"test.test-agent": BackupAgentError("Boom!")},
@@ -2362,29 +2390,33 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2404,50 +2436,55 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-1",
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-2",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-3",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-5": MagicMock(
+                "backup-5": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-5",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2478,49 +2515,54 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-1",
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-2",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-3",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-5": MagicMock(
+                "backup-5": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={
                         "test.test-agent": MagicMock(spec=AgentBackupStatus),
                         "test.test-agent2": MagicMock(spec=AgentBackupStatus),
                     },
+                    backup_id="backup-5",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2547,17 +2589,19 @@ async def test_config_schedule_logic(
                 "schedule": {"recurrence": "daily"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2942,29 +2986,33 @@ async def test_config_retention_copies_logic(
                 "schedule": {"recurrence": "never"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -2980,29 +3028,33 @@ async def test_config_retention_copies_logic(
                 "schedule": {"recurrence": "never"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3018,35 +3070,40 @@ async def test_config_retention_copies_logic(
                 "schedule": {"recurrence": "never"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-5": MagicMock(
+                "backup-5": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-5",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3062,35 +3119,40 @@ async def test_config_retention_copies_logic(
                 "schedule": {"recurrence": "never"},
             },
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-5": MagicMock(
+                "backup-5": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-5",
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3210,23 +3272,26 @@ async def test_config_retention_copies_logic_manual_backup(
             2,
             [],
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3242,23 +3307,26 @@ async def test_config_retention_copies_logic_manual_backup(
             None,
             [],
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3281,23 +3349,26 @@ async def test_config_retention_copies_logic_manual_backup(
                 }
             ],
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3319,23 +3390,26 @@ async def test_config_retention_copies_logic_manual_backup(
                 }
             ],
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3357,23 +3431,26 @@ async def test_config_retention_copies_logic_manual_backup(
                 }
             ],
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3395,29 +3472,33 @@ async def test_config_retention_copies_logic_manual_backup(
                 }
             ],
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3439,23 +3520,26 @@ async def test_config_retention_copies_logic_manual_backup(
                 }
             ],
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {"test-agent": BackupAgentError("Boom!")},
@@ -3477,23 +3561,26 @@ async def test_config_retention_copies_logic_manual_backup(
                 }
             ],
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},
@@ -3515,29 +3602,33 @@ async def test_config_retention_copies_logic_manual_backup(
                 }
             ],
             {
-                "backup-1": MagicMock(
+                "backup-1": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-1",
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-2": MagicMock(
+                "backup-2": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-2",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-3": MagicMock(
+                "backup-3": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-3",
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
-                    spec=ManagerBackup,
                 ),
-                "backup-4": MagicMock(
+                "backup-4": replace(
+                    TEST_MANAGER_BACKUP,
                     agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    backup_id="backup-4",
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
-                    spec=ManagerBackup,
                 ),
             },
             {},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Always filter backups to delete per agent, and honor the set global setting per agent. Eg 3 backups to keep means, every agent will keep 3 backups regardless what backups those are. Ie they don't need to be the same backups.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
