### PR TITLE
Add door binary sensor to Whirlpool

### DIFF
--- a/homeassistant/components/whirlpool/__init__.py
+++ b/homeassistant/components/whirlpool/__init__.py
@@ -17,7 +17,7 @@ from .const import CONF_BRAND, CONF_BRANDS_MAP, CONF_REGIONS_MAP, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.SENSOR]
 
 type WhirlpoolConfigEntry = ConfigEntry[AppliancesManager]
 

--- a/homeassistant/components/whirlpool/binary_sensor.py
+++ b/homeassistant/components/whirlpool/binary_sensor.py
@@ -1,0 +1,68 @@
+"""Binary sensors for the Whirlpool Appliances integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import timedelta
+
+from whirlpool.appliance import Appliance
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import WhirlpoolConfigEntry
+from .entity import WhirlpoolEntity
+
+SCAN_INTERVAL = timedelta(minutes=5)
+
+
+@dataclass(frozen=True, kw_only=True)
+class WhirlpoolBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes a Whirlpool binary sensor entity."""
+
+    value_fn: Callable[[Appliance], bool | None]
+
+
+WASHER_DRYER_SENSORS: list[WhirlpoolBinarySensorEntityDescription] = [
+    WhirlpoolBinarySensorEntityDescription(
+        key="door",
+        device_class=BinarySensorDeviceClass.DOOR,
+        value_fn=lambda appliance: appliance.get_door_open(),
+    )
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: WhirlpoolConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Config flow entry for Whirlpool binary sensors."""
+    entities: list = []
+    appliances_manager = config_entry.runtime_data
+    for washer_dryer in appliances_manager.washer_dryers:
+        entities.extend(
+            WhirlpoolBinarySensor(washer_dryer, description)
+            for description in WASHER_DRYER_SENSORS
+        )
+    async_add_entities(entities)
+
+
+class WhirlpoolBinarySensor(WhirlpoolEntity, BinarySensorEntity):
+    """A class for the Whirlpool binary sensors."""
+
+    def __init__(
+        self, appliance: Appliance, description: WhirlpoolBinarySensorEntityDescription
+    ) -> None:
+        """Initialize the washer sensor."""
+        super().__init__(appliance, unique_id_suffix=f"-{description.key}")
+        self.entity_description: WhirlpoolBinarySensorEntityDescription = description
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        return self.entity_description.value_fn(self._appliance)

--- a/tests/components/whirlpool/__init__.py
+++ b/tests/components/whirlpool/__init__.py
@@ -1,5 +1,7 @@
 """Tests for the Whirlpool Sixth Sense integration."""
 
+from unittest.mock import MagicMock
+
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.whirlpool.const import CONF_BRAND, DOMAIN
@@ -49,3 +51,14 @@ def snapshot_whirlpool_entities(
         entity_entry = entity_registry.async_get(entity_state.entity_id)
         assert entity_entry == snapshot(name=f"{entity_entry.entity_id}-entry")
         assert entity_state == snapshot(name=f"{entity_entry.entity_id}-state")
+
+
+async def trigger_attr_callback(
+    hass: HomeAssistant, mock_api_instance: MagicMock
+) -> None:
+    """Simulate an update trigger from the API."""
+
+    for call in mock_api_instance.register_attr_callback.call_args_list:
+        update_ha_state_cb = call[0][0]
+        update_ha_state_cb()
+    await hass.async_block_till_done()

--- a/tests/components/whirlpool/snapshots/test_binary_sensor.ambr
+++ b/tests/components/whirlpool/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,97 @@
+# serializer version: 1
+# name: test_all_entities[binary_sensor.dryer_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.dryer_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Door',
+    'platform': 'whirlpool',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'said_dryer-door',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.dryer_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Dryer Door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.dryer_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.washer_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.washer_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Door',
+    'platform': 'whirlpool',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'said_washer-door',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.washer_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Washer Door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.washer_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/whirlpool/test_binary_sensor.py
+++ b/tests/components/whirlpool/test_binary_sensor.py
@@ -1,0 +1,55 @@
+"""Test the Whirlpool Binary Sensor domain."""
+
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration, snapshot_whirlpool_entities, trigger_attr_callback
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    await init_integration(hass)
+    snapshot_whirlpool_entities(hass, entity_registry, snapshot, Platform.BINARY_SENSOR)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "mock_fixture", "mock_method"),
+    [
+        ("binary_sensor.washer_door", "mock_washer_api", "get_door_open"),
+        ("binary_sensor.dryer_door", "mock_dryer_api", "get_door_open"),
+    ],
+)
+async def test_simple_binary_sensors(
+    hass: HomeAssistant,
+    entity_id: str,
+    mock_fixture: str,
+    mock_method: str,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test simple binary sensors states."""
+    mock_instance = request.getfixturevalue(mock_fixture)
+    mock_method = getattr(mock_instance, mock_method)
+    await init_integration(hass)
+
+    mock_method.return_value = False
+    await trigger_attr_callback(hass, mock_instance)
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+    mock_method.return_value = True
+    await trigger_attr_callback(hass, mock_instance)
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    mock_method.return_value = None
+    await trigger_attr_callback(hass, mock_instance)
+    state = hass.states.get(entity_id)
+    assert state.state is STATE_UNKNOWN

--- a/tests/components/whirlpool/test_climate.py
+++ b/tests/components/whirlpool/test_climate.py
@@ -39,7 +39,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from . import init_integration, snapshot_whirlpool_entities
+from . import init_integration, snapshot_whirlpool_entities, trigger_attr_callback
 
 
 @pytest.fixture(
@@ -60,10 +60,7 @@ async def update_ac_state(
     mock_aircon_api_instance: MagicMock,
 ):
     """Simulate an update trigger from the API."""
-    for call in mock_aircon_api_instance.register_attr_callback.call_args_list:
-        update_ha_state_cb = call[0][0]
-        update_ha_state_cb()
-        await hass.async_block_till_done()
+    await trigger_attr_callback(hass, mock_aircon_api_instance)
     return hass.states.get(entity_id)
 
 

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -1,7 +1,6 @@
 """Test the Whirlpool Sensor domain."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -14,23 +13,12 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import as_timestamp, utc_from_timestamp, utcnow
 
-from . import init_integration, snapshot_whirlpool_entities
+from . import init_integration, snapshot_whirlpool_entities, trigger_attr_callback
 
 from tests.common import async_fire_time_changed, mock_restore_cache_with_extra_data
 
 WASHER_ENTITY_ID_BASE = "sensor.washer"
 DRYER_ENTITY_ID_BASE = "sensor.dryer"
-
-
-async def trigger_attr_callback(
-    hass: HomeAssistant, mock_api_instance: MagicMock
-) -> None:
-    """Simulate an update trigger from the API."""
-
-    for call in mock_api_instance.register_attr_callback.call_args_list:
-        update_ha_state_cb = call[0][0]
-        update_ha_state_cb()
-    await hass.async_block_till_done()
 
 
 # Freeze time for WasherDryerTimeSensor


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new binary_sensor platform to the Whirlpool integration with a single door sensor.

The door state was previously available as part of the mixed states of the "machine state" sensor, but it is more appropriate to have it as its own binary_sensor, and leave the "machine state" sensor for the machine cycle states. An upcoming PR will remove the door state from the "machine state" sensor (which is a breaking change).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38824
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
