### PR TITLE
Fix removing of smarthome templates on startup of AVM Fritz!SmartHome integration

### DIFF
--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -92,7 +92,7 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
 
         available_main_ains = [
             ain
-            for ain, dev in data.devices.items()
+            for ain, dev in data.devices.items() | data.templates.items()
             if dev.device_and_unit_id[1] is None
         ]
         device_reg = dr.async_get(self.hass)

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
-from . import FritzDeviceCoverMock, FritzDeviceSwitchMock
+from . import FritzDeviceCoverMock, FritzDeviceSwitchMock, FritzEntityBaseMock
 from .const import MOCK_CONFIG
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -84,6 +84,8 @@ async def test_coordinator_automatic_registry_cleanup(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test automatic registry cleanup."""
+
+    # init with 2 devices and 1 template
     fritz().get_devices.return_value = [
         FritzDeviceSwitchMock(
             ain="fake ain switch",
@@ -96,6 +98,13 @@ async def test_coordinator_automatic_registry_cleanup(
             name="fake_cover",
         ),
     ]
+    fritz().get_templates.return_value = [
+        FritzEntityBaseMock(
+            ain="fake ain template",
+            device_and_unit_id=("fake ain template", None),
+            name="fake_template",
+        )
+    ]
     entry = MockConfigEntry(
         domain=FB_DOMAIN,
         data=MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0],
@@ -105,9 +114,10 @@ async def test_coordinator_automatic_registry_cleanup(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 19
-    assert len(dr.async_entries_for_config_entry(device_registry, entry.entry_id)) == 2
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 20
+    assert len(dr.async_entries_for_config_entry(device_registry, entry.entry_id)) == 3
 
+    # remove one device, keep the template
     fritz().get_devices.return_value = [
         FritzDeviceSwitchMock(
             ain="fake ain switch",
@@ -115,6 +125,15 @@ async def test_coordinator_automatic_registry_cleanup(
             name="fake_switch",
         )
     ]
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 13
+    assert len(dr.async_entries_for_config_entry(device_registry, entry.entry_id)) == 2
+
+    # remove the template, keep the device
+    fritz().get_templates.return_value = []
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
     await hass.async_block_till_done(wait_background_tasks=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes the unintentional removing of smarthome templates on startup of the integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #144461
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
