### PR TITLE
Fix  intermittent unavailability for lamarzocco brew active sensor

### DIFF
--- a/homeassistant/components/lamarzocco/binary_sensor.py
+++ b/homeassistant/components/lamarzocco/binary_sensor.py
@@ -52,7 +52,7 @@ ENTITIES: tuple[LaMarzoccoBinarySensorEntityDescription, ...] = (
             ).status
             is MachineState.BREWING
         ),
-        available_fn=lambda device: device.websocket.connected,
+        available_fn=lambda coordinator: not coordinator.websocket_terminated,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     LaMarzoccoBinarySensorEntityDescription(

--- a/homeassistant/components/lamarzocco/coordinator.py
+++ b/homeassistant/components/lamarzocco/coordinator.py
@@ -44,6 +44,7 @@ class LaMarzoccoUpdateCoordinator(DataUpdateCoordinator[None]):
 
     _default_update_interval = SCAN_INTERVAL
     config_entry: LaMarzoccoConfigEntry
+    websocket_terminated = True
 
     def __init__(
         self,
@@ -92,15 +93,9 @@ class LaMarzoccoConfigUpdateCoordinator(LaMarzoccoUpdateCoordinator):
         await self.device.get_dashboard()
         _LOGGER.debug("Current status: %s", self.device.dashboard.to_dict())
 
-        _LOGGER.debug("Init WebSocket in background task")
-
         self.config_entry.async_create_background_task(
             hass=self.hass,
-            target=self.device.connect_dashboard_websocket(
-                update_callback=lambda _: self.async_set_updated_data(None),
-                connect_callback=self.async_update_listeners,
-                disconnect_callback=self.async_update_listeners,
-            ),
+            target=self.connect_websocket(),
             name="lm_websocket_task",
         )
 
@@ -111,6 +106,22 @@ class LaMarzoccoConfigUpdateCoordinator(LaMarzoccoUpdateCoordinator):
             self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, websocket_close)
         )
         self.config_entry.async_on_unload(websocket_close)
+
+    async def connect_websocket(self) -> None:
+        """Connect to the websocket."""
+
+        _LOGGER.debug("Init WebSocket in background task")
+        self.websocket_terminated = False
+
+        self.async_update_listeners()
+        await self.device.connect_dashboard_websocket(
+            update_callback=lambda _: self.async_set_updated_data(None),
+            connect_callback=self.async_update_listeners,
+            disconnect_callback=self.async_update_listeners,
+        )
+        self.websocket_terminated = True
+
+        self.async_update_listeners()
 
 
 class LaMarzoccoSettingsUpdateCoordinator(LaMarzoccoUpdateCoordinator):

--- a/homeassistant/components/lamarzocco/coordinator.py
+++ b/homeassistant/components/lamarzocco/coordinator.py
@@ -111,16 +111,17 @@ class LaMarzoccoConfigUpdateCoordinator(LaMarzoccoUpdateCoordinator):
         """Connect to the websocket."""
 
         _LOGGER.debug("Init WebSocket in background task")
-        self.websocket_terminated = False
 
+        self.websocket_terminated = False
         self.async_update_listeners()
+
         await self.device.connect_dashboard_websocket(
             update_callback=lambda _: self.async_set_updated_data(None),
             connect_callback=self.async_update_listeners,
             disconnect_callback=self.async_update_listeners,
         )
-        self.websocket_terminated = True
 
+        self.websocket_terminated = True
         self.async_update_listeners()
 
 

--- a/homeassistant/components/lamarzocco/entity.py
+++ b/homeassistant/components/lamarzocco/entity.py
@@ -3,7 +3,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from pylamarzocco import LaMarzoccoMachine
 from pylamarzocco.const import FirmwareType
 
 from homeassistant.const import CONF_ADDRESS, CONF_MAC
@@ -23,7 +22,7 @@ from .coordinator import LaMarzoccoUpdateCoordinator
 class LaMarzoccoEntityDescription(EntityDescription):
     """Description for all LM entities."""
 
-    available_fn: Callable[[LaMarzoccoMachine], bool] = lambda _: True
+    available_fn: Callable[[LaMarzoccoUpdateCoordinator], bool] = lambda _: True
     supported_fn: Callable[[LaMarzoccoUpdateCoordinator], bool] = lambda _: True
 
 
@@ -74,7 +73,7 @@ class LaMarzoccoEntity(LaMarzoccoBaseEntity):
     def available(self) -> bool:
         """Return True if entity is available."""
         if super().available:
-            return self.entity_description.available_fn(self.coordinator.device)
+            return self.entity_description.available_fn(self.coordinator)
         return False
 
     def __init__(

--- a/homeassistant/components/lamarzocco/number.py
+++ b/homeassistant/components/lamarzocco/number.py
@@ -100,8 +100,9 @@ ENTITIES: tuple[LaMarzoccoNumberEntityDescription, ...] = (
             .seconds.seconds_out
         ),
         available_fn=(
-            lambda machine: cast(
-                PreBrewing, machine.dashboard.config[WidgetType.CM_PRE_BREWING]
+            lambda coordinator: cast(
+                PreBrewing,
+                coordinator.device.dashboard.config[WidgetType.CM_PRE_BREWING],
             ).mode
             is PreExtractionMode.PREINFUSION
         ),
@@ -140,8 +141,8 @@ ENTITIES: tuple[LaMarzoccoNumberEntityDescription, ...] = (
             .times.pre_brewing[0]
             .seconds.seconds_in
         ),
-        available_fn=lambda machine: cast(
-            PreBrewing, machine.dashboard.config[WidgetType.CM_PRE_BREWING]
+        available_fn=lambda coordinator: cast(
+            PreBrewing, coordinator.device.dashboard.config[WidgetType.CM_PRE_BREWING]
         ).mode
         is PreExtractionMode.PREBREWING,
         supported_fn=(
@@ -180,8 +181,9 @@ ENTITIES: tuple[LaMarzoccoNumberEntityDescription, ...] = (
             .seconds.seconds_out
         ),
         available_fn=(
-            lambda machine: cast(
-                PreBrewing, machine.dashboard.config[WidgetType.CM_PRE_BREWING]
+            lambda coordinator: cast(
+                PreBrewing,
+                coordinator.device.dashboard.config[WidgetType.CM_PRE_BREWING],
             ).mode
             is PreExtractionMode.PREBREWING
         ),

--- a/tests/components/lamarzocco/test_binary_sensor.py
+++ b/tests/components/lamarzocco/test_binary_sensor.py
@@ -1,5 +1,6 @@
 """Tests for La Marzocco binary sensors."""
 
+from collections.abc import Generator
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -31,6 +32,16 @@ async def test_binary_sensors(
     ):
         await async_init_integration(hass, mock_config_entry)
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.fixture(autouse=True)
+def mock_websocket_terminated() -> Generator[bool]:
+    """Mock websocket terminated."""
+    with patch(
+        "homeassistant.components.lamarzocco.coordinator.LaMarzoccoUpdateCoordinator.websocket_terminated",
+        new=False,
+    ) as mock_websocket_terminated:
+        yield mock_websocket_terminated
 
 
 async def test_brew_active_unavailable(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With #144011 we added callbacks to the websocket connectivity so now the `CONNECTIVITY` sensor does report its status correctly. The `brew_active` sensor is only available on an active WebSocket connection (which its availablility property represenents). However, since the weboscket reconnects once per hour this sensor now goes `unavailable` for a second. While this is *technically* correct it's annoying in the device timeline. Therefore we are making this change so it's only going unavailable if the task closes, meaning the websocket is terminated for good.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
