### PR TITLE
Synology DSM (synology photos): Added shared space to the list of all the albums

### DIFF
--- a/homeassistant/components/synology_dsm/media_source.py
+++ b/homeassistant/components/synology_dsm/media_source.py
@@ -145,6 +145,17 @@ class SynologyPhotosMediaSource(MediaSource):
                     can_expand=True,
                 )
             ]
+            ret += [
+                BrowseMediaSource(
+                    domain=DOMAIN,
+                    identifier=f"{item.identifier}/shared",
+                    media_class=MediaClass.DIRECTORY,
+                    media_content_type=MediaClass.IMAGE,
+                    title="Shared space",
+                    can_play=False,
+                    can_expand=True,
+                )
+            ]
             ret.extend(
                 BrowseMediaSource(
                     domain=DOMAIN,
@@ -162,13 +173,24 @@ class SynologyPhotosMediaSource(MediaSource):
 
         # Request items of album
         # Get Items
-        album = SynoPhotosAlbum(int(identifier.album_id), "", 0, identifier.passphrase)
-        try:
-            album_items = await diskstation.api.photos.get_items_from_album(
-                album, 0, 1000
+        if identifier.album_id == "shared":
+            # Get items from shared space
+            try:
+                album_items = await diskstation.api.photos.get_items_from_shared_space(
+                    0, 1000
+                )
+            except SynologyDSMException:
+                return []
+        else:
+            album = SynoPhotosAlbum(
+                int(identifier.album_id), "", 0, identifier.passphrase
             )
-        except SynologyDSMException:
-            return []
+            try:
+                album_items = await diskstation.api.photos.get_items_from_album(
+                    album, 0, 1000
+                )
+            except SynologyDSMException:
+                return []
         assert album_items is not None
 
         ret = []

--- a/tests/components/synology_dsm/test_media_source.py
+++ b/tests/components/synology_dsm/test_media_source.py
@@ -257,13 +257,15 @@ async def test_browse_media_get_albums(
     result = await source.async_browse_media(item)
 
     assert result
-    assert len(result.children) == 2
+    assert len(result.children) == 3
     assert isinstance(result.children[0], BrowseMedia)
     assert result.children[0].identifier == "mocked_syno_dsm_entry/0"
     assert result.children[0].title == "All images"
+    assert result.children[1].identifier == "mocked_syno_dsm_entry/shared"
+    assert result.children[1].title == "Shared space"
     assert isinstance(result.children[1], BrowseMedia)
-    assert result.children[1].identifier == "mocked_syno_dsm_entry/1_"
-    assert result.children[1].title == "Album 1"
+    assert result.children[2].identifier == "mocked_syno_dsm_entry/1_"
+    assert result.children[2].title == "Album 1"
 
 
 @pytest.mark.usefixtures("setup_media_source")

--- a/tests/components/synology_dsm/test_media_source.py
+++ b/tests/components/synology_dsm/test_media_source.py
@@ -266,9 +266,10 @@ async def test_browse_media_get_albums(
     assert isinstance(result.children[0], BrowseMedia)
     assert result.children[0].identifier == "mocked_syno_dsm_entry/0"
     assert result.children[0].title == "All images"
+    assert isinstance(result.children[1], BrowseMedia)
     assert result.children[1].identifier == "mocked_syno_dsm_entry/shared"
     assert result.children[1].title == "Shared space"
-    assert isinstance(result.children[1], BrowseMedia)
+    assert isinstance(result.children[2], BrowseMedia)
     assert result.children[2].identifier == "mocked_syno_dsm_entry/1_"
     assert result.children[2].title == "Album 1"
 


### PR DESCRIPTION
## Proposed change
Synology photos currently only shows all items and users created albums. But not images from the shared space.
This change adds the shared space to the media browser


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #142913
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
