### PR TITLE
Use config entry title to name SamsungTV entities

### DIFF
--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_MAC,
     CONF_MODEL,
-    CONF_NAME,
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
@@ -41,7 +40,6 @@ class SamsungTVEntity(CoordinatorEntity[SamsungTVDataUpdateCoordinator], Entity)
         # Fallback for legacy models that doesn't have a API to retrieve MAC or SerialNumber
         self._attr_unique_id = config_entry.unique_id or config_entry.entry_id
         self._attr_device_info = DeviceInfo(
-            name=config_entry.data.get(CONF_NAME),
             manufacturer=config_entry.data.get(CONF_MANUFACTURER),
             model=config_entry.data.get(CONF_MODEL),
             model_id=config_entry.data.get(CONF_MODEL),

--- a/tests/components/samsungtv/snapshots/test_init.ambr
+++ b/tests/components/samsungtv/snapshots/test_init.ambr
@@ -89,7 +89,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'tv',
-      'friendly_name': 'any',
+      'friendly_name': 'Mock Title',
       'is_volume_muted': False,
       'source_list': list([
         'TV',
@@ -98,7 +98,7 @@
       'supported_features': <MediaPlayerEntityFeature: 24509>,
     }),
     'context': <ANY>,
-    'entity_id': 'media_player.any',
+    'entity_id': 'media_player.mock_title',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -123,7 +123,7 @@
     'disabled_by': None,
     'domain': 'media_player',
     'entity_category': None,
-    'entity_id': 'media_player.any',
+    'entity_id': 'media_player.mock_title',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,

--- a/tests/components/samsungtv/test_device_trigger.py
+++ b/tests/components/samsungtv/test_device_trigger.py
@@ -54,7 +54,7 @@ async def test_if_fires_on_turn_on_request(
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
-    entity_id = "media_player.fake"
+    entity_id = "media_player.mock_title"
 
     device = device_registry.async_get_device(
         identifiers={(DOMAIN, "be9554b9-c9fb-41f4-8920-22da015376a4")}

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -49,7 +49,7 @@ from .const import (
 
 from tests.common import MockConfigEntry, load_json_object_fixture
 
-ENTITY_ID = f"{MP_DOMAIN}.fake_name"
+ENTITY_ID = f"{MP_DOMAIN}.mock_title"
 MOCK_CONFIG = {
     CONF_HOST: "fake_host",
     CONF_NAME: "fake_name",
@@ -65,7 +65,7 @@ async def test_setup(hass: HomeAssistant) -> None:
 
     # test name and turn_on
     assert state
-    assert state.name == "fake_name"
+    assert state.name == "Mock Title"
     assert (
         state.attributes[ATTR_SUPPORTED_FEATURES]
         == SUPPORT_SAMSUNGTV | MediaPlayerEntityFeature.TURN_ON
@@ -151,8 +151,8 @@ async def test_setup_updates_from_ssdp(
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-    assert hass.states.get("media_player.any") == snapshot
-    assert entity_registry.async_get("media_player.any") == snapshot
+    assert hass.states.get("media_player.mock_title") == snapshot
+    assert entity_registry.async_get("media_player.mock_title") == snapshot
     assert (
         entry.data[CONF_SSDP_MAIN_TV_AGENT_LOCATION]
         == "https://fake_host:12345/tv_agent"

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -94,7 +94,7 @@ from tests.common import (
     load_json_object_fixture,
 )
 
-ENTITY_ID = f"{MP_DOMAIN}.fake"
+ENTITY_ID = f"{MP_DOMAIN}.mock_title"
 MOCK_CONFIGWS = {
     CONF_HOST: "fake_host",
     CONF_NAME: "fake",
@@ -158,12 +158,9 @@ async def test_setup_websocket_2(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test setup of platform from config entry."""
-    entity_id = f"{MP_DOMAIN}.fake"
-
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_ENTRY_WS,
-        unique_id=entity_id,
     )
     entry.add_to_hass(hass)
 
@@ -188,7 +185,7 @@ async def test_setup_websocket_2(
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    state = hass.states.get(entity_id)
+    state = hass.states.get(ENTITY_ID)
     assert state
     remote_class.assert_called_once_with(**MOCK_CALLS_WS)
 
@@ -640,7 +637,7 @@ async def test_name(hass: HomeAssistant) -> None:
     """Test for name property."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "fake"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Mock Title"
 
 
 @pytest.mark.usefixtures("remote")

--- a/tests/components/samsungtv/test_remote.py
+++ b/tests/components/samsungtv/test_remote.py
@@ -21,7 +21,7 @@ from .const import MOCK_CONFIG, MOCK_ENTRY_WS_WITH_MAC, MOCK_ENTRYDATA_ENCRYPTED
 
 from tests.common import MockConfigEntry
 
-ENTITY_ID = f"{REMOTE_DOMAIN}.fake"
+ENTITY_ID = f"{REMOTE_DOMAIN}.mock_title"
 
 
 @pytest.mark.usefixtures("remoteencws", "rest_api")

--- a/tests/components/samsungtv/test_trigger.py
+++ b/tests/components/samsungtv/test_trigger.py
@@ -28,7 +28,7 @@ async def test_turn_on_trigger_device_id(
     """Test for turn_on triggers by device_id firing."""
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
 
-    entity_id = f"{entity_domain}.fake"
+    entity_id = f"{entity_domain}.mock_title"
 
     device = device_registry.async_get_device(
         identifiers={(DOMAIN, "be9554b9-c9fb-41f4-8920-22da015376a4")}
@@ -92,7 +92,7 @@ async def test_turn_on_trigger_entity_id(
     """Test for turn_on triggers by entity_id firing."""
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
 
-    entity_id = f"{entity_domain}.fake"
+    entity_id = f"{entity_domain}.mock_title"
 
     assert await async_setup_component(
         hass,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Preliminary work for #144225

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
