### PR TITLE
Skip the update right after the migration in Opower

### DIFF
--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -421,6 +421,9 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
         for stat_id, stats in processed_stats.items():
             _LOGGER.debug("Applying %d migrated stats for %s", len(stats), stat_id)
             async_add_external_statistics(self.hass, metadata_map[stat_id], stats)
+        # Wait for the migration to finish before continuing
+        # to avoid appending new values to the old statistics.
+        await get_instance(self.hass).async_block_till_done()
 
         ir.async_create_issue(
             self.hass,

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -190,7 +190,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 return_sum = 0.0
                 last_stats_time = None
             else:
-                await self._async_maybe_migrate_statistics(
+                migrated = await self._async_maybe_migrate_statistics(
                     account.utility_account_id,
                     {
                         cost_statistic_id: compensation_statistic_id,
@@ -203,6 +203,13 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                         return_statistic_id: return_metadata,
                     },
                 )
+                if migrated:
+                    # Skip update to avoid working on old data since the migration is done
+                    # asynchronously. Update the statistics in the next refresh in 12h.
+                    _LOGGER.debug(
+                        "Statistics migration completed. Skipping update for now"
+                    )
+                    continue
                 cost_reads = await self._async_get_cost_reads(
                     account,
                     self.api.utility.timezone(),
@@ -326,7 +333,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
         utility_account_id: str,
         migration_map: dict[str, str],
         metadata_map: dict[str, StatisticMetaData],
-    ) -> None:
+    ) -> bool:
         """Perform one-time statistics migration based on the provided map.
 
         Splits negative values from source IDs into target IDs.
@@ -339,7 +346,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
 
         """
         if not migration_map:
-            return
+            return False
 
         need_migration_source_ids = set()
         for source_id, target_id in migration_map.items():
@@ -354,7 +361,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
             if not last_target_stat:
                 need_migration_source_ids.add(source_id)
         if not need_migration_source_ids:
-            return
+            return False
 
         _LOGGER.info("Starting one-time migration for: %s", need_migration_source_ids)
 
@@ -416,7 +423,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
 
         if not need_migration_source_ids:
             _LOGGER.debug("No migration needed")
-            return
+            return False
 
         for stat_id, stats in processed_stats.items():
             _LOGGER.debug("Applying %d migrated stats for %s", len(stats), stat_id)
@@ -442,9 +449,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
             },
         )
 
-        # Wait for the migration to finish before continuing
-        # to avoid appending new values to the old statistics.
-        await get_instance(self.hass).async_block_till_done()
+        return True
 
     async def _async_get_cost_reads(
         self, account: Account, time_zone_str: str, start_time: float | None = None

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -421,9 +421,6 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
         for stat_id, stats in processed_stats.items():
             _LOGGER.debug("Applying %d migrated stats for %s", len(stats), stat_id)
             async_add_external_statistics(self.hass, metadata_map[stat_id], stats)
-        # Wait for the migration to finish before continuing
-        # to avoid appending new values to the old statistics.
-        await get_instance(self.hass).async_block_till_done()
 
         ir.async_create_issue(
             self.hass,
@@ -444,6 +441,10 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 ),
             },
         )
+
+        # Wait for the migration to finish before continuing
+        # to avoid appending new values to the old statistics.
+        await get_instance(self.hass).async_block_till_done()
 
     async def _async_get_cost_reads(
         self, account: Account, time_zone_str: str, start_time: float | None = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The migration in Opower calls async_add_external_statistics followed by the existing code that calls: statistics_during_period and async_add_external_statistics to append new cost reads to existing ones. The issue is that recorder uses an internal queue resulting to the appended values to be based on the values before the migration. Fix it by skipping the update right after the migration and waiting for the next refresh 12h later.

Before the fix:
![image](https://github.com/user-attachments/assets/306e591b-9032-4114-ab15-f4a73d23af66)

After the fix:
![image](https://github.com/user-attachments/assets/e36746fd-d11c-46d7-b31c-383fac1dacfa)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
