### PR TITLE
Remove deprecated camera async_handle_web_rtc_offer function

### DIFF
--- a/homeassistant/components/camera/webrtc.py
+++ b/homeassistant/components/camera/webrtc.py
@@ -111,13 +111,11 @@ class WebRTCClientConfiguration:
 
     configuration: RTCConfiguration = field(default_factory=RTCConfiguration)
     data_channel: str | None = None
-    get_candidates_upfront: bool = False
 
     def to_frontend_dict(self) -> dict[str, Any]:
         """Return a dict that can be used by the frontend."""
         data: dict[str, Any] = {
             "configuration": self.configuration.to_dict(),
-            "getCandidatesUpfront": self.get_candidates_upfront,
         }
         if self.data_channel is not None:
             data["dataChannel"] = self.data_channel

--- a/tests/components/camera/conftest.py
+++ b/tests/components/camera/conftest.py
@@ -165,13 +165,15 @@ async def mock_test_webrtc_cameras(hass: HomeAssistant) -> None:
         async def stream_source(self) -> str | None:
             return STREAM_SOURCE
 
-    class SyncCamera(BaseCamera):
-        """Mock Camera with native sync WebRTC support."""
+    class AsyncNoCandidateCamera(BaseCamera):
+        """Mock Camera with native async WebRTC support but not implemented candidate support."""
 
-        _attr_name = "Sync"
+        _attr_name = "Async No Candidate"
 
-        async def async_handle_web_rtc_offer(self, offer_sdp: str) -> str | None:
-            return WEBRTC_ANSWER
+        async def async_handle_async_webrtc_offer(
+            self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
+        ) -> None:
+            send_message(WebRTCAnswer(WEBRTC_ANSWER))
 
     class AsyncCamera(BaseCamera):
         """Mock Camera with native async WebRTC support."""
@@ -221,7 +223,10 @@ async def mock_test_webrtc_cameras(hass: HomeAssistant) -> None:
         ),
     )
     setup_test_component_platform(
-        hass, camera.DOMAIN, [SyncCamera(), AsyncCamera()], from_config_entry=True
+        hass,
+        camera.DOMAIN,
+        [AsyncNoCandidateCamera(), AsyncCamera()],
+        from_config_entry=True,
     )
     mock_platform(hass, f"{domain}.config_flow", Mock())
 

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -972,19 +972,15 @@ async def test_camera_capabilities_webrtc(
     )
 
 
-@pytest.mark.parametrize(
-    ("entity_id", "expect_native_async_webrtc"),
-    [("camera.async", True)],
-)
 @pytest.mark.usefixtures("mock_test_webrtc_cameras", "register_test_provider")
 async def test_webrtc_provider_not_added_for_native_webrtc(
-    hass: HomeAssistant, entity_id: str, expect_native_async_webrtc: bool
+    hass: HomeAssistant,
 ) -> None:
     """Test that a WebRTC provider is not added to a camera when the camera has native WebRTC support."""
-    camera_obj = get_camera_from_entity_id(hass, entity_id)
+    camera_obj = get_camera_from_entity_id(hass, "camera.async")
     assert camera_obj
     assert camera_obj._webrtc_provider is None
-    assert camera_obj._supports_native_async_webrtc is expect_native_async_webrtc
+    assert camera_obj._supports_native_async_webrtc is True
 
 
 @pytest.mark.usefixtures("mock_camera", "mock_stream_source")

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -1015,14 +1015,12 @@ async def test_camera_capabilities_changing_non_native_support(
 
 
 @pytest.mark.usefixtures("mock_test_webrtc_cameras")
-@pytest.mark.parametrize(("entity_id"), ["camera.async"])
 async def test_camera_capabilities_changing_native_support(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    entity_id: str,
 ) -> None:
     """Test WebRTC camera capabilities."""
-    cam = get_camera_from_entity_id(hass, entity_id)
+    cam = get_camera_from_entity_id(hass, "camera.async")
     assert cam.supported_features == camera.CameraEntityFeature.STREAM
 
     await _test_capabilities(

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -968,13 +968,13 @@ async def test_camera_capabilities_webrtc(
     """Test WebRTC camera capabilities."""
 
     await _test_capabilities(
-        hass, hass_ws_client, "camera.sync", {StreamType.WEB_RTC}, {StreamType.WEB_RTC}
+        hass, hass_ws_client, "camera.async", {StreamType.WEB_RTC}, {StreamType.WEB_RTC}
     )
 
 
 @pytest.mark.parametrize(
     ("entity_id", "expect_native_async_webrtc"),
-    [("camera.sync", False), ("camera.async", True)],
+    [("camera.async", True)],
 )
 @pytest.mark.usefixtures("mock_test_webrtc_cameras", "register_test_provider")
 async def test_webrtc_provider_not_added_for_native_webrtc(
@@ -984,7 +984,6 @@ async def test_webrtc_provider_not_added_for_native_webrtc(
     camera_obj = get_camera_from_entity_id(hass, entity_id)
     assert camera_obj
     assert camera_obj._webrtc_provider is None
-    assert camera_obj._supports_native_sync_webrtc is not expect_native_async_webrtc
     assert camera_obj._supports_native_async_webrtc is expect_native_async_webrtc
 
 
@@ -1016,7 +1015,7 @@ async def test_camera_capabilities_changing_non_native_support(
 
 
 @pytest.mark.usefixtures("mock_test_webrtc_cameras")
-@pytest.mark.parametrize(("entity_id"), ["camera.sync", "camera.async"])
+@pytest.mark.parametrize(("entity_id"), ["camera.async"])
 async def test_camera_capabilities_changing_native_support(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,

--- a/tests/components/camera/test_webrtc.py
+++ b/tests/components/camera/test_webrtc.py
@@ -1,7 +1,6 @@
 """Test camera WebRTC."""
 
 from collections.abc import AsyncGenerator
-import logging
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -10,9 +9,7 @@ from webrtc_models import RTCIceCandidate, RTCIceCandidateInit, RTCIceServer
 
 from homeassistant.components.camera import (
     DATA_ICE_SERVERS,
-    DOMAIN as CAMERA_DOMAIN,
     Camera,
-    CameraEntityFeature,
     CameraWebRTCProvider,
     StreamType,
     WebRTCAnswer,
@@ -25,22 +22,12 @@ from homeassistant.components.camera import (
     get_camera_from_entity_id,
 )
 from homeassistant.components.websocket_api import TYPE_RESULT
-from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.core_config import async_process_ha_core_config
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from .common import STREAM_SOURCE, WEBRTC_ANSWER, SomeTestProvider
 
-from tests.common import (
-    MockConfigEntry,
-    MockModule,
-    mock_config_flow,
-    mock_integration,
-    mock_platform,
-    setup_test_component_platform,
-)
 from tests.typing import WebSocketGenerator
 
 WEBRTC_OFFER = "v=0\r\n"
@@ -55,84 +42,6 @@ class Go2RTCProvider(SomeTestProvider):
     def domain(self) -> str:
         """Return the integration domain of the provider."""
         return "go2rtc"
-
-
-class MockCamera(Camera):
-    """Mock Camera Entity."""
-
-    _attr_name = "Test"
-    _attr_supported_features: CameraEntityFeature = CameraEntityFeature.STREAM
-
-    def __init__(self) -> None:
-        """Initialize the mock entity."""
-        super().__init__()
-        self._sync_answer: str | None | Exception = WEBRTC_ANSWER
-
-    def set_sync_answer(self, value: str | None | Exception) -> None:
-        """Set sync offer answer."""
-        self._sync_answer = value
-
-    async def async_handle_web_rtc_offer(self, offer_sdp: str) -> str | None:
-        """Handle the WebRTC offer and return the answer."""
-        if isinstance(self._sync_answer, Exception):
-            raise self._sync_answer
-        return self._sync_answer
-
-    async def stream_source(self) -> str | None:
-        """Return the source of the stream.
-
-        This is used by cameras with CameraEntityFeature.STREAM
-        and StreamType.HLS.
-        """
-        return "rtsp://stream"
-
-
-@pytest.fixture
-async def init_test_integration(
-    hass: HomeAssistant,
-) -> MockCamera:
-    """Initialize components."""
-
-    entry = MockConfigEntry(domain=TEST_INTEGRATION_DOMAIN)
-    entry.add_to_hass(hass)
-
-    async def async_setup_entry_init(
-        hass: HomeAssistant, config_entry: ConfigEntry
-    ) -> bool:
-        """Set up test config entry."""
-        await hass.config_entries.async_forward_entry_setups(
-            config_entry, [CAMERA_DOMAIN]
-        )
-        return True
-
-    async def async_unload_entry_init(
-        hass: HomeAssistant, config_entry: ConfigEntry
-    ) -> bool:
-        """Unload test config entry."""
-        await hass.config_entries.async_forward_entry_unload(
-            config_entry, CAMERA_DOMAIN
-        )
-        return True
-
-    mock_integration(
-        hass,
-        MockModule(
-            TEST_INTEGRATION_DOMAIN,
-            async_setup_entry=async_setup_entry_init,
-            async_unload_entry=async_unload_entry_init,
-        ),
-    )
-    test_camera = MockCamera()
-    setup_test_component_platform(
-        hass, CAMERA_DOMAIN, [test_camera], from_config_entry=True
-    )
-    mock_platform(hass, f"{TEST_INTEGRATION_DOMAIN}.config_flow", Mock())
-
-    with mock_config_flow(TEST_INTEGRATION_DOMAIN, ConfigFlow):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    return test_camera
 
 
 @pytest.mark.usefixtures("mock_camera", "mock_stream_source")
@@ -342,29 +251,6 @@ async def test_ws_get_client_config(
             ],
         },
         "getCandidatesUpfront": False,
-    }
-
-
-@pytest.mark.usefixtures("mock_test_webrtc_cameras")
-async def test_ws_get_client_config_sync_offer(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
-) -> None:
-    """Test get WebRTC client config, when camera is supporting sync offer."""
-    await async_setup_component(hass, "camera", {})
-    await hass.async_block_till_done()
-
-    client = await hass_ws_client(hass)
-    await client.send_json_auto_id(
-        {"type": "camera/webrtc/get_client_config", "entity_id": "camera.sync"}
-    )
-    msg = await client.receive_json()
-
-    # Assert WebSocket response
-    assert msg["type"] == TYPE_RESULT
-    assert msg["success"]
-    assert msg["result"] == {
-        "configuration": {},
-        "getCandidatesUpfront": True,
     }
 
 
@@ -625,144 +511,6 @@ async def test_websocket_webrtc_offer_missing_offer(
     assert response["error"]["code"] == "invalid_format"
 
 
-@pytest.mark.parametrize(
-    ("error", "expected_message"),
-    [
-        (ValueError("value error"), "value error"),
-        (HomeAssistantError("offer failed"), "offer failed"),
-        (TimeoutError(), "Timeout handling WebRTC offer"),
-    ],
-)
-async def test_websocket_webrtc_offer_failure(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    init_test_integration: MockCamera,
-    error: Exception,
-    expected_message: str,
-) -> None:
-    """Test WebRTC stream that fails handling the offer."""
-    client = await hass_ws_client(hass)
-    init_test_integration.set_sync_answer(error)
-
-    await client.send_json_auto_id(
-        {
-            "type": "camera/webrtc/offer",
-            "entity_id": "camera.test",
-            "offer": WEBRTC_OFFER,
-        }
-    )
-    response = await client.receive_json()
-
-    assert response["type"] == TYPE_RESULT
-    assert response["success"]
-    subscription_id = response["id"]
-
-    # Session id
-    response = await client.receive_json()
-    assert response["id"] == subscription_id
-    assert response["type"] == "event"
-    assert response["event"]["type"] == "session"
-
-    # Error
-    response = await client.receive_json()
-    assert response["id"] == subscription_id
-    assert response["type"] == "event"
-    assert response["event"] == {
-        "type": "error",
-        "code": "webrtc_offer_failed",
-        "message": expected_message,
-    }
-
-
-@pytest.mark.usefixtures("mock_test_webrtc_cameras")
-async def test_websocket_webrtc_offer_sync(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test sync WebRTC stream offer."""
-    client = await hass_ws_client(hass)
-
-    await client.send_json_auto_id(
-        {
-            "type": "camera/webrtc/offer",
-            "entity_id": "camera.sync",
-            "offer": WEBRTC_OFFER,
-        }
-    )
-    response = await client.receive_json()
-
-    assert (
-        "tests.components.camera.conftest",
-        logging.WARNING,
-        (
-            "async_handle_web_rtc_offer was called from camera, this is a deprecated "
-            "function which will be removed in HA Core 2025.6. Use "
-            "async_handle_async_webrtc_offer instead"
-        ),
-    ) in caplog.record_tuples
-    assert response["type"] == TYPE_RESULT
-    assert response["success"]
-    subscription_id = response["id"]
-
-    # Session id
-    response = await client.receive_json()
-    assert response["id"] == subscription_id
-    assert response["type"] == "event"
-    assert response["event"]["type"] == "session"
-
-    # Answer
-    response = await client.receive_json()
-    assert response["id"] == subscription_id
-    assert response["type"] == "event"
-    assert response["event"] == {"type": "answer", "answer": WEBRTC_ANSWER}
-
-
-async def test_websocket_webrtc_offer_sync_no_answer(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    caplog: pytest.LogCaptureFixture,
-    init_test_integration: MockCamera,
-) -> None:
-    """Test sync WebRTC stream offer with no answer."""
-    client = await hass_ws_client(hass)
-    init_test_integration.set_sync_answer(None)
-
-    await client.send_json_auto_id(
-        {
-            "type": "camera/webrtc/offer",
-            "entity_id": "camera.test",
-            "offer": WEBRTC_OFFER,
-        }
-    )
-    response = await client.receive_json()
-
-    assert response["type"] == TYPE_RESULT
-    assert response["success"]
-    subscription_id = response["id"]
-
-    # Session id
-    response = await client.receive_json()
-    assert response["id"] == subscription_id
-    assert response["type"] == "event"
-    assert response["event"]["type"] == "session"
-
-    # Answer
-    response = await client.receive_json()
-    assert response["id"] == subscription_id
-    assert response["type"] == "event"
-    assert response["event"] == {
-        "type": "error",
-        "code": "webrtc_offer_failed",
-        "message": "No answer on WebRTC offer",
-    }
-    assert (
-        "homeassistant.components.camera",
-        logging.ERROR,
-        "Error handling WebRTC offer: No answer",
-    ) in caplog.record_tuples
-
-
 @pytest.mark.usefixtures("mock_camera")
 async def test_websocket_webrtc_offer_invalid_stream_type(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
@@ -901,7 +649,7 @@ async def test_ws_webrtc_candidate_not_supported(
     await client.send_json_auto_id(
         {
             "type": "camera/webrtc/candidate",
-            "entity_id": "camera.sync",
+            "entity_id": "camera.async_no_candidate",
             "session_id": "session_id",
             "candidate": {"candidate": "candidate"},
         }

--- a/tests/components/camera/test_webrtc.py
+++ b/tests/components/camera/test_webrtc.py
@@ -211,7 +211,6 @@ async def test_ws_get_client_config(
                 },
             ],
         },
-        "getCandidatesUpfront": False,
     }
 
     @callback
@@ -250,7 +249,6 @@ async def test_ws_get_client_config(
                 },
             ],
         },
-        "getCandidatesUpfront": False,
     }
 
 
@@ -277,7 +275,6 @@ async def test_ws_get_client_config_custom_config(
     assert msg["success"]
     assert msg["result"] == {
         "configuration": {"iceServers": [{"urls": ["stun:custom_stun_server:3478"]}]},
-        "getCandidatesUpfront": False,
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The deprecated camera function `async_handle_web_rtc_offer` has been removed. Please use `async_handle_async_webrtc_offer` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Remove deprecated camera `async_handle_web_rtc_offer` function
- Removing the `get_candidates_upfront` field from `WebRTCClientConfiguration` as it is now never used in code and, therefore, always false.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/25399

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
