### PR TITLE
Fix incorrect return types in samsungtv tests

### DIFF
--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -53,7 +53,7 @@ def silent_ssdp_scanner() -> Generator[None]:
 
 
 @pytest.fixture(autouse=True)
-def samsungtv_mock_async_get_local_ip():
+def samsungtv_mock_async_get_local_ip() -> Generator[None]:
     """Mock upnp util's async_get_local_ip."""
     with patch(
         "homeassistant.components.samsungtv.media_player.async_get_local_ip",
@@ -63,7 +63,7 @@ def samsungtv_mock_async_get_local_ip():
 
 
 @pytest.fixture(autouse=True)
-def fake_host_fixture() -> None:
+def fake_host_fixture() -> Generator[None]:
     """Patch gethostbyname."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -73,14 +73,14 @@ def fake_host_fixture() -> None:
 
 
 @pytest.fixture(autouse=True)
-def app_list_delay_fixture() -> None:
+def app_list_delay_fixture() -> Generator[None]:
     """Patch APP_LIST_DELAY."""
     with patch("homeassistant.components.samsungtv.media_player.APP_LIST_DELAY", 0):
         yield
 
 
 @pytest.fixture(name="upnp_factory", autouse=True)
-def upnp_factory_fixture() -> Mock:
+def upnp_factory_fixture() -> Generator[Mock]:
     """Patch UpnpFactory."""
     with patch(
         "homeassistant.components.samsungtv.media_player.UpnpFactory",
@@ -92,7 +92,7 @@ def upnp_factory_fixture() -> Mock:
 
 
 @pytest.fixture(name="upnp_device")
-async def upnp_device_fixture(upnp_factory: Mock) -> Mock:
+def upnp_device_fixture(upnp_factory: Mock) -> Generator[Mock]:
     """Patch async_upnp_client."""
     upnp_device = Mock(UpnpDevice)
     upnp_device.services = {}
@@ -102,7 +102,7 @@ async def upnp_device_fixture(upnp_factory: Mock) -> Mock:
 
 
 @pytest.fixture(name="dmr_device")
-async def dmr_device_fixture(upnp_device: Mock) -> Mock:
+def dmr_device_fixture(upnp_device: Mock) -> Generator[Mock]:
     """Patch async_upnp_client."""
     with patch(
         "homeassistant.components.samsungtv.media_player.DmrDevice",
@@ -137,7 +137,7 @@ async def dmr_device_fixture(upnp_device: Mock) -> Mock:
 
 
 @pytest.fixture(name="upnp_notify_server")
-async def upnp_notify_server_fixture(upnp_factory: Mock) -> Mock:
+def upnp_notify_server_fixture(upnp_factory: Mock) -> Generator[Mock]:
     """Patch async_upnp_client."""
     with patch(
         "homeassistant.components.samsungtv.media_player.AiohttpNotifyServer",
@@ -149,7 +149,7 @@ async def upnp_notify_server_fixture(upnp_factory: Mock) -> Mock:
 
 
 @pytest.fixture(name="remote")
-def remote_fixture() -> Mock:
+def remote_fixture() -> Generator[Mock]:
     """Patch the samsungctl Remote."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote_class:
         remote = Mock(Remote)
@@ -160,7 +160,7 @@ def remote_fixture() -> Mock:
 
 
 @pytest.fixture(name="rest_api")
-def rest_api_fixture() -> Mock:
+def rest_api_fixture() -> Generator[Mock]:
     """Patch the samsungtvws SamsungTVAsyncRest."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",
@@ -173,7 +173,7 @@ def rest_api_fixture() -> Mock:
 
 
 @pytest.fixture(name="rest_api_non_ssl_only")
-def rest_api_fixture_non_ssl_only() -> Mock:
+def rest_api_fixture_non_ssl_only() -> Generator[None]:
     """Patch the samsungtvws SamsungTVAsyncRest non-ssl only."""
 
     class MockSamsungTVAsyncRest:
@@ -198,7 +198,7 @@ def rest_api_fixture_non_ssl_only() -> Mock:
 
 
 @pytest.fixture(name="rest_api_failing")
-def rest_api_failure_fixture() -> Mock:
+def rest_api_failure_fixture() -> Generator[None]:
     """Patch the samsungtvws SamsungTVAsyncRest."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",
@@ -209,7 +209,7 @@ def rest_api_failure_fixture() -> Mock:
 
 
 @pytest.fixture(name="remoteencws_failing")
-def remoteencws_failing_fixture():
+def remoteencws_failing_fixture() -> Generator[None]:
     """Patch the samsungtvws SamsungTVEncryptedWSAsyncRemote."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVEncryptedWSAsyncRemote.start_listening",
@@ -219,7 +219,7 @@ def remoteencws_failing_fixture():
 
 
 @pytest.fixture(name="remotews")
-def remotews_fixture() -> Mock:
+def remotews_fixture() -> Generator[Mock]:
     """Patch the samsungtvws SamsungTVWS."""
     remotews = Mock(SamsungTVWSAsyncRemote)
     remotews.__aenter__ = AsyncMock(return_value=remotews)
@@ -260,7 +260,7 @@ def remotews_fixture() -> Mock:
 
 
 @pytest.fixture(name="remoteencws")
-def remoteencws_fixture() -> Mock:
+def remoteencws_fixture() -> Generator[Mock]:
     """Patch the samsungtvws SamsungTVEncryptedWSAsyncRemote."""
     remoteencws = Mock(SamsungTVEncryptedWSAsyncRemote)
     remoteencws.__aenter__ = AsyncMock(return_value=remoteencws)
@@ -292,7 +292,7 @@ def mock_now() -> datetime:
 
 
 @pytest.fixture(name="mac_address", autouse=True)
-def mac_address_fixture() -> Mock:
+def mac_address_fixture() -> Generator[Mock]:
     """Patch getmac.get_mac_address."""
     with patch("getmac.get_mac_address", return_value=None) as mac:
         yield mac


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
