### PR TITLE
Revert "Disable S3 checksums" (#144092)

### DIFF
--- a/homeassistant/components/s3/__init__.py
+++ b/homeassistant/components/s3/__init__.py
@@ -7,7 +7,6 @@ from typing import cast
 
 from aiobotocore.client import AioBaseClient as S3Client
 from aiobotocore.session import AioSession
-from botocore.config import Config
 from botocore.exceptions import ClientError, ConnectionError, ParamValidationError
 
 from homeassistant.config_entries import ConfigEntry
@@ -33,11 +32,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
     """Set up S3 from a config entry."""
 
     data = cast(dict, entry.data)
-    # due to https://github.com/home-assistant/core/issues/143995
-    config = Config(
-        request_checksum_calculation="when_required",
-        response_checksum_validation="when_required",
-    )
     try:
         session = AioSession()
         # pylint: disable-next=unnecessary-dunder-call
@@ -46,7 +40,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
             endpoint_url=data.get(CONF_ENDPOINT_URL),
             aws_secret_access_key=data[CONF_SECRET_ACCESS_KEY],
             aws_access_key_id=data[CONF_ACCESS_KEY_ID],
-            config=config,
         ).__aenter__()
         await client.head_bucket(Bucket=data[CONF_BUCKET])
     except ClientError as err:

--- a/tests/components/s3/test_init.py
+++ b/tests/components/s3/test_init.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import AsyncMock, patch
 
-from botocore.config import Config
 from botocore.exceptions import (
     ClientError,
     EndpointConnectionError,
@@ -74,19 +73,3 @@ async def test_setup_entry_head_bucket_error(
     )
     await setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
-
-
-async def test_checksum_settings_present(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
-) -> None:
-    """Test that checksum validation is set to be compatible with third-party S3 providers."""
-    # due to https://github.com/home-assistant/core/issues/143995
-    with patch(
-        "homeassistant.components.s3.AioSession.create_client"
-    ) as mock_create_client:
-        await setup_integration(hass, mock_config_entry)
-
-        config_arg = mock_create_client.call_args[1]["config"]
-        assert isinstance(config_arg, Config)
-        assert config_arg.request_checksum_calculation == "when_required"
-        assert config_arg.response_checksum_validation == "when_required"


### PR DESCRIPTION
Reverts home-assistant/core#144092

We discussed this topic internally, and as S3 is not an open standard, we will revert this compatibility PR.
Also, I will create a follow-up PR, renaming the integration to `aws_s3` to make it clear it's for aws.

@tomasbedrich @zweckj 
