### PR TITLE
Make the network device tracking feature optional in AVM Fritz!Tools

### DIFF
--- a/homeassistant/components/fritz/__init__.py
+++ b/homeassistant/components/fritz/__init__.py
@@ -15,6 +15,8 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    CONF_FEATURE_DEVICE_TRACKING,
+    DEFAULT_CONF_FEATURE_DEVICE_TRACKING,
     DEFAULT_SSL,
     DOMAIN,
     FRITZ_AUTH_EXCEPTIONS,
@@ -38,6 +40,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: FritzConfigEntry) -> bool:
     """Set up fritzboxtools from config entry."""
     _LOGGER.debug("Setting up FRITZ!Box Tools component")
+
     avm_wrapper = AvmWrapper(
         hass=hass,
         config_entry=entry,
@@ -46,6 +49,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: FritzConfigEntry) -> boo
         username=entry.data[CONF_USERNAME],
         password=entry.data[CONF_PASSWORD],
         use_tls=entry.data.get(CONF_SSL, DEFAULT_SSL),
+        device_discovery_enabled=entry.options.get(
+            CONF_FEATURE_DEVICE_TRACKING, DEFAULT_CONF_FEATURE_DEVICE_TRACKING
+        ),
     )
 
     try:
@@ -62,6 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: FritzConfigEntry) -> boo
         raise ConfigEntryAuthFailed("Missing UPnP configuration")
 
     await avm_wrapper.async_config_entry_first_refresh()
+    await avm_wrapper.async_trigger_cleanup()
 
     entry.runtime_data = avm_wrapper
 

--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -35,7 +35,9 @@ from homeassistant.helpers.service_info.ssdp import (
 from homeassistant.helpers.typing import VolDictType
 
 from .const import (
+    CONF_FEATURE_DEVICE_TRACKING,
     CONF_OLD_DISCOVERY,
+    DEFAULT_CONF_FEATURE_DEVICE_TRACKING,
     DEFAULT_CONF_OLD_DISCOVERY,
     DEFAULT_HOST,
     DEFAULT_HTTP_PORT,
@@ -72,7 +74,8 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
         """Initialize FRITZ!Box Tools flow."""
         self._name: str = ""
         self._password: str = ""
-        self._use_tls: bool = False
+        self._use_tls: bool = DEFAULT_SSL
+        self._feature_device_discovery: bool = DEFAULT_CONF_FEATURE_DEVICE_TRACKING
         self._port: int | None = None
         self._username: str = ""
         self._model: str = ""
@@ -141,6 +144,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
             options={
                 CONF_CONSIDER_HOME: DEFAULT_CONSIDER_HOME.total_seconds(),
                 CONF_OLD_DISCOVERY: DEFAULT_CONF_OLD_DISCOVERY,
+                CONF_FEATURE_DEVICE_TRACKING: self._feature_device_discovery,
             },
         )
 
@@ -204,6 +208,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
         self._username = user_input[CONF_USERNAME]
         self._password = user_input[CONF_PASSWORD]
         self._use_tls = user_input[CONF_SSL]
+        self._feature_device_discovery = user_input[CONF_FEATURE_DEVICE_TRACKING]
         self._port = self._determine_port(user_input)
 
         error = await self.async_fritz_tools_init()
@@ -234,6 +239,10 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
                     vol.Optional(CONF_SSL, default=DEFAULT_SSL): bool,
+                    vol.Required(
+                        CONF_FEATURE_DEVICE_TRACKING,
+                        default=DEFAULT_CONF_FEATURE_DEVICE_TRACKING,
+                    ): bool,
                 }
             ),
             errors=errors or {},
@@ -250,6 +259,10 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
                     vol.Optional(CONF_SSL, default=DEFAULT_SSL): bool,
+                    vol.Required(
+                        CONF_FEATURE_DEVICE_TRACKING,
+                        default=DEFAULT_CONF_FEATURE_DEVICE_TRACKING,
+                    ): bool,
                 }
             ),
             description_placeholders={"name": self._name},
@@ -405,7 +418,7 @@ class FritzBoxToolsOptionsFlowHandler(OptionsFlow):
         """Handle options flow."""
 
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            return self.async_create_entry(data=user_input)
 
         options = self.config_entry.options
         data_schema = vol.Schema(
@@ -419,6 +432,13 @@ class FritzBoxToolsOptionsFlowHandler(OptionsFlow):
                 vol.Optional(
                     CONF_OLD_DISCOVERY,
                     default=options.get(CONF_OLD_DISCOVERY, DEFAULT_CONF_OLD_DISCOVERY),
+                ): bool,
+                vol.Optional(
+                    CONF_FEATURE_DEVICE_TRACKING,
+                    default=options.get(
+                        CONF_FEATURE_DEVICE_TRACKING,
+                        DEFAULT_CONF_FEATURE_DEVICE_TRACKING,
+                    ),
                 ): bool,
             }
         )

--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -40,6 +40,9 @@ PLATFORMS = [
 CONF_OLD_DISCOVERY = "old_discovery"
 DEFAULT_CONF_OLD_DISCOVERY = False
 
+CONF_FEATURE_DEVICE_TRACKING = "feature_device_tracking"
+DEFAULT_CONF_FEATURE_DEVICE_TRACKING = True
+
 DSL_CONNECTION: Literal["dsl"] = "dsl"
 
 DEFAULT_DEVICE_NAME = "Unknown device"

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -39,6 +39,7 @@ from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     CONF_OLD_DISCOVERY,
+    DEFAULT_CONF_FEATURE_DEVICE_TRACKING,
     DEFAULT_CONF_OLD_DISCOVERY,
     DEFAULT_HOST,
     DEFAULT_SSL,
@@ -175,6 +176,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         username: str = DEFAULT_USERNAME,
         host: str = DEFAULT_HOST,
         use_tls: bool = DEFAULT_SSL,
+        device_discovery_enabled: bool = DEFAULT_CONF_FEATURE_DEVICE_TRACKING,
     ) -> None:
         """Initialize FritzboxTools class."""
         super().__init__(
@@ -202,6 +204,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         self.port = port
         self.username = username
         self.use_tls = use_tls
+        self.device_discovery_enabled = device_discovery_enabled
         self.has_call_deflections: bool = False
         self._model: str | None = None
         self._current_firmware: str | None = None
@@ -332,10 +335,15 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
             "entity_states": {},
         }
         try:
-            await self.async_scan_devices()
+            await self.async_update_device_info()
+
+            if self.device_discovery_enabled:
+                await self.async_scan_devices()
+
             entity_data["entity_states"] = await self.hass.async_add_executor_job(
                 self._entity_states_update
             )
+
             if self.has_call_deflections:
                 entity_data[
                     "call_deflections"
@@ -551,12 +559,8 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         if new_device:
             async_dispatcher_send(self.hass, self.signal_device_new)
 
-    async def async_scan_devices(self, now: datetime | None = None) -> None:
+    async def async_update_device_info(self, now: datetime | None = None) -> None:
         """Scan for new devices and return a list of found device ids."""
-
-        if self.hass.is_stopping:
-            _ha_is_stopping("scan devices")
-            return
 
         _LOGGER.debug("Checking host info for FRITZ!Box device %s", self.host)
         (
@@ -564,6 +568,13 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
             self._latest_firmware,
             self._release_url,
         ) = await self._async_update_device_info()
+
+    async def async_scan_devices(self, now: datetime | None = None) -> None:
+        """Scan for new devices."""
+
+        if self.hass.is_stopping:
+            _ha_is_stopping("scan devices")
+            return
 
         _LOGGER.debug("Checking devices for FRITZ!Box device %s", self.host)
         _default_consider_home = DEFAULT_CONSIDER_HOME.total_seconds()
@@ -683,7 +694,10 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
 
     async def async_trigger_cleanup(self) -> None:
         """Trigger device trackers cleanup."""
-        device_hosts = await self._async_update_hosts_info()
+        _LOGGER.debug("Deviec tracker cleanup triggered")
+        device_hosts = {self.mac: Device(True, "", "", "", "", None)}
+        if self.device_discovery_enabled:
+            device_hosts = await self._async_update_hosts_info()
         entity_reg: er.EntityRegistry = er.async_get(self.hass)
         config_entry = self.config_entry
 

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -694,7 +694,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
 
     async def async_trigger_cleanup(self) -> None:
         """Trigger device trackers cleanup."""
-        _LOGGER.debug("Deviec tracker cleanup triggered")
+        _LOGGER.debug("Device tracker cleanup triggered")
         device_hosts = {self.mac: Device(True, "", "", "", "", None)}
         if self.device_discovery_enabled:
             device_hosts = await self._async_update_hosts_info()

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -560,7 +560,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
             async_dispatcher_send(self.hass, self.signal_device_new)
 
     async def async_update_device_info(self, now: datetime | None = None) -> None:
-        """Scan for new devices and return a list of found device ids."""
+        """Update own device information."""
 
         _LOGGER.debug("Checking host info for FRITZ!Box device %s", self.host)
         (
@@ -570,7 +570,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         ) = await self._async_update_device_info()
 
     async def async_scan_devices(self, now: datetime | None = None) -> None:
-        """Scan for new devices."""
+        """Scan for new network devices."""
 
         if self.hass.is_stopping:
             _ha_is_stopping("scan devices")

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -4,7 +4,9 @@
     "data_description_port": "Leave empty to use the default port.",
     "data_description_username": "Username for the FRITZ!Box.",
     "data_description_password": "Password for the FRITZ!Box.",
-    "data_description_ssl": "Use SSL to connect to the FRITZ!Box."
+    "data_description_ssl": "Use SSL to connect to the FRITZ!Box.",
+    "data_description_feature_device_tracking": "Enable or disable the network device tracking feature.",
+    "data_feature_device_tracking": "Enable network device tracking"
   },
   "config": {
     "flow_title": "{name}",
@@ -15,12 +17,14 @@
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "ssl": "[%key:common::config_flow::data::ssl%]"
+          "ssl": "[%key:common::config_flow::data::ssl%]",
+          "feature_device_tracking": "[%key:component::fritz::common::data_feature_device_tracking%]"
         },
         "data_description": {
           "username": "[%key:component::fritz::common::data_description_username%]",
           "password": "[%key:component::fritz::common::data_description_password%]",
-          "ssl": "[%key:component::fritz::common::data_description_ssl%]"
+          "ssl": "[%key:component::fritz::common::data_description_ssl%]",
+          "feature_device_tracking": "[%key:component::fritz::common::data_description_feature_device_tracking%]"
         }
       },
       "reauth_confirm": {
@@ -57,14 +61,16 @@
           "port": "[%key:common::config_flow::data::port%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "ssl": "[%key:common::config_flow::data::ssl%]"
+          "ssl": "[%key:common::config_flow::data::ssl%]",
+          "feature_device_tracking": "[%key:component::fritz::common::data_feature_device_tracking%]"
         },
         "data_description": {
           "host": "[%key:component::fritz::common::data_description_host%]",
           "port": "[%key:component::fritz::common::data_description_port%]",
           "username": "[%key:component::fritz::common::data_description_username%]",
           "password": "[%key:component::fritz::common::data_description_password%]",
-          "ssl": "[%key:component::fritz::common::data_description_ssl%]"
+          "ssl": "[%key:component::fritz::common::data_description_ssl%]",
+          "feature_device_tracking": "[%key:component::fritz::common::data_description_feature_device_tracking%]"
         }
       }
     },
@@ -89,11 +95,13 @@
       "init": {
         "data": {
           "consider_home": "Seconds to consider a device at 'home'",
-          "old_discovery": "Enable old discovery method"
+          "old_discovery": "Enable old discovery method",
+          "feature_device_tracking": "[%key:component::fritz::common::data_feature_device_tracking%]"
         },
         "data_description": {
           "consider_home": "Time in seconds to consider a device at home. Default is 180 seconds.",
-          "old_discovery": "Enable old discovery method. This is needed for some scenarios."
+          "old_discovery": "Enable old discovery method. This is needed for some scenarios.",
+          "feature_device_tracking": "[%key:component::fritz::common::data_description_feature_device_tracking%]"
         }
       }
     }

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components.device_tracker import (
     DEFAULT_CONSIDER_HOME,
 )
 from homeassistant.components.fritz.const import (
+    CONF_FEATURE_DEVICE_TRACKING,
     CONF_OLD_DISCOVERY,
     DOMAIN,
     ERROR_AUTH_INVALID,
@@ -744,6 +745,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     assert result["data"] == {
         CONF_OLD_DISCOVERY: False,
         CONF_CONSIDER_HOME: 37,
+        CONF_FEATURE_DEVICE_TRACKING: True,
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows the user to disable the network device tracking feature, if they only want to monitor the Fritz!Box router or control the wifi state. This feature has been asked for multiple times, there is also [this feature request](https://community.home-assistant.io/t/avm-fritz-box-tools-add-possibility-to-disable-device-tracker-on-initial-setup/776956).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38863
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
