### PR TITLE
Cleanup unused CONF_IP_ADDRESS from SamsungTV tests

### DIFF
--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -8,7 +8,6 @@ from homeassistant.components.samsungtv.const import (
 )
 from homeassistant.const import (
     CONF_HOST,
-    CONF_IP_ADDRESS,
     CONF_MAC,
     CONF_METHOD,
     CONF_MODEL,
@@ -33,7 +32,6 @@ MOCK_CONFIG_ENCRYPTED_WS = {
 }
 MOCK_ENTRYDATA_ENCRYPTED_WS = {
     **MOCK_CONFIG_ENCRYPTED_WS,
-    CONF_IP_ADDRESS: "test",
     CONF_METHOD: "encrypted",
     CONF_MAC: "aa:bb:cc:dd:ee:ff",
     CONF_TOKEN: "037739871315caef138547b03e348b72",
@@ -47,7 +45,6 @@ MOCK_ENTRYDATA_WS = {
     CONF_NAME: "any",
 }
 MOCK_ENTRY_WS_WITH_MAC = {
-    CONF_IP_ADDRESS: "test",
     CONF_HOST: "fake_host",
     CONF_METHOD: "websocket",
     CONF_MAC: "aa:bb:cc:dd:ee:ff",

--- a/tests/components/samsungtv/snapshots/test_diagnostics.ambr
+++ b/tests/components/samsungtv/snapshots/test_diagnostics.ambr
@@ -14,7 +14,6 @@
     'entry': dict({
       'data': dict({
         'host': 'fake_host',
-        'ip_address': 'test',
         'mac': 'aa:bb:cc:dd:ee:ff',
         'method': 'websocket',
         'model': '82GXARRS',
@@ -47,7 +46,6 @@
     'entry': dict({
       'data': dict({
         'host': 'fake_host',
-        'ip_address': 'test',
         'mac': 'aa:bb:cc:dd:ee:ff',
         'method': 'encrypted',
         'name': 'fake',
@@ -107,7 +105,6 @@
     'entry': dict({
       'data': dict({
         'host': 'fake_host',
-        'ip_address': 'test',
         'mac': 'aa:bb:cc:dd:ee:ff',
         'method': 'encrypted',
         'model': 'UE48JU6400',

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -35,7 +35,6 @@ from homeassistant.components.samsungtv.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_HOST,
-    CONF_IP_ADDRESS,
     CONF_MAC,
     CONF_METHOD,
     CONF_MODEL,
@@ -89,7 +88,6 @@ MOCK_ZEROCONF_DATA = ZeroconfServiceInfo(
 )
 MOCK_OLD_ENTRY = {
     CONF_HOST: "10.10.12.34",
-    CONF_IP_ADDRESS: EXISTING_IP,
     CONF_METHOD: "legacy",
     CONF_PORT: None,
 }
@@ -1257,14 +1255,13 @@ async def test_autodetect_none(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
 async def test_update_old_entry(hass: HomeAssistant) -> None:
-    """Test update of old entry."""
+    """Test update of old entry sets unique id."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY)
     entry.add_to_hass(hass)
 
     config_entries_domain = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries_domain) == 1
     assert entry is config_entries_domain[0]
-    assert entry.data[CONF_IP_ADDRESS] == EXISTING_IP
     assert not entry.unique_id
 
     assert await async_setup_component(hass, DOMAIN, {}) is True
@@ -1282,7 +1279,6 @@ async def test_update_old_entry(hass: HomeAssistant) -> None:
     entry2 = config_entries_domain[0]
 
     # check updated device info
-    assert entry2.data.get(CONF_IP_ADDRESS) is not None
     assert entry2.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -53,7 +53,6 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_SUPPORTED_FEATURES,
     CONF_HOST,
-    CONF_IP_ADDRESS,
     CONF_MAC,
     CONF_METHOD,
     CONF_MODEL,
@@ -111,7 +110,6 @@ MOCK_CALLS_WS = {
 }
 
 MOCK_ENTRY_WS = {
-    CONF_IP_ADDRESS: "test",
     CONF_HOST: "fake_host",
     CONF_METHOD: "websocket",
     CONF_NAME: "fake",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Leftover from #48022 (May 2021)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
