### PR TITLE
Merge websocket test constants in samsungtv tests

### DIFF
--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     CONF_MAC,
     CONF_METHOD,
     CONF_MODEL,
-    CONF_NAME,
     CONF_PORT,
     CONF_TOKEN,
 )
@@ -40,14 +39,8 @@ ENTRYDATA_WEBSOCKET = {
     CONF_HOST: "10.10.12.34",
     CONF_METHOD: METHOD_WEBSOCKET,
     CONF_PORT: WEBSOCKET_SSL_PORT,
-    CONF_MODEL: "UE43LS003",
-}
-MOCK_ENTRY_WS_WITH_MAC = {
-    CONF_HOST: "fake_host",
-    CONF_METHOD: "websocket",
     CONF_MAC: "aa:bb:cc:dd:ee:ff",
-    CONF_NAME: "fake",
-    CONF_PORT: 8002,
+    CONF_MODEL: "UE43LS003",
     CONF_TOKEN: "123456789",
 }
 

--- a/tests/components/samsungtv/snapshots/test_diagnostics.ambr
+++ b/tests/components/samsungtv/snapshots/test_diagnostics.ambr
@@ -13,11 +13,10 @@
     }),
     'entry': dict({
       'data': dict({
-        'host': 'fake_host',
+        'host': '10.10.12.34',
         'mac': 'aa:bb:cc:dd:ee:ff',
         'method': 'websocket',
-        'model': '82GXARRS',
-        'name': 'fake',
+        'model': 'UE43LS003',
         'port': 8002,
         'token': '**REDACTED**',
       }),

--- a/tests/components/samsungtv/test_diagnostics.py
+++ b/tests/components/samsungtv/test_diagnostics.py
@@ -11,7 +11,7 @@ from homeassistant.components.samsungtv.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from . import setup_samsungtv_entry
-from .const import ENTRYDATA_ENCRYPTED_WEBSOCKET, MOCK_ENTRY_WS_WITH_MAC
+from .const import ENTRYDATA_ENCRYPTED_WEBSOCKET, ENTRYDATA_WEBSOCKET
 
 from tests.common import load_json_object_fixture
 from tests.components.diagnostics import get_diagnostics_for_config_entry
@@ -25,7 +25,7 @@ async def test_entry_diagnostics(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
-    config_entry = await setup_samsungtv_entry(hass, MOCK_ENTRY_WS_WITH_MAC)
+    config_entry = await setup_samsungtv_entry(hass, ENTRYDATA_WEBSOCKET)
 
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, config_entry

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -83,7 +83,7 @@ from . import setup_samsungtv_entry
 from .const import (
     ENTRYDATA_ENCRYPTED_WEBSOCKET,
     ENTRYDATA_LEGACY,
-    MOCK_ENTRY_WS_WITH_MAC,
+    ENTRYDATA_WEBSOCKET,
     SAMPLE_DEVICE_INFO_WIFI,
 )
 
@@ -996,7 +996,7 @@ async def test_turn_on_wol(hass: HomeAssistant) -> None:
     """Test turn on."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=MOCK_ENTRY_WS_WITH_MAC,
+        data=ENTRYDATA_WEBSOCKET,
         unique_id="be9554b9-c9fb-41f4-8920-22da015376a4",
     )
     entry.add_to_hass(hass)

--- a/tests/components/samsungtv/test_remote.py
+++ b/tests/components/samsungtv/test_remote.py
@@ -17,11 +17,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_samsungtv_entry
-from .const import (
-    ENTRYDATA_ENCRYPTED_WEBSOCKET,
-    ENTRYDATA_LEGACY,
-    MOCK_ENTRY_WS_WITH_MAC,
-)
+from .const import ENTRYDATA_ENCRYPTED_WEBSOCKET, ENTRYDATA_LEGACY, ENTRYDATA_WEBSOCKET
 
 from tests.common import MockConfigEntry
 
@@ -111,7 +107,7 @@ async def test_turn_on_wol(hass: HomeAssistant) -> None:
     """Test turn on."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=MOCK_ENTRY_WS_WITH_MAC,
+        data=ENTRYDATA_WEBSOCKET,
         unique_id="be9554b9-c9fb-41f4-8920-22da015376a4",
     )
     entry.add_to_hass(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, there is no need to use separate `MOCK_ENTRY_WS_WITH_MAC` constant

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
