### PR TITLE
Fix missing head forwarding in ingress

### DIFF
--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -107,8 +107,8 @@ class HassIOIngress(HomeAssistantView):
     post = _handle
     put = _handle
     delete = _handle
-    options = _handle
     patch = _handle
+    options = _handle
     connect = _handle
     head = _handle
     trace = _handle

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -110,7 +110,6 @@ class HassIOIngress(HomeAssistantView):
     patch = _handle
     options = _handle
     head = _handle
-    trace = _handle
 
     async def _handle_websocket(
         self, request: web.Request, token: str, path: str

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -109,7 +109,6 @@ class HassIOIngress(HomeAssistantView):
     delete = _handle
     patch = _handle
     options = _handle
-    connect = _handle
     head = _handle
     trace = _handle
 

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -103,12 +103,15 @@ class HassIOIngress(HomeAssistantView):
 
         raise HTTPBadGateway from None
 
+    connect = _handle
     get = _handle
+    head = _handle
     post = _handle
     put = _handle
     delete = _handle
     patch = _handle
     options = _handle
+    trace = _handle
 
     async def _handle_websocket(
         self, request: web.Request, token: str, path: str

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -103,14 +103,14 @@ class HassIOIngress(HomeAssistantView):
 
         raise HTTPBadGateway from None
 
-    connect = _handle
     get = _handle
-    head = _handle
     post = _handle
     put = _handle
     delete = _handle
-    patch = _handle
     options = _handle
+    patch = _handle
+    connect = _handle
+    head = _handle
     trace = _handle
 
     async def _handle_websocket(

--- a/tests/components/hassio/test_ingress.py
+++ b/tests/components/hassio/test_ingress.py
@@ -279,49 +279,6 @@ async def test_ingress_request_options(
         ("fsadjf10312", ""),
     ],
 )
-async def test_ingress_request_trace(
-    hassio_noauth_client, build_type, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test no auth needed for ."""
-    aioclient_mock.trace(
-        f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
-        text="test",
-    )
-
-    resp = await hassio_noauth_client.trace(
-        f"/api/hassio_ingress/{build_type[0]}/{build_type[1]}",
-        headers={"X-Test-Header": "beer"},
-    )
-
-    # Check we got right response
-    assert resp.status == HTTPStatus.OK
-    body = await resp.text()
-    assert body == "test"
-
-    # Check we forwarded command
-    assert len(aioclient_mock.mock_calls) == 1
-    assert X_AUTH_TOKEN not in aioclient_mock.mock_calls[-1][3]
-    assert aioclient_mock.mock_calls[-1][3]["X-Hass-Source"] == "core.ingress"
-    assert (
-        aioclient_mock.mock_calls[-1][3]["X-Ingress-Path"]
-        == f"/api/hassio_ingress/{build_type[0]}"
-    )
-    assert aioclient_mock.mock_calls[-1][3]["X-Test-Header"] == "beer"
-    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_FOR]
-    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_HOST]
-    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_PROTO]
-
-
-@pytest.mark.parametrize(
-    "build_type",
-    [
-        ("a3_vl", "test/beer/ping?index=1"),
-        ("core", "index.html"),
-        ("local", "panel/config"),
-        ("jk_921", "editor.php?idx=3&ping=5"),
-        ("fsadjf10312", ""),
-    ],
-)
 async def test_ingress_request_head(
     hassio_noauth_client, build_type, aioclient_mock: AiohttpClientMocker
 ) -> None:
@@ -339,7 +296,7 @@ async def test_ingress_request_head(
     # Check we got right response
     assert resp.status == HTTPStatus.OK
     body = await resp.text()
-    assert body == "test"
+    assert body == ""  # head does not return a body
 
     # Check we forwarded command
     assert len(aioclient_mock.mock_calls) == 1

--- a/tests/components/hassio/test_ingress.py
+++ b/tests/components/hassio/test_ingress.py
@@ -272,6 +272,135 @@ async def test_ingress_request_options(
 @pytest.mark.parametrize(
     "build_type",
     [
+        ("a3_vl", "test/beer/ping?index=1"),
+        ("core", "index.html"),
+        ("local", "panel/config"),
+        ("jk_921", "editor.php?idx=3&ping=5"),
+        ("fsadjf10312", ""),
+    ],
+)
+async def test_ingress_request_connect(
+    hassio_noauth_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test no auth needed for ."""
+    aioclient_mock.connect(
+        f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
+        text="test",
+    )
+
+    resp = await hassio_noauth_client.connect(
+        f"/api/hassio_ingress/{build_type[0]}/{build_type[1]}",
+        headers={"X-Test-Header": "beer"},
+    )
+
+    # Check we got right response
+    assert resp.status == HTTPStatus.OK
+    body = await resp.text()
+    assert body == "test"
+
+    # Check we forwarded command
+    assert len(aioclient_mock.mock_calls) == 1
+    assert X_AUTH_TOKEN not in aioclient_mock.mock_calls[-1][3]
+    assert aioclient_mock.mock_calls[-1][3]["X-Hass-Source"] == "core.ingress"
+    assert (
+        aioclient_mock.mock_calls[-1][3]["X-Ingress-Path"]
+        == f"/api/hassio_ingress/{build_type[0]}"
+    )
+    assert aioclient_mock.mock_calls[-1][3]["X-Test-Header"] == "beer"
+    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_FOR]
+    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_HOST]
+    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_PROTO]
+
+
+@pytest.mark.parametrize(
+    "build_type",
+    [
+        ("a3_vl", "test/beer/ping?index=1"),
+        ("core", "index.html"),
+        ("local", "panel/config"),
+        ("jk_921", "editor.php?idx=3&ping=5"),
+        ("fsadjf10312", ""),
+    ],
+)
+async def test_ingress_request_trace(
+    hassio_noauth_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test no auth needed for ."""
+    aioclient_mock.trace(
+        f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
+        text="test",
+    )
+
+    resp = await hassio_noauth_client.trace(
+        f"/api/hassio_ingress/{build_type[0]}/{build_type[1]}",
+        headers={"X-Test-Header": "beer"},
+    )
+
+    # Check we got right response
+    assert resp.status == HTTPStatus.OK
+    body = await resp.text()
+    assert body == "test"
+
+    # Check we forwarded command
+    assert len(aioclient_mock.mock_calls) == 1
+    assert X_AUTH_TOKEN not in aioclient_mock.mock_calls[-1][3]
+    assert aioclient_mock.mock_calls[-1][3]["X-Hass-Source"] == "core.ingress"
+    assert (
+        aioclient_mock.mock_calls[-1][3]["X-Ingress-Path"]
+        == f"/api/hassio_ingress/{build_type[0]}"
+    )
+    assert aioclient_mock.mock_calls[-1][3]["X-Test-Header"] == "beer"
+    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_FOR]
+    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_HOST]
+    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_PROTO]
+
+
+@pytest.mark.parametrize(
+    "build_type",
+    [
+        ("a3_vl", "test/beer/ping?index=1"),
+        ("core", "index.html"),
+        ("local", "panel/config"),
+        ("jk_921", "editor.php?idx=3&ping=5"),
+        ("fsadjf10312", ""),
+    ],
+)
+async def test_ingress_request_head(
+    hassio_noauth_client, build_type, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test no auth needed for ."""
+    aioclient_mock.head(
+        f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
+        text="test",
+    )
+
+    resp = await hassio_noauth_client.head(
+        f"/api/hassio_ingress/{build_type[0]}/{build_type[1]}",
+        headers={"X-Test-Header": "beer"},
+    )
+
+    # Check we got right response
+    assert resp.status == HTTPStatus.OK
+    body = await resp.text()
+    assert body == "test"
+
+    # Check we forwarded command
+    assert len(aioclient_mock.mock_calls) == 1
+    assert X_AUTH_TOKEN not in aioclient_mock.mock_calls[-1][3]
+    assert aioclient_mock.mock_calls[-1][3]["X-Hass-Source"] == "core.ingress"
+    assert (
+        aioclient_mock.mock_calls[-1][3]["X-Ingress-Path"]
+        == f"/api/hassio_ingress/{build_type[0]}"
+    )
+    assert aioclient_mock.mock_calls[-1][3]["X-Test-Header"] == "beer"
+    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_FOR]
+    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_HOST]
+    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_PROTO]
+
+
+@pytest.mark.parametrize(
+    "build_type",
+    [
         ("a3_vl", "test/beer/ws"),
         ("core", "ws.php"),
         ("local", "panel/config/stream"),

--- a/tests/components/hassio/test_ingress.py
+++ b/tests/components/hassio/test_ingress.py
@@ -279,49 +279,6 @@ async def test_ingress_request_options(
         ("fsadjf10312", ""),
     ],
 )
-async def test_ingress_request_connect(
-    hassio_noauth_client, build_type, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test no auth needed for ."""
-    aioclient_mock.connect(
-        f"http://127.0.0.1/ingress/{build_type[0]}/{build_type[1]}",
-        text="test",
-    )
-
-    resp = await hassio_noauth_client.connect(
-        f"/api/hassio_ingress/{build_type[0]}/{build_type[1]}",
-        headers={"X-Test-Header": "beer"},
-    )
-
-    # Check we got right response
-    assert resp.status == HTTPStatus.OK
-    body = await resp.text()
-    assert body == "test"
-
-    # Check we forwarded command
-    assert len(aioclient_mock.mock_calls) == 1
-    assert X_AUTH_TOKEN not in aioclient_mock.mock_calls[-1][3]
-    assert aioclient_mock.mock_calls[-1][3]["X-Hass-Source"] == "core.ingress"
-    assert (
-        aioclient_mock.mock_calls[-1][3]["X-Ingress-Path"]
-        == f"/api/hassio_ingress/{build_type[0]}"
-    )
-    assert aioclient_mock.mock_calls[-1][3]["X-Test-Header"] == "beer"
-    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_FOR]
-    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_HOST]
-    assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_PROTO]
-
-
-@pytest.mark.parametrize(
-    "build_type",
-    [
-        ("a3_vl", "test/beer/ping?index=1"),
-        ("core", "index.html"),
-        ("local", "panel/config"),
-        ("jk_921", "editor.php?idx=3&ping=5"),
-        ("fsadjf10312", ""),
-    ],
-)
 async def test_ingress_request_trace(
     hassio_noauth_client, build_type, aioclient_mock: AiohttpClientMocker
 ) -> None:

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -110,10 +110,6 @@ class AiohttpClientMocker:
         """Register a mock patch request."""
         self.request("patch", *args, **kwargs)
 
-    def connect(self, *args, **kwargs):
-        """Register a mock connect request."""
-        self.request("connect", *args, **kwargs)
-
     def head(self, *args, **kwargs):
         """Register a mock head request."""
         self.request("head", *args, **kwargs)

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -85,6 +85,7 @@ class AiohttpClientMocker:
                 closing=closing,
             )
         )
+    
 
     def get(self, *args, **kwargs):
         """Register a mock get request."""
@@ -109,6 +110,18 @@ class AiohttpClientMocker:
     def patch(self, *args, **kwargs):
         """Register a mock patch request."""
         self.request("patch", *args, **kwargs)
+
+    def connect(self, *args, **kwargs):
+        """Register a mock connect request."""
+        self.request("connect", *args, **kwargs)
+
+    def head(self, *args, **kwargs):
+        """Register a mock head request."""
+        self.request("head", *args, **kwargs)
+
+    def trace(self, *args, **kwargs):
+        """Register a mock trace request."""
+        self.request("trace", *args, **kwargs)
 
     @property
     def call_count(self):

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -114,10 +114,6 @@ class AiohttpClientMocker:
         """Register a mock head request."""
         self.request("head", *args, **kwargs)
 
-    def trace(self, *args, **kwargs):
-        """Register a mock trace request."""
-        self.request("trace", *args, **kwargs)
-
     @property
     def call_count(self):
         """Return the number of requests made."""

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -85,7 +85,6 @@ class AiohttpClientMocker:
                 closing=closing,
             )
         )
-    
 
     def get(self, *args, **kwargs):
         """Register a mock get request."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
FileBrowser addon fails with the new version because it uses tus.io which uses HEAD requests.

Added rest of the standard http request headers https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
