### PR TITLE
Airthings DHCP discovery

### DIFF
--- a/homeassistant/components/airthings/manifest.json
+++ b/homeassistant/components/airthings/manifest.json
@@ -8,7 +8,12 @@
       "hostname": "airthings-view"
     },
     {
+      "hostname": "airthings-hub",
       "macaddress": "D0141190*"
+    },
+    {
+      "hostname": "airthings-hub",
+      "macaddress": "70B3D52A0*"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/airthings",

--- a/homeassistant/components/airthings/manifest.json
+++ b/homeassistant/components/airthings/manifest.json
@@ -5,11 +5,9 @@
   "config_flow": true,
   "dhcp": [
     {
-      "hostname": "airthings-view",
-      "macaddress": "6C79B8*"
+      "hostname": "airthings-view"
     },
     {
-      "hostname": "airthings-hub",
       "macaddress": "D0141190*"
     }
   ],

--- a/homeassistant/components/airthings/manifest.json
+++ b/homeassistant/components/airthings/manifest.json
@@ -3,6 +3,16 @@
   "name": "Airthings",
   "codeowners": ["@danielhiversen", "@LaStrada"],
   "config_flow": true,
+  "dhcp": [
+    {
+      "hostname": "airthings-view",
+      "macaddress": "6C79B8*"
+    },
+    {
+      "hostname": "airthings-hub",
+      "macaddress": "D0141190*"
+    }
+  ],
   "documentation": "https://www.home-assistant.io/integrations/airthings",
   "iot_class": "cloud_polling",
   "loggers": ["airthings"],

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -14,7 +14,13 @@ DHCP: Final[list[dict[str, str | bool]]] = [
     },
     {
         "domain": "airthings",
+        "hostname": "airthings-hub",
         "macaddress": "D0141190*",
+    },
+    {
+        "domain": "airthings",
+        "hostname": "airthings-hub",
+        "macaddress": "70B3D52A0*",
     },
     {
         "domain": "airzone",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -11,11 +11,9 @@ DHCP: Final[list[dict[str, str | bool]]] = [
     {
         "domain": "airthings",
         "hostname": "airthings-view",
-        "macaddress": "6C79B8*",
     },
     {
         "domain": "airthings",
-        "hostname": "airthings-hub",
         "macaddress": "D0141190*",
     },
     {

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -9,6 +9,16 @@ from typing import Final
 
 DHCP: Final[list[dict[str, str | bool]]] = [
     {
+        "domain": "airthings",
+        "hostname": "airthings-view",
+        "macaddress": "6C79B8*",
+    },
+    {
+        "domain": "airthings",
+        "hostname": "airthings-hub",
+        "macaddress": "D0141190*",
+    },
+    {
         "domain": "airzone",
         "macaddress": "E84F25*",
     },

--- a/tests/components/airthings/test_config_flow.py
+++ b/tests/components/airthings/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.airthings.const import CONF_SECRET, DOMAIN
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -16,6 +17,25 @@ TEST_DATA = {
     CONF_ID: "client_id",
     CONF_SECRET: "secret",
 }
+
+DHCP_SERVICE_INFO_VIEW_SERIES = DhcpServiceInfo(
+    hostname="airthings-view",
+    ip="192.168.1.100",
+    macaddress="00:00:00:00:00:00",
+)
+
+DHCP_SERVICE_INFO_HUBS = [
+    DhcpServiceInfo(
+        hostname="airthings-hub",
+        ip="192.168.1.101",
+        macaddress="D0:14:11:90:00:00",
+    ),
+    DhcpServiceInfo(
+        hostname="airthings-hub",
+        ip="192.168.1.102",
+        macaddress="70:B3:D5:2A:00:00",
+    ),
+]
 
 
 async def test_form(hass: HomeAssistant) -> None:
@@ -120,6 +140,94 @@ async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=TEST_DATA
         )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_dhcp_flow_view_series(hass: HomeAssistant) -> None:
+    """Test that DHCP discovery works for Airthings View series."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=DHCP_SERVICE_INFO_VIEW_SERIES,
+        context={"source": config_entries.SOURCE_DHCP},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with (
+        patch(
+            "homeassistant.components.airthings.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+        patch(
+            "airthings.get_token",
+            return_value="test_token",
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            TEST_DATA,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Airthings"
+    assert result2["data"] == TEST_DATA
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_dhcp_flow_hub(hass: HomeAssistant) -> None:
+    """Test that DHCP discovery works for Airthings Hub."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=DHCP_SERVICE_INFO_HUBS[0],
+        context={"source": config_entries.SOURCE_DHCP},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with (
+        patch(
+            "homeassistant.components.airthings.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+        patch(
+            "airthings.get_token",
+            return_value="test_token",
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            TEST_DATA,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Airthings"
+    assert result2["data"] == TEST_DATA
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_dhcp_flow_hub_already_configured(hass: HomeAssistant) -> None:
+    """Test that DHCP discovery fails when already configured."""
+
+    first_entry = MockConfigEntry(
+        domain="airthings",
+        data=TEST_DATA,
+        unique_id=TEST_DATA[CONF_ID],
+    )
+    first_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=DHCP_SERVICE_INFO_HUBS[1],
+        context={"source": config_entries.SOURCE_DHCP},
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/airthings/test_config_flow.py
+++ b/tests/components/airthings/test_config_flow.py
@@ -57,15 +57,15 @@ async def test_form(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             TEST_DATA,
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Airthings"
-    assert result2["data"] == TEST_DATA
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Airthings"
+    assert result["data"] == TEST_DATA
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -79,13 +79,13 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
         "airthings.get_token",
         side_effect=airthings.AirthingsAuthError,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             TEST_DATA,
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_auth"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
 
 
 async def test_form_cannot_connect(hass: HomeAssistant) -> None:
@@ -98,13 +98,13 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         "airthings.get_token",
         side_effect=airthings.AirthingsConnectionError,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             TEST_DATA,
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_form_unknown_error(hass: HomeAssistant) -> None:
@@ -117,13 +117,13 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
         "airthings.get_token",
         side_effect=Exception,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             TEST_DATA,
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "unknown"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
 
 
 async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:

--- a/tests/components/airthings/test_config_flow.py
+++ b/tests/components/airthings/test_config_flow.py
@@ -148,69 +148,13 @@ async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
 async def test_dhcp_flow_view_series(hass: HomeAssistant) -> None:
     """Test that DHCP discovery works for Airthings View series."""
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        data=DHCP_SERVICE_INFO_VIEW_SERIES,
-        context={"source": config_entries.SOURCE_DHCP},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-
-    with (
-        patch(
-            "homeassistant.components.airthings.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
-        patch(
-            "airthings.get_token",
-            return_value="test_token",
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            TEST_DATA,
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Airthings"
-    assert result2["data"] == TEST_DATA
-    assert len(mock_setup_entry.mock_calls) == 1
+    _test_dhcp_flow(hass, DHCP_SERVICE_INFO_VIEW_SERIES)
 
 
 async def test_dhcp_flow_hub(hass: HomeAssistant) -> None:
     """Test that DHCP discovery works for Airthings Hub."""
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        data=DHCP_SERVICE_INFO_HUBS[0],
-        context={"source": config_entries.SOURCE_DHCP},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-
-    with (
-        patch(
-            "homeassistant.components.airthings.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
-        patch(
-            "airthings.get_token",
-            return_value="test_token",
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            TEST_DATA,
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Airthings"
-    assert result2["data"] == TEST_DATA
-    assert len(mock_setup_entry.mock_calls) == 1
+    _test_dhcp_flow(hass, DHCP_SERVICE_INFO_HUBS[0])
 
 
 async def test_dhcp_flow_hub_already_configured(hass: HomeAssistant) -> None:
@@ -231,3 +175,36 @@ async def test_dhcp_flow_hub_already_configured(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def _test_dhcp_flow(
+    hass: HomeAssistant, dhcp_service_info: DhcpServiceInfo
+) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=dhcp_service_info,
+        context={"source": config_entries.SOURCE_DHCP},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with (
+        patch(
+            "homeassistant.components.airthings.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+        patch(
+            "airthings.get_token",
+            return_value="test_token",
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            TEST_DATA,
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Airthings"
+    assert result["data"] == TEST_DATA
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding DHCP discovery for Airthings (cloud).

* Airthings Hub is using wired connection, and is either `D0:14:11:90:*` or `70:B3:D5:2A:0*`. The device name will always be `airthings-hub`.
* Airthings View series is using a Texas Instruments chip (wifi), and we cannot really guarantee the mac address, but we can use the device name, which always is `airthings-view`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
