### PR TITLE
Add WebSocket API to ssdp to observe discovery

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -36,6 +36,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_ssdp, bind_hass
 from homeassistant.util.logging import catch_log_exception
 
+from . import websocket_api
 from .const import DOMAIN, SSDP_SCANNER, UPNP_SERVER
 from .scanner import (
     IntegrationMatchers,
@@ -213,6 +214,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     await scanner.async_start()
     await server.async_start()
+    websocket_api.async_setup(hass)
 
     return True
 

--- a/homeassistant/components/ssdp/websocket_api.py
+++ b/homeassistant/components/ssdp/websocket_api.py
@@ -1,0 +1,101 @@
+"""The ssdp integration websocket apis."""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HassJob, HomeAssistant, callback
+from homeassistant.helpers.json import json_bytes
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+
+from .const import DOMAIN, SSDP_SCANNER
+from .scanner import Scanner, SsdpChange
+
+
+@callback
+def async_setup(hass: HomeAssistant) -> None:
+    """Set up the ssdp websocket API."""
+    websocket_api.async_register_command(hass, ws_subscribe_discovery)
+
+
+FIELD_LOCATION: Final = "location"
+FIELD_ST: Final = "st"
+
+
+def serialize_service_info(service_info: SsdpServiceInfo) -> dict[str, Any]:
+    """Serialize a SsdpServiceInfo object."""
+    return {FIELD_ST: service_info.ssdp_st, FIELD_LOCATION: service_info.ssdp_location}
+
+
+class _DiscoverySubscription:
+    """Class to hold and manage the subscription data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        ws_msg_id: int,
+        scanner: Scanner,
+    ) -> None:
+        """Initialize the subscription data."""
+        self.hass = hass
+        self.ws_msg_id = ws_msg_id
+        self.connection = connection
+        self.scanner = scanner
+        self._job = HassJob(self._async_on_data)
+
+    async def async_start(self) -> None:
+        """Start the subscription."""
+        connection = self.connection
+        cancel_adv_callback = await self.scanner.async_register_callback(
+            self._job, None
+        )
+        connection.subscriptions[self.ws_msg_id] = cancel_adv_callback
+        self.connection.send_message(
+            json_bytes(websocket_api.result_message(self.ws_msg_id))
+        )
+
+    @callback
+    def _async_on_data(self, info: SsdpServiceInfo, change: SsdpChange) -> None:
+        if change is SsdpChange.BYEBYE:
+            self._async_removed(info)
+        else:
+            self._async_added(info)
+
+    def _async_event_message(self, message: dict[str, Any]) -> None:
+        self.connection.send_message(
+            json_bytes(websocket_api.event_message(self.ws_msg_id, message))
+        )
+
+    def _async_added(self, service_info: SsdpServiceInfo) -> None:
+        self._async_event_message({"add": [serialize_service_info(service_info)]})
+
+    def _async_removed(self, service_info: SsdpServiceInfo) -> None:
+        self._async_event_message(
+            {
+                "remove": [
+                    {
+                        FIELD_ST: service_info.ssdp_st,
+                        FIELD_LOCATION: service_info.ssdp_location,
+                    }
+                ]
+            }
+        )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "ssdp/subscribe_discovery",
+    }
+)
+@websocket_api.async_response
+async def ws_subscribe_discovery(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Handle subscribe advertisements websocket command."""
+    scanner: Scanner = hass.data[DOMAIN][SSDP_SCANNER]
+    await _DiscoverySubscription(hass, connection, msg["id"], scanner).async_start()

--- a/homeassistant/components/ssdp/websocket_api.py
+++ b/homeassistant/components/ssdp/websocket_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from typing import Any, Final
 
 import voluptuous as vol
@@ -21,13 +22,13 @@ def async_setup(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_subscribe_discovery)
 
 
-FIELD_LOCATION: Final = "location"
-FIELD_ST: Final = "st"
+FIELD_SSDP_ST: Final = "ssdp_st"
+FIELD_SSDP_LOCATION: Final = "ssdp_location"
 
 
 def serialize_service_info(service_info: SsdpServiceInfo) -> dict[str, Any]:
     """Serialize a SsdpServiceInfo object."""
-    return {FIELD_ST: service_info.ssdp_st, FIELD_LOCATION: service_info.ssdp_location}
+    return asdict(service_info)
 
 
 class _DiscoverySubscription:
@@ -71,15 +72,15 @@ class _DiscoverySubscription:
         )
 
     def _async_added(self, service_info: SsdpServiceInfo) -> None:
-        self._async_event_message({"add": [serialize_service_info(service_info)]})
+        self._async_event_message({"add": [asdict(service_info)]})
 
     def _async_removed(self, service_info: SsdpServiceInfo) -> None:
         self._async_event_message(
             {
                 "remove": [
                     {
-                        FIELD_ST: service_info.ssdp_st,
-                        FIELD_LOCATION: service_info.ssdp_location,
+                        FIELD_SSDP_ST: service_info.ssdp_st,
+                        FIELD_SSDP_LOCATION: service_info.ssdp_location,
                     }
                 ]
             }

--- a/homeassistant/components/ssdp/websocket_api.py
+++ b/homeassistant/components/ssdp/websocket_api.py
@@ -56,5 +56,5 @@ async def ws_subscribe_discovery(
         _async_event_message({"remove": [remove_msg]})
 
     job = HassJob(_async_on_data)
-    connection.subscriptions[msg_id] = await scanner.async_register_callback(job, None)
     connection.send_message(json_bytes(websocket_api.result_message(msg_id)))
+    connection.subscriptions[msg_id] = await scanner.async_register_callback(job, None)

--- a/homeassistant/components/ssdp/websocket_api.py
+++ b/homeassistant/components/ssdp/websocket_api.py
@@ -62,28 +62,22 @@ class _DiscoverySubscription:
     @callback
     def _async_on_data(self, info: SsdpServiceInfo, change: SsdpChange) -> None:
         if change is SsdpChange.BYEBYE:
-            self._async_removed(info)
-        else:
-            self._async_added(info)
+            self._async_event_message(
+                {
+                    "remove": [
+                        {
+                            FIELD_SSDP_ST: info.ssdp_st,
+                            FIELD_SSDP_LOCATION: info.ssdp_location,
+                        }
+                    ]
+                }
+            )
+            return
+        self._async_event_message({"add": [asdict(info)]})
 
     def _async_event_message(self, message: dict[str, Any]) -> None:
         self.connection.send_message(
             json_bytes(websocket_api.event_message(self.ws_msg_id, message))
-        )
-
-    def _async_added(self, service_info: SsdpServiceInfo) -> None:
-        self._async_event_message({"add": [asdict(service_info)]})
-
-    def _async_removed(self, service_info: SsdpServiceInfo) -> None:
-        self._async_event_message(
-            {
-                "remove": [
-                    {
-                        FIELD_SSDP_ST: service_info.ssdp_st,
-                        FIELD_SSDP_LOCATION: service_info.ssdp_location,
-                    }
-                ]
-            }
         )
 
 

--- a/homeassistant/components/ssdp/websocket_api.py
+++ b/homeassistant/components/ssdp/websocket_api.py
@@ -37,11 +37,11 @@ async def ws_subscribe_discovery(
 ) -> None:
     """Handle subscribe advertisements websocket command."""
     scanner: Scanner = hass.data[DOMAIN][SSDP_SCANNER]
-    ws_msg_id: int = msg["id"]
+    msg_id: int = msg["id"]
 
     def _async_event_message(message: dict[str, Any]) -> None:
         connection.send_message(
-            json_bytes(websocket_api.event_message(ws_msg_id, message))
+            json_bytes(websocket_api.event_message(msg_id, message))
         )
 
     @callback
@@ -61,7 +61,5 @@ async def ws_subscribe_discovery(
         )
 
     job = HassJob(_async_on_data)
-    connection.subscriptions[ws_msg_id] = await scanner.async_register_callback(
-        job, None
-    )
-    connection.send_message(json_bytes(websocket_api.result_message(ws_msg_id)))
+    connection.subscriptions[msg_id] = await scanner.async_register_callback(job, None)
+    connection.send_message(json_bytes(websocket_api.result_message(msg_id)))

--- a/homeassistant/components/ssdp/websocket_api.py
+++ b/homeassistant/components/ssdp/websocket_api.py
@@ -49,16 +49,11 @@ async def ws_subscribe_discovery(
         if change is not SsdpChange.BYEBYE:
             _async_event_message({"add": [asdict(info)]})
             return
-        _async_event_message(
-            {
-                "remove": [
-                    {
-                        FIELD_SSDP_ST: info.ssdp_st,
-                        FIELD_SSDP_LOCATION: info.ssdp_location,
-                    }
-                ]
-            }
-        )
+        remove_msg = {
+            FIELD_SSDP_ST: info.ssdp_st,
+            FIELD_SSDP_LOCATION: info.ssdp_location,
+        }
+        _async_event_message({"remove": [remove_msg]})
 
     job = HassJob(_async_on_data)
     connection.subscriptions[msg_id] = await scanner.async_register_callback(job, None)

--- a/tests/components/ssdp/__init__.py
+++ b/tests/components/ssdp/__init__.py
@@ -1,1 +1,27 @@
 """Tests for the SSDP integration."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from async_upnp_client.ssdp import udn_from_headers
+from async_upnp_client.ssdp_listener import SsdpListener
+from async_upnp_client.utils import CaseInsensitiveDict
+
+from homeassistant.components import ssdp
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+
+async def init_ssdp_component(hass: HomeAssistant) -> SsdpListener:
+    """Initialize ssdp component and get SsdpListener."""
+    await async_setup_component(hass, ssdp.DOMAIN, {ssdp.DOMAIN: {}})
+    await hass.async_block_till_done()
+    return hass.data[ssdp.DOMAIN][ssdp.SSDP_SCANNER]._ssdp_listeners[0]
+
+
+def _ssdp_headers(headers) -> CaseInsensitiveDict:
+    """Create a CaseInsensitiveDict with headers and a timestamp."""
+    ssdp_headers = CaseInsensitiveDict(headers, _timestamp=datetime.now())
+    ssdp_headers["_udn"] = udn_from_headers(ssdp_headers)
+    return ssdp_headers

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -1,14 +1,11 @@
 """Test the SSDP integration."""
 
-from datetime import datetime
 from ipaddress import IPv4Address
 from typing import Any
 from unittest.mock import ANY, AsyncMock, patch
 
 from async_upnp_client.server import UpnpServer
-from async_upnp_client.ssdp import udn_from_headers
 from async_upnp_client.ssdp_listener import SsdpListener
-from async_upnp_client.utils import CaseInsensitiveDict
 import pytest
 
 from homeassistant import config_entries
@@ -39,8 +36,9 @@ from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_UPC,
     SsdpServiceInfo,
 )
-from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
+
+from . import _ssdp_headers, init_ssdp_component
 
 from tests.common import (
     MockConfigEntry,
@@ -50,19 +48,6 @@ from tests.common import (
     mock_integration,
 )
 from tests.test_util.aiohttp import AiohttpClientMocker
-
-
-def _ssdp_headers(headers):
-    ssdp_headers = CaseInsensitiveDict(headers, _timestamp=datetime.now())
-    ssdp_headers["_udn"] = udn_from_headers(ssdp_headers)
-    return ssdp_headers
-
-
-async def init_ssdp_component(hass: HomeAssistant) -> SsdpListener:
-    """Initialize ssdp component and get SsdpListener."""
-    await async_setup_component(hass, ssdp.DOMAIN, {ssdp.DOMAIN: {}})
-    await hass.async_block_till_done()
-    return hass.data[ssdp.DOMAIN][ssdp.SSDP_SCANNER]._ssdp_listeners[0]
 
 
 @patch(

--- a/tests/components/ssdp/test_websocket_api.py
+++ b/tests/components/ssdp/test_websocket_api.py
@@ -1,4 +1,4 @@
-"""The tests for the dhcp WebSocket API."""
+"""The tests for the ssdp WebSocket API."""
 
 import asyncio
 from unittest.mock import ANY, AsyncMock, Mock, patch

--- a/tests/components/ssdp/test_websocket_api.py
+++ b/tests/components/ssdp/test_websocket_api.py
@@ -1,0 +1,136 @@
+"""The tests for the dhcp WebSocket API."""
+
+import asyncio
+from unittest.mock import ANY, AsyncMock, Mock, patch
+
+from homeassistant.core import EVENT_HOMEASSISTANT_STARTED, HomeAssistant
+
+from . import _ssdp_headers, init_ssdp_component
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import WebSocketGenerator
+
+
+@patch(
+    "homeassistant.components.ssdp.async_get_ssdp",
+    return_value={"mock-domain": [{"deviceType": "Paulus"}]},
+)
+async def test_subscribe_discovery(
+    mock_get_ssdp: Mock,
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_flow_init: AsyncMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test ssdp subscribe_discovery."""
+    aioclient_mock.get(
+        "http://1.1.1.1",
+        text="""
+<root>
+  <device>
+    <deviceType>Paulus</deviceType>
+  </device>
+</root>
+    """,
+    )
+    ssdp_listener = await init_ssdp_component(hass)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    mock_ssdp_search_response = _ssdp_headers(
+        {
+            "st": "mock-st",
+            "location": "http://1.1.1.1",
+            "usn": "uuid:mock-udn::mock-st",
+            "_source": "search",
+        }
+    )
+    ssdp_listener._on_search(mock_ssdp_search_response)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "ssdp/subscribe_discovery",
+        }
+    )
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["success"]
+
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+
+    assert response["event"]["add"] == [
+        {
+            "ssdp_all_locations": ["http://1.1.1.1"],
+            "ssdp_ext": None,
+            "ssdp_headers": {
+                "_source": "search",
+                "_timestamp": ANY,
+                "_udn": "uuid:mock-udn",
+                "location": "http://1.1.1.1",
+                "st": "mock-st",
+                "usn": "uuid:mock-udn::mock-st",
+            },
+            "ssdp_location": "http://1.1.1.1",
+            "ssdp_nt": None,
+            "ssdp_server": None,
+            "ssdp_st": "mock-st",
+            "ssdp_udn": "uuid:mock-udn",
+            "ssdp_usn": "uuid:mock-udn::mock-st",
+            "upnp": {"UDN": "uuid:mock-udn", "deviceType": "Paulus"},
+            "x_homeassistant_matching_domains": [],
+        }
+    ]
+
+    mock_ssdp_advertisement = _ssdp_headers(
+        {
+            "location": "http://1.1.1.1",
+            "usn": "uuid:mock-udn::mock-st",
+            "nt": "upnp:rootdevice",
+            "nts": "ssdp:alive",
+            "_source": "advertisement",
+        }
+    )
+    ssdp_listener._on_alive(mock_ssdp_advertisement)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+
+    assert response["event"]["add"] == [
+        {
+            "ssdp_all_locations": ["http://1.1.1.1"],
+            "ssdp_ext": None,
+            "ssdp_headers": {
+                "_source": "advertisement",
+                "_timestamp": ANY,
+                "_udn": "uuid:mock-udn",
+                "location": "http://1.1.1.1",
+                "nt": "upnp:rootdevice",
+                "nts": "ssdp:alive",
+                "usn": "uuid:mock-udn::mock-st",
+            },
+            "ssdp_location": "http://1.1.1.1",
+            "ssdp_nt": "upnp:rootdevice",
+            "ssdp_server": None,
+            "ssdp_st": "upnp:rootdevice",
+            "ssdp_udn": "uuid:mock-udn",
+            "ssdp_usn": "uuid:mock-udn::mock-st",
+            "upnp": {"UDN": "uuid:mock-udn", "deviceType": "Paulus"},
+            "x_homeassistant_matching_domains": ["mock-domain"],
+        }
+    ]
+
+    mock_ssdp_advertisement["nts"] = "ssdp:byebye"
+    ssdp_listener._on_byebye(mock_ssdp_advertisement)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+
+    assert response["event"]["remove"] == [
+        {"ssdp_location": "http://1.1.1.1", "ssdp_st": "upnp:rootdevice"}
+    ]


### PR DESCRIPTION
frontend: https://github.com/home-assistant/frontend/pull/25217

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add WebSocket API to ssdp for frontend discovery panel. This panel will allow users to review discovered devices and help troubleshoot issues that require inspecting SSDP data.


This is similar to the existing Bluetooth/Zeroconf/DHCP subscribe APIs

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
