### PR TITLE
Move more SamsungTV test constants to fixture files

### DIFF
--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -68,6 +68,9 @@ SAMPLE_DEVICE_INFO_WIFI = {
     },
 }
 
+MOCK_SSDP_DATA = SsdpServiceInfo(
+    **load_json_object_fixture("ssdp_service_remote_control_receiver.json", DOMAIN)
+)
 
 MOCK_SSDP_DATA_RENDERING_CONTROL_ST = SsdpServiceInfo(
     **load_json_object_fixture("ssdp_service_rendering_control.json", DOMAIN)

--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components.samsungtv.const import (
     CONF_SESSION_ID,
+    DOMAIN,
     METHOD_LEGACY,
     METHOD_WEBSOCKET,
 )
@@ -15,13 +16,9 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_TOKEN,
 )
-from homeassistant.helpers.service_info.ssdp import (
-    ATTR_UPNP_FRIENDLY_NAME,
-    ATTR_UPNP_MANUFACTURER,
-    ATTR_UPNP_MODEL_NAME,
-    ATTR_UPNP_UDN,
-    SsdpServiceInfo,
-)
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+
+from tests.common import load_json_object_fixture
 
 MOCK_CONFIG = {
     CONF_HOST: "fake_host",
@@ -59,28 +56,6 @@ MOCK_ENTRY_WS_WITH_MAC = {
     CONF_TOKEN: "123456789",
 }
 
-MOCK_SSDP_DATA_RENDERING_CONTROL_ST = SsdpServiceInfo(
-    ssdp_usn="mock_usn",
-    ssdp_st="urn:schemas-upnp-org:service:RenderingControl:1",
-    ssdp_location="https://fake_host:12345/test",
-    upnp={
-        ATTR_UPNP_FRIENDLY_NAME: "[TV] fake_name",
-        ATTR_UPNP_MANUFACTURER: "Samsung fake_manufacturer",
-        ATTR_UPNP_MODEL_NAME: "fake_model",
-        ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de",
-    },
-)
-MOCK_SSDP_DATA_MAIN_TV_AGENT_ST = SsdpServiceInfo(
-    ssdp_usn="mock_usn",
-    ssdp_st="urn:samsung.com:service:MainTVAgent2:1",
-    ssdp_location="https://fake_host:12345/tv_agent",
-    upnp={
-        ATTR_UPNP_FRIENDLY_NAME: "[TV] fake_name",
-        ATTR_UPNP_MANUFACTURER: "Samsung fake_manufacturer",
-        ATTR_UPNP_MODEL_NAME: "fake_model",
-        ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de",
-    },
-)
 
 SAMPLE_DEVICE_INFO_WIFI = {
     "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
@@ -92,3 +67,12 @@ SAMPLE_DEVICE_INFO_WIFI = {
         "networkType": "wireless",
     },
 }
+
+
+MOCK_SSDP_DATA_RENDERING_CONTROL_ST = SsdpServiceInfo(
+    **load_json_object_fixture("ssdp_service_rendering_control.json", DOMAIN)
+)
+
+MOCK_SSDP_DATA_MAIN_TV_AGENT_ST = SsdpServiceInfo(
+    **load_json_object_fixture("ssdp_device_main_tv_agent.json", DOMAIN)
+)

--- a/tests/components/samsungtv/fixtures/ssdp_device_main_tv_agent.json
+++ b/tests/components/samsungtv/fixtures/ssdp_device_main_tv_agent.json
@@ -1,0 +1,11 @@
+{
+  "ssdp_usn": "mock_usn",
+  "ssdp_st": "urn:samsung.com:service:MainTVAgent2:1",
+  "upnp": {
+    "friendlyName": "[TV] fake_name",
+    "manufacturer": "Samsung fake_manufacturer",
+    "modelName": "fake_model",
+    "UDN": "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de"
+  },
+  "ssdp_location": "https://fake_host:12345/tv_agent"
+}

--- a/tests/components/samsungtv/fixtures/ssdp_device_main_tv_agent.json
+++ b/tests/components/samsungtv/fixtures/ssdp_device_main_tv_agent.json
@@ -1,5 +1,5 @@
 {
-  "ssdp_usn": "mock_usn",
+  "ssdp_usn": "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de::urn:samsung.com:service:MainTVAgent2:1",
   "ssdp_st": "urn:samsung.com:service:MainTVAgent2:1",
   "upnp": {
     "friendlyName": "[TV] fake_name",

--- a/tests/components/samsungtv/fixtures/ssdp_service_remote_control_receiver.json
+++ b/tests/components/samsungtv/fixtures/ssdp_service_remote_control_receiver.json
@@ -1,0 +1,11 @@
+{
+  "ssdp_usn": "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de::urn:samsung.com:device:RemoteControlReceiver:1",
+  "ssdp_st": "urn:samsung.com:device:RemoteControlReceiver:1",
+  "upnp": {
+    "friendlyName": "[TV] fake_name",
+    "manufacturer": "Samsung fake_manufacturer",
+    "modelName": "fake_model",
+    "UDN": "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de"
+  },
+  "ssdp_location": "http://fake_host:7676/smp_7_"
+}

--- a/tests/components/samsungtv/fixtures/ssdp_service_rendering_control.json
+++ b/tests/components/samsungtv/fixtures/ssdp_service_rendering_control.json
@@ -1,5 +1,5 @@
 {
-  "ssdp_usn": "mock_usn",
+  "ssdp_usn": "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de::urn:schemas-upnp-org:service:RenderingControl:1",
   "ssdp_st": "urn:schemas-upnp-org:service:RenderingControl:1",
   "upnp": {
     "friendlyName": "[TV] fake_name",

--- a/tests/components/samsungtv/fixtures/ssdp_service_rendering_control.json
+++ b/tests/components/samsungtv/fixtures/ssdp_service_rendering_control.json
@@ -1,0 +1,11 @@
+{
+  "ssdp_usn": "mock_usn",
+  "ssdp_st": "urn:schemas-upnp-org:service:RenderingControl:1",
+  "upnp": {
+    "friendlyName": "[TV] fake_name",
+    "manufacturer": "Samsung fake_manufacturer",
+    "modelName": "fake_model",
+    "UDN": "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de"
+  },
+  "ssdp_location": "https://fake_host:12345/test"
+}

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -51,8 +51,6 @@ from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_MANUFACTURER,
-    ATTR_UPNP_MODEL_NAME,
-    ATTR_UPNP_UDN,
     SsdpServiceInfo,
 )
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -86,17 +84,6 @@ MOCK_IMPORT_WSDATA = {
 }
 MOCK_USER_DATA = {CONF_HOST: "fake_host", CONF_NAME: "fake_name"}
 
-MOCK_SSDP_DATA_WRONGMODEL = SsdpServiceInfo(
-    ssdp_usn="mock_usn",
-    ssdp_st="mock_st",
-    ssdp_location="http://fake2_host:12345/test",
-    upnp={
-        ATTR_UPNP_FRIENDLY_NAME: "fake2_name",
-        ATTR_UPNP_MANUFACTURER: "fake2_manufacturer",
-        ATTR_UPNP_MODEL_NAME: "HW-Qfake",
-        ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
-    },
-)
 MOCK_DHCP_DATA = DhcpServiceInfo(
     ip="fake_host", macaddress="aabbccddeeff", hostname="fake_hostname"
 )
@@ -775,14 +762,15 @@ async def test_ssdp_websocket_cannot_connect(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp_model_not_supported(hass: HomeAssistant) -> None:
+async def test_ssdp_wrong_manufacturer(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery."""
-
+    ssdp_data = deepcopy(MOCK_SSDP_DATA)
+    ssdp_data.upnp[ATTR_UPNP_MANUFACTURER] = ssdp_data.upnp[ATTR_UPNP_MANUFACTURER][7:]
     # confirm to add the entry
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=MOCK_SSDP_DATA_WRONGMODEL,
+        data=ssdp_data,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == RESULT_NOT_SUPPORTED


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
