### PR TITLE
apply for platinum quality scale for enphase_envoy

### DIFF
--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
-  "quality_scale": "bronze",
+  "quality_scale": "platinum",
   "requirements": ["pyenphase==1.26.0"],
   "zeroconf": [
     {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enphase_envoy integration [quality_scale.yaml](https://github.com/home-assistant/core/blob/dev/homeassistant/components/enphase_envoy/quality_scale.yaml) has all items for all levels as done or exempt already by the time #136332 was merged and the bronze level was established. So current merged code qualifies for platinum. This PR request for this status. Quality_scale.yaml is unaltered and not included in changed files of this PR.

Full checklist

## Bronze
- [x] `action-setup` - Service actions are registered in async_setup
    - platform native actions for switch, select and number
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
    - fixed [1 minute cycle](https://github.com/home-assistant/core/blob/4203345550eec59f2f917866a140bb0a61ce232e/homeassistant/components/enphase_envoy/coordinator.py#L23) based on Enphase Envoy device characteristics
- [x] `brands` - Has branding assets available for the integration
    - https://github.com/home-assistant/brands/tree/master/core_integrations/enphase_envoy
- [x] `common-modules` - Place common patterns in common modules
    - [coordinator.py](homeassistant/components/enphase_envoy/coordinator.py), [entity.py](homeassistant/components/enphase_envoy/entity.py)
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
    - [test_config_flow.py](tests/components/enphase_envoy/test_config_flow.py): homeassistant/components/enphase_envoy/config_flow.py       135      0   100%
- [x] `config-flow` - Integration needs to be able to be set up via the UI
        - [manifest.json](https://github.com/home-assistant/core/blob/208805a930b13dfd0f96b1388d6f792248089e3e/homeassistant/components/enphase_envoy/manifest.json#L5)
    - [x] Uses `data_description` to give context to fields
        - [strings.json](homeassistant/components/enphase_envoy/strings.json)
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
        - [ConfigEntry.data](https://github.com/home-assistant/core/blob/208805a930b13dfd0f96b1388d6f792248089e3e/homeassistant/components/enphase_envoy/config_flow.py#L253), [ConfigEntry.options](https://github.com/home-assistant/core/blob/208805a930b13dfd0f96b1388d6f792248089e3e/homeassistant/components/enphase_envoy/config_flow.py#L320)
- [x] `dependency-transparency` - Dependency transparency
    - [pyenphase](https://github.com/pyenphase/pyenphase): [PyPI](https://pypi.org/project/pyenphase/), [Docs](https://pyenphase.readthedocs.io/en/stable/index.html), [License](https://pyenphase.readthedocs.io/en/stable/license.html),
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
    - [actions documentation](https://www.home-assistant.io/integrations/enphase_envoy/#actions)
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
    - [High level documentation](https://www.home-assistant.io/integrations/enphase_envoy)
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
    - [Installation instructions documentation](https://www.home-assistant.io/integrations/enphase_envoy/#prerequisites)
- [x] `docs-removal-instructions` - The documentation provides removal instructions
    - [Removal documentation](https://www.home-assistant.io/integrations/enphase_envoy/#removing-the-integration)
- [x] `entity-event-setup` - Entities event setup
    - Entities do not subscribe to events.
- [x] `entity-unique-id` - Entities have a unique ID
    - All entities have unique id: [binary_sensors](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/binary_sensor.py#L119), [number](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/number.py#L118), [select](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/select.py#L173), [sensors](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/sensor.py#L962), [switch](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/switch.py#L133)
- [x] `has-entity-name` - Entities use has_entity_name = True
    - [entity.py](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/entity.py#L16)
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
    - [coordinator and its data is stored in runtime data](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/__init__.py#L63)
- [x] `test-before-configure` - Test a connection in the config flow
    - [user](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/config_flow.py#L225), [reconfigure](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/config_flow.py#L282) and [reauth confirm](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/config_flow.py#L185) steps use [validate input](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/config_flow.py#L55) with connection test
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
    - If setup fails, no envoy serial is known and [ConfigEntryNotReady](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/__init__.py#L53) is result, If Authentication fails [ConfigEntrAuthFailed](https://github.com/home-assistant/core/blob/dc24f83407855a7d01b4742858467a4a74d03ff4/homeassistant/components/enphase_envoy/coordinator.py#L201) is result. (using await coordinator.async_config_entry_first_refresh())
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
    - Envoy device serial number used as unique id. Device setup uses device IP address and reads serial number from device. If device with read serial in unique ID exists, it's data is [updated and not created as another device](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/config_flow.py#L243).

## Silver
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
    - actions use @exception_handler decorator, for example switch.py [async_turn_off](https://github.com/home-assistant/core/blob/245eb644051fa47ddd647b3b8d22a159074f2bfb/homeassistant/components/enphase_envoy/switch.py#L265). 
    - @exception_handler is implemented in [entity.py](https://github.com/home-assistant/core/blob/245eb644051fa47ddd647b3b8d22a159074f2bfb/homeassistant/components/enphase_envoy/entity.py#L47)
- [x] `config-entry-unloading` - Support config entry unloading
    - [cancels scheduled functions and awaits platform unloads](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/__init__.py#L78)
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options
    - [options](https://www.home-assistant.io/integrations/enphase_envoy/#options)
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
    - [Required manual input](https://www.home-assistant.io/integrations/enphase_envoy/#required-manual-input)
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
    - _async_update_data returns [UpdateFailed](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/coordinator.py#L209)
- [x] `integration-owner` - Has an integration owner
    - see [manifest](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/manifest.json#L4)
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
    - handled by core when returning [UpdateFailed](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/coordinator.py#L209) by _async_update_data 
- [x] `parallel-updates` - Set Parallel updates
    - uses coordinator, read-only [binary_sensor](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/binary_sensor.py#L25), [sensor](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/sensor.py#L64) set to 0, action calls [number](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/number.py#L28), [select](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/select.py#L23) and [switch](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/switch.py#L23) set to 1
- [x] `reauthentication-flow` - Reauthentication flow
    - implements [async_step_reauth](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/config_flow.py#L171) and [async_step_reauth_confirm](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/config_flow.py#L177)
- [x] `test-coverage` - Above 95% test coverage for all integration modules
    - TOTAL    1097      0   100%

## Gold
- [x] `devices` - The integration creates devices
    - [binary_sensor.py](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/binary_sensor.py#L122), [number.py](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/number.py#L119), [select.py](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/select.py#L174), [sensor.py](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/sensor.py#L963), [switch.py](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/switch.py#L134)
- [x] `diagnostics` - Implements diagnostics
    - [diagnostics.py](homeassistant/components/enphase_envoy/diagnostics.py) and [documentation](https://www.home-assistant.io/integrations/enphase_envoy/#diagnostics)
- [x] `discovery-update-info` - Integration uses discovery info to update network information
    - [manifest](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/manifest.json#L12), [async_step_zeroconf](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/config_flow.py#L143)
- [x] `discovery` - Can be discovered
    - [async_step_zeroconf](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/config_flow.py#L143)
- [x] `docs-data-update` - The documentation describes how data is updated
    - [documented data updates](https://www.home-assistant.io/integrations/enphase_envoy/#data-polling-interval)
- [x] `docs-examples` - The documentation provides automation examples the user can use.
    - [example split grid value](https://www.home-assistant.io/integrations/enphase_envoy/#electricity-grid-with-total-consumption-ct), [example battery power import/export split](https://www.home-assistant.io/integrations/enphase_envoy/#home-battery-storage-data-using-battery-power), [example battery energy split](https://www.home-assistant.io/integrations/enphase_envoy/#home-battery-storage-data-on-the-available-battery-energy), [action examples](https://www.home-assistant.io/integrations/enphase_envoy/#actions)
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
    - [documented known issues and limitations](https://www.home-assistant.io/integrations/enphase_envoy/#know-issues-and-limitations)
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices
    - [documented supported devices](https://www.home-assistant.io/integrations/enphase_envoy/#supported-devices)
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
    - [documented capabilities](https://www.home-assistant.io/integrations/enphase_envoy/#capabilities)
- [x] `docs-troubleshooting` - The documentation provides troubleshooting information
    - [documented troubleshooting](https://www.home-assistant.io/integrations/enphase_envoy/#troubleshooting)
- [x] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
    - [capabilities](https://www.home-assistant.io/integrations/enphase_envoy/#capabilities), [energy dashboad](https://www.home-assistant.io/integrations/enphase_envoy/#energy-dashboard)
- [x] `dynamic-devices` - Devices added after integration setup
    - based on actual Envoy setup and configuration, child devices are added when discovered during config entry load. Firmware changes in the Envoy are monitored and will trigger a reload and addition of devices  as needed. [Encharge binary_sensor](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/binary_sensor.py#L160), [Enpower binary_sensor](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/binary_sensor.py#L160), [Relay number](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/number.py#L125), [Enpower number](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/number.py#L166), [Relay select](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/select.py#L180), [Solar inverter sensors](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/sensor.py#L1206)
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
    - EntityCategory.DIAGNOSTIC is used for applicable entities like [sensor CT metering Status](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/sensor.py#L373) or [Encharge binary_sensor](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/binary_sensor.py#L40). EntityCategory.CONFIG is used for [battery configuration](https://github.com/home-assistant/core/blob/05bdfe7aa6bdfa353980afcc3f91e043c27f8a1e/homeassistant/components/enphase_envoy/number.py#L51).
- [x] `entity-device-class` - Entities use device classes where possible
    - all platforms use devoce_class where possible. for example [Inverter sensors](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/sensor.py#L74), [production sensors](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/sensor.py#L101) or [Encharge binary_sensor](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/binary_sensor.py#L35)
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
    - multiple entities are disabled by default, for example all [multi-phase sensor](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/sensor.py#L148) as [documented](https://www.home-assistant.io/integrations/enphase_envoy/#production-sensor-entities)
- [x] `entity-translations` - Entities have translated names
    - translatable names provided in [strings.json](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/strings.json#L70)
- [x] `exception-translations` - Exception messages are translatable
    - translatable exceptions are provided in [strings.json](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/strings.json#L394) or raised by [coordinator](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/coordinator.py#L201)
- [x] `icon-translations` - Icon translations
    - icon translations are provided in [icon.json](homeassistant/components/enphase_envoy/icons.json) for entities deviating from default deviceclass icons.
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
    - [async_step_reconfigure](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/config_flow.py#L270) enbales chaning credentials or Envody IP address
- [x] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
    - exempt, currently not needed nor used. Not applicable. 
- [x] `stale-devices` - Clean up stale devices
    - [async_remove_config_entry_device](https://github.com/home-assistant/core/blob/52f77626f722de89fa7b048a5e183c87a7a42cc9/homeassistant/components/enphase_envoy/__init__.py#L86) is implemented in \_\_init\_\_.py. It will not allow removing sub-devices if these still have data in last collected data-set. 

## Platinum
- [x] `async-dependency` - Dependency is async
    - [pyenphase library](https://pyenphase.readthedocs.io/en/latest/usage.html) is async
- [x] `inject-websession` - The integration dependency supports passing in a websession
    - [pyenphase dependency supports passing web client](https://pyenphase.readthedocs.io/en/latest/model_autodoc.html#pyenphase.Envoy)
- [x] `strict-typing` - Strict typing
    - enphase_envoy is in [.strict-typing](https://github.com/home-assistant/core/blob/73bd21e0ab0a7fc51d52d83d308d7590ebe2a4f8/.strict-typing#L184)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
