### PR TITLE
Add SetTopBox and StreamingStick device support to HomeKit Bridge

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -89,8 +89,10 @@ from .const import (
     TYPE_FAN,
     TYPE_FAUCET,
     TYPE_OUTLET,
+    TYPE_SET_TOP_BOX,
     TYPE_SHOWER,
     TYPE_SPRINKLER,
+    TYPE_STREAMING_STICK,
     TYPE_SWITCH,
     TYPE_VALVE,
 )
@@ -206,6 +208,10 @@ def get_accessory(  # noqa: C901
             a_type = "ReceiverMediaPlayer"
         elif device_class == MediaPlayerDeviceClass.TV:
             a_type = "TelevisionMediaPlayer"
+        elif device_class == TYPE_SET_TOP_BOX:
+            a_type = "SetTopBoxMediaPlayer"
+        elif device_class == TYPE_STREAMING_STICK:
+            a_type = "StreamingStickMediaPlayer"
         elif validate_media_player_features(state, feature_list):
             a_type = "MediaPlayer"
 

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -132,6 +132,12 @@ TYPE_AIR_PURIFIER = "air_purifier"
 
 # #### Categories ####
 CATEGORY_RECEIVER = 34
+CATEGORY_SET_TOP_BOX = 35
+CATEGORY_STREAMING_STICK = 36
+
+# ### Additional Media Player Types ###
+TYPE_SET_TOP_BOX = "set_top_box"
+TYPE_STREAMING_STICK = "streaming_stick"
 
 # #### Services ####
 SERV_ACCESSORY_INFO = "AccessoryInformation"

--- a/homeassistant/components/homekit/type_media_players.py
+++ b/homeassistant/components/homekit/type_media_players.py
@@ -40,6 +40,8 @@ from .accessories import TYPES, HomeAccessory
 from .const import (
     ATTR_KEY_NAME,
     CATEGORY_RECEIVER,
+    CATEGORY_SET_TOP_BOX,
+    CATEGORY_STREAMING_STICK,
     CHAR_ACTIVE,
     CHAR_CONFIGURED_NAME,
     CHAR_MUTE,
@@ -412,3 +414,31 @@ class ReceiverMediaPlayer(TelevisionMediaPlayer):
     def __init__(self, *args: Any) -> None:
         """Initialize a Receiver Media Player accessory object."""
         super().__init__(*args, category=CATEGORY_RECEIVER)
+
+
+@TYPES.register("SetTopBoxMediaPlayer")
+class SetTopBoxMediaPlayer(TelevisionMediaPlayer):
+    """Generate a Set-Top Box Media Player accessory.
+
+    For HomeKit, a Set-Top Box Media Player is exactly the same as a
+    Television Media Player except it has a different category
+    which will tell HomeKit how to render the device.
+    """
+
+    def __init__(self, *args: Any) -> None:
+        """Initialize a Set-Top Box Media Player accessory object."""
+        super().__init__(*args, category=CATEGORY_SET_TOP_BOX)
+
+
+@TYPES.register("StreamingStickMediaPlayer")
+class StreamingStickMediaPlayer(TelevisionMediaPlayer):
+    """Generate a Streaming Stick Media Player accessory.
+
+    For HomeKit, a Streaming Stick Media Player is exactly the same as a
+    Television Media Player except it has a different category
+    which will tell HomeKit how to render the device.
+    """
+
+    def __init__(self, *args: Any) -> None:
+        """Initialize a Streaming Stick Media Player accessory object."""
+        super().__init__(*args, category=CATEGORY_STREAMING_STICK)

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -109,8 +109,10 @@ from .const import (
     TYPE_FAN,
     TYPE_FAUCET,
     TYPE_OUTLET,
+    TYPE_SET_TOP_BOX,
     TYPE_SHOWER,
     TYPE_SPRINKLER,
+    TYPE_STREAMING_STICK,
     TYPE_SWITCH,
     TYPE_VALVE,
     VIDEO_CODEC_COPY,
@@ -693,7 +695,12 @@ def state_needs_accessory_mode(state: State) -> bool:
     return (
         state.domain == MEDIA_PLAYER_DOMAIN
         and state.attributes.get(ATTR_DEVICE_CLASS)
-        in (MediaPlayerDeviceClass.TV, MediaPlayerDeviceClass.RECEIVER)
+        in (
+            MediaPlayerDeviceClass.TV,
+            MediaPlayerDeviceClass.RECEIVER,
+            TYPE_SET_TOP_BOX,
+            TYPE_STREAMING_STICK,
+        )
     ) or (
         state.domain == REMOTE_DOMAIN
         and state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for Set-Top Box and Streaming Stick Media Player devices to the HomeKit Bridge integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Apple documentation:
- https://developer.apple.com/documentation/homekit/hmaccessorycategorytypetelevisionsettopbox
- https://developer.apple.com/documentation/homekit/hmaccessorycategorytypetelevisionstreamingstick

These device types all function the same, but display differently within Home. Here are some examples of this working:

Receiver:
![440D0B0E-744A-471C-97BC-CDF46815FE33_4_5005_c](https://github.com/user-attachments/assets/31807d25-98b4-4122-b6c9-00a50377cb9a)

Set-Top Box:
![67661B48-87FE-40E4-8330-977B9865C9DF_4_5005_c](https://github.com/user-attachments/assets/76da06f2-0368-4017-87ba-2c16114745c6)

Streaming Stick:
![33938CBA-6771-4DD5-AE07-16D82C76D1C5_4_5005_c](https://github.com/user-attachments/assets/3b94e250-57d5-4409-abfe-25b9165528ce)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
