### PR TITLE
Add support for s3 compatible storage providers

### DIFF
--- a/homeassistant/components/aws_s3/config_flow.py
+++ b/homeassistant/components/aws_s3/config_flow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urlparse
 
 from aiobotocore.session import AioSession
 from botocore.exceptions import ClientError, ConnectionError, ParamValidationError
@@ -18,7 +17,6 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
-    AWS_DOMAIN,
     CONF_ACCESS_KEY_ID,
     CONF_BUCKET,
     CONF_ENDPOINT_URL,
@@ -60,33 +58,28 @@ class S3ConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             )
 
-            if not urlparse(user_input[CONF_ENDPOINT_URL]).hostname.endswith(
-                AWS_DOMAIN
-            ):
+            try:
+                session = AioSession()
+                async with session.create_client(
+                    "s3",
+                    endpoint_url=user_input.get(CONF_ENDPOINT_URL),
+                    aws_secret_access_key=user_input[CONF_SECRET_ACCESS_KEY],
+                    aws_access_key_id=user_input[CONF_ACCESS_KEY_ID],
+                ) as client:
+                    await client.head_bucket(Bucket=user_input[CONF_BUCKET])
+            except ClientError:
+                errors["base"] = "invalid_credentials"
+            except ParamValidationError as err:
+                if "Invalid bucket name" in str(err):
+                    errors[CONF_BUCKET] = "invalid_bucket_name"
+            except ValueError:
                 errors[CONF_ENDPOINT_URL] = "invalid_endpoint_url"
+            except ConnectionError:
+                errors[CONF_ENDPOINT_URL] = "cannot_connect"
             else:
-                try:
-                    session = AioSession()
-                    async with session.create_client(
-                        "s3",
-                        endpoint_url=user_input.get(CONF_ENDPOINT_URL),
-                        aws_secret_access_key=user_input[CONF_SECRET_ACCESS_KEY],
-                        aws_access_key_id=user_input[CONF_ACCESS_KEY_ID],
-                    ) as client:
-                        await client.head_bucket(Bucket=user_input[CONF_BUCKET])
-                except ClientError:
-                    errors["base"] = "invalid_credentials"
-                except ParamValidationError as err:
-                    if "Invalid bucket name" in str(err):
-                        errors[CONF_BUCKET] = "invalid_bucket_name"
-                except ValueError:
-                    errors[CONF_ENDPOINT_URL] = "invalid_endpoint_url"
-                except ConnectionError:
-                    errors[CONF_ENDPOINT_URL] = "cannot_connect"
-                else:
-                    return self.async_create_entry(
-                        title=user_input[CONF_BUCKET], data=user_input
-                    )
+                return self.async_create_entry(
+                    title=user_input[CONF_BUCKET], data=user_input
+                )
 
         return self.async_show_form(
             step_id="user",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The new AWS S3 backup provider supports S3 storage. The existing implementation checks whether the URL ends with _amazonaws.com_. There are other backup providers like [iDrive e2](https://www.idrive.com/s3-storage-e2/) that provide Amazon S3 compatible  object storage. They use the same interface but have a different url (for instance: _a4y1.par.idrivee2-50.com_).
This PR removes the explicit check whether the URL ends with _amazonaws.com_. By removing this check the AWS S3 backup provider also works with any AWS S3 compatible storage provider like [iDrive e2](https://www.idrive.com/s3-storage-e2/).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
