### PR TITLE
Remove deprecated freebox reboot service

### DIFF
--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -1,22 +1,19 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
 
 from datetime import timedelta
-import logging
 
 from freebox_api.exceptions import HttpRequestError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import Event, HomeAssistant, ServiceCall
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DOMAIN, PLATFORMS, SERVICE_REBOOT
+from .const import DOMAIN, PLATFORMS
 from .router import FreeboxRouter, get_api
 
 SCAN_INTERVAL = timedelta(seconds=30)
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -40,20 +37,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Services
-    async def async_reboot(call: ServiceCall) -> None:
-        """Handle reboot service call."""
-        # The Freebox reboot service has been replaced by a
-        # dedicated button entity and marked as deprecated
-        _LOGGER.warning(
-            "The 'freebox.reboot' service is deprecated and "
-            "replaced by a dedicated reboot button entity; please "
-            "use that entity to reboot the freebox instead"
-        )
-        await router.reboot()
-
-    hass.services.async_register(DOMAIN, SERVICE_REBOOT, async_reboot)
-
     async def async_close_connection(event: Event) -> None:
         """Close Freebox connection on HA Stop."""
         await router.close()
@@ -71,6 +54,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         router: FreeboxRouter = hass.data[DOMAIN].pop(entry.unique_id)
         await router.close()
-        hass.services.async_remove(DOMAIN, SERVICE_REBOOT)
 
     return unload_ok

--- a/homeassistant/components/freebox/const.py
+++ b/homeassistant/components/freebox/const.py
@@ -8,7 +8,6 @@ import socket
 from homeassistant.const import Platform
 
 DOMAIN = "freebox"
-SERVICE_REBOOT = "reboot"
 
 APP_DESC = {
     "app_id": "hass",

--- a/tests/components/freebox/test_init.py
+++ b/tests/components/freebox/test_init.py
@@ -1,11 +1,11 @@
 """Tests for the Freebox init."""
 
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock
 
 from pytest_unordered import unordered
 
 from homeassistant.components.device_tracker import DOMAIN as DT_DOMAIN
-from homeassistant.components.freebox.const import DOMAIN, SERVICE_REBOOT
+from homeassistant.components.freebox.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -33,19 +33,6 @@ async def test_setup(hass: HomeAssistant, router: Mock) -> None:
     assert router.call_count == 1
     assert router().open.call_count == 1
 
-    assert hass.services.has_service(DOMAIN, SERVICE_REBOOT)
-
-    with patch(
-        "homeassistant.components.freebox.router.FreeboxRouter.reboot"
-    ) as mock_service:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_REBOOT,
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        mock_service.assert_called_once()
-
 
 async def test_setup_import(hass: HomeAssistant, router: Mock) -> None:
     """Test setup of integration from import."""
@@ -64,8 +51,6 @@ async def test_setup_import(hass: HomeAssistant, router: Mock) -> None:
 
     assert router.call_count == 1
     assert router().open.call_count == 1
-
-    assert hass.services.has_service(DOMAIN, SERVICE_REBOOT)
 
 
 async def test_unload_remove(hass: HomeAssistant, router: Mock) -> None:
@@ -106,7 +91,6 @@ async def test_unload_remove(hass: HomeAssistant, router: Mock) -> None:
     assert state_switch.state == STATE_UNAVAILABLE
 
     assert router().close.call_count == 1
-    assert not hass.services.has_service(DOMAIN, SERVICE_REBOOT)
 
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The deprecated 'freebox.reboot' service has been removed; please use the dedicated reboot button entity to reboot the freebox instead

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as follow-up to #65501

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
