### PR TITLE
Prevent errors during cleaning of connections/identifiers in device registry

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -575,9 +575,11 @@ class DeviceRegistryItems[_EntryTypeT: (DeviceEntry, DeletedDeviceEntry)](
         """Unindex an entry."""
         old_entry = self.data[key]
         for connection in old_entry.connections:
-            del self._connections[connection]
+            if connection in self._connections:
+                del self._connections[connection]
         for identifier in old_entry.identifiers:
-            del self._identifiers[identifier]
+            if identifier in self._identifiers:
+                del self._identifiers[identifier]
 
     def get_entry(
         self,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Split out from PR: https://github.com/home-assistant/core/pull/144554

When there are multiple devices with the same MAC in the connection, when using `device_reg.async_update_device(device.id, new_connections=set())` to clean up, the first device cleans up as expected.
But for the second and all subsequent devices you get this error:

```
2025-05-09 12:49:44.939 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Reolink NVR for reolink
Traceback (most recent call last):
  File "/home/hass/home-assistant/homeassistant/config_entries.py", line 749, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hass/home-assistant/homeassistant/components/reolink/__init__.py", line 215, in async_setup_entry
    migrate_entity_ids(hass, config_entry.entry_id, host)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hass/home-assistant/homeassistant/components/reolink/__init__.py", line 389, in migrate_entity_ids
    device_reg.async_update_device(device.id, new_connections=new_connections)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hass/home-assistant/homeassistant/helpers/device_registry.py", line 1156, in async_update_device
    self.devices[device_id] = new
    ~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/hass/home-assistant/homeassistant/helpers/registry.py", line 42, in __setitem__
    self._unindex_entry(key, entry)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/hass/home-assistant/homeassistant/helpers/device_registry.py", line 654, in _unindex_entry
    super()._unindex_entry(key, replacement_entry)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hass/home-assistant/homeassistant/helpers/device_registry.py", line 578, in _unindex_entry
    del self._connections[connection]
        ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: ('mac', 'xx:xx:xx:xx:xx:xx')
```

I know diffrent devices are not supposed to have the same connection. But due to a bug I introduced in the Reolink intgeration in HA 2025.4.0 there are now quite some users that do have this. It is fixed in HA 2025.5.0, but now the device registry still needs cleaning. This bug in the HA core device registry is preventing me from cleaning up in one go.
(at each HA restart 1 device is cleanup up, then you get this error on the 2nd device, eventually after enough restarts it will clean up, but with this fix it cleans up in 1 go as expected).

Note that this same check is already used in `get_entry` and `get_entries` functions of the same class.

I do not know how to write tests for core itself, some help with that  would be apreciated.
I could write a test illustrating the issue for the reolink integration:
- set up 3 devices with diffrent identifiers but with the same MAC connection
- use `device_reg.async_update_device(device.id, new_connections=set())` on 2 of the 3 devices to cleanup the wrong MAC connections
- The first device will clean as expected, you will get the error above on the second device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/144004 https://github.com/home-assistant/core/issues/143578 https://github.com/home-assistant/core/issues/143518
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
