### PR TITLE
Bump Bluetooth deps to improve auto recovery process

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -21,6 +21,6 @@
     "bluetooth-auto-recovery==1.5.1",
     "bluetooth-data-tools==1.28.1",
     "dbus-fast==2.43.0",
-    "habluetooth==3.47.0"
+    "habluetooth==3.47.1"
   ]
 }

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -18,9 +18,9 @@
     "bleak==0.22.3",
     "bleak-retry-connector==3.9.0",
     "bluetooth-adapters==0.21.4",
-    "bluetooth-auto-recovery==1.4.5",
+    "bluetooth-auto-recovery==1.5.0",
     "bluetooth-data-tools==1.28.1",
     "dbus-fast==2.43.0",
-    "habluetooth==3.45.0"
+    "habluetooth==3.46.0"
   ]
 }

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -18,9 +18,9 @@
     "bleak==0.22.3",
     "bleak-retry-connector==3.9.0",
     "bluetooth-adapters==0.21.4",
-    "bluetooth-auto-recovery==1.5.0",
+    "bluetooth-auto-recovery==1.5.1",
     "bluetooth-data-tools==1.28.1",
     "dbus-fast==2.43.0",
-    "habluetooth==3.46.0"
+    "habluetooth==3.47.0"
   ]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -23,7 +23,7 @@ bcrypt==4.2.0
 bleak-retry-connector==3.9.0
 bleak==0.22.3
 bluetooth-adapters==0.21.4
-bluetooth-auto-recovery==1.4.5
+bluetooth-auto-recovery==1.5.0
 bluetooth-data-tools==1.28.1
 cached-ipaddress==0.10.0
 certifi>=2021.5.30
@@ -34,7 +34,7 @@ dbus-fast==2.43.0
 fnv-hash-fast==1.5.0
 go2rtc-client==0.1.2
 ha-ffmpeg==3.2.2
-habluetooth==3.45.0
+habluetooth==3.46.0
 hass-nabucasa==0.96.0
 hassil==2.2.3
 home-assistant-bluetooth==1.13.1

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -23,7 +23,7 @@ bcrypt==4.2.0
 bleak-retry-connector==3.9.0
 bleak==0.22.3
 bluetooth-adapters==0.21.4
-bluetooth-auto-recovery==1.5.0
+bluetooth-auto-recovery==1.5.1
 bluetooth-data-tools==1.28.1
 cached-ipaddress==0.10.0
 certifi>=2021.5.30
@@ -34,7 +34,7 @@ dbus-fast==2.43.0
 fnv-hash-fast==1.5.0
 go2rtc-client==0.1.2
 ha-ffmpeg==3.2.2
-habluetooth==3.46.0
+habluetooth==3.47.0
 hass-nabucasa==0.96.0
 hassil==2.2.3
 home-assistant-bluetooth==1.13.1

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -34,7 +34,7 @@ dbus-fast==2.43.0
 fnv-hash-fast==1.5.0
 go2rtc-client==0.1.2
 ha-ffmpeg==3.2.2
-habluetooth==3.47.0
+habluetooth==3.47.1
 hass-nabucasa==0.96.0
 hassil==2.2.3
 home-assistant-bluetooth==1.13.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1118,7 +1118,7 @@ ha-silabs-firmware-client==0.2.0
 habiticalib==0.3.7
 
 # homeassistant.components.bluetooth
-habluetooth==3.47.0
+habluetooth==3.47.1
 
 # homeassistant.components.cloud
 hass-nabucasa==0.96.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -637,7 +637,7 @@ bluemaestro-ble==0.4.0
 bluetooth-adapters==0.21.4
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.5.0
+bluetooth-auto-recovery==1.5.1
 
 # homeassistant.components.bluetooth
 # homeassistant.components.ld2410_ble
@@ -1118,7 +1118,7 @@ ha-silabs-firmware-client==0.2.0
 habiticalib==0.3.7
 
 # homeassistant.components.bluetooth
-habluetooth==3.46.0
+habluetooth==3.47.0
 
 # homeassistant.components.cloud
 hass-nabucasa==0.96.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -637,7 +637,7 @@ bluemaestro-ble==0.4.0
 bluetooth-adapters==0.21.4
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.4.5
+bluetooth-auto-recovery==1.5.0
 
 # homeassistant.components.bluetooth
 # homeassistant.components.ld2410_ble
@@ -1118,7 +1118,7 @@ ha-silabs-firmware-client==0.2.0
 habiticalib==0.3.7
 
 # homeassistant.components.bluetooth
-habluetooth==3.45.0
+habluetooth==3.46.0
 
 # homeassistant.components.cloud
 hass-nabucasa==0.96.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -562,7 +562,7 @@ bluemaestro-ble==0.4.0
 bluetooth-adapters==0.21.4
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.4.5
+bluetooth-auto-recovery==1.5.0
 
 # homeassistant.components.bluetooth
 # homeassistant.components.ld2410_ble
@@ -960,7 +960,7 @@ ha-silabs-firmware-client==0.2.0
 habiticalib==0.3.7
 
 # homeassistant.components.bluetooth
-habluetooth==3.45.0
+habluetooth==3.46.0
 
 # homeassistant.components.cloud
 hass-nabucasa==0.96.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -562,7 +562,7 @@ bluemaestro-ble==0.4.0
 bluetooth-adapters==0.21.4
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.5.0
+bluetooth-auto-recovery==1.5.1
 
 # homeassistant.components.bluetooth
 # homeassistant.components.ld2410_ble
@@ -960,7 +960,7 @@ ha-silabs-firmware-client==0.2.0
 habiticalib==0.3.7
 
 # homeassistant.components.bluetooth
-habluetooth==3.46.0
+habluetooth==3.47.0
 
 # homeassistant.components.cloud
 hass-nabucasa==0.96.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -960,7 +960,7 @@ ha-silabs-firmware-client==0.2.0
 habiticalib==0.3.7
 
 # homeassistant.components.bluetooth
-habluetooth==3.47.0
+habluetooth==3.47.1
 
 # homeassistant.components.cloud
 hass-nabucasa==0.96.0


### PR DESCRIPTION
https://github.com/home-assistant/core/pull/144129 should merge fix to avoid a potential ABI compatibility issue that might result in a seg fault.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps the following dependencies, which must be updated together:

- **habluetooth**: [v3.45.0 → v3.47.1](https://github.com/Bluetooth-Devices/habluetooth/compare/v3.45.0...v3.47.1)  
- **bluetooth-auto-recovery**: [v1.4.5 → v1.5.1](https://github.com/Bluetooth-Devices/bluetooth-auto-recovery/compare/v1.4.5...v1.5.1)

**Note:** The test `test_we_switch_adapters_on_failure` has been intentionally removed.  
There are recent changes in `habluetooth` internal logic to avoid thundering herd connection issues, which alters connection order behavior.  
This makes the test obsolete, and its functionality is now covered by internal tests within the `habluetooth` library.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
