### PR TITLE
Add repair flow for Shelly BLE scanner with unsupported firmware

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -332,16 +332,18 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
         )
 
         # Latest available firmware for Plug S Gen3 and Outdoor Plug S Gen3 is 1.2.3.
-        if (
-            runtime_data.rpc_supports_scripts
-            and entry.options.get(CONF_BLE_SCANNER_MODE) == BLEScannerMode.ACTIVE
-            and runtime_data.rpc.model not in (MODEL_PLUG_S_G3, MODEL_OUT_PLUG_S_G3)
+        if runtime_data.rpc_supports_scripts and runtime_data.rpc.model not in (
+            MODEL_PLUG_S_G3,
+            MODEL_OUT_PLUG_S_G3,
         ):
             firmware = AwesomeVersion(device.shelly["ver"])
             issue_id = BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(
                 unique=entry.unique_id
             )
-            if firmware < BLE_SCANNER_MIN_FIRMWARE:
+            if (
+                firmware < BLE_SCANNER_MIN_FIRMWARE
+                and entry.options.get(CONF_BLE_SCANNER_MODE) == BLEScannerMode.ACTIVE
+            ):
                 ir.async_create_issue(
                     hass,
                     DOMAIN,

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -338,13 +338,14 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
             and runtime_data.rpc.model not in (MODEL_PLUG_S_G3, MODEL_OUT_PLUG_S_G3)
         ):
             firmware = AwesomeVersion(device.shelly["ver"])
+            issue_id = BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(
+                unique=entry.unique_id
+            )
             if firmware < BLE_SCANNER_MIN_FIRMWARE:
                 ir.async_create_issue(
                     hass,
                     DOMAIN,
-                    BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(
-                        unique=runtime_data.rpc.mac
-                    ),
+                    issue_id,
                     is_fixable=True,
                     is_persistent=True,
                     severity=ir.IssueSeverity.WARNING,
@@ -360,9 +361,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                 ir.async_delete_issue(
                     hass,
                     DOMAIN,
-                    BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(
-                        unique=entry.unique_id
-                    ),
+                    issue_id,
                 )
     elif (
         sleep_period is None

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -40,6 +40,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID,
+    BLE_SCANNER_MIN_FIRMWARE,
     BLOCK_EXPECTED_SLEEP_PERIOD,
     BLOCK_WRONG_SLEEP_PERIOD,
     CONF_BLE_SCANNER_MODE,
@@ -330,7 +331,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
             and entry.options.get(CONF_BLE_SCANNER_MODE) == BLEScannerMode.ACTIVE
         ):
             firmware = AwesomeVersion(device.shelly["ver"])
-            if firmware < "1.5.0":
+            if firmware < BLE_SCANNER_MIN_FIRMWARE:
                 ir.async_create_issue(
                     hass,
                     DOMAIN,

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -339,7 +339,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                         unique=runtime_data.rpc.mac
                     ),
                     is_fixable=True,
-                    is_persistent=False,
+                    is_persistent=True,
                     severity=ir.IssueSeverity.WARNING,
                     translation_key="ble_scanner_firmware_unsupported",
                     translation_placeholders={
@@ -348,6 +348,14 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                         "firmware": firmware,
                     },
                     data={"entry_id": entry.entry_id},
+                )
+            else:
+                ir.async_delete_issue(
+                    hass,
+                    DOMAIN,
+                    BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(
+                        unique=entry.unique_id
+                    ),
                 )
     elif (
         sleep_period is None
@@ -391,12 +399,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ShellyConfigEntry) -> b
     )
     ir.async_delete_issue(
         hass, DOMAIN, PUSH_UPDATE_ISSUE_ID.format(unique=entry.unique_id)
-    )
-
-    ir.async_delete_issue(
-        hass,
-        DOMAIN,
-        BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(unique=entry.unique_id),
     )
 
     runtime_data = entry.runtime_data

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -343,8 +343,8 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                     severity=ir.IssueSeverity.WARNING,
                     translation_key="ble_scanner_firmware_unsupported",
                     translation_placeholders={
-                        "device_name": runtime_data.rpc.name,
-                        "ip_address": runtime_data.rpc.device.ip_address,
+                        "device_name": device.name,
+                        "ip_address": device.ip_address,
                         "firmware": firmware,
                     },
                     data={"entry_id": entry.entry_id},

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -337,7 +337,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                     BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(
                         unique=runtime_data.rpc.mac
                     ),
-                    is_fixable=False,
+                    is_fixable=True,
                     is_persistent=False,
                     severity=ir.IssueSeverity.WARNING,
                     translation_key="ble_scanner_firmware_unsupported",
@@ -346,6 +346,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                         "ip_address": runtime_data.rpc.device.ip_address,
                         "firmware": firmware,
                     },
+                    data={"entry_id": entry.entry_id},
                 )
     elif (
         sleep_period is None

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -7,7 +7,12 @@ from typing import Final
 from aioshelly.ble.const import BLE_SCRIPT_NAME
 from aioshelly.block_device import BlockDevice
 from aioshelly.common import ConnectionOptions
-from aioshelly.const import DEFAULT_COAP_PORT, RPC_GENERATIONS
+from aioshelly.const import (
+    DEFAULT_COAP_PORT,
+    MODEL_OUT_PLUG_S_G3,
+    MODEL_PLUG_S_G3,
+    RPC_GENERATIONS,
+)
 from aioshelly.exceptions import (
     DeviceConnectionError,
     InvalidAuthError,
@@ -326,9 +331,11 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
             entry, runtime_data.platforms
         )
 
+        # Latest available firmware for Plug S Gen3 and Outdoor Plug S Gen3 is 1.2.3.
         if (
             runtime_data.rpc_supports_scripts
             and entry.options.get(CONF_BLE_SCANNER_MODE) == BLEScannerMode.ACTIVE
+            and runtime_data.rpc.model not in (MODEL_PLUG_S_G3, MODEL_OUT_PLUG_S_G3)
         ):
             firmware = AwesomeVersion(device.shelly["ver"])
             if firmware < BLE_SCANNER_MIN_FIRMWARE:

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -7,12 +7,7 @@ from typing import Final
 from aioshelly.ble.const import BLE_SCRIPT_NAME
 from aioshelly.block_device import BlockDevice
 from aioshelly.common import ConnectionOptions
-from aioshelly.const import (
-    DEFAULT_COAP_PORT,
-    MODEL_OUT_PLUG_S_G3,
-    MODEL_PLUG_S_G3,
-    RPC_GENERATIONS,
-)
+from aioshelly.const import DEFAULT_COAP_PORT, RPC_GENERATIONS
 from aioshelly.exceptions import (
     DeviceConnectionError,
     InvalidAuthError,
@@ -73,6 +68,7 @@ from .utils import (
     get_http_port,
     get_rpc_scripts_event_types,
     get_ws_context,
+    is_firmware_update_available,
 )
 
 PLATFORMS: Final = [
@@ -331,10 +327,8 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
             entry, runtime_data.platforms
         )
 
-        # Latest available firmware for Plug S Gen3 and Outdoor Plug S Gen3 is 1.2.3.
-        if runtime_data.rpc_supports_scripts and runtime_data.rpc.model not in (
-            MODEL_PLUG_S_G3,
-            MODEL_OUT_PLUG_S_G3,
+        if runtime_data.rpc_supports_scripts and is_firmware_update_available(
+            runtime_data.rpc.model
         ):
             firmware = AwesomeVersion(device.shelly["ver"])
             issue_id = BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -227,7 +227,7 @@ class BLEScannerMode(StrEnum):
     PASSIVE = "passive"
 
 
-BLE_SCANNER_MIN_FIRMWARE = "1.5.0"
+BLE_SCANNER_MIN_FIRMWARE = "1.5.1"
 
 MAX_PUSH_UPDATE_FAILURES = 5
 PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -227,6 +227,8 @@ class BLEScannerMode(StrEnum):
     PASSIVE = "passive"
 
 
+BLE_SCANNER_MIN_FIRMWARE = "1.5.0"
+
 MAX_PUSH_UPDATE_FAILURES = 5
 PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -234,6 +234,8 @@ NOT_CALIBRATED_ISSUE_ID = "not_calibrated_{unique}"
 
 FIRMWARE_UNSUPPORTED_ISSUE_ID = "firmware_unsupported_{unique}"
 
+BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID = "ble_scanner_firmware_unsupported_{unique}"
+
 GAS_VALVE_OPEN_STATES = ("opening", "opened")
 
 OTA_BEGIN = "ota_begin"

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -49,13 +49,11 @@ class BleScannerFirmwareUpdateFlow(RepairsFlow):
         self, user_input: dict[str, str] | None = None
     ) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""
+        if not self._device.status["sys"]["available_updates"]:
+            return self.async_abort(reason="update_not_available")
         try:
             await self._device.trigger_ota_update()
-        except RpcCallError as err:
-            if "Resource unavailable: No update info!" in str(err):
-                return self.async_abort(reason="update_not_available")
-            return self.async_abort(reason="cannot_connect")
-        except DeviceConnectionError:
+        except (DeviceConnectionError, RpcCallError):
             return self.async_abort(reason="cannot_connect")
 
         return self.async_create_entry(title="", data={})

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant import data_entry_flow
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 
 
 class BleScannerFirmwareUpdateFlow(RepairsFlow):
@@ -16,7 +17,7 @@ class BleScannerFirmwareUpdateFlow(RepairsFlow):
 
     _device: RpcDevice
 
-    def __init__(self, *, device: RpcDevice) -> None:
+    def __init__(self, device: RpcDevice) -> None:
         """Initialize."""
         self._device = device
 
@@ -33,7 +34,16 @@ class BleScannerFirmwareUpdateFlow(RepairsFlow):
         if user_input is not None:
             return await self.async_step_update_firmware()
 
-        return self.async_show_form(step_id="confirm", data_schema=vol.Schema({}))
+        issue_registry = ir.async_get(self.hass)
+        description_placeholders = None
+        if issue := issue_registry.async_get_issue(self.handler, self.issue_id):
+            description_placeholders = issue.translation_placeholders
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders=description_placeholders,
+        )
 
     async def async_step_update_firmware(
         self, user_input: dict[str, str] | None = None

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -61,7 +61,7 @@ async def async_create_fix_flow(
             and (entry_id := data.get("entry_id")) is not None
             and (entry := hass.config_entries.async_get_entry(entry_id)) is not None
         ):
-            device = entry.runtime_data.rpc.device
+            device: RpcDevice = entry.runtime_data.rpc.device
             return BleScannerFirmwareUpdateFlow(device=device)
 
     return ConfirmRepairFlow()

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -1,0 +1,67 @@
+"""Repairs flow for Shelly."""
+
+from __future__ import annotations
+
+from aioshelly.exceptions import DeviceConnectionError, RpcCallError
+from aioshelly.rpc_device import RpcDevice
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.core import HomeAssistant
+
+
+class BleScannerFirmwareUpdateFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    _device: RpcDevice
+
+    def __init__(self, *, device: RpcDevice) -> None:
+        """Initialize."""
+        self._device = device
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            return await self.async_step_update_firmware()
+
+        return self.async_show_form(step_id="confirm", data_schema=vol.Schema({}))
+
+    async def async_step_update_firmware(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        try:
+            await self._device.trigger_ota_update()
+        except RpcCallError as err:
+            if "Resource unavailable: No update info!" in str(err):
+                return self.async_abort(reason="update_not_available")
+            return self.async_abort(reason="cannot_connect")
+        except DeviceConnectionError:
+            return self.async_abort(reason="cannot_connect")
+
+        return self.async_create_entry(title="", data={})
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict[str, str] | None
+) -> RepairsFlow:
+    """Create flow."""
+    if issue_id.startswith("ble_scanner_firmware_unsupported"):
+        if (
+            data is not None
+            and (entry_id := data.get("entry_id")) is not None
+            and (entry := hass.config_entries.async_get_entry(entry_id)) is not None
+        ):
+            device = entry.runtime_data.rpc.device
+            return BleScannerFirmwareUpdateFlow(device=device)
+
+    return ConfirmRepairFlow()

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -2,20 +2,20 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from aioshelly.exceptions import DeviceConnectionError, RpcCallError
 from aioshelly.rpc_device import RpcDevice
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
-from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
 
 class BleScannerFirmwareUpdateFlow(RepairsFlow):
     """Handler for an issue fixing flow."""
-
-    _device: RpcDevice
 
     def __init__(self, device: RpcDevice) -> None:
         """Initialize."""
@@ -63,13 +63,14 @@ async def async_create_fix_flow(
     hass: HomeAssistant, issue_id: str, data: dict[str, str] | None
 ) -> RepairsFlow:
     """Create flow."""
-    if issue_id.startswith("ble_scanner_firmware_unsupported"):
-        if (
-            data is not None
-            and (entry_id := data.get("entry_id")) is not None
-            and (entry := hass.config_entries.async_get_entry(entry_id)) is not None
-        ):
-            device: RpcDevice = entry.runtime_data.rpc.device
-            return BleScannerFirmwareUpdateFlow(device=device)
+    if TYPE_CHECKING:
+        assert isinstance(data, dict)
 
-    return ConfirmRepairFlow()
+    entry_id = data["entry_id"]
+    entry = hass.config_entries.async_get_entry(entry_id)
+
+    if TYPE_CHECKING:
+        assert entry is not None
+
+    device = entry.runtime_data.rpc.device
+    return BleScannerFirmwareUpdateFlow(device)

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -263,8 +263,19 @@
   },
   "issues": {
     "ble_scanner_firmware_unsupported": {
-      "title": "Shelly BLE scanner {device_name} with unsupported firmware",
-      "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware} and acts as BLE scanner with active mode. Please update the firmware.\n\nIf the device does not offer an update, check internet connectivity (gateway, DNS, time) and restart the device."
+      "title": "{device_name} is running unsupported firmware",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "{device_name} is running unsupported firmware",
+            "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware} and acts as BLE scanner with active mode. This firmware version is not supported for BLE scanner active mode.\n\nSelect **Submit** button to start the OTA update to the latest stable firmware version."
+          }
+        },
+        "abort": {
+          "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+          "update_not_available": "Device does not offer firmware update. Check internet connectivity (gateway, DNS, time) and restart the device."
+        }
+      }
     },
     "device_not_calibrated": {
       "title": "Shelly device {device_name} is not calibrated",

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -262,6 +262,10 @@
     }
   },
   "issues": {
+    "ble_scanner_firmware_unsupported": {
+      "title": "Shelly BLE scanner {device_name} with unsupported firmware",
+      "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware} and acts as BLE scanner with active mode. Please update the firmware.\n\nIf the device does not offer an update, check internet connectivity (gateway, DNS, time) and restart the device."
+    },
     "device_not_calibrated": {
       "title": "Shelly device {device_name} is not calibrated",
       "description": "Shelly device {device_name} with IP address {ip_address} requires calibration. To calibrate the device, it must be rebooted after proper installation on the valve. You can reboot the device in its web panel, go to 'Settings' > 'Device Reboot'."

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -19,6 +19,8 @@ from aioshelly.const import (
     MODEL_EM3,
     MODEL_I3,
     MODEL_NAMES,
+    MODEL_OUT_PLUG_S_G3,
+    MODEL_PLUG_S_G3,
     RPC_GENERATIONS,
 )
 from aioshelly.rpc_device import RpcDevice, WsServer
@@ -691,3 +693,14 @@ async def get_rpc_scripts_event_types(
         script_events[script_id] = await get_rpc_script_event_types(device, script_id)
 
     return script_events
+
+
+def is_firmware_update_available(model: str) -> bool:
+    """Return true if firmware update should be available for the device.
+
+    Latest available firmware for Plug S Gen3 and Outdoor Plug S Gen3 is 1.2.3.
+    """
+    if model in (MODEL_PLUG_S_G3, MODEL_OUT_PLUG_S_G3):
+        return False
+
+    return True

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -19,8 +19,6 @@ from aioshelly.const import (
     MODEL_EM3,
     MODEL_I3,
     MODEL_NAMES,
-    MODEL_OUT_PLUG_S_G3,
-    MODEL_PLUG_S_G3,
     RPC_GENERATIONS,
 )
 from aioshelly.rpc_device import RpcDevice, WsServer
@@ -693,14 +691,3 @@ async def get_rpc_scripts_event_types(
         script_events[script_id] = await get_rpc_script_event_types(device, script_id)
 
     return script_events
-
-
-def is_firmware_update_available(model: str) -> bool:
-    """Return true if firmware update should be available for the device.
-
-    Latest available firmware for Plug S Gen3 and Outdoor Plug S Gen3 is 1.2.3.
-    """
-    if model in (MODEL_PLUG_S_G3, MODEL_OUT_PLUG_S_G3):
-        return False
-
-    return True

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -499,6 +499,7 @@ def _mock_rpc_device(version: str | None = None):
         ),
         xmod_info={},
         zigbee_enabled=False,
+        ip_address="10.10.10.10",
     )
     type(device).name = PropertyMock(return_value="Test name")
     return device

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -17,6 +17,7 @@ import pytest
 
 from homeassistant.components.shelly.const import (
     BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID,
+    BLE_SCANNER_MIN_FIRMWARE,
     BLOCK_EXPECTED_SLEEP_PERIOD,
     BLOCK_WRONG_SLEEP_PERIOD,
     CONF_BLE_SCANNER_MODE,
@@ -597,7 +598,7 @@ async def test_ble_scanner_unsupported_firmware_fixed(
     assert issue_registry.async_get_issue(DOMAIN, issue_id)
     assert len(issue_registry.issues) == 1
 
-    monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1.5.1")
+    monkeypatch.setitem(mock_rpc_device.shelly, "ver", BLE_SCANNER_MIN_FIRMWARE)
 
     await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -16,6 +16,7 @@ from aioshelly.rpc_device.utils import bluetooth_mac_from_primary_mac
 import pytest
 
 from homeassistant.components.shelly.const import (
+    BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID,
     BLOCK_EXPECTED_SLEEP_PERIOD,
     BLOCK_WRONG_SLEEP_PERIOD,
     CONF_BLE_SCANNER_MODE,
@@ -38,7 +39,7 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceRegistry, format_mac
 from homeassistant.setup import async_setup_component
 
-from . import init_integration, mutate_rpc_device_status
+from . import MOCK_MAC, init_integration, mutate_rpc_device_status
 
 
 async def test_custom_coap_port(
@@ -579,3 +580,27 @@ async def test_device_script_getcode_error(
 
     entry = await init_integration(hass, 2)
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_ble_scanner_unsupported_firmware_fixed(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test device init with unsupported firmware."""
+    issue_id = BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(unique=MOCK_MAC)
+    entry = await init_integration(
+        hass, 2, options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE}
+    )
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+    monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1.5.1")
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 0

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -10,19 +10,46 @@ from homeassistant.components.shelly.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.setup import async_setup_component
 
 from . import MOCK_MAC, init_integration
 
+from tests.components.repairs import (
+    async_process_repairs_platforms,
+    process_repair_fix_flow,
+    start_repair_fix_flow,
+)
+from tests.typing import ClientSessionGenerator
+
 
 async def test_ble_scanner_unsupported_firmware_issue(
-    hass: HomeAssistant, mock_rpc_device: Mock, issue_registry: ir.IssueRegistry
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repair issues handling for BLE scanner with unsupported firmware."""
+    issue_id = BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(unique=MOCK_MAC)
+    assert await async_setup_component(hass, "repairs", {})
+    await hass.async_block_till_done()
     await init_integration(
         hass, 2, options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE}
     )
 
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert issue_registry.async_get_issue(
-        DOMAIN, BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(unique=MOCK_MAC)
-    )
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+    await async_process_repairs_platforms(hass)
+    client = await hass_client()
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+
+    flow_id = result["flow_id"]
+    assert result["step_id"] == "confirm"
+
+    result = await process_repair_fix_flow(client, flow_id)
+    assert result["type"] == "create_entry"
+    assert mock_rpc_device.trigger_ota_update.call_count == 1
+
+    # Assert the issue is no longer present
+    assert not issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 0

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -1,0 +1,28 @@
+"""Test repairs handling for Shelly."""
+
+from unittest.mock import Mock
+
+from homeassistant.components.shelly.const import (
+    BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID,
+    CONF_BLE_SCANNER_MODE,
+    DOMAIN,
+    BLEScannerMode,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+from . import MOCK_MAC, init_integration
+
+
+async def test_ble_scanner_unsupported_firmware_issue(
+    hass: HomeAssistant, mock_rpc_device: Mock, issue_registry: ir.IssueRegistry
+) -> None:
+    """Test repair issues handling for BLE scanner with unsupported firmware."""
+    await init_integration(
+        hass, 2, options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE}
+    )
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert issue_registry.async_get_issue(
+        DOMAIN, BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(unique=MOCK_MAC)
+    )

--- a/tests/components/shelly/test_repairs.py
+++ b/tests/components/shelly/test_repairs.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import Mock
 
+from aioshelly.exceptions import DeviceConnectionError, RpcCallError
+import pytest
+
 from homeassistant.components.shelly.const import (
     BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID,
     CONF_BLE_SCANNER_MODE,
@@ -53,3 +56,77 @@ async def test_ble_scanner_unsupported_firmware_issue(
     # Assert the issue is no longer present
     assert not issue_registry.async_get_issue(DOMAIN, issue_id)
     assert len(issue_registry.issues) == 0
+
+
+async def test_unsupported_firmware_issue_update_not_available(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test repair issues handling when firmware update is not available."""
+    issue_id = BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(unique=MOCK_MAC)
+    assert await async_setup_component(hass, "repairs", {})
+    await hass.async_block_till_done()
+    await init_integration(
+        hass, 2, options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE}
+    )
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+    await async_process_repairs_platforms(hass)
+    client = await hass_client()
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+
+    flow_id = result["flow_id"]
+    assert result["step_id"] == "confirm"
+
+    mock_rpc_device.trigger_ota_update.side_effect = RpcCallError(
+        -114, "Resource unavailable: No update info!"
+    )
+    result = await process_repair_fix_flow(client, flow_id)
+    assert result["type"] == "abort"
+    assert result["reason"] == "update_not_available"
+    assert mock_rpc_device.trigger_ota_update.call_count == 1
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+
+@pytest.mark.parametrize(
+    "exception", [DeviceConnectionError, RpcCallError(999, "Unknown error")]
+)
+async def test_unsupported_firmware_issue_exc(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_rpc_device: Mock,
+    issue_registry: ir.IssueRegistry,
+    exception: Exception,
+) -> None:
+    """Test repair issues handling when OTA update ends with an exception."""
+    issue_id = BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(unique=MOCK_MAC)
+    assert await async_setup_component(hass, "repairs", {})
+    await hass.async_block_till_done()
+    await init_integration(
+        hass, 2, options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE}
+    )
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1
+
+    await async_process_repairs_platforms(hass)
+    client = await hass_client()
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+
+    flow_id = result["flow_id"]
+    assert result["step_id"] == "confirm"
+
+    mock_rpc_device.trigger_ota_update.side_effect = exception
+    result = await process_repair_fix_flow(client, flow_id)
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
+    assert mock_rpc_device.trigger_ota_update.call_count == 1
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert len(issue_registry.issues) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Shelly firmware earlier than 1.5.1 contains bugs and should not be used with BLE scanner in active mode. This PR introduces a repair flow to allow the user to update the device firmware.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
