### PR TITLE
Ensure legacy TTS providers are hidden if entity exists

### DIFF
--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -418,9 +418,11 @@ class CloudTTSEntity(TextToSpeechEntity):
                     language=language,
                     voice=options.get(
                         ATTR_VOICE,
-                        self._voice
-                        if language == self._language
-                        else DEFAULT_VOICES[language],
+                        (
+                            self._voice
+                            if language == self._language
+                            else DEFAULT_VOICES[language]
+                        ),
                     ),
                     gender=options.get(ATTR_GENDER),
                 ),
@@ -434,6 +436,8 @@ class CloudTTSEntity(TextToSpeechEntity):
 
 class CloudProvider(Provider):
     """Home Assistant Cloud speech API provider."""
+
+    has_entity = True
 
     def __init__(self, cloud: Cloud[CloudClient]) -> None:
         """Initialize cloud provider."""

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -1212,6 +1212,9 @@ def websocket_list_engines(
         if entity.platform:
             entity_domains.add(entity.platform.platform_name)
     for engine_id, provider in hass.data[DATA_TTS_MANAGER].providers.items():
+        if provider.has_entity:
+            continue
+
         provider_info = {
             "engine_id": engine_id,
             "name": provider.name,

--- a/homeassistant/components/tts/legacy.py
+++ b/homeassistant/components/tts/legacy.py
@@ -207,6 +207,7 @@ class Provider:
 
     hass: HomeAssistant | None = None
     name: str | None = None
+    has_entity: bool = False
 
     @property
     def default_language(self) -> str | None:

--- a/homeassistant/components/tts/media_source.py
+++ b/homeassistant/components/tts/media_source.py
@@ -145,13 +145,20 @@ class TTSMediaSource(MediaSource):
             return self._engine_item(engine, params)
 
         # Root. List providers.
-        children = [
-            self._engine_item(engine)
-            for engine in self.hass.data[DATA_TTS_MANAGER].providers
-        ] + [
-            self._engine_item(entity.entity_id)
-            for entity in self.hass.data[DATA_COMPONENT].entities
-        ]
+        children = sorted(
+            [
+                self._engine_item(engine_id)
+                for engine_id, provider in self.hass.data[
+                    DATA_TTS_MANAGER
+                ].providers.items()
+                if not provider.has_entity
+            ]
+            + [
+                self._engine_item(entity.entity_id)
+                for entity in self.hass.data[DATA_COMPONENT].entities
+            ],
+            key=lambda x: x.title,
+        )
         return BrowseMediaSource(
             domain=DOMAIN,
             identifier=None,

--- a/tests/components/tts/test_media_source.py
+++ b/tests/components/tts/test_media_source.py
@@ -114,6 +114,13 @@ async def test_legacy_resolving(
     await mock_setup(hass, mock_provider)
     mock_get_tts_audio = mock_provider.get_tts_audio
 
+    mock_provider.has_entity = True
+    root = await media_source.async_browse_media(hass, "media-source://tts")
+    assert len(root.children) == 0
+    mock_provider.has_entity = False
+    root = await media_source.async_browse_media(hass, "media-source://tts")
+    assert len(root.children) == 1
+
     mock_get_tts_audio.reset_mock()
     media_id = "media-source://tts/test?message=Hello%20World"
     media = await media_source.async_resolve_media(hass, media_id, None)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
TTS providers that have been migrated to entities but still provide the old one for backwards compatibility now have an option to hide the old provider.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
