### PR TITLE
Add a helper to create config flow `step_id` names from functions

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -901,11 +901,12 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         """Set in progress task."""
         self.__progress_task = progress_task
 
-    def get_step_id(self, step_function: Callable) -> str:
+    @staticmethod
+    def get_step_id(step_function: Callable) -> str:
         """Get the step id for a step function."""
         name = step_function.__name__
         if not name.startswith("async_step_"):
-            raise ValueError(f"{step_function!r} is not a valid step function")
+            raise ValueError(f"{name!r} is not a valid step function")
 
         return name.removeprefix("async_step_")
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -901,6 +901,14 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         """Set in progress task."""
         self.__progress_task = progress_task
 
+    def get_step_id(self, step_function: Callable) -> str:
+        """Get the step id for a step function."""
+        name = step_function.__name__
+        if not name.startswith("async_step_"):
+            raise ValueError(f"{step_function!r} is not a valid step function")
+
+        return name.removeprefix("async_step_")
+
 
 class SectionConfig(TypedDict, total=False):
     """Class to represent a section config."""

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -1222,3 +1222,25 @@ def test_nested_section_in_serializer() -> None:
                 {"collapsed": False},
             )
         )
+
+
+def test_get_step_id_error() -> None:
+    """Test get_step_id with an invalid step ID."""
+
+    class TestFlow(data_entry_flow.FlowHandler):
+        VERSION = 1
+
+        def some_helper(self):
+            pass
+
+        async def async_step_first(self, user_input=None):
+            pass
+
+        async def async_step_second(self, user_input=None):
+            pass
+
+    assert TestFlow.get_step_id(TestFlow.async_step_first) == "first"
+    assert TestFlow.get_step_id(TestFlow.async_step_second) == "second"
+
+    with pytest.raises(ValueError, match="'some_helper' is not a valid step function"):
+        TestFlow.get_step_id(TestFlow.some_helper)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During development, I've run into a few situations where the config flow step ID string does not refer to a real step. This is only caught at runtime, as opposed to by the type checker.

This PR introduces `FlowHandler.get_step_id` to derive the `step_id` directly from a reference to the function:

```diff
 return self.async_show_form(
-    step_id="first",
+    step_id=self.get_step_id(self.async_step_first),
     data_schema=vol.Schema([str]),
 )
```

Any mistakes are caught by mypy directly:

```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

homeassistant/components/zha/config_flow.py:779: error: "ZhaOptionsFlowHandler" has no attribute "async_step_intent_migrates"; maybe "async_step_intent_migrate" or "async_step_intent_reconfigure"?  [attr-defined]
Found 1 error in 1 file (checked 1 source file)
```

An alternative implementation would be to add a `step=` kwarg to all of the `FlowHandler` functions and pass the step function in directly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
