### PR TITLE
Bump devolo_home_control_api to 0.19.0

### DIFF
--- a/homeassistant/components/devolo_home_control/manifest.json
+++ b/homeassistant/components/devolo_home_control/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["devolo_home_control_api"],
-  "requirements": ["devolo-home-control-api==0.18.3"],
+  "requirements": ["devolo-home-control-api==0.19.0"],
   "zeroconf": ["_dvl-deviceapi._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -782,7 +782,7 @@ denonavr==1.1.0
 devialet==1.5.7
 
 # homeassistant.components.devolo_home_control
-devolo-home-control-api==0.18.3
+devolo-home-control-api==0.19.0
 
 # homeassistant.components.devolo_home_network
 devolo-plc-api==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -673,7 +673,7 @@ denonavr==1.1.0
 devialet==1.5.7
 
 # homeassistant.components.devolo_home_control
-devolo-home-control-api==0.18.3
+devolo-home-control-api==0.19.0
 
 # homeassistant.components.devolo_home_network
 devolo-plc-api==1.5.1

--- a/tests/components/devolo_home_control/mocks.py
+++ b/tests/components/devolo_home_control/mocks.py
@@ -1,5 +1,6 @@
 """Mocks for tests."""
 
+from datetime import UTC
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -28,6 +29,7 @@ class BinarySensorPropertyMock(BinarySensorProperty):
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self._logger = MagicMock()
+        self._timezone = UTC
         self.element_uid = "Test"
         self.key_count = 1
         self.sensor_type = "door"
@@ -41,6 +43,7 @@ class BinarySwitchPropertyMock(BinarySwitchProperty):
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self._logger = MagicMock()
+        self._timezone = UTC
         self.element_uid = "Test"
         self.state = False
 
@@ -51,6 +54,7 @@ class ConsumptionPropertyMock(ConsumptionProperty):
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self._logger = MagicMock()
+        self._timezone = UTC
         self.element_uid = "devolo.Meter:Test"
         self.current_unit = "W"
         self.total_unit = "kWh"
@@ -68,6 +72,7 @@ class MultiLevelSensorPropertyMock(MultiLevelSensorProperty):
         self._unit = "°C"
         self._value = 20
         self._logger = MagicMock()
+        self._timezone = UTC
 
 
 class BrightnessSensorPropertyMock(MultiLevelSensorProperty):
@@ -80,6 +85,7 @@ class BrightnessSensorPropertyMock(MultiLevelSensorProperty):
         self._unit = "%"
         self._value = 20
         self._logger = MagicMock()
+        self._timezone = UTC
 
 
 class MultiLevelSwitchPropertyMock(MultiLevelSwitchProperty):
@@ -92,6 +98,7 @@ class MultiLevelSwitchPropertyMock(MultiLevelSwitchProperty):
         self.max = 24
         self._value = 20
         self._logger = MagicMock()
+        self._timezone = UTC
 
 
 class SirenPropertyMock(MultiLevelSwitchProperty):
@@ -105,6 +112,7 @@ class SirenPropertyMock(MultiLevelSwitchProperty):
         self.switch_type = "tone"
         self._value = 0
         self._logger = MagicMock()
+        self._timezone = UTC
 
 
 class SettingsMock(SettingsProperty):
@@ -113,6 +121,7 @@ class SettingsMock(SettingsProperty):
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self._logger = MagicMock()
+        self._timezone = UTC
         self.name = "Test"
         self.zone = "Test"
         self.tone = 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump devolo_home_control_api to 0.19.0. It introduced the SPDX license identifier. The internal representation of properties changed a little so I had to adjust the mocks of the tests, too.

Changelog: https://github.com/2Fake/devolo_home_control_api/releases/tag/v0.19.0
Git diff: https://github.com/2Fake/devolo_home_control_api/compare/v0.18.3...v0.19.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
