### PR TITLE
Add support for updating ESPHome deep sleep devices

### DIFF
--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -198,7 +198,7 @@
       "message": "Error during OTA (Over-The-Air) of {configuration}; Try again in ESPHome dashboard for more information."
     },
     "ota_in_progress": {
-      "message": "An OTA (Over-The-Air) update is already progress for {configuration}."
+      "message": "An OTA (Over-The-Air) update is already in progress for {configuration}."
     }
   }
 }

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -195,10 +195,10 @@
       "message": "Error compiling {configuration}; Try again in ESPHome dashboard for more information."
     },
     "error_uploading": {
-      "message": "Error during OTA of {configuration}; Try again in ESPHome dashboard for more information."
+      "message": "Error during OTA (Over-The-Air) of {configuration}; Try again in ESPHome dashboard for more information."
     },
     "ota_in_progress": {
-      "message": "An over the air update is already progress for {configuration}."
+      "message": "An OTA (Over-The-Air) update is already progress for {configuration}."
     }
   }
 }

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -196,6 +196,9 @@
     },
     "error_uploading": {
       "message": "Error during OTA of {configuration}; Try again in ESPHome dashboard for more information."
+    },
+    "ota_in_progress": {
+      "message": "An over the air update is already progress for {configuration}."
     }
   }
 }

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -225,6 +225,7 @@ class ESPHomeDashboardUpdateEntity(
                     "configuration": self._device_info.name,
                 },
             )
+
         # Ensure only one OTA per device at a time
         async with self._install_lock:
             # Ensure only one compile at a time for ALL devices
@@ -243,10 +244,10 @@ class ESPHomeDashboardUpdateEntity(
                         },
                     )
 
-            # If its deep sleep we need to try twice since
-            # we may start the update just as the device goes to sleep
-            # and it won't be able to receive the update, so we need
-            # to wait for a second wakeup.
+            # If the device uses deep sleep, there's a small chance it goes
+            # to sleep right after the dashboard connects but before the OTA
+            # starts. In that case, the update won't go through, so we try
+            # again to catch it on its next wakeup.
             attempts = 2 if self._device_info.has_deep_sleep else 1
             try:
                 for attempt in range(1, attempts + 1):

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -251,10 +251,9 @@ class ESPHomeDashboardUpdateEntity(
             try:
                 for attempt in range(1, attempts + 1):
                     await self._async_wait_available()
-                    if (
-                        not await api.upload(configuration, "OTA")
-                        and attempt == attempts
-                    ):
+                    if await api.upload(configuration, "OTA"):
+                        break
+                    if attempt == attempts:
                         raise HomeAssistantError(
                             translation_domain=DOMAIN,
                             translation_key="error_uploading",

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -714,7 +714,7 @@ async def test_update_deep_sleep_offline_sleep_during_ota(
     mock_esphome_device: MockESPHomeDeviceType,
     mock_dashboard: dict[str, Any],
 ) -> None:
-    """Test device comes online too late during update."""
+    """Test device goes to sleep right as we start the OTA."""
     mock_dashboard["configured"] = [
         {
             "name": "test",

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -744,7 +744,8 @@ async def test_update_deep_sleep_offline_sleep_during_ota(
         nonlocal upload_attempt
         upload_attempt += 1
         if upload_attempt == 1:
-            # First attempt fails
+            # Wait for the device to disconnect
+            # before returning false
             await disconnect_future
             return False
         upload_attempt_2_future.set_result(None)

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -777,6 +777,9 @@ async def test_update_deep_sleep_offline_sleep_during_ota(
         await device.mock_connect()
         # Mock device being at the end of its sleep cycle
         # and going to sleep right as the upload starts
+        # This can happen because there is non zero time
+        # between when we tell the dashboard to upload and
+        # when the upload actually starts
         await device.mock_disconnect(True)
         disconnect_future.set_result(None)
         assert not upload_attempt_2_future.done()

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -1,5 +1,6 @@
 """Test ESPHome update entities."""
 
+import asyncio
 from typing import Any
 from unittest.mock import patch
 
@@ -546,3 +547,235 @@ async def test_generic_device_update_entity_has_update(
     )
 
     mock_client.update_command.assert_called_with(key=1, command=UpdateCommand.CHECK)
+
+
+async def test_attempt_to_update_twice(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test attempting to update twice."""
+    mock_dashboard["configured"] = [
+        {
+            "name": "test",
+            "current_version": "2023.2.0-dev",
+            "configuration": "test.yaml",
+        }
+    ]
+    await async_get_dashboard(hass).async_refresh()
+    await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=[],
+        user_service=[],
+        states=[],
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("update.test_firmware")
+    assert state is not None
+
+    async def delayed_compile(*args: Any, **kwargs: Any) -> None:
+        """Delay the update."""
+        await asyncio.sleep(0)
+        return True
+
+    # Compile success, upload fails
+    with (
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",
+            delayed_compile,
+        ),
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.upload",
+            return_value=False,
+        ),
+    ):
+        update_task = hass.async_create_task(
+            hass.services.async_call(
+                UPDATE_DOMAIN,
+                SERVICE_INSTALL,
+                {ATTR_ENTITY_ID: "update.test_firmware"},
+                blocking=True,
+            )
+        )
+
+        with pytest.raises(HomeAssistantError, match="update is already in progress"):
+            await hass.services.async_call(
+                UPDATE_DOMAIN,
+                SERVICE_INSTALL,
+                {ATTR_ENTITY_ID: "update.test_firmware"},
+                blocking=True,
+            )
+
+        with pytest.raises(HomeAssistantError, match="OTA"):
+            await update_task
+
+
+async def test_update_deep_sleep_already_online(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test attempting to update twice."""
+    mock_dashboard["configured"] = [
+        {
+            "name": "test",
+            "current_version": "2023.2.0-dev",
+            "configuration": "test.yaml",
+        }
+    ]
+    await async_get_dashboard(hass).async_refresh()
+    await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=[],
+        user_service=[],
+        states=[],
+        device_info={"has_deep_sleep": True},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("update.test_firmware")
+    assert state is not None
+
+    # Compile success, upload fails
+    with (
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.upload",
+            return_value=True,
+        ),
+    ):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: "update.test_firmware"},
+            blocking=True,
+        )
+
+
+async def test_update_deep_sleep_offline(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test device comes online while updating."""
+    mock_dashboard["configured"] = [
+        {
+            "name": "test",
+            "current_version": "2023.2.0-dev",
+            "configuration": "test.yaml",
+        }
+    ]
+    await async_get_dashboard(hass).async_refresh()
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=[],
+        user_service=[],
+        states=[],
+        device_info={"has_deep_sleep": True},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("update.test_firmware")
+    assert state is not None
+    await device.mock_disconnect(True)
+
+    # Compile success, upload fails
+    with (
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.upload",
+            return_value=True,
+        ),
+    ):
+        update_task = hass.async_create_task(
+            hass.services.async_call(
+                UPDATE_DOMAIN,
+                SERVICE_INSTALL,
+                {ATTR_ENTITY_ID: "update.test_firmware"},
+                blocking=True,
+            )
+        )
+        await asyncio.sleep(0)
+        assert not update_task.done()
+        await device.mock_connect()
+        await hass.async_block_till_done()
+
+
+async def test_update_deep_sleep_offline_sleep_during_ota(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test device comes online too late during update."""
+    mock_dashboard["configured"] = [
+        {
+            "name": "test",
+            "current_version": "2023.2.0-dev",
+            "configuration": "test.yaml",
+        }
+    ]
+    await async_get_dashboard(hass).async_refresh()
+    device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=[],
+        user_service=[],
+        states=[],
+        device_info={"has_deep_sleep": True},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("update.test_firmware")
+    assert state is not None
+    await device.mock_disconnect(True)
+
+    upload_attempt = 0
+    upload_attempt_2_future = hass.loop.create_future()
+
+    async def upload_takes_a_while(*args: Any, **kwargs: Any) -> None:
+        """Delay the update."""
+        nonlocal upload_attempt
+        upload_attempt += 1
+        if upload_attempt == 1:
+            # First attempt fails
+            await asyncio.sleep(0)
+            return False
+        upload_attempt_2_future.set_result(None)
+        return True
+
+    # Compile success, upload fails
+    with (
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.upload",
+            upload_takes_a_while,
+        ),
+    ):
+        update_task = hass.async_create_task(
+            hass.services.async_call(
+                UPDATE_DOMAIN,
+                SERVICE_INSTALL,
+                {ATTR_ENTITY_ID: "update.test_firmware"},
+                blocking=True,
+            )
+        )
+        await asyncio.sleep(0)
+        assert not update_task.done()
+        await device.mock_connect()
+        # Mock device being at the end of its sleep cycle
+        # and going to sleep right as the upload starts
+        await device.mock_disconnect(True)
+        assert not upload_attempt_2_future.done()
+        # Now the device wakes up and the upload is attempted
+        await device.mock_connect()
+        await upload_attempt_2_future
+        await hass.async_block_till_done()

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -637,7 +637,7 @@ async def test_update_deep_sleep_already_online(
     state = hass.states.get("update.test_firmware")
     assert state is not None
 
-    # Compile success, upload fails
+    # Compile success, upload success
     with (
         patch(
             "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",
@@ -683,7 +683,7 @@ async def test_update_deep_sleep_offline(
     assert state is not None
     await device.mock_disconnect(True)
 
-    # Compile success, upload fails
+    # Compile success, upload success
     with (
         patch(
             "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",
@@ -753,7 +753,7 @@ async def test_update_deep_sleep_offline_sleep_during_ota(
         upload_attempt_2_future.set_result(None)
         return True
 
-    # Compile success, upload fails
+    # Compile success, upload fails first time, success second time
     with (
         patch(
             "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",
@@ -816,7 +816,7 @@ async def test_update_deep_sleep_offline_cancelled_unload(
     assert state is not None
     await device.mock_disconnect(True)
 
-    # Compile success, upload fails
+    # Compile success, upload success, but we cancel the update
     with (
         patch(
             "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -744,7 +744,9 @@ async def test_update_deep_sleep_offline_sleep_during_ota(
         nonlocal upload_attempt
         upload_attempt += 1
         if upload_attempt == 1:
-            # Wait for the device to disconnect
+            # We are simulating the device going back to sleep
+            # before the upload can be started
+            # Wait for the device to go unavailable
             # before returning false
             await disconnect_future
             return False

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -737,6 +737,7 @@ async def test_update_deep_sleep_offline_sleep_during_ota(
 
     upload_attempt = 0
     upload_attempt_2_future = hass.loop.create_future()
+    disconnect_future = hass.loop.create_future()
 
     async def upload_takes_a_while(*args: Any, **kwargs: Any) -> None:
         """Delay the update."""
@@ -744,6 +745,7 @@ async def test_update_deep_sleep_offline_sleep_during_ota(
         upload_attempt += 1
         if upload_attempt == 1:
             # First attempt fails
+            await disconnect_future
             return False
         upload_attempt_2_future.set_result(None)
         return True
@@ -773,6 +775,7 @@ async def test_update_deep_sleep_offline_sleep_during_ota(
         # Mock device being at the end of its sleep cycle
         # and going to sleep right as the upload starts
         await device.mock_disconnect(True)
+        disconnect_future.set_result(None)
         assert not upload_attempt_2_future.done()
         # Now the device wakes up and the upload is attempted
         await device.mock_connect()

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -744,7 +744,6 @@ async def test_update_deep_sleep_offline_sleep_during_ota(
         upload_attempt += 1
         if upload_attempt == 1:
             # First attempt fails
-            await asyncio.sleep(0)
             return False
         upload_attempt_2_future.set_result(None)
         return True


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updating deep sleep devices is currently a challenge since they can only receive OTA updates while awake. This modification ensures the update entity waits for the device to wake up before sending the OTA. This removes the need to time updates perfectly and hope they upload before the device goes back to sleep.

This is a WTH/Feature request:
https://community.home-assistant.io/t/wth-esphome-cant-handle-firmware-updates-automatically-for-deep-sleep-devices/471258
https://community.home-assistant.io/t/allow-deep-sleep-esphome-devices-to-install-updates-using-ha/791196

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
