### PR TITLE
Avoid delaying HA startup in Rehlko

### DIFF
--- a/homeassistant/components/rehlko/__init__.py
+++ b/homeassistant/components/rehlko/__init__.py
@@ -48,8 +48,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: RehlkoConfigEntry) -> bo
             entry.data.get(CONF_REFRESH_TOKEN),
         )
         homes = await rehlko.get_homes()
-        # Retrys enabled after successful connection to prevent blocking startup
-        rehlko.set_retry_policy(retry_count=3, retry_delays=[5, 10, 20])
     except AuthenticationError as ex:
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,
@@ -87,6 +85,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: RehlkoConfigEntry) -> bo
             await coordinator.async_config_entry_first_refresh()
             coordinators[device_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    # Retrys enabled after successful connection to prevent blocking startup
+    rehlko.set_retry_policy(retry_count=3, retry_delays=[5, 10, 20])
     return True
 
 

--- a/homeassistant/components/rehlko/__init__.py
+++ b/homeassistant/components/rehlko/__init__.py
@@ -40,7 +40,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: RehlkoConfigEntry) -> bo
         )
 
     rehlko.set_refresh_token_callback(async_refresh_token_update)
-    rehlko.set_retry_policy(retry_count=3, retry_delays=[5, 10, 20])
 
     try:
         await rehlko.authenticate(
@@ -48,6 +47,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: RehlkoConfigEntry) -> bo
             entry.data[CONF_PASSWORD],
             entry.data.get(CONF_REFRESH_TOKEN),
         )
+        homes = await rehlko.get_homes()
+        # Retrys enabled after successful connection to prevent blocking startup
+        rehlko.set_retry_policy(retry_count=3, retry_delays=[5, 10, 20])
     except AuthenticationError as ex:
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,
@@ -60,7 +62,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: RehlkoConfigEntry) -> bo
             translation_key="cannot_connect",
         ) from ex
     coordinators: dict[int, RehlkoUpdateCoordinator] = {}
-    homes = await rehlko.get_homes()
 
     entry.runtime_data = RehlkoRuntimeData(
         coordinators=coordinators,


### PR DESCRIPTION
## Proposed change

Avoid blocking startup when there are Rehlko cloud service issues. We have seen this behavior occasionally during the beta

a) During startup if get_home fails or timesout a ConfigEntryNotReady exception is raised
b) Enable retries once initialization is successful.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
