### PR TITLE
Use async_release_notes in ESPHome update entity

### DIFF
--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -134,6 +134,22 @@ def esphome_state_property[_R, _EntityT: EsphomeEntity[Any, Any]](
     return _wrapper
 
 
+def async_esphome_state_property[_R, _EntityT: EsphomeEntity[Any, Any]](
+    func: Callable[[_EntityT], Awaitable[_R | None]],
+) -> Callable[[_EntityT], Coroutine[Any, Any, _R | None]]:
+    """Wrap a state property of an esphome entity.
+
+    This checks if the state object in the entity is set
+    and returns None if it is not set.
+    """
+
+    @functools.wraps(func)
+    async def _wrapper(self: _EntityT) -> _R | None:
+        return await func(self) if self._has_state else None
+
+    return _wrapper
+
+
 def esphome_float_state_property[_EntityT: EsphomeEntity[Any, Any]](
     func: Callable[[_EntityT], float | None],
 ) -> Callable[[_EntityT], float | None]:

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -270,7 +270,9 @@ class ESPHomeUpdateEntity(EsphomeEntity[UpdateInfo, UpdateState], UpdateEntity):
     """A update implementation for esphome."""
 
     _attr_supported_features = (
-        UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
+        UpdateEntityFeature.INSTALL
+        | UpdateEntityFeature.PROGRESS
+        | UpdateEntityFeature.RELEASE_NOTES
     )
 
     @callback
@@ -300,11 +302,11 @@ class ESPHomeUpdateEntity(EsphomeEntity[UpdateInfo, UpdateState], UpdateEntity):
         """Return the latest version."""
         return self._state.latest_version
 
-    @property
-    @esphome_state_property
-    def release_summary(self) -> str:
-        """Return the release summary."""
-        return self._state.release_summary
+    async def async_release_notes(self) -> str | None:
+        """Return the release notes."""
+        if self._state.release_summary:
+            return self._state.release_summary
+        return None
 
     @property
     @esphome_state_property

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -31,6 +31,7 @@ from .coordinator import ESPHomeDashboardCoordinator
 from .dashboard import async_get_dashboard
 from .entity import (
     EsphomeEntity,
+    async_esphome_state_property,
     convert_api_error_ha_error,
     esphome_state_property,
     platform_async_setup_entry,
@@ -302,6 +303,7 @@ class ESPHomeUpdateEntity(EsphomeEntity[UpdateInfo, UpdateState], UpdateEntity):
         """Return the latest version."""
         return self._state.latest_version
 
+    @async_esphome_state_property
     async def async_release_notes(self) -> str | None:
         """Return the release notes."""
         if self._state.release_summary:

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -13,6 +13,8 @@ from homeassistant.components.homeassistant import (
     SERVICE_UPDATE_ENTITY,
 )
 from homeassistant.components.update import (
+    ATTR_IN_PROGRESS,
+    ATTR_UPDATE_PERCENTAGE,
     DOMAIN as UPDATE_DOMAIN,
     SERVICE_INSTALL,
     UpdateEntityFeature,
@@ -30,6 +32,10 @@ from homeassistant.exceptions import HomeAssistantError
 from .conftest import MockESPHomeDeviceType, MockGenericDeviceEntryType
 
 from tests.typing import WebSocketGenerator
+
+RELEASE_SUMMARY = "This is a release summary"
+RELEASE_URL = "https://esphome.io/changelog"
+ENTITY_ID = "update.test_myupdate"
 
 
 @pytest.fixture(autouse=True)
@@ -463,8 +469,8 @@ async def test_generic_device_update_entity(
             current_version="2024.6.0",
             latest_version="2024.6.0",
             title="ESPHome Project",
-            release_summary="This is a release summary",
-            release_url="https://esphome.io/changelog",
+            release_summary=RELEASE_SUMMARY,
+            release_url=RELEASE_URL,
         )
     ]
     user_service = []
@@ -474,7 +480,7 @@ async def test_generic_device_update_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("update.test_myupdate")
+    state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_OFF
 
@@ -483,7 +489,6 @@ async def test_generic_device_update_entity_has_update(
     hass: HomeAssistant,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
-    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test a generic device update entity with an update."""
     entity_info = [
@@ -494,18 +499,14 @@ async def test_generic_device_update_entity_has_update(
             unique_id="my_update",
         )
     ]
-
-    release_summary = "This is a release summary"
-    release_url = "https://esphome.io/changelog"
-
     states = [
         UpdateState(
             key=1,
             current_version="2024.6.0",
             latest_version="2024.6.1",
             title="ESPHome Project",
-            release_summary=release_summary,
-            release_url=release_url,
+            release_summary=RELEASE_SUMMARY,
+            release_url=RELEASE_URL,
         )
     ]
     user_service = []
@@ -515,31 +516,14 @@ async def test_generic_device_update_entity_has_update(
         user_service=user_service,
         states=states,
     )
-
-    entity_id = "update.test_myupdate"
-
-    state = hass.states.get(entity_id)
+    state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON
-
-    # release notes
-    client = await hass_ws_client(hass)
-    await hass.async_block_till_done()
-
-    await client.send_json(
-        {
-            "id": 1,
-            "type": "update/release_notes",
-            "entity_id": entity_id,
-        }
-    )
-    result = await client.receive_json()
-    assert result["result"] == release_summary
 
     await hass.services.async_call(
         UPDATE_DOMAIN,
         SERVICE_INSTALL,
-        {ATTR_ENTITY_ID: entity_id},
+        {ATTR_ENTITY_ID: ENTITY_ID},
         blocking=True,
     )
 
@@ -552,25 +536,127 @@ async def test_generic_device_update_entity_has_update(
             current_version="2024.6.0",
             latest_version="2024.6.1",
             title="ESPHome Project",
-            release_summary=release_summary,
-            release_url=release_url,
+            release_summary=RELEASE_SUMMARY,
+            release_url=RELEASE_URL,
         )
     )
 
-    state = hass.states.get(entity_id)
+    state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON
-    assert state.attributes["in_progress"] is True
-    assert state.attributes["update_percentage"] == 50
-
+    assert state.attributes[ATTR_IN_PROGRESS] is True
+    assert state.attributes[ATTR_UPDATE_PERCENTAGE] == 50
     await hass.services.async_call(
         HOMEASSISTANT_DOMAIN,
         SERVICE_UPDATE_ENTITY,
-        {ATTR_ENTITY_ID: entity_id},
+        {ATTR_ENTITY_ID: ENTITY_ID},
         blocking=True,
     )
 
+    mock_device.set_state(
+        UpdateState(
+            key=1,
+            in_progress=True,
+            has_progress=False,
+            current_version="2024.6.0",
+            latest_version="2024.6.1",
+            title="ESPHome Project",
+            release_summary=RELEASE_SUMMARY,
+            release_url=RELEASE_URL,
+        )
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_IN_PROGRESS] is True
+    assert state.attributes[ATTR_UPDATE_PERCENTAGE] is None
+
     mock_client.update_command.assert_called_with(key=1, command=UpdateCommand.CHECK)
+
+
+async def test_update_entity_release_notes(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test ESPHome update entity release notes."""
+    entity_info = [
+        UpdateInfo(
+            object_id="myupdate",
+            key=1,
+            name="my update",
+            unique_id="my_update",
+        )
+    ]
+
+    user_service = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=[],
+    )
+
+    # release notes
+    client = await hass_ws_client(hass)
+    await hass.async_block_till_done()
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "update/release_notes",
+            "entity_id": ENTITY_ID,
+        }
+    )
+
+    result = await client.receive_json()
+    assert result["result"] is None
+
+    mock_device.set_state(
+        UpdateState(
+            key=1,
+            current_version="2024.6.0",
+            latest_version="2024.6.1",
+            title="ESPHome Project",
+            release_summary="",
+            release_url=RELEASE_URL,
+        )
+    )
+
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "update/release_notes",
+            "entity_id": ENTITY_ID,
+        }
+    )
+
+    result = await client.receive_json()
+    assert result["result"] is None
+
+    mock_device.set_state(
+        UpdateState(
+            key=1,
+            current_version="2024.6.0",
+            latest_version="2024.6.1",
+            title="ESPHome Project",
+            release_summary=RELEASE_SUMMARY,
+            release_url=RELEASE_URL,
+        )
+    )
+
+    await client.send_json(
+        {
+            "id": 3,
+            "type": "update/release_notes",
+            "entity_id": ENTITY_ID,
+        }
+    )
+
+    result = await client.receive_json()
+    assert result["result"] == RELEASE_SUMMARY
 
 
 async def test_attempt_to_update_twice(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Instead of putting the `release_summary` from the device in the `release_summary` attribute which is stored in the database, implement `async_release_notes` so it is just rendered for the UI when needed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
