### PR TITLE
Add stale device cleanup to Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -97,6 +97,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     # Create the stream
     stream: TeslemetryStream | None = None
 
+    # Remember each device identifier we create
+    current_devices: set[tuple[str, str]] = set()
+
     for product in products:
         if (
             "vin" in product
@@ -116,6 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 model=api.model,
                 serial_number=vin,
             )
+            current_devices.add((DOMAIN, vin))
 
             # Create stream if required
             if not stream:
@@ -171,6 +175,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 name=product.get("site_name", "Energy Site"),
                 serial_number=str(site_id),
             )
+            current_devices.add((DOMAIN, str(site_id)))
 
             # Check live status endpoint works before creating its coordinator
             try:
@@ -234,6 +239,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id, **energysite.device
         )
+
+    # Remove devices that are no longer present
+    for device_entry in dr.async_entries_for_config_entry(
+        device_registry, entry.entry_id
+    ):
+        if not any(
+            identifier in current_devices for identifier in device_entry.identifiers
+        ):
+            LOGGER.debug("Removing stale device %s", device_entry.id)
+            device_registry.async_update_device(
+                device_id=device_entry.id,
+                remove_config_entry_id=entry.entry_id,
+            )
 
     # Setup Platforms
     entry.runtime_data = TeslemetryData(vehicles, energysites, scopes, stream)

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -177,6 +177,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             )
             current_devices.add((DOMAIN, str(site_id)))
 
+            if wall_connector:
+                for connector in product["components"]["wall_connectors"]:
+                    current_devices.add((DOMAIN, connector.get("din", "")))
+
             # Check live status endpoint works before creating its coordinator
             try:
                 live_status = (await api.live_status())["response"]

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -179,7 +179,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
             if wall_connector:
                 for connector in product["components"]["wall_connectors"]:
-                    current_devices.add((DOMAIN, connector.get("din", "")))
+                    current_devices.add((DOMAIN, connector["din"]))
 
             # Check live status endpoint works before creating its coordinator
             try:

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -240,8 +240,7 @@ async def test_stale_device_removal(
         updated_device = device_registry.async_get_device(
             identifiers={(DOMAIN, "stale-vin")}
         )
-        if updated_device:
-            assert entry.entry_id not in updated_device.config_entries
+        assert entry.entry_id not in updated_device.config_entries
 
 
 async def test_device_retention_during_reload(

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -196,8 +196,6 @@ async def test_stale_device_removal(
     mock_products: AsyncMock,
 ) -> None:
     """Test removal of stale devices."""
-    # Create a modified products response with no VINs/devices
-    empty_products = {"response": []}
 
     # Setup the entry first to get a valid config_entry_id
     entry = await setup_platform(hass)
@@ -220,7 +218,7 @@ async def test_stale_device_removal(
     # Update products with an empty response (no devices) and reload entry
     with patch(
         "tesla_fleet_api.teslemetry.Teslemetry.products",
-        return_value=empty_products,
+        return_value={"response": []},
     ):
         await hass.config_entries.async_reload(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -234,11 +234,12 @@ async def test_stale_device_removal(
         # Verify the stale device has been removed
         assert (DOMAIN, "stale-vin") not in post_identifiers
 
-        # Verify the device itself is no longer associated with this config entry
+        # Verify the device itself has been completely removed from the registry
+        # since it had no other config entries
         updated_device = device_registry.async_get_device(
             identifiers={(DOMAIN, "stale-vin")}
         )
-        assert entry.entry_id not in updated_device.config_entries
+        assert updated_device is None
 
 
 async def test_device_retention_during_reload(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add stale device cleanup to Teslemetry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
