### PR TITLE
Add support for Tasmota camera

### DIFF
--- a/homeassistant/components/tasmota/camera.py
+++ b/homeassistant/components/tasmota/camera.py
@@ -67,14 +67,12 @@ class TasmotaCamera(
     TasmotaEntity,
     Camera,
 ):
-    """An implementation of an IP camera that is reachable over a URL."""
+    """Representation of a Tasmota Camera."""
 
     _tasmota_entity: tasmota_camera.TasmotaCamera
 
-    """Representation of a Tasmota Camera."""
-
     def __init__(self, **kwds: Any) -> None:
-        """Initialize a MJPEG camera."""
+        """Initialize."""
         super().__init__(**kwds)
         Camera.__init__(self)
 
@@ -87,7 +85,6 @@ class TasmotaCamera(
         try:
             async with asyncio.timeout(TIMEOUT):
                 response = await self._tasmota_entity.get_still_image_stream(websession)
-
                 return await response.read()
 
         except TimeoutError as err:

--- a/homeassistant/components/tasmota/camera.py
+++ b/homeassistant/components/tasmota/camera.py
@@ -15,6 +15,7 @@ from homeassistant.components import camera
 from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import (
     async_aiohttp_proxy_web,
     async_get_clientsession,
@@ -74,9 +75,7 @@ class TasmotaCamera(
 
     def __init__(self, **kwds: Any) -> None:
         """Initialize a MJPEG camera."""
-        super().__init__(
-            **kwds,
-        )
+        super().__init__(**kwds)
         Camera.__init__(self)
 
     async def async_camera_image(
@@ -91,11 +90,15 @@ class TasmotaCamera(
 
                 return await response.read()
 
-        except TimeoutError:
-            _LOGGER.error("Timeout getting camera image from %s", self.name)
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                f"Timeout getting camera image from {self.name}: {err}"
+            ) from err
 
         except aiohttp.ClientError as err:
-            _LOGGER.error("Error getting new camera image from %s: %s", self.name, err)
+            raise HomeAssistantError(
+                f"Error getting new camera image from {self.name}: {err}"
+            ) from err
 
         return None
 

--- a/homeassistant/components/tasmota/camera.py
+++ b/homeassistant/components/tasmota/camera.py
@@ -1,0 +1,110 @@
+"""Support for Tasmota Camera."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+from hatasmota import camera as tasmota_camera
+from hatasmota.entity import TasmotaEntity as HATasmotaEntity
+from hatasmota.models import DiscoveryHashType
+
+from homeassistant.components import camera
+from homeassistant.components.camera import Camera
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import (
+    async_aiohttp_proxy_web,
+    async_get_clientsession,
+)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DATA_REMOVE_DISCOVER_COMPONENT
+from .discovery import TASMOTA_DISCOVERY_ENTITY_NEW
+from .entity import TasmotaAvailability, TasmotaDiscoveryUpdate, TasmotaEntity
+
+TIMEOUT = 10
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Tasmota light dynamically through discovery."""
+
+    @callback
+    def async_discover(
+        tasmota_entity: HATasmotaEntity, discovery_hash: DiscoveryHashType
+    ) -> None:
+        """Discover and add a Tasmota camera."""
+        async_add_entities(
+            [
+                TasmotaCamera(
+                    tasmota_entity=tasmota_entity, discovery_hash=discovery_hash
+                )
+            ]
+        )
+
+    hass.data[DATA_REMOVE_DISCOVER_COMPONENT.format(camera.DOMAIN)] = (
+        async_dispatcher_connect(
+            hass,
+            TASMOTA_DISCOVERY_ENTITY_NEW.format(camera.DOMAIN),
+            async_discover,
+        )
+    )
+
+
+class TasmotaCamera(
+    TasmotaAvailability,
+    TasmotaDiscoveryUpdate,
+    TasmotaEntity,
+    Camera,
+):
+    """An implementation of an IP camera that is reachable over a URL."""
+
+    _tasmota_entity: tasmota_camera.TasmotaCamera
+
+    """Representation of a Tasmota Camera."""
+
+    def __init__(self, **kwds: Any) -> None:
+        """Initialize a MJPEG camera."""
+        super().__init__(
+            **kwds,
+        )
+        Camera.__init__(self)
+
+    async def async_camera_image(
+        self, width: int | None = None, height: int | None = None
+    ) -> bytes | None:
+        """Return a still image response from the camera."""
+
+        websession = async_get_clientsession(self.hass)
+        try:
+            async with asyncio.timeout(TIMEOUT):
+                response = await self._tasmota_entity.get_still_image_stream(websession)
+
+                return await response.read()
+
+        except TimeoutError:
+            _LOGGER.error("Timeout getting camera image from %s", self.name)
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Error getting new camera image from %s: %s", self.name, err)
+
+        return None
+
+    async def handle_async_mjpeg_stream(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.StreamResponse | None:
+        """Generate an HTTP MJPEG stream from the camera."""
+        # connect to stream
+        websession = async_get_clientsession(self.hass)
+        stream_coro = self._tasmota_entity.get_mjpeg_stream(websession)
+
+        return await async_aiohttp_proxy_web(self.hass, request, stream_coro)

--- a/homeassistant/components/tasmota/const.py
+++ b/homeassistant/components/tasmota/const.py
@@ -13,6 +13,7 @@ DOMAIN = "tasmota"
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.CAMERA,
     Platform.COVER,
     Platform.FAN,
     Platform.LIGHT,

--- a/tests/components/tasmota/test_camera.py
+++ b/tests/components/tasmota/test_camera.py
@@ -1,0 +1,202 @@
+"""The tests for the Tasmota camera platform."""
+
+import copy
+import json
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.camera import CameraState
+from homeassistant.components.tasmota.const import DEFAULT_PREFIX
+from homeassistant.const import ATTR_ASSUMED_STATE, Platform
+from homeassistant.core import HomeAssistant
+
+from .test_common import (
+    DEFAULT_CONFIG,
+    help_test_availability,
+    help_test_availability_discovery_update,
+    help_test_availability_poll_state,
+    help_test_availability_when_connection_lost,
+    help_test_deep_sleep_availability,
+    help_test_deep_sleep_availability_when_connection_lost,
+    help_test_discovery_device_remove,
+    help_test_discovery_removal,
+    help_test_discovery_update_unchanged,
+    help_test_entity_id_update_discovery_update,
+)
+
+from tests.common import async_fire_mqtt_message
+from tests.typing import MqttMockHAClient, MqttMockPahoClient
+
+
+async def test_controlling_state_via_mqtt(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
+    """Test state update via MQTT."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    mac = config["mac"]
+
+    async_fire_mqtt_message(
+        hass,
+        f"{DEFAULT_PREFIX}/{mac}/config",
+        json.dumps(config),
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("camera.tasmota")
+    assert state.state == "unavailable"
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
+    state = hass.states.get("camera.tasmota")
+    assert state.state == CameraState.IDLE
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+
+async def test_availability_when_connection_lost(
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
+    """Test availability after MQTT disconnection."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    await help_test_availability_when_connection_lost(
+        hass, mqtt_client_mock, mqtt_mock, Platform.CAMERA, config, object_id="tasmota"
+    )
+
+
+async def test_deep_sleep_availability_when_connection_lost(
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
+    """Test availability after MQTT disconnection."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    await help_test_deep_sleep_availability_when_connection_lost(
+        hass, mqtt_client_mock, mqtt_mock, Platform.CAMERA, config, object_id="tasmota"
+    )
+
+
+async def test_availability(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
+    """Test availability."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    await help_test_availability(
+        hass, mqtt_mock, Platform.CAMERA, config, object_id="tasmota"
+    )
+
+
+async def test_deep_sleep_availability(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
+    """Test availability."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    await help_test_deep_sleep_availability(
+        hass, mqtt_mock, Platform.CAMERA, config, object_id="tasmota"
+    )
+
+
+async def test_availability_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
+    """Test availability discovery update."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    await help_test_availability_discovery_update(
+        hass, mqtt_mock, Platform.CAMERA, config, object_id="tasmota"
+    )
+
+
+async def test_availability_poll_state(
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
+) -> None:
+    """Test polling after MQTT connection (re)established."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    poll_topic = "tasmota_49A3BC/cmnd/STATE"
+    await help_test_availability_poll_state(
+        hass, mqtt_client_mock, mqtt_mock, Platform.CAMERA, config, poll_topic, ""
+    )
+
+
+async def test_discovery_removal_camera(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
+    """Test removal of discovered camera."""
+    config1 = copy.deepcopy(DEFAULT_CONFIG)
+    config1["cam"] = 1
+    config2 = copy.deepcopy(DEFAULT_CONFIG)
+    config2["cam"] = 0
+
+    await help_test_discovery_removal(
+        hass,
+        mqtt_mock,
+        caplog,
+        Platform.CAMERA,
+        config1,
+        config2,
+        object_id="tasmota",
+        name="Tasmota",
+    )
+
+
+async def test_discovery_update_unchanged_camera(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    setup_tasmota,
+) -> None:
+    """Test update of discovered camera."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    with patch(
+        "homeassistant.components.tasmota.camera.TasmotaCamera.discovery_update"
+    ) as discovery_update:
+        await help_test_discovery_update_unchanged(
+            hass,
+            mqtt_mock,
+            caplog,
+            Platform.CAMERA,
+            config,
+            discovery_update,
+            object_id="tasmota",
+            name="Tasmota",
+        )
+
+
+async def test_discovery_device_remove(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
+    """Test device registry remove."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    unique_id = f"{DEFAULT_CONFIG['mac']}_camera_camera_0"
+    await help_test_discovery_device_remove(
+        hass, mqtt_mock, Platform.CAMERA, unique_id, config
+    )
+
+
+async def test_entity_id_update_discovery_update(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota
+) -> None:
+    """Test MQTT discovery update when entity_id is updated."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["cam"] = 1
+    await help_test_entity_id_update_discovery_update(
+        hass, mqtt_mock, Platform.CAMERA, config, object_id="tasmota"
+    )

--- a/tests/components/tasmota/test_common.py
+++ b/tests/components/tasmota/test_common.py
@@ -36,6 +36,7 @@ DEFAULT_CONFIG = {
     "fn": ["Test", "Beer", "Milk", "Four", None],
     "hn": "tasmota_49A3BC-0956",
     "if": 0,  # iFan
+    "cam": 0,  # webcam
     "lk": 1,  # RGB + white channels linked to a single light
     "mac": "00000049A3BC",
     "md": "Sonoff Basic",


### PR DESCRIPTION
## Proposed change
ESP32-cam (and other esp32 variants with camera support) have been around for a while and the tasmota32-webcam firmware has been stable.
The HA integration supports the other entity types, but the camera support is not available. This PR adds the missing support for camera.
While esphome integration supports esp32-cam, tasmota firmware has many other well-documented features that can be controlled by mqtt.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This change is dependent on the [hatasmota change](https://github.com/emontnemery/hatasmota/pull/353). One test added fails without that PR.
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/36939

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
