### PR TITLE
Add option to treat events that start and end at midnight as all day events

### DIFF
--- a/homeassistant/components/remote_calendar/__init__.py
+++ b/homeassistant/components/remote_calendar/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
@@ -22,6 +23,7 @@ async def async_setup_entry(
     coordinator = RemoteCalendarDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+    entry.async_on_unload(entry.add_update_listener(async_update_entry))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -31,3 +33,8 @@ async def async_unload_entry(
 ) -> bool:
     """Handle unload of an entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload remote calendar component when options are changed."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/remote_calendar/calendar.py
+++ b/homeassistant/components/remote_calendar/calendar.py
@@ -1,6 +1,6 @@
 """Calendar platform for a Remote Calendar."""
 
-from datetime import datetime
+from datetime import datetime, time
 import logging
 
 from ical.event import Event
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from . import RemoteCalendarConfigEntry
-from .const import CONF_CALENDAR_NAME
+from .const import CONF_CALENDAR_NAME, CONF_MIDNIGHT_AS_ALL_DAY
 from .coordinator import RemoteCalendarDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,6 +38,7 @@ class RemoteCalendarEntity(
     """A calendar entity backed by a remote iCalendar url."""
 
     _attr_has_entity_name = True
+    _midnight_as_all_day = False
 
     def __init__(
         self,
@@ -48,6 +49,7 @@ class RemoteCalendarEntity(
         super().__init__(coordinator)
         self._attr_name = entry.data[CONF_CALENDAR_NAME]
         self._attr_unique_id = entry.entry_id
+        self._midnight_as_all_day = entry.options.get(CONF_MIDNIGHT_AS_ALL_DAY, False)
 
     @property
     def event(self) -> CalendarEvent | None:
@@ -55,7 +57,7 @@ class RemoteCalendarEntity(
         now = dt_util.now()
         events = self.coordinator.data.timeline_tz(now.tzinfo).active_after(now)
         if event := next(events, None):
-            return _get_calendar_event(event)
+            return _get_calendar_event(event, self._midnight_as_all_day)
         return None
 
     async def async_get_events(
@@ -66,24 +68,34 @@ class RemoteCalendarEntity(
             start_date,
             end_date,
         )
-        return [_get_calendar_event(event) for event in events]
+        return [
+            _get_calendar_event(event, self._midnight_as_all_day) for event in events
+        ]
 
 
-def _get_calendar_event(event: Event) -> CalendarEvent:
+def _get_calendar_event(event: Event, midnight_as_all_day: bool) -> CalendarEvent:
     """Return a CalendarEvent from an API event."""
+
+    start = (
+        dt_util.as_local(event.start)
+        if isinstance(event.start, datetime)
+        else event.start
+    )
+    end = dt_util.as_local(event.end) if isinstance(event.end, datetime) else event.end
+    if (
+        midnight_as_all_day
+        and isinstance(start, datetime)
+        and isinstance(end, datetime)
+        and start.time() == time.min
+        and end.time() == time.min
+    ):
+        start = start.date()
+        end = end.date()
 
     return CalendarEvent(
         summary=event.summary,
-        start=(
-            dt_util.as_local(event.start)
-            if isinstance(event.start, datetime)
-            else event.start
-        ),
-        end=(
-            dt_util.as_local(event.end)
-            if isinstance(event.end, datetime)
-            else event.end
-        ),
+        start=start,
+        end=end,
         description=event.description,
         uid=event.uid,
         rrule=event.rrule.as_rrule_str() if event.rrule else None,

--- a/homeassistant/components/remote_calendar/const.py
+++ b/homeassistant/components/remote_calendar/const.py
@@ -2,3 +2,4 @@
 
 DOMAIN = "remote_calendar"
 CONF_CALENDAR_NAME = "calendar_name"
+CONF_MIDNIGHT_AS_ALL_DAY = "midnight_as_all_day"

--- a/homeassistant/components/remote_calendar/strings.json
+++ b/homeassistant/components/remote_calendar/strings.json
@@ -30,5 +30,18 @@
     "unable_to_parse": {
       "message": "Unable to parse calendar data: {err}"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Configure calendar",
+        "data": {
+          "midnight_as_all_day": "Treat events that start and end at midnight as all day events"
+        },
+        "data_description": {
+          "midnight_as_all_day": "Events that start and end at midnight in the same time zone as Home Assistant are treated as all day events."
+        }
+      }
+    }
   }
 }

--- a/tests/components/remote_calendar/test_config_flow.py
+++ b/tests/components/remote_calendar/test_config_flow.py
@@ -4,7 +4,11 @@ from httpx import ConnectError, Response, UnsupportedProtocol
 import pytest
 import respx
 
-from homeassistant.components.remote_calendar.const import CONF_CALENDAR_NAME, DOMAIN
+from homeassistant.components.remote_calendar.const import (
+    CONF_CALENDAR_NAME,
+    CONF_MIDNIGHT_AS_ALL_DAY,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
@@ -312,3 +316,24 @@ async def test_duplicate_url(
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
+
+
+async def test_options_flow(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test the options flow form."""
+
+    await setup_integration(hass, config_entry)
+
+    # Test show Options form
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    # Test option is set
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id, data={CONF_MIDNIGHT_AS_ALL_DAY: True}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_MIDNIGHT_AS_ALL_DAY: True}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add an configurable option to treat events that start and end at midnight as all day events. This is required for e.g. Google resource calendars, as they are exposed with time information even when the Google Calendar UI treats them as all day events, as explained in [this discussion](https://support.google.com/calendar/thread/10074544?hl=en&msgid=15693057)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/38874
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
