### PR TITLE
Add Resources support to MCP Server

### DIFF
--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -17,9 +17,10 @@ from mcp.server import Server
 import voluptuous as vol
 from voluptuous_openapi import convert
 
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import llm
+from homeassistant.helpers import llm, entity_registry
 
 from .const import STATELESS_LLM_API
 
@@ -116,11 +117,14 @@ async def create_server(
 
     @server.list_resources()  # type: ignore[no-untyped-call, misc]
     async def list_resources() -> list[types.Resource]:
+        registry = entity_registry.async_get(hass)
         return [
             types.Resource(
-                uri="homeassistant://entities/lights/light1",
-                name="Light 1",
+                uri=f"homeassistant://entities/{entity.unique_id}",
+                name=entity.name or entity.unique_id,
+                description=f"{entity.entity_id} is in area {entity.area_id}.",
             )
+            for entity in registry.entities.values()
         ]
 
     return server

--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -14,13 +14,13 @@ from typing import Any
 
 from mcp import types
 from mcp.server import Server
+from pydantic import AnyUrl
 import voluptuous as vol
 from voluptuous_openapi import convert
 
-from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import llm, entity_registry
+from homeassistant.helpers import entity_registry as er, llm
 
 from .const import STATELESS_LLM_API
 
@@ -117,14 +117,14 @@ async def create_server(
 
     @server.list_resources()  # type: ignore[no-untyped-call, misc]
     async def list_resources() -> list[types.Resource]:
-        registry = entity_registry.async_get(hass)
+        entity_registry = er.async_get(hass)
         return [
             types.Resource(
-                uri=f"homeassistant://entities/{entity.unique_id}",
+                uri=AnyUrl(url=f"homeassistant://entities/{entity.unique_id}"),
                 name=entity.name or entity.unique_id,
                 description=f"{entity.entity_id} is in area {entity.area_id}.",
             )
-            for entity in registry.entities.values()
+            for entity in entity_registry.entities.values()
         ]
 
     return server

--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -114,4 +114,13 @@ async def create_server(
             )
         ]
 
+    @server.list_resources()  # type: ignore[no-untyped-call, misc]
+    async def list_resources() -> list[types.Resource]:
+        return [
+            types.Resource(
+                uri="homeassistant://entities/lights/light1",
+                name="Light 1",
+            )
+        ]
+
     return server

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -461,3 +461,18 @@ async def test_read_resource(
         assert result.contents[0].mimeType == "application/json"
         light_state = json.loads(result.contents[0].text)
         assert light_state.get("state") == "off"
+
+
+async def test_read_non_existent_resource(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_sse_url: str,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test read resource endpoint throws error on non existent resource."""
+
+    async with mcp_session(mcp_sse_url, hass_supervisor_access_token) as session:
+        with pytest.raises(McpError):
+            await session.read_resource(
+                AnyUrl("homeassistant://entities/does.not.exist")
+            )

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -436,4 +436,8 @@ async def test_list_resources(
 
     async with mcp_session(mcp_sse_url, hass_supervisor_access_token) as session:
         result = await session.list_resources()
-        print(result)
+        assert len(result.resources) == 1
+        kitchen_light = result.resources[0]
+        assert str(kitchen_light.uri) == "homeassistant://entities/test-light-unique-id"
+        assert kitchen_light.name == "test-light-unique-id"
+        assert kitchen_light.description == "light.kitchen is in area kitchen."

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -424,3 +424,16 @@ async def test_get_unknwon_prompt(
     async with mcp_session(mcp_sse_url, hass_supervisor_access_token) as session:
         with pytest.raises(McpError):
             await session.get_prompt(name="Unknown")
+
+
+async def test_list_resources(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_sse_url: str,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test list resources endpoint."""
+
+    async with mcp_session(mcp_sse_url, hass_supervisor_access_token) as session:
+        result = await session.list_resources()
+        print(result)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The goal of this PR is to add basic support of [resources ](https://modelcontextprotocol.io/docs/concepts/resources) to the `mcp_server` integration.  This allows an LLM client (ex., Claude Desktop) to understand what resources are available within HomeAssistant and what their current state is.  This should allow the llm to be able to answer questions like "Did I leave the office lights on?" or "What's the temperature in the dining room?"


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
