### PR TITLE
Only create a single resolver object if there are multiple aiohttp sessions

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -28,6 +28,7 @@ from homeassistant.util.json import json_loads
 
 from .frame import warn_use
 from .json import json_dumps
+from .singleton import singleton
 
 if TYPE_CHECKING:
     from aiohttp.typedefs import JSONDecoder
@@ -392,18 +393,15 @@ def _async_get_connector(
     return connector
 
 
+@singleton(DATA_RESOLVER)
 def _async_get_or_create_resolver(hass: HomeAssistant) -> HassAsyncDNSResolver:
     """Return the HassAsyncDNSResolver."""
-    if DATA_RESOLVER in hass.data:
-        return hass.data[DATA_RESOLVER]
-
     resolver = _async_make_resolver(hass)
 
     async def _async_close_resolver(event: Event) -> None:
         await resolver.real_close()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_close_resolver)
-    hass.data[DATA_RESOLVER] = resolver
     return resolver
 
 

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -394,6 +394,7 @@ def _async_get_connector(
 
 
 @singleton(DATA_RESOLVER)
+@callback
 def _async_get_or_create_resolver(hass: HomeAssistant) -> HassAsyncDNSResolver:
     """Return the HassAsyncDNSResolver."""
     resolver = _async_make_resolver(hass)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1319,9 +1319,11 @@ def disable_translations_once(
 @pytest_asyncio.fixture(autouse=True, scope="session", loop_scope="session")
 async def mock_zeroconf_resolver() -> AsyncGenerator[_patch]:
     """Mock out the zeroconf resolver."""
+    resolver = AsyncResolver()
+    resolver.real_close = resolver.close
     patcher = patch(
         "homeassistant.helpers.aiohttp_client._async_make_resolver",
-        return_value=AsyncResolver(),
+        return_value=resolver,
     )
     patcher.start()
     try:

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -401,3 +401,12 @@ async def test_async_mdnsresolver(
     resp = await session.post("http://localhost/xyz", json={"x": 1})
     assert resp.status == 200
     assert await resp.json() == {"x": 1}
+
+
+async def test_resolver_is_singleton(hass: HomeAssistant) -> None:
+    """Test that the resolver is a singleton."""
+    session = client.async_get_clientsession(hass)
+    session2 = client.async_get_clientsession(hass)
+    assert isinstance(session._connector, aiohttp.TCPConnector)
+    assert isinstance(session2._connector, aiohttp.TCPConnector)
+    assert session._connector._resolver is session2._connector._resolver

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -407,6 +407,9 @@ async def test_resolver_is_singleton(hass: HomeAssistant) -> None:
     """Test that the resolver is a singleton."""
     session = client.async_get_clientsession(hass)
     session2 = client.async_get_clientsession(hass)
+    session3 = client.async_create_clientsession(hass)
     assert isinstance(session._connector, aiohttp.TCPConnector)
     assert isinstance(session2._connector, aiohttp.TCPConnector)
+    assert isinstance(session3._connector, aiohttp.TCPConnector)
     assert session._connector._resolver is session2._connector._resolver
+    assert session._connector._resolver is session3._connector._resolver


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A single c-ares channel can handle unlimited queries, so creating multiple `AsyncDualMDNSResolver` instances is unnecessary and wastes resources.

Once https://github.com/aio-libs/aiodns/pull/145 is merged, `aiodns` will support automatically reinitializing the c-ares channel when the resolver configuration changes. If multiple `AsyncDualMDNSResolver` instances are active, each will independently watch `/etc/resolv.conf` and reload its own channel, leading to redundant monitoring and unnecessary overhead. This change avoids that inefficiency.

Note that the work on aiodns was done mostly to avoid having to do a workaround in supervisor for c-ares not being `reinit`ed when resolv.conf changes in the hopes of avoiding having to do things manually in https://github.com/home-assistant/supervisor/pull/5862

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
