### PR TITLE
Fix wrong state in Husqvarna Automower

### DIFF
--- a/homeassistant/components/husqvarna_automower/lawn_mower.py
+++ b/homeassistant/components/husqvarna_automower/lawn_mower.py
@@ -110,14 +110,14 @@ class AutomowerLawnMowerEntity(AutomowerAvailableEntity, LawnMowerEntity):
         mower_attributes = self.mower_attributes
         if mower_attributes.mower.state in PAUSED_STATES:
             return LawnMowerActivity.PAUSED
-        if mower_attributes.mower.state in MowerStates.IN_OPERATION:
-            if mower_attributes.mower.activity == MowerActivities.GOING_HOME:
-                return LawnMowerActivity.RETURNING
-            return LawnMowerActivity.MOWING
         if (mower_attributes.mower.state == "RESTRICTED") or (
             mower_attributes.mower.activity in DOCKED_ACTIVITIES
         ):
             return LawnMowerActivity.DOCKED
+        if mower_attributes.mower.state in MowerStates.IN_OPERATION:
+            if mower_attributes.mower.activity == MowerActivities.GOING_HOME:
+                return LawnMowerActivity.RETURNING
+            return LawnMowerActivity.MOWING
         return LawnMowerActivity.ERROR
 
     @property

--- a/tests/components/husqvarna_automower/test_lawn_mower.py
+++ b/tests/components/husqvarna_automower/test_lawn_mower.py
@@ -40,7 +40,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
         (
             MowerActivities.PARKED_IN_CS,
             MowerStates.IN_OPERATION,
-            LawnMowerActivity.DOCKED
+            LawnMowerActivity.DOCKED,
         ),
     ],
 )

--- a/tests/components/husqvarna_automower/test_lawn_mower.py
+++ b/tests/components/husqvarna_automower/test_lawn_mower.py
@@ -38,7 +38,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
             LawnMowerActivity.MOWING,
         ),
         (
-            MowingActivities.PARKED_CS,
+            MowerActivities.PARKED_CS,
             MowerStates.IN_OPERATION,
             LawnMowerActivity.DOCKED
         ),

--- a/tests/components/husqvarna_automower/test_lawn_mower.py
+++ b/tests/components/husqvarna_automower/test_lawn_mower.py
@@ -37,7 +37,11 @@ from tests.common import MockConfigEntry, async_fire_time_changed
             MowerStates.IN_OPERATION,
             LawnMowerActivity.MOWING,
         ),
-        (MowerActivities.PARKED_IN_CS, MowerStates.IN_OPERATION, LawnMowerActivity.DOCKED),
+        (
+            MowerActivities.PARKED_IN_CS,
+            MowerStates.IN_OPERATION,
+            LawnMowerActivity.DOCKED
+        ),
     ],
 )
 async def test_lawn_mower_states(

--- a/tests/components/husqvarna_automower/test_lawn_mower.py
+++ b/tests/components/husqvarna_automower/test_lawn_mower.py
@@ -37,6 +37,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
             MowerStates.IN_OPERATION,
             LawnMowerActivity.MOWING,
         ),
+        (MowingActivities.PARKED_CS, MowerStates.IN_OPERATION, LawnMowerActivity.DOCKED),
     ],
 )
 async def test_lawn_mower_states(

--- a/tests/components/husqvarna_automower/test_lawn_mower.py
+++ b/tests/components/husqvarna_automower/test_lawn_mower.py
@@ -37,11 +37,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
             MowerStates.IN_OPERATION,
             LawnMowerActivity.MOWING,
         ),
-        (
-            MowerActivities.PARKED_CS,
-            MowerStates.IN_OPERATION,
-            LawnMowerActivity.DOCKED
-        ),
+        (MowerActivities.PARKED_CS, MowerStates.IN_OPERATION, LawnMowerActivity.DOCKED),
     ],
 )
 async def test_lawn_mower_states(

--- a/tests/components/husqvarna_automower/test_lawn_mower.py
+++ b/tests/components/husqvarna_automower/test_lawn_mower.py
@@ -37,7 +37,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
             MowerStates.IN_OPERATION,
             LawnMowerActivity.MOWING,
         ),
-        (MowerActivities.PARKED_CS, MowerStates.IN_OPERATION, LawnMowerActivity.DOCKED),
+        (MowerActivities.PARKED_IN_CS, MowerStates.IN_OPERATION, LawnMowerActivity.DOCKED),
     ],
 )
 async def test_lawn_mower_states(

--- a/tests/components/husqvarna_automower/test_lawn_mower.py
+++ b/tests/components/husqvarna_automower/test_lawn_mower.py
@@ -37,7 +37,11 @@ from tests.common import MockConfigEntry, async_fire_time_changed
             MowerStates.IN_OPERATION,
             LawnMowerActivity.MOWING,
         ),
-        (MowingActivities.PARKED_CS, MowerStates.IN_OPERATION, LawnMowerActivity.DOCKED),
+        (
+            MowingActivities.PARKED_CS,
+            MowerStates.IN_OPERATION,
+            LawnMowerActivity.DOCKED
+        ),
     ],
 )
 async def test_lawn_mower_states(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix wrong state of the lawn mower entity, when docked.
Please include in next bugfix release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #144661
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
