### PR TITLE
Bump ZHA to 0.0.57

### DIFF
--- a/homeassistant/components/zha/diagnostics.py
+++ b/homeassistant/components/zha/diagnostics.py
@@ -32,6 +32,7 @@ KEYS_TO_REDACT = {
     "network_key",
     CONF_NWK_EXTENDED_PAN_ID,
     "partner_ieee",
+    "device_ieee",
 }
 
 ATTRIBUTES = "attributes"

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.56"],
+  "requirements": ["zha==0.0.57"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -7,6 +7,10 @@ import functools
 import logging
 from typing import Any
 
+from zha.application.platforms.sensor.const import (
+    SensorDeviceClass as ZHASensorDeviceClass,
+)
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -137,6 +141,9 @@ class Sensor(ZHAEntity, SensorEntity):
                 self._attr_device_class = SensorDeviceClass(
                     entity_description.device_class.value
                 )
+
+        if entity.device_class is ZHASensorDeviceClass.ENUM:
+            self._attr_options = entity.info_object.options
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -145,6 +145,11 @@ class Sensor(ZHAEntity, SensorEntity):
         if entity.device_class is ZHASensorDeviceClass.ENUM:
             self._attr_options = entity.info_object.options
 
+        if entity.info_object.suggested_display_precision is not None:
+            self._attr_suggested_display_precision = (
+                entity.info_object.suggested_display_precision
+            )
+
     @property
     def native_value(self) -> StateType:
         """Return the state of the entity."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -7,10 +7,6 @@ import functools
 import logging
 from typing import Any
 
-from zha.application.platforms.sensor.const import (
-    SensorDeviceClass as ZHASensorDeviceClass,
-)
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -141,9 +137,6 @@ class Sensor(ZHAEntity, SensorEntity):
                 self._attr_device_class = SensorDeviceClass(
                     entity_description.device_class.value
                 )
-
-        if entity.device_class is ZHASensorDeviceClass.ENUM:
-            self._attr_options = entity.info_object.options
 
         if entity.info_object.suggested_display_precision is not None:
             self._attr_suggested_display_precision = (

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1128,6 +1128,15 @@
       },
       "water_interval": {
         "name": "Water interval"
+      },
+      "hush_duration": {
+        "name": "Hush duration"
+      },
+      "temperature_control_accuracy": {
+        "name": "Temperature control accuracy"
+      },
+      "external_temperature_sensor_value": {
+        "name": "External temperature sensor value"
       }
     },
     "select": {
@@ -1349,6 +1358,15 @@
       },
       "speed": {
         "name": "Speed"
+      },
+      "led_brightness": {
+        "name": "LED brightness"
+      },
+      "alarm_sound_level": {
+        "name": "Alarm sound level"
+      },
+      "alarm_sound_mode": {
+        "name": "Alarm sound mode"
       }
     },
     "sensor": {
@@ -1699,6 +1717,9 @@
       },
       "device_status": {
         "name": "Device status"
+      },
+      "lifetime": {
+        "name": "Lifetime"
       }
     },
     "switch": {
@@ -1908,6 +1929,12 @@
       },
       "auto_clean": {
         "name": "Auto clean"
+      },
+      "test_mode": {
+        "name": "Test mode"
+      },
+      "external_temperature_sensor": {
+        "name": "External temperature sensor"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3162,7 +3162,7 @@ zeroconf==0.146.5
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.56
+zha==0.0.57
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2561,7 +2561,7 @@ zeroconf==0.146.5
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.56
+zha==0.0.57
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.63.0

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -17,6 +17,7 @@ from zigpy.const import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 import zigpy.device
 import zigpy.group
 import zigpy.profiles
+from zigpy.profiles import zha
 import zigpy.quirks
 import zigpy.state
 import zigpy.types
@@ -173,6 +174,7 @@ async def zigpy_app_controller():
     dev.model = "Coordinator Model"
 
     ep = dev.add_endpoint(1)
+    ep.profile_id = zha.PROFILE_ID
     ep.add_input_cluster(Basic.cluster_id)
     ep.add_input_cluster(Groups.cluster_id)
 

--- a/tests/components/zha/snapshots/test_diagnostics.ambr
+++ b/tests/components/zha/snapshots/test_diagnostics.ambr
@@ -154,31 +154,21 @@
 # name: test_diagnostics_for_device
   dict({
     'active_coordinator': False,
-    'area_id': None,
     'available': True,
-    'cluster_details': dict({
+    'device_type': 'EndDevice',
+    'endpoints': dict({
       '1': dict({
         'device_type': dict({
           'id': 1025,
           'name': 'IAS_ANCILLARY_CONTROL',
         }),
-        'in_clusters': dict({
-          '0x0500': dict({
-            'attributes': dict({
-              '0x0000': dict({
-                'attribute': "ZCLAttributeDef(id=0x0000, name='zone_state', type=<enum 'ZoneState'>, zcl_type=<DataTypeId.enum8: 48>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
-                'value': None,
-              }),
-              '0x0001': dict({
-                'attribute': "ZCLAttributeDef(id=0x0001, name='zone_type', type=<enum 'ZoneType'>, zcl_type=<DataTypeId.uint16: 33>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
-                'value': None,
-              }),
-              '0x0002': dict({
-                'attribute': "ZCLAttributeDef(id=0x0002, name='zone_status', type=<flag 'ZoneStatus'>, zcl_type=<DataTypeId.map16: 25>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
-                'value': None,
-              }),
-              '0x0010': dict({
-                'attribute': "ZCLAttributeDef(id=0x0010, name='cie_addr', type=<class 'zigpy.types.named.EUI64'>, zcl_type=<DataTypeId.EUI64: 240>, access=<ZCLAttributeAccess.Read|Write: 3>, mandatory=True, is_manufacturer_specific=False)",
+        'in_clusters': list([
+          dict({
+            'attributes': list([
+              dict({
+                'id': '0x0010',
+                'name': 'cie_addr',
+                'unsupported': False,
                 'value': list([
                   50,
                   79,
@@ -189,61 +179,82 @@
                   21,
                   0,
                 ]),
+                'zcl_type': 'EUI64',
               }),
-              '0x0011': dict({
-                'attribute': "ZCLAttributeDef(id=0x0011, name='zone_id', type=<class 'zigpy.types.basic.uint8_t'>, zcl_type=<DataTypeId.uint8: 32>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
+              dict({
+                'id': '0x0013',
+                'name': 'current_zone_sensitivity_level',
+                'unsupported': False,
                 'value': None,
+                'zcl_type': 'uint8',
               }),
-              '0x0012': dict({
-                'attribute': "ZCLAttributeDef(id=0x0012, name='num_zone_sensitivity_levels_supported', type=<class 'zigpy.types.basic.uint8_t'>, zcl_type=<DataTypeId.uint8: 32>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              dict({
+                'id': '0x0012',
+                'name': 'num_zone_sensitivity_levels_supported',
+                'unsupported': True,
                 'value': None,
+                'zcl_type': 'uint8',
               }),
-              '0x0013': dict({
-                'attribute': "ZCLAttributeDef(id=0x0013, name='current_zone_sensitivity_level', type=<class 'zigpy.types.basic.uint8_t'>, zcl_type=<DataTypeId.uint8: 32>, access=<ZCLAttributeAccess.Read|Write: 3>, mandatory=False, is_manufacturer_specific=False)",
+              dict({
+                'id': '0x0011',
+                'name': 'zone_id',
+                'unsupported': False,
                 'value': None,
+                'zcl_type': 'uint8',
               }),
-            }),
+              dict({
+                'id': '0x0000',
+                'name': 'zone_state',
+                'unsupported': False,
+                'value': None,
+                'zcl_type': 'enum8',
+              }),
+              dict({
+                'id': '0x0002',
+                'name': 'zone_status',
+                'unsupported': False,
+                'value': None,
+                'zcl_type': 'map16',
+              }),
+              dict({
+                'id': '0x0001',
+                'name': 'zone_type',
+                'unsupported': False,
+                'value': None,
+                'zcl_type': 'uint16',
+              }),
+            ]),
+            'cluster_id': '0x0500',
             'endpoint_attribute': 'ias_zone',
-            'unsupported_attributes': list([
-              18,
-              'current_zone_sensitivity_level',
-            ]),
           }),
-          '0x0501': dict({
-            'attributes': dict({
-              '0xfffd': dict({
-                'attribute': "ZCLAttributeDef(id=0xFFFD, name='cluster_revision', type=<class 'zigpy.types.basic.uint16_t'>, zcl_type=<DataTypeId.uint16: 33>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
+          dict({
+            'attributes': list([
+              dict({
+                'id': '0xfffd',
+                'name': 'cluster_revision',
+                'unsupported': False,
                 'value': None,
+                'zcl_type': 'uint16',
               }),
-              '0xfffe': dict({
-                'attribute': "ZCLAttributeDef(id=0xFFFE, name='reporting_status', type=<enum 'AttributeReportingStatus'>, zcl_type=<DataTypeId.enum8: 48>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              dict({
+                'id': '0xfffe',
+                'name': 'reporting_status',
+                'unsupported': False,
                 'value': None,
+                'zcl_type': 'enum8',
               }),
-            }),
+            ]),
+            'cluster_id': '0x0501',
             'endpoint_attribute': 'ias_ace',
-            'unsupported_attributes': list([
-              4096,
-              'unknown_attribute_name',
-            ]),
           }),
-        }),
-        'out_clusters': dict({
-        }),
+        ]),
+        'out_clusters': list([
+        ]),
         'profile_id': 260,
       }),
     }),
-    'device_type': 'EndDevice',
-    'endpoint_names': list([
-      dict({
-        'name': 'IAS_ANCILLARY_CONTROL',
-      }),
-    ]),
-    'entities': list([
-      dict({
-        'entity_id': 'alarm_control_panel.fakemanufacturer_fakemodel_alarm_control_panel',
-        'name': 'FakeManufacturer FakeModel',
-      }),
-    ]),
+    'friendly_manufacturer': 'FakeManufacturer',
+    'friendly_model': 'FakeModel',
     'ieee': '**REDACTED**',
     'lqi': None,
     'manufacturer': 'FakeManufacturer',
@@ -252,7 +263,22 @@
     'name': 'FakeManufacturer FakeModel',
     'neighbors': list([
     ]),
-    'nwk': 47004,
+    'node_descriptor': dict({
+      'aps_flags': 0,
+      'complex_descriptor_available': False,
+      'descriptor_capability_field': 0,
+      'frequency_band': 8,
+      'logical_type': 'EndDevice',
+      'mac_capability_flags': 140,
+      'manufacturer_code': 4098,
+      'maximum_buffer_size': 82,
+      'maximum_incoming_transfer_size': 82,
+      'maximum_outgoing_transfer_size': 82,
+      'reserved': 0,
+      'server_mask': 0,
+      'user_descriptor_available': False,
+    }),
+    'nwk': '0xB79C',
     'power_source': 'Mains',
     'quirk_applied': False,
     'quirk_class': 'zigpy.device.Device',
@@ -260,37 +286,100 @@
     'routes': list([
     ]),
     'rssi': None,
-    'signature': dict({
-      'endpoints': dict({
-        '1': dict({
-          'device_type': '0x0401',
-          'input_clusters': list([
-            '0x0500',
-            '0x0501',
-          ]),
-          'output_clusters': list([
-          ]),
-          'profile_id': '0x0104',
+    'version': 1,
+    'zha_lib_entities': dict({
+      'alarm_control_panel': list([
+        dict({
+          'info_object': dict({
+            'available': True,
+            'class_name': 'AlarmControlPanel',
+            'cluster_handlers': list([
+              dict({
+                'class_name': 'IasAceClusterHandler',
+                'cluster': dict({
+                  'id': 1281,
+                  'name': 'IAS Ancillary Control Equipment',
+                  'type': 'server',
+                }),
+                'endpoint_id': 1,
+                'generic_id': 'cluster_handler_0x0501',
+                'id': '1:0x0501',
+                'status': 'INITIALIZED',
+                'unique_id': '**REDACTED**',
+                'value_attribute': None,
+              }),
+            ]),
+            'code_arm_required': False,
+            'code_format': 'number',
+            'device_class': None,
+            'device_ieee': '**REDACTED**',
+            'enabled': True,
+            'endpoint_id': 1,
+            'entity_category': None,
+            'entity_registry_enabled_default': True,
+            'fallback_name': None,
+            'group_id': None,
+            'migrate_unique_ids': list([
+            ]),
+            'platform': 'alarm_control_panel',
+            'primary': False,
+            'state_class': None,
+            'supported_features': 15,
+            'translation_key': 'alarm_control_panel',
+            'unique_id': '**REDACTED**',
+          }),
+          'state': dict({
+            'available': True,
+            'class_name': 'AlarmControlPanel',
+            'state': 'disarmed',
+          }),
         }),
-      }),
-      'manufacturer': 'FakeManufacturer',
-      'model': 'FakeModel',
-      'node_descriptor': dict({
-        'aps_flags': 0,
-        'complex_descriptor_available': 0,
-        'descriptor_capability_field': 0,
-        'frequency_band': 8,
-        'logical_type': 2,
-        'mac_capability_flags': 140,
-        'manufacturer_code': 4098,
-        'maximum_buffer_size': 82,
-        'maximum_incoming_transfer_size': 82,
-        'maximum_outgoing_transfer_size': 82,
-        'reserved': 0,
-        'server_mask': 0,
-        'user_descriptor_available': 0,
-      }),
+      ]),
+      'binary_sensor': list([
+        dict({
+          'info_object': dict({
+            'attribute_name': 'zone_status',
+            'available': True,
+            'class_name': 'IASZone',
+            'cluster_handlers': list([
+              dict({
+                'class_name': 'IASZoneClusterHandler',
+                'cluster': dict({
+                  'id': 1280,
+                  'name': 'IAS Zone',
+                  'type': 'server',
+                }),
+                'endpoint_id': 1,
+                'generic_id': 'cluster_handler_0x0500',
+                'id': '1:0x0500',
+                'status': 'INITIALIZED',
+                'unique_id': '**REDACTED**',
+                'value_attribute': None,
+              }),
+            ]),
+            'device_class': None,
+            'device_ieee': '**REDACTED**',
+            'enabled': True,
+            'endpoint_id': 1,
+            'entity_category': None,
+            'entity_registry_enabled_default': True,
+            'fallback_name': None,
+            'group_id': None,
+            'migrate_unique_ids': list([
+            ]),
+            'platform': 'binary_sensor',
+            'primary': True,
+            'state_class': None,
+            'translation_key': 'ias_zone',
+            'unique_id': '**REDACTED**',
+          }),
+          'state': dict({
+            'available': True,
+            'class_name': 'IASZone',
+            'state': False,
+          }),
+        }),
+      ]),
     }),
-    'user_given_name': None,
   })
 # ---

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -80,8 +80,8 @@ async def test_cover(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
     # load up cover domain
     cluster = zigpy_device.endpoints[1].window_covering
     cluster.PLUGGED_ATTR_READS = {
-        WCAttrs.current_position_lift_percentage.name: 0,
-        WCAttrs.current_position_tilt_percentage.name: 100,
+        WCAttrs.current_position_lift_percentage.name: 0,  # Zigbee open %
+        WCAttrs.current_position_tilt_percentage.name: 100,  # Zigbee closed %
         WCAttrs.window_covering_type.name: WCT.Tilt_blind_tilt_and_lift,
         WCAttrs.config_status.name: WCCS(~WCCS.Open_up_commands_reversed),
     }
@@ -114,8 +114,8 @@ async def test_cover(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
     state = hass.states.get(entity_id)
     assert state
     assert state.state == CoverState.OPEN
-    assert state.attributes[ATTR_CURRENT_POSITION] == 100
-    assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
+    assert state.attributes[ATTR_CURRENT_POSITION] == 100  # HA open %
+    assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 0  # HA closed %
 
     # test that the state has changed from open to closed
     await send_attributes_report(
@@ -164,7 +164,7 @@ async def test_cover(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
     await send_attributes_report(
         hass, cluster, {WCAttrs.current_position_tilt_percentage.id: 0}
     )
-    assert hass.states.get(entity_id).state == CoverState.OPEN
+    assert hass.states.get(entity_id).state == CoverState.CLOSED  # CLOSED lift state currently takes precendence over OPEN tilt
     with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
             COVER_DOMAIN,

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -164,7 +164,9 @@ async def test_cover(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
     await send_attributes_report(
         hass, cluster, {WCAttrs.current_position_tilt_percentage.id: 0}
     )
-    assert hass.states.get(entity_id).state == CoverState.CLOSED  # CLOSED lift state currently takes precendence over OPEN tilt
+    assert (
+        hass.states.get(entity_id).state == CoverState.CLOSED
+    )  # CLOSED lift state currently takes precedence over OPEN tilt
     with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
         await hass.services.async_call(
             COVER_DOMAIN,

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -209,7 +209,7 @@ async def test_action(
         cluster_handler = (
             gateway.get_device(zigpy_device.ieee)
             .endpoints[1]
-            .client_cluster_handlers["1:0x0006"]
+            .client_cluster_handlers["1:0x0006_client"]
         )
         cluster_handler.zha_send_event(COMMAND_SINGLE, [])
         await hass.async_block_till_done()
@@ -252,7 +252,7 @@ async def test_invalid_zha_event_type(
     cluster_handler = (
         gateway.get_device(zigpy_device.ieee)
         .endpoints[1]
-        .client_cluster_handlers["1:0x0006"]
+        .client_cluster_handlers["1:0x0006_client"]
     )
 
     # `zha_send_event` accepts only zigpy responses, lists, and dicts

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -199,6 +199,7 @@ async def test_if_fires_on_event(
     )
     ep = zigpy_device.add_endpoint(1)
     ep.add_output_cluster(0x0006)
+    ep.profile_id = zigpy.profiles.zha.PROFILE_ID
 
     zigpy_device.device_automation_triggers = {
         (SHAKEN, SHAKEN): {COMMAND: COMMAND_SHAKE},

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -62,10 +62,10 @@ async def async_test_temperature(hass: HomeAssistant, cluster: Cluster, entity_i
 async def async_test_pressure(hass: HomeAssistant, cluster: Cluster, entity_id: str):
     """Test pressure sensor."""
     await send_attributes_report(hass, cluster, {1: 1, 0: 1000, 2: 10000})
-    assert_state(hass, entity_id, "1000", UnitOfPressure.HPA)
+    assert_state(hass, entity_id, "1000.0", UnitOfPressure.HPA)
 
     await send_attributes_report(hass, cluster, {0: 1000, 20: -1, 16: 10000})
-    assert_state(hass, entity_id, "1000", UnitOfPressure.HPA)
+    assert_state(hass, entity_id, "1000.0", UnitOfPressure.HPA)
 
 
 async def async_test_illuminance(hass: HomeAssistant, cluster: Cluster, entity_id: str):
@@ -167,14 +167,14 @@ async def async_test_electrical_measurement(
     # update divisor cached value
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 1})
     await send_attributes_report(hass, cluster, {0: 1, 1291: 100, 10: 1000})
-    assert_state(hass, entity_id, "100", UnitOfPower.WATT)
+    assert_state(hass, entity_id, "100.0", UnitOfPower.WATT)
 
     await send_attributes_report(hass, cluster, {0: 1, 1291: 99, 10: 1000})
-    assert_state(hass, entity_id, "99", UnitOfPower.WATT)
+    assert_state(hass, entity_id, "99.0", UnitOfPower.WATT)
 
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 10})
     await send_attributes_report(hass, cluster, {0: 1, 1291: 1000, 10: 5000})
-    assert_state(hass, entity_id, "100", UnitOfPower.WATT)
+    assert_state(hass, entity_id, "100.0", UnitOfPower.WATT)
 
     await send_attributes_report(hass, cluster, {0: 1, 1291: 99, 10: 5000})
     assert_state(hass, entity_id, "9.9", UnitOfPower.WATT)
@@ -191,14 +191,14 @@ async def async_test_em_apparent_power(
     # update divisor cached value
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 1})
     await send_attributes_report(hass, cluster, {0: 1, 0x050F: 100, 10: 1000})
-    assert_state(hass, entity_id, "100", UnitOfApparentPower.VOLT_AMPERE)
+    assert_state(hass, entity_id, "100.0", UnitOfApparentPower.VOLT_AMPERE)
 
     await send_attributes_report(hass, cluster, {0: 1, 0x050F: 99, 10: 1000})
-    assert_state(hass, entity_id, "99", UnitOfApparentPower.VOLT_AMPERE)
+    assert_state(hass, entity_id, "99.0", UnitOfApparentPower.VOLT_AMPERE)
 
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 10})
     await send_attributes_report(hass, cluster, {0: 1, 0x050F: 1000, 10: 5000})
-    assert_state(hass, entity_id, "100", UnitOfApparentPower.VOLT_AMPERE)
+    assert_state(hass, entity_id, "100.0", UnitOfApparentPower.VOLT_AMPERE)
 
     await send_attributes_report(hass, cluster, {0: 1, 0x050F: 99, 10: 5000})
     assert_state(hass, entity_id, "9.9", UnitOfApparentPower.VOLT_AMPERE)
@@ -211,17 +211,17 @@ async def async_test_em_power_factor(
     # update divisor cached value
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 1})
     await send_attributes_report(hass, cluster, {0: 1, 0x0510: 100, 10: 1000})
-    assert_state(hass, entity_id, "100", PERCENTAGE)
+    assert_state(hass, entity_id, "100.0", PERCENTAGE)
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0510: 99, 10: 1000})
-    assert_state(hass, entity_id, "99", PERCENTAGE)
+    assert_state(hass, entity_id, "99.0", PERCENTAGE)
 
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 10})
     await send_attributes_report(hass, cluster, {0: 1, 0x0510: 100, 10: 5000})
-    assert_state(hass, entity_id, "100", PERCENTAGE)
+    assert_state(hass, entity_id, "100.0", PERCENTAGE)
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0510: 99, 10: 5000})
-    assert_state(hass, entity_id, "99", PERCENTAGE)
+    assert_state(hass, entity_id, "99.0", PERCENTAGE)
 
 
 async def async_test_em_rms_current(
@@ -230,14 +230,14 @@ async def async_test_em_rms_current(
     """Test electrical measurement RMS Current sensor."""
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0508: 1234, 10: 1000})
-    assert_state(hass, entity_id, "1.2", UnitOfElectricCurrent.AMPERE)
+    assert_state(hass, entity_id, "1.234", UnitOfElectricCurrent.AMPERE)
 
     await send_attributes_report(hass, cluster, {"ac_current_divisor": 10})
     await send_attributes_report(hass, cluster, {0: 1, 0x0508: 236, 10: 1000})
     assert_state(hass, entity_id, "23.6", UnitOfElectricCurrent.AMPERE)
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0508: 1236, 10: 1000})
-    assert_state(hass, entity_id, "124", UnitOfElectricCurrent.AMPERE)
+    assert_state(hass, entity_id, "123.6", UnitOfElectricCurrent.AMPERE)
 
     assert "rms_current_max" not in hass.states.get(entity_id).attributes
     await send_attributes_report(hass, cluster, {0: 1, 0x050A: 88, 10: 5000})
@@ -250,18 +250,18 @@ async def async_test_em_rms_voltage(
     """Test electrical measurement RMS Voltage sensor."""
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0505: 1234, 10: 1000})
-    assert_state(hass, entity_id, "123", UnitOfElectricPotential.VOLT)
+    assert_state(hass, entity_id, "123.4", UnitOfElectricPotential.VOLT)
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0505: 234, 10: 1000})
     assert_state(hass, entity_id, "23.4", UnitOfElectricPotential.VOLT)
 
     await send_attributes_report(hass, cluster, {"ac_voltage_divisor": 100})
     await send_attributes_report(hass, cluster, {0: 1, 0x0505: 2236, 10: 1000})
-    assert_state(hass, entity_id, "22.4", UnitOfElectricPotential.VOLT)
+    assert_state(hass, entity_id, "22.36", UnitOfElectricPotential.VOLT)
 
     assert "rms_voltage_max" not in hass.states.get(entity_id).attributes
     await send_attributes_report(hass, cluster, {0: 1, 0x0507: 888, 10: 5000})
-    assert hass.states.get(entity_id).attributes["rms_voltage_max"] == 8.9
+    assert hass.states.get(entity_id).attributes["rms_voltage_max"] == 8.88
 
 
 async def async_test_powerconfiguration(
@@ -269,7 +269,7 @@ async def async_test_powerconfiguration(
 ):
     """Test powerconfiguration/battery sensor."""
     await send_attributes_report(hass, cluster, {33: 98})
-    assert_state(hass, entity_id, "49", "%")
+    assert_state(hass, entity_id, "49.0", "%")
     assert hass.states.get(entity_id).attributes["battery_voltage"] == 2.9
     assert hass.states.get(entity_id).attributes["battery_quantity"] == 3
     assert hass.states.get(entity_id).attributes["battery_size"] == "AAA"
@@ -288,7 +288,7 @@ async def async_test_powerconfiguration2(
     assert_state(hass, entity_id, STATE_UNKNOWN, "%")
 
     await send_attributes_report(hass, cluster, {33: 98})
-    assert_state(hass, entity_id, "49", "%")
+    assert_state(hass, entity_id, "49.0", "%")
 
 
 async def async_test_device_temperature(
@@ -317,7 +317,7 @@ async def async_test_pi_heating_demand(
     await send_attributes_report(
         hass, cluster, {Thermostat.AttributeDefs.pi_heating_demand.id: 1}
     )
-    assert_state(hass, entity_id, "1", "%")
+    assert_state(hass, entity_id, "1.0", "%")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This bumps ZHA to [0.0.57](https://github.com/zigpy/zha/releases/tag/0.0.57) (full diff: https://github.com/zigpy/zha/compare/0.0.56...0.0.57). These dependency upgrades are bundled with it: 

- `zha-quirks` [0.0.137](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.137)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.136...0.0.137

- `zigpy` [0.79.0](https://github.com/zigpy/zigpy/releases/tag/0.79.0)
full diff: https://github.com/zigpy/zigpy/compare/0.78.1...0.79.0

- `bellows` [0.45.0](https://github.com/zigpy/bellows/releases/tag/0.45.0), including [0.44.2](https://github.com/zigpy/bellows/releases/tag/0.44.2) changes
full diff: https://github.com/zigpy/bellows/compare/0.44.1...0.45.0

- `zigpy-deconz` [0.24.2](https://github.com/zigpy/zigpy-deconz/releases/tag/0.24.2)
full diff: https://github.com/zigpy/zigpy-deconz/compare/0.24.1...0.24.2


This ZHA release removes library rounding from entity state and exposes the full precision to Home Assistant, creates a new diagnostic JSON format for devices, and fixes a few bugs with Cover entities.
This zigpy release forces route discovery on retries and fixes IKEA OTAs.
This zha-quirks release also adds a few entities via the quirks v2 API. The entity names are added to `strings.json`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
