### PR TITLE
Add generator status sensors for Rehlko

### DIFF
--- a/homeassistant/components/rehlko/icons.json
+++ b/homeassistant/components/rehlko/icons.json
@@ -12,6 +12,12 @@
       },
       "server_ip_address": {
         "default": "mdi:server-network"
+      },
+      "generator_status": {
+        "default": "mdi:home-lightning-bolt"
+      },
+      "power_source": {
+        "default": "mdi:transmission-tower"
       }
     }
   }

--- a/homeassistant/components/rehlko/sensor.py
+++ b/homeassistant/components/rehlko/sensor.py
@@ -168,6 +168,20 @@ SENSORS: tuple[RehlkoSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    RehlkoSensorEntityDescription(
+        key="status",
+        translation_key="generator_status",
+        use_device_key=True,
+    ),
+    RehlkoSensorEntityDescription(
+        key="engineState",
+        translation_key="engine_state",
+    ),
+    RehlkoSensorEntityDescription(
+        key="powerSource",
+        icon="mdi:home-lightning-bolt",
+        translation_key="power_source",
+    ),
 )
 
 

--- a/homeassistant/components/rehlko/strings.json
+++ b/homeassistant/components/rehlko/strings.json
@@ -82,6 +82,15 @@
       },
       "generator_load_percent": {
         "name": "Generator load percentage"
+      },
+      "engine_state": {
+        "name": "Engine state"
+      },
+      "power_source": {
+        "name": "Power source"
+      },
+      "generator_status": {
+        "name": "Generator status"
       }
     }
   },

--- a/tests/components/rehlko/snapshots/test_sensor.ambr
+++ b/tests/components/rehlko/snapshots/test_sensor.ambr
@@ -412,6 +412,53 @@
     'state': '0',
   })
 # ---
+# name: test_sensors[sensor.generator_1_engine_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.generator_1_engine_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Engine state',
+    'platform': 'rehlko',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'engine_state',
+    'unique_id': 'myemail@email.com_12345_engineState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.generator_1_engine_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Generator 1 Engine state',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.generator_1_engine_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Standby',
+  })
+# ---
 # name: test_sensors[sensor.generator_1_generator_load-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -515,6 +562,53 @@
     'state': '0',
   })
 # ---
+# name: test_sensors[sensor.generator_1_generator_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.generator_1_generator_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Generator status',
+    'platform': 'rehlko',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'generator_status',
+    'unique_id': 'myemail@email.com_12345_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.generator_1_generator_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Generator 1 Generator status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.generator_1_generator_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'ReadyToRun',
+  })
+# ---
 # name: test_sensors[sensor.generator_1_lube_oil_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -565,6 +659,54 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '6.0',
+  })
+# ---
+# name: test_sensors[sensor.generator_1_power_source-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.generator_1_power_source',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:home-lightning-bolt',
+    'original_name': 'Power source',
+    'platform': 'rehlko',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_source',
+    'unique_id': 'myemail@email.com_12345_powerSource',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.generator_1_power_source-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Generator 1 Power source',
+      'icon': 'mdi:home-lightning-bolt',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.generator_1_power_source',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Utility',
   })
 # ---
 # name: test_sensors[sensor.generator_1_runtime_since_last_maintenance-entry]


### PR DESCRIPTION
## Proposed change

Add status sensors for generator status, engine status and power source. These sensors are essential for determining the status of the generator and/or power outage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
