### PR TITLE
Rename samsung websocket test fixtures and constants

### DIFF
--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -6,6 +6,7 @@ from homeassistant.components.samsungtv.const import (
     LEGACY_PORT,
     METHOD_LEGACY,
     METHOD_WEBSOCKET,
+    WEBSOCKET_SSL_PORT,
 )
 from homeassistant.const import (
     CONF_HOST,
@@ -37,12 +38,11 @@ MOCK_ENTRYDATA_ENCRYPTED_WS = {
     CONF_TOKEN: "037739871315caef138547b03e348b72",
     CONF_SESSION_ID: "2",
 }
-MOCK_ENTRYDATA_WS = {
+ENTRYDATA_WEBSOCKET = {
     CONF_HOST: "10.10.12.34",
     CONF_METHOD: METHOD_WEBSOCKET,
-    CONF_PORT: 8002,
-    CONF_MODEL: "any",
-    CONF_NAME: "any",
+    CONF_PORT: WEBSOCKET_SSL_PORT,
+    CONF_MODEL: "UE43LS003",
 }
 MOCK_ENTRY_WS_WITH_MAC = {
     CONF_HOST: "fake_host",

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -56,8 +56,8 @@ from homeassistant.setup import async_setup_component
 
 from .const import (
     ENTRYDATA_LEGACY,
+    ENTRYDATA_WEBSOCKET,
     MOCK_ENTRYDATA_ENCRYPTED_WS,
-    MOCK_ENTRYDATA_WS,
     MOCK_SSDP_DATA,
     MOCK_SSDP_DATA_MAIN_TV_AGENT_ST,
     MOCK_SSDP_DATA_RENDERING_CONTROL_ST,
@@ -193,7 +193,7 @@ async def test_user_legacy_does_not_ok_first_time(hass: HomeAssistant) -> None:
     assert result3["result"].unique_id is None
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_user_websocket(hass: HomeAssistant) -> None:
     """Test starting a flow by user."""
     with patch(
@@ -518,7 +518,7 @@ async def test_ssdp_noprefix(hass: HomeAssistant) -> None:
     assert result["result"].unique_id == "068e7781-006e-1000-bbbf-84a4668d8423"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api_failing")
 async def test_ssdp_legacy_missing_auth(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery with authentication."""
     with patch(
@@ -553,7 +553,7 @@ async def test_ssdp_legacy_missing_auth(hass: HomeAssistant) -> None:
     assert result["result"].unique_id == "068e7781-006e-1000-bbbf-84a4668d8423"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api_failing")
 async def test_ssdp_legacy_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery for not supported device."""
     with patch(
@@ -568,7 +568,7 @@ async def test_ssdp_legacy_not_supported(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_ssdp_websocket_success_populates_mac_address_and_ssdp_location(
     hass: HomeAssistant,
 ) -> None:
@@ -597,7 +597,7 @@ async def test_ssdp_websocket_success_populates_mac_address_and_ssdp_location(
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_ssdp_websocket_success_populates_mac_address_and_main_tv_ssdp_location(
     hass: HomeAssistant,
 ) -> None:
@@ -711,8 +711,8 @@ async def test_ssdp_websocket_cannot_connect(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.samsungtv.bridge.SamsungTVWSAsyncRemote",
-        ) as remotews,
-        patch.object(remotews, "open", side_effect=WebSocketException("Boom")),
+        ) as remote_websocket,
+        patch.object(remote_websocket, "open", side_effect=WebSocketException("Boom")),
     ):
         # device not supported
         result = await hass.config_entries.flow.async_init(
@@ -823,7 +823,7 @@ async def test_ssdp_already_in_progress(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_ALREADY_IN_PROGRESS
 
 
-@pytest.mark.usefixtures("remotews", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "remoteencws_failing")
 async def test_ssdp_already_configured(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery when already configured."""
     with patch(
@@ -851,7 +851,9 @@ async def test_ssdp_already_configured(hass: HomeAssistant) -> None:
         assert entry.unique_id == "123"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api_non_ssl_only", "remoteencws_failing")
+@pytest.mark.usefixtures(
+    "remote_websocket", "rest_api_non_ssl_only", "remoteencws_failing"
+)
 async def test_dhcp_wireless(hass: HomeAssistant) -> None:
     """Test starting a flow from dhcp."""
     # confirm to add the entry
@@ -877,7 +879,7 @@ async def test_dhcp_wireless(hass: HomeAssistant) -> None:
     assert result["result"].unique_id == "223da676-497a-4e06-9507-5e27ec4f0fb3"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_dhcp_wired(hass: HomeAssistant, rest_api: Mock) -> None:
     """Test starting a flow from dhcp."""
     # Even though it is named "wifiMac", it matches the mac of the wired connection
@@ -907,7 +909,9 @@ async def test_dhcp_wired(hass: HomeAssistant, rest_api: Mock) -> None:
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api_non_ssl_only", "remoteencws_failing")
+@pytest.mark.usefixtures(
+    "remote_websocket", "rest_api_non_ssl_only", "remoteencws_failing"
+)
 @pytest.mark.parametrize(
     ("source1", "data1", "source2", "data2", "is_matching_result"),
     [
@@ -979,7 +983,7 @@ async def test_dhcp_zeroconf_already_in_progress(
     assert return_values == [is_matching_result]
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf."""
     result = await hass.config_entries.flow.async_init(
@@ -1004,7 +1008,7 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "remoteencws_failing")
 async def test_zeroconf_ignores_soundbar(hass: HomeAssistant, rest_api: Mock) -> None:
     """Test starting a flow from zeroconf where the device is actually a soundbar."""
     rest_api.rest_device_info.return_value = {
@@ -1027,7 +1031,9 @@ async def test_zeroconf_ignores_soundbar(hass: HomeAssistant, rest_api: Mock) ->
     assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("remote_legacy", "remotews", "remoteencws", "rest_api_failing")
+@pytest.mark.usefixtures(
+    "remote_legacy", "remote_websocket", "remoteencws", "rest_api_failing"
+)
 async def test_zeroconf_no_device_info(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf where device_info returns None."""
     result = await hass.config_entries.flow.async_init(
@@ -1040,7 +1046,7 @@ async def test_zeroconf_no_device_info(hass: HomeAssistant) -> None:
     assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf and dhcp."""
     result = await hass.config_entries.flow.async_init(
@@ -1072,7 +1078,7 @@ async def test_autodetect_websocket(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.samsungtv.bridge.SamsungTVWSAsyncRemote"
-        ) as remotews,
+        ) as remote_websocket,
         patch(
             "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",
         ) as rest_api_class,
@@ -1095,7 +1101,7 @@ async def test_autodetect_websocket(hass: HomeAssistant) -> None:
             }
         )
         remote.token = "123456789"
-        remotews.return_value = remote
+        remote_websocket.return_value = remote
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_USER_DATA
@@ -1103,7 +1109,7 @@ async def test_autodetect_websocket(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_METHOD] == "websocket"
         assert result["data"][CONF_TOKEN] == "123456789"
-        remotews.assert_called_once_with(**AUTODETECT_WEBSOCKET_SSL)
+        remote_websocket.assert_called_once_with(**AUTODETECT_WEBSOCKET_SSL)
         rest_api_class.assert_called_once_with(**DEVICEINFO_WEBSOCKET_SSL)
         await hass.async_block_till_done()
 
@@ -1123,7 +1129,7 @@ async def test_websocket_no_mac(hass: HomeAssistant, mac_address: Mock) -> None:
         ),
         patch(
             "homeassistant.components.samsungtv.bridge.SamsungTVWSAsyncRemote"
-        ) as remotews,
+        ) as remote_websocket,
         patch(
             "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",
         ) as rest_api_class,
@@ -1145,7 +1151,7 @@ async def test_websocket_no_mac(hass: HomeAssistant, mac_address: Mock) -> None:
         )
 
         remote.token = "123456789"
-        remotews.return_value = remote
+        remote_websocket.return_value = remote
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_USER_DATA
@@ -1154,7 +1160,7 @@ async def test_websocket_no_mac(hass: HomeAssistant, mac_address: Mock) -> None:
         assert result["data"][CONF_METHOD] == "websocket"
         assert result["data"][CONF_TOKEN] == "123456789"
         assert result["data"][CONF_MAC] == "gg:ee:tt:mm:aa:cc"
-        remotews.assert_called_once_with(**AUTODETECT_WEBSOCKET_SSL)
+        remote_websocket.assert_called_once_with(**AUTODETECT_WEBSOCKET_SSL)
         rest_api_class.assert_called_once_with(**DEVICEINFO_WEBSOCKET_SSL)
         await hass.async_block_till_done()
 
@@ -1244,7 +1250,7 @@ async def test_autodetect_none(hass: HomeAssistant) -> None:
         assert rest_device_info.call_count == 2
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_old_entry(hass: HomeAssistant) -> None:
     """Test update of old entry sets unique id."""
     entry = MockConfigEntry(domain=DOMAIN, data=ENTRYDATA_LEGACY)
@@ -1273,7 +1279,7 @@ async def test_update_old_entry(hass: HomeAssistant) -> None:
     assert entry2.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_from_dhcp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1295,7 +1301,7 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_incorrectly_formatted_mac_unique_id_added_from_dhcp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1319,7 +1325,7 @@ async def test_update_incorrectly_formatted_mac_unique_id_added_from_dhcp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_from_zeroconf(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1370,7 +1376,7 @@ async def test_update_missing_model_added_from_ssdp(
     assert entry.data[CONF_MODEL] == "UE55H6400"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_ssdp_location_added_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1395,7 +1401,7 @@ async def test_update_missing_mac_unique_id_ssdp_location_added_from_ssdp(
 
 
 @pytest.mark.usefixtures(
-    "remote_legacy", "remotews", "remoteencws_failing", "rest_api_failing"
+    "remote_legacy", "remote_websocket", "remoteencws_failing", "rest_api_failing"
 )
 async def test_update_zeroconf_discovery_preserved_unique_id(
     hass: HomeAssistant,
@@ -1419,7 +1425,7 @@ async def test_update_zeroconf_discovery_preserved_unique_id(
     assert entry.unique_id == "original"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_ssdp_location_updated_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1452,7 +1458,7 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_updated_from_ssd
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_ssdp_location_rendering_st_updated_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1486,7 +1492,7 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_rendering_st_upd
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_missing_mac_unique_id_added_ssdp_location_main_tv_agent_st_updated_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1524,7 +1530,7 @@ async def test_update_missing_mac_unique_id_added_ssdp_location_main_tv_agent_st
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_ssdp_location_rendering_st_updated_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1555,7 +1561,7 @@ async def test_update_ssdp_location_rendering_st_updated_from_ssdp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_main_tv_ssdp_location_rendering_st_updated_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1585,7 +1591,7 @@ async def test_update_main_tv_ssdp_location_rendering_st_updated_from_ssdp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api")
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
 async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1676,7 +1682,7 @@ async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
     assert entry.unique_id is None
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_ssdp_location_unique_id_added_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1704,7 +1710,7 @@ async def test_update_ssdp_location_unique_id_added_from_ssdp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_ssdp_location_unique_id_added_from_ssdp_with_rendering_control_st(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1753,10 +1759,10 @@ async def test_form_reauth_legacy(hass: HomeAssistant) -> None:
     assert result2["reason"] == "reauth_successful"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api")
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
 async def test_form_reauth_websocket(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRYDATA_WS)
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRYDATA_WEBSOCKET)
     entry.add_to_hass(hass)
     assert entry.state is ConfigEntryState.NOT_LOADED
 
@@ -1776,16 +1782,16 @@ async def test_form_reauth_websocket(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("rest_api")
 async def test_form_reauth_websocket_cannot_connect(
-    hass: HomeAssistant, remotews: Mock
+    hass: HomeAssistant, remote_websocket: Mock
 ) -> None:
     """Test reauthenticate websocket when we cannot connect on the first attempt."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRYDATA_WS)
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRYDATA_WEBSOCKET)
     entry.add_to_hass(hass)
     result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with patch.object(remotews, "open", side_effect=ConnectionFailure):
+    with patch.object(remote_websocket, "open", side_effect=ConnectionFailure):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {},
@@ -1807,7 +1813,7 @@ async def test_form_reauth_websocket_cannot_connect(
 
 async def test_form_reauth_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket when the device is not supported."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRYDATA_WS)
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRYDATA_WEBSOCKET)
     entry.add_to_hass(hass)
     result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
@@ -1897,7 +1903,7 @@ async def test_form_reauth_encrypted(hass: HomeAssistant) -> None:
     assert entry.data[CONF_SESSION_ID] == "1"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_incorrect_udn_matching_upnp_udn_unique_id_added_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1923,7 +1929,7 @@ async def test_update_incorrect_udn_matching_upnp_udn_unique_id_added_from_ssdp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_incorrect_udn_matching_mac_unique_id_added_from_ssdp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
@@ -1949,14 +1955,14 @@ async def test_update_incorrect_udn_matching_mac_unique_id_added_from_ssdp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_update_incorrect_udn_matching_mac_from_dhcp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test that DHCP updates the wrong udn from ssdp via mac match."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={**MOCK_ENTRYDATA_WS, CONF_MAC: "aa:bb:aa:aa:aa:aa"},
+        data={**ENTRYDATA_WEBSOCKET, CONF_MAC: "aa:bb:aa:aa:aa:aa"},
         source=config_entries.SOURCE_SSDP,
         unique_id="0d1cef00-00dc-1000-9c80-4844f7b172de",
     )
@@ -1976,14 +1982,14 @@ async def test_update_incorrect_udn_matching_mac_from_dhcp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "rest_api", "remoteencws_failing")
 async def test_no_update_incorrect_udn_not_matching_mac_from_dhcp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test that DHCP does not update the wrong udn from ssdp via host match."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={**MOCK_ENTRYDATA_WS, CONF_MAC: "aa:bb:ss:ss:dd:pp"},
+        data={**ENTRYDATA_WEBSOCKET, CONF_MAC: "aa:bb:ss:ss:dd:pp"},
         source=config_entries.SOURCE_SSDP,
         unique_id="0d1cef00-00dc-1000-9c80-4844f7b172de",
     )
@@ -2003,7 +2009,7 @@ async def test_no_update_incorrect_udn_not_matching_mac_from_dhcp(
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-@pytest.mark.usefixtures("remotews", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "remoteencws_failing")
 async def test_ssdp_update_mac(hass: HomeAssistant) -> None:
     """Ensure that MAC address is correctly updated from SSDP."""
     with patch(

--- a/tests/components/samsungtv/test_diagnostics.py
+++ b/tests/components/samsungtv/test_diagnostics.py
@@ -18,7 +18,7 @@ from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 
-@pytest.mark.usefixtures("remotews", "rest_api")
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -40,9 +40,9 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_samsungtv_entry
 from .const import (
+    ENTRYDATA_WEBSOCKET,
     MOCK_ENTRY_WS_WITH_MAC,
     MOCK_ENTRYDATA_ENCRYPTED_WS,
-    MOCK_ENTRYDATA_WS,
     MOCK_SSDP_DATA_MAIN_TV_AGENT_ST,
     MOCK_SSDP_DATA_RENDERING_CONTROL_ST,
 )
@@ -57,7 +57,7 @@ MOCK_CONFIG = {
 }
 
 
-@pytest.mark.usefixtures("remotews", "remoteencws_failing", "rest_api")
+@pytest.mark.usefixtures("remote_websocket", "remoteencws_failing", "rest_api")
 async def test_setup(hass: HomeAssistant) -> None:
     """Test Samsung TV integration is setup."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
@@ -101,7 +101,7 @@ async def test_setup_without_port_device_offline(hass: HomeAssistant) -> None:
     assert config_entries_domain[0].state is ConfigEntryState.SETUP_RETRY
 
 
-@pytest.mark.usefixtures("remotews", "remoteencws_failing", "rest_api")
+@pytest.mark.usefixtures("remote_websocket", "remoteencws_failing", "rest_api")
 async def test_setup_without_port_device_online(hass: HomeAssistant) -> None:
     """Test import from yaml when the device is online."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
@@ -111,7 +111,7 @@ async def test_setup_without_port_device_online(hass: HomeAssistant) -> None:
     assert config_entries_domain[0].data[CONF_MAC] == "aa:bb:aa:aa:aa:aa"
 
 
-@pytest.mark.usefixtures("remotews", "remoteencws_failing")
+@pytest.mark.usefixtures("remote_websocket", "remoteencws_failing")
 async def test_setup_h_j_model(
     hass: HomeAssistant, rest_api: Mock, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -126,13 +126,13 @@ async def test_setup_h_j_model(
     assert "H and J series use an encrypted protocol" in caplog.text
 
 
-@pytest.mark.usefixtures("remotews", "remoteencws_failing", "rest_api")
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
 async def test_setup_updates_from_ssdp(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
 ) -> None:
     """Test setting up the entry fetches data from ssdp cache."""
     entry = MockConfigEntry(
-        domain="samsungtv", data=MOCK_ENTRYDATA_WS, entry_id="sample-entry-id"
+        domain="samsungtv", data=ENTRYDATA_WEBSOCKET, entry_id="sample-entry-id"
     )
     entry.add_to_hass(hass)
 
@@ -200,7 +200,7 @@ async def test_update_imported_legacy(
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
 
 
-@pytest.mark.usefixtures("remotews", "rest_api")
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
 async def test_incorrectly_formatted_mac_fixed(hass: HomeAssistant) -> None:
     """Test incorrectly formatted mac is corrected."""
     with patch(
@@ -230,7 +230,7 @@ async def test_incorrectly_formatted_mac_fixed(hass: HomeAssistant) -> None:
         assert config_entries[0].data[CONF_MAC] == "aa:bb:aa:aa:aa:aa"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api")
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
 @pytest.mark.xfail
 async def test_cleanup_mac(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, snapshot: SnapshotAssertion

--- a/tests/components/samsungtv/test_remote.py
+++ b/tests/components/samsungtv/test_remote.py
@@ -98,7 +98,7 @@ async def test_send_command_service(hass: HomeAssistant, remoteencws: Mock) -> N
     assert command.body["param3"] == "dash"
 
 
-@pytest.mark.usefixtures("remotews", "rest_api")
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
 async def test_turn_on_wol(hass: HomeAssistant) -> None:
     """Test turn on."""
     entry = MockConfigEntry(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Makes it clearer when we are testing websocket methods:
- rename `remotews` fixture to `remote_websocket` 
- rename `MOCK_ENTRYDATA_WS` constant to `ENTRYDATA_WEBSOCKET` (and drop outdated `CONF_NAME`)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
