### PR TITLE
Make name a top-level key for SSDP discovery WebSocket API

### DIFF
--- a/homeassistant/components/ssdp/websocket_api.py
+++ b/homeassistant/components/ssdp/websocket_api.py
@@ -10,7 +10,10 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import HassJob, HomeAssistant, callback
 from homeassistant.helpers.json import json_bytes
-from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    SsdpServiceInfo,
+)
 
 from .const import DOMAIN, SSDP_SCANNER
 from .scanner import Scanner, SsdpChange
@@ -47,7 +50,13 @@ async def ws_subscribe_discovery(
     @callback
     def _async_on_data(info: SsdpServiceInfo, change: SsdpChange) -> None:
         if change is not SsdpChange.BYEBYE:
-            _async_event_message({"add": [asdict(info)]})
+            _async_event_message(
+                {
+                    "add": [
+                        {"name": info.upnp.get(ATTR_UPNP_FRIENDLY_NAME), **asdict(info)}
+                    ]
+                }
+            )
             return
         remove_msg = {
             FIELD_SSDP_ST: info.ssdp_st,

--- a/tests/components/ssdp/test_websocket_api.py
+++ b/tests/components/ssdp/test_websocket_api.py
@@ -29,6 +29,7 @@ async def test_subscribe_discovery(
 <root>
   <device>
     <deviceType>Paulus</deviceType>
+    <friendlyName>Bedroom TV</friendlyName>
   </device>
 </root>
     """,
@@ -80,7 +81,12 @@ async def test_subscribe_discovery(
             "ssdp_st": "mock-st",
             "ssdp_udn": "uuid:mock-udn",
             "ssdp_usn": "uuid:mock-udn::mock-st",
-            "upnp": {"UDN": "uuid:mock-udn", "deviceType": "Paulus"},
+            "upnp": {
+                "UDN": "uuid:mock-udn",
+                "deviceType": "Paulus",
+                "friendlyName": "Bedroom TV",
+            },
+            "name": "Bedroom TV",
             "x_homeassistant_matching_domains": [],
         }
     ]
@@ -119,7 +125,12 @@ async def test_subscribe_discovery(
             "ssdp_st": "upnp:rootdevice",
             "ssdp_udn": "uuid:mock-udn",
             "ssdp_usn": "uuid:mock-udn::mock-st",
-            "upnp": {"UDN": "uuid:mock-udn", "deviceType": "Paulus"},
+            "upnp": {
+                "UDN": "uuid:mock-udn",
+                "deviceType": "Paulus",
+                "friendlyName": "Bedroom TV",
+            },
+            "name": "Bedroom TV",
             "x_homeassistant_matching_domains": ["mock-domain"],
         }
     ]


### PR DESCRIPTION
frontend https://github.com/home-assistant/frontend/pull/25232

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Initial feedback on the new SSDP panel noted that it was difficult to identify devices, as the device name was buried deep in the UPnP data and not easily searchable. This change promotes the name to a top-level field in the WebSocket API response to improve discoverability and usability.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
