### PR TITLE
Remove deprecated binary sensor in Husqvarna Automower

### DIFF
--- a/homeassistant/components/husqvarna_automower/binary_sensor.py
+++ b/homeassistant/components/husqvarna_automower/binary_sensor.py
@@ -3,42 +3,24 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING
 
 from aioautomower.model import MowerActivities, MowerAttributes
 
-from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.binary_sensor import (
-    DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.components.script import scripts_with_entity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.issue_registry import (
-    IssueSeverity,
-    async_create_issue,
-    async_delete_issue,
-)
 
 from . import AutomowerConfigEntry
-from .const import DOMAIN
 from .coordinator import AutomowerDataUpdateCoordinator
 from .entity import AutomowerBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 # Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
-
-
-def entity_used_in(hass: HomeAssistant, entity_id: str) -> list[str]:
-    """Get list of related automations and scripts."""
-    used_in = automations_with_entity(hass, entity_id)
-    used_in += scripts_with_entity(hass, entity_id)
-    return used_in
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -58,12 +40,6 @@ MOWER_BINARY_SENSOR_TYPES: tuple[AutomowerBinarySensorEntityDescription, ...] = 
         key="leaving_dock",
         translation_key="leaving_dock",
         value_fn=lambda data: data.mower.activity == MowerActivities.LEAVING,
-    ),
-    AutomowerBinarySensorEntityDescription(
-        key="returning_to_dock",
-        translation_key="returning_to_dock",
-        value_fn=lambda data: data.mower.activity == MowerActivities.GOING_HOME,
-        entity_registry_enabled_default=False,
     ),
 )
 
@@ -107,39 +83,3 @@ class AutomowerBinarySensorEntity(AutomowerBaseEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return the state of the binary sensor."""
         return self.entity_description.value_fn(self.mower_attributes)
-
-    async def async_added_to_hass(self) -> None:
-        """Raise issue when entity is registered and was not disabled."""
-        if TYPE_CHECKING:
-            assert self.unique_id
-        if not (
-            entity_id := er.async_get(self.hass).async_get_entity_id(
-                BINARY_SENSOR_DOMAIN, DOMAIN, self.unique_id
-            )
-        ):
-            return
-        if (
-            self.enabled
-            and self.entity_description.key == "returning_to_dock"
-            and entity_used_in(self.hass, entity_id)
-        ):
-            async_create_issue(
-                self.hass,
-                DOMAIN,
-                f"deprecated_entity_{self.entity_description.key}",
-                breaks_in_ha_version="2025.6.0",
-                is_fixable=False,
-                severity=IssueSeverity.WARNING,
-                translation_key="deprecated_entity",
-                translation_placeholders={
-                    "entity_name": str(self.name),
-                    "entity": entity_id,
-                },
-            )
-        else:
-            async_delete_issue(
-                self.hass,
-                DOMAIN,
-                f"deprecated_task_entity_{self.entity_description.key}",
-            )
-        await super().async_added_to_hass()

--- a/homeassistant/components/husqvarna_automower/quality_scale.yaml
+++ b/homeassistant/components/husqvarna_automower/quality_scale.yaml
@@ -67,7 +67,9 @@ rules:
   reconfiguration-flow:
     status: exempt
     comment: no configuration possible
-  repair-issues: done
+  repair-issues:
+    status: exempt
+    comment: no issues available
   stale-devices: done
 
   # Platinum

--- a/homeassistant/components/husqvarna_automower/strings.json
+++ b/homeassistant/components/husqvarna_automower/strings.json
@@ -39,9 +39,6 @@
     "binary_sensor": {
       "leaving_dock": {
         "name": "Leaving dock"
-      },
-      "returning_to_dock": {
-        "name": "Returning to dock"
       }
     },
     "button": {
@@ -321,12 +318,6 @@
         "mow": "Mow",
         "park": "Park"
       }
-    }
-  },
-  "issues": {
-    "deprecated_entity": {
-      "title": "The Husqvarna Automower {entity_name} sensor is deprecated",
-      "description": "The Husqvarna Automower entity `{entity}` is deprecated and will be removed in a future release.\nYou can use the new returning state of the lawn mower entity instead.\nPlease update your automations and scripts to replace the sensor entity with the newly added lawn mower entity.\nWhen you are done migrating you can disable `{entity}`."
     }
   },
   "services": {

--- a/tests/components/husqvarna_automower/snapshots/test_binary_sensor.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_binary_sensor.ambr
@@ -94,53 +94,6 @@
     'state': 'off',
   })
 # ---
-# name: test_binary_sensor_snapshot[binary_sensor.test_mower_1_returning_to_dock-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': None,
-    'entity_id': 'binary_sensor.test_mower_1_returning_to_dock',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Returning to dock',
-    'platform': 'husqvarna_automower',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'returning_to_dock',
-    'unique_id': 'c7233734-b219-4287-a173-08e3643f89f0_returning_to_dock',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_binary_sensor_snapshot[binary_sensor.test_mower_1_returning_to_dock-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Test Mower 1 Returning to dock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.test_mower_1_returning_to_dock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_binary_sensor_snapshot[binary_sensor.test_mower_2_charging-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -230,53 +183,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.test_mower_2_leaving_dock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_binary_sensor_snapshot[binary_sensor.test_mower_2_returning_to_dock-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': None,
-    'entity_id': 'binary_sensor.test_mower_2_returning_to_dock',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Returning to dock',
-    'platform': 'husqvarna_automower',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'returning_to_dock',
-    'unique_id': '1234_returning_to_dock',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_binary_sensor_snapshot[binary_sensor.test_mower_2_returning_to_dock-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Test Mower 2 Returning to dock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.test_mower_2_returning_to_dock',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/husqvarna_automower/test_binary_sensor.py
+++ b/tests/components/husqvarna_automower/test_binary_sensor.py
@@ -2,54 +2,16 @@
 
 from unittest.mock import AsyncMock, patch
 
-from aioautomower.model import MowerActivities, MowerAttributes
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.husqvarna_automower.coordinator import SCAN_INTERVAL
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
-from .const import TEST_MOWER_ID
 
-from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
-
-
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_binary_sensor_states(
-    hass: HomeAssistant,
-    mock_automower_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
-    values: dict[str, MowerAttributes],
-) -> None:
-    """Test binary sensor states."""
-    await setup_integration(hass, mock_config_entry)
-    state = hass.states.get("binary_sensor.test_mower_1_charging")
-    assert state is not None
-    assert state.state == "off"
-    state = hass.states.get("binary_sensor.test_mower_1_leaving_dock")
-    assert state is not None
-    assert state.state == "off"
-    state = hass.states.get("binary_sensor.test_mower_1_returning_to_dock")
-    assert state is not None
-    assert state.state == "off"
-
-    for activity, entity in (
-        (MowerActivities.CHARGING, "test_mower_1_charging"),
-        (MowerActivities.LEAVING, "test_mower_1_leaving_dock"),
-        (MowerActivities.GOING_HOME, "test_mower_1_returning_to_dock"),
-    ):
-        values[TEST_MOWER_ID].mower.activity = activity
-        mock_automower_client.get_status.return_value = values
-        freezer.tick(SCAN_INTERVAL)
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done()
-        state = hass.states.get(f"binary_sensor.{entity}")
-        assert state.state == "on"
+from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -33,6 +33,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 ADDITIONAL_NUMBER_ENTITIES = 1
 ADDITIONAL_SENSOR_ENTITIES = 2
 ADDITIONAL_SWITCH_ENTITIES = 1
+NUMBER_OF_ENTITIES_MOWER_2 = 11
 
 
 async def test_load_unload_entry(
@@ -250,7 +251,7 @@ async def test_coordinator_automatic_registry_cleanup(
 
     assert (
         len(er.async_entries_for_config_entry(entity_registry, entry.entry_id))
-        == current_entites - 12
+        == current_entites - NUMBER_OF_ENTITIES_MOWER_2
     )
     assert (
         len(dr.async_entries_for_config_entry(device_registry, entry.entry_id))
@@ -278,7 +279,10 @@ async def test_coordinator_automatic_registry_cleanup(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 12
+    assert (
+        len(er.async_entries_for_config_entry(entity_registry, entry.entry_id))
+        == NUMBER_OF_ENTITIES_MOWER_2
+    )
     assert (
         len(dr.async_entries_for_config_entry(device_registry, entry.entry_id))
         == current_devices - 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Husqvarna Automower returning to dock entity was deprecated and is being removed now. You can use the new returning state of the lawn mower entity instead. Please update your automations and scripts to replace the sensor entity with the newly added lawn mower entity.
Was deprecated in 2024.12
https://github.com/home-assistant/core/pull/130649

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
