### PR TITLE
Do not allow to enable BT scanner for Shelly Gen4 device with Zigbee enabled

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -293,6 +293,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                     translation_key="firmware_unsupported",
                     translation_placeholders={"device": entry.title},
                 )
+            runtime_data.rpc_zigbee_enabled = device.zigbee_enabled
             runtime_data.rpc_supports_scripts = await device.supports_scripts()
             if runtime_data.rpc_supports_scripts:
                 runtime_data.rpc_script_events = await get_rpc_scripts_event_types(

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -475,6 +475,8 @@ class OptionsFlowHandler(OptionsFlow):
             return self.async_abort(reason="cannot_connect")
         if not supports_scripts:
             return self.async_abort(reason="no_scripts_support")
+        if self.config_entry.runtime_data.rpc_zigbee_enabled:
+            return self.async_abort(reason="zigbee_enabled")
 
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -90,6 +90,7 @@ class ShellyEntryData:
     rpc_poll: ShellyRpcPollingCoordinator | None = None
     rpc_script_events: dict[int, list[str]] | None = None
     rpc_supports_scripts: bool | None = None
+    rpc_zigbee_enabled: bool | None = None
 
 
 type ShellyConfigEntry = ConfigEntry[ShellyEntryData]
@@ -717,7 +718,10 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
         is updated.
         """
         if not self.sleep_period:
-            if self.config_entry.runtime_data.rpc_supports_scripts:
+            if (
+                self.config_entry.runtime_data.rpc_supports_scripts
+                and not self.config_entry.runtime_data.rpc_zigbee_enabled
+            ):
                 await self._async_connect_ble_scanner()
         else:
             await self._async_setup_outbound_websocket()

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -104,7 +104,8 @@
     },
     "abort": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "no_scripts_support": "Device does not support scripts and cannot be used as a Bluetooth scanner."
+      "no_scripts_support": "Device does not support scripts and cannot be used as a Bluetooth scanner.",
+      "zigbee_enabled": "Device with Zigbee enabled cannot be used as a Bluetooth scanner. Please disable it to use the device as a Bluetooth scanner."
     }
   },
   "selector": {

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -498,6 +498,7 @@ def _mock_rpc_device(version: str | None = None):
             }
         ),
         xmod_info={},
+        zigbee_enabled=False,
     )
     type(device).name = PropertyMock(return_value="Test name")
     return device

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -870,6 +870,19 @@ async def test_options_flow_abort_no_scripts_support(
     assert result["reason"] == "no_scripts_support"
 
 
+async def test_options_flow_abort_zigbee_enabled(
+    hass: HomeAssistant, mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test ble options abort if Zigbee is enabled for the device."""
+    monkeypatch.setattr(mock_rpc_device, "zigbee_enabled", True)
+    entry = await init_integration(hass, 4)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "zigbee_enabled"
+
+
 async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
     """Test we get the form."""
 

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -853,17 +853,28 @@ async def test_rpc_update_entry_fw_ver(
     assert device.sw_version == "99.0.0"
 
 
-@pytest.mark.parametrize(("supports_scripts"), [True, False])
+@pytest.mark.parametrize(
+    ("supports_scripts", "zigbee_enabled", "result"),
+    [
+        (True, False, True),
+        (True, True, False),
+        (False, True, False),
+        (False, False, False),
+    ],
+)
 async def test_rpc_runs_connected_events_when_initialized(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
     supports_scripts: bool,
+    zigbee_enabled: bool,
+    result: bool,
 ) -> None:
     """Test RPC runs connected events when initialized."""
     monkeypatch.setattr(
         mock_rpc_device, "supports_scripts", AsyncMock(return_value=supports_scripts)
     )
+    monkeypatch.setattr(mock_rpc_device, "zigbee_enabled", zigbee_enabled)
     monkeypatch.setattr(mock_rpc_device, "initialized", False)
     await init_integration(hass, 2)
 
@@ -875,8 +886,8 @@ async def test_rpc_runs_connected_events_when_initialized(
     await hass.async_block_till_done()
 
     assert call.supports_scripts() in mock_rpc_device.mock_calls
-    # BLE script list is called during connected events if device supports scripts
-    assert bool(call.script_list() in mock_rpc_device.mock_calls) == supports_scripts
+    # BLE script list is called during connected events if device supports scripts and Zigbee is disabled
+    assert bool(call.script_list() in mock_rpc_device.mock_calls) == result
 
 
 async def test_rpc_sleeping_device_unload_ignore_ble_scanner(

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -886,7 +886,8 @@ async def test_rpc_runs_connected_events_when_initialized(
     await hass.async_block_till_done()
 
     assert call.supports_scripts() in mock_rpc_device.mock_calls
-    # BLE script list is called during connected events if device supports scripts and Zigbee is disabled
+    # BLE script list is called during connected events if device supports scripts
+    # and Zigbee is disabled
     assert bool(call.script_list() in mock_rpc_device.mock_calls) == result
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Shelly Gen4 devices don't support Bluetooth when Zigbee is enabled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
