### PR TITLE
Discover Heos players using Zeroconf

### DIFF
--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import selector
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN, ENTRY_TITLE
 from .coordinator import HeosConfigEntry
@@ -142,51 +143,16 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         if TYPE_CHECKING:
             assert discovery_info.ssdp_location
 
-        entry: HeosConfigEntry | None = await self.async_set_unique_id(DOMAIN)
         hostname = urlparse(discovery_info.ssdp_location).hostname
         assert hostname is not None
 
-        # Abort early when discovery is ignored or host is part of the current system
-        if entry and (
-            entry.source == SOURCE_IGNORE or hostname in _get_current_hosts(entry)
-        ):
-            return self.async_abort(reason="single_instance_allowed")
+        return await self._async_handle_discovered(hostname)
 
-        # Connect to discovered host and get system information
-        heos = Heos(HeosOptions(hostname, events=False, heart_beat=False))
-        try:
-            await heos.connect()
-            system_info = await heos.get_system_info()
-        except HeosError as error:
-            _LOGGER.debug(
-                "Failed to retrieve system information from discovered HEOS device %s",
-                hostname,
-                exc_info=error,
-            )
-            return self.async_abort(reason="cannot_connect")
-        finally:
-            await heos.disconnect()
-
-        # Select the preferred host, if available
-        if system_info.preferred_hosts:
-            hostname = system_info.preferred_hosts[0].ip_address
-
-        # Move to confirmation when not configured
-        if entry is None:
-            self._discovered_host = hostname
-            return await self.async_step_confirm_discovery()
-
-        # Only update if the configured host isn't part of the discovered hosts to ensure new players that come online don't trigger a reload
-        if entry.data[CONF_HOST] not in [host.ip_address for host in system_info.hosts]:
-            _LOGGER.debug(
-                "Updated host %s to discovered host %s", entry.data[CONF_HOST], hostname
-            )
-            return self.async_update_reload_and_abort(
-                entry,
-                data_updates={CONF_HOST: hostname},
-                reason="reconfigure_successful",
-            )
-        return self.async_abort(reason="single_instance_allowed")
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+        return await self._async_handle_discovered(discovery_info.host)
 
     async def async_step_confirm_discovery(
         self, user_input: dict[str, Any] | None = None
@@ -266,6 +232,50 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
                 AUTH_SCHEMA, user_input or entry.options
             ),
         )
+
+    async def _async_handle_discovered(self, hostname: str) -> ConfigFlowResult:
+        entry: HeosConfigEntry | None = await self.async_set_unique_id(DOMAIN)
+        # Abort early when discovery is ignored or host is part of the current system
+        if entry and (
+            entry.source == SOURCE_IGNORE or hostname in _get_current_hosts(entry)
+        ):
+            return self.async_abort(reason="single_instance_allowed")
+
+        # Connect to discovered host and get system information
+        heos = Heos(HeosOptions(hostname, events=False, heart_beat=False))
+        try:
+            await heos.connect()
+            system_info = await heos.get_system_info()
+        except HeosError as error:
+            _LOGGER.debug(
+                "Failed to retrieve system information from discovered HEOS device %s",
+                hostname,
+                exc_info=error,
+            )
+            return self.async_abort(reason="cannot_connect")
+        finally:
+            await heos.disconnect()
+
+        # Select the preferred host, if available
+        if system_info.preferred_hosts and system_info.preferred_hosts[0].ip_address:
+            hostname = system_info.preferred_hosts[0].ip_address
+
+        # Move to confirmation when not configured
+        if entry is None:
+            self._discovered_host = hostname
+            return await self.async_step_confirm_discovery()
+
+        # Only update if the configured host isn't part of the discovered hosts to ensure new players that come online don't trigger a reload
+        if entry.data[CONF_HOST] not in [host.ip_address for host in system_info.hosts]:
+            _LOGGER.debug(
+                "Updated host %s to discovered host %s", entry.data[CONF_HOST], hostname
+            )
+            return self.async_update_reload_and_abort(
+                entry,
+                data_updates={CONF_HOST: hostname},
+                reason="reconfigure_successful",
+            )
+        return self.async_abort(reason="single_instance_allowed")
 
 
 class HeosOptionsFlowHandler(OptionsFlow):

--- a/homeassistant/components/heos/manifest.json
+++ b/homeassistant/components/heos/manifest.json
@@ -13,5 +13,6 @@
     {
       "st": "urn:schemas-denon-com:device:ACT-Denon:1"
     }
-  ]
+  ],
+  "zeroconf": ["_heos-audio._tcp.local."]
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -534,6 +534,11 @@ ZEROCONF = {
             "domain": "homekit_controller",
         },
     ],
+    "_heos-audio._tcp.local.": [
+        {
+            "domain": "heos",
+        },
+    ],
     "_homeconnect._tcp.local.": [
         {
             "domain": "home_connect",

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
+from ipaddress import ip_address
 from unittest.mock import Mock, patch
 
 from pyheos import (
@@ -39,6 +40,7 @@ from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_UDN,
     SsdpServiceInfo,
 )
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import MockHeos
 
@@ -281,6 +283,36 @@ def discovery_data_fixture_bedroom() -> SsdpServiceInfo:
             ATTR_UPNP_SERIAL: None,
             ATTR_UPNP_UDN: "uuid:e61de70c-2250-1c22-0080-0005cdf512be",
         },
+    )
+
+
+@pytest.fixture(name="zeroconf_discovery_data")
+def zeroconf_discovery_data_fixture() -> ZeroconfServiceInfo:
+    """Return mock discovery data for testing."""
+    host = "127.0.0.1"
+    return ZeroconfServiceInfo(
+        ip_address=ip_address(host),
+        ip_addresses=[ip_address(host)],
+        port=10101,
+        hostname=host,
+        type="mock_type",
+        name="MyDenon._heos-audio._tcp.local.",
+        properties={},
+    )
+
+
+@pytest.fixture(name="zeroconf_discovery_data_bedroom")
+def zeroconf_discovery_data_fixture_bedroom() -> ZeroconfServiceInfo:
+    """Return mock discovery data for testing."""
+    host = "127.0.0.2"
+    return ZeroconfServiceInfo(
+        ip_address=ip_address(host),
+        ip_addresses=[ip_address(host)],
+        port=10101,
+        hostname=host,
+        type="mock_type",
+        name="MyDenonBedroom._heos-audio._tcp.local.",
+        properties={},
     )
 
 

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -18,12 +18,14 @@ from homeassistant.config_entries import (
     SOURCE_IGNORE,
     SOURCE_SSDP,
     SOURCE_USER,
+    SOURCE_ZEROCONF,
     ConfigEntryState,
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import MockHeos
 
@@ -238,6 +240,143 @@ async def test_discovery_updates(
     controller.get_system_info.return_value = HeosSystem(None, host, [host])
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data_bedroom
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_HOST] == "127.0.0.2"
+
+
+async def test_zeroconf_discovery(
+    hass: HomeAssistant,
+    zeroconf_discovery_data: ZeroconfServiceInfo,
+    zeroconf_discovery_data_bedroom: ZeroconfServiceInfo,
+    controller: MockHeos,
+    system: HeosSystem,
+) -> None:
+    """Test discovery shows form to confirm, then creates entry."""
+    # Single discovered, selects preferred host, shows confirm
+    controller.get_system_info.return_value = system
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf_discovery_data_bedroom,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm_discovery"
+    assert controller.connect.call_count == 1
+    assert controller.get_system_info.call_count == 1
+    assert controller.disconnect.call_count == 1
+
+    # Subsequent discovered hosts abort.
+    subsequent_result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=zeroconf_discovery_data
+    )
+    assert subsequent_result["type"] is FlowResultType.ABORT
+    assert subsequent_result["reason"] == "already_in_progress"
+
+    # Confirm set up
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == DOMAIN
+    assert result["title"] == "HEOS System"
+    assert result["data"] == {CONF_HOST: "127.0.0.1"}
+
+
+async def test_zeroconf_discovery_flow_aborts_already_setup(
+    hass: HomeAssistant,
+    zeroconf_discovery_data_bedroom: ZeroconfServiceInfo,
+    config_entry: MockConfigEntry,
+    controller: MockHeos,
+) -> None:
+    """Test discovery flow aborts when entry already setup and hosts didn't change."""
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf_discovery_data_bedroom,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+    assert controller.get_system_info.call_count == 0
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
+
+
+async def test_zeroconf_discovery_aborts_same_system(
+    hass: HomeAssistant,
+    zeroconf_discovery_data_bedroom: ZeroconfServiceInfo,
+    controller: MockHeos,
+    config_entry: MockConfigEntry,
+    system: HeosSystem,
+) -> None:
+    """Test discovery does not update when current host is part of discovered's system."""
+    config_entry.add_to_hass(hass)
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
+
+    controller.get_system_info.return_value = system
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf_discovery_data_bedroom,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+    assert controller.get_system_info.call_count == 1
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
+
+
+async def test_zeroconf_discovery_ignored_aborts(
+    hass: HomeAssistant,
+    zeroconf_discovery_data: ZeroconfServiceInfo,
+) -> None:
+    """Test discovery aborts when ignored."""
+    MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, source=SOURCE_IGNORE).add_to_hass(
+        hass
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=zeroconf_discovery_data
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_zeroconf_discovery_fails_to_connect_aborts(
+    hass: HomeAssistant,
+    zeroconf_discovery_data: ZeroconfServiceInfo,
+    controller: MockHeos,
+) -> None:
+    """Test discovery aborts when trying to connect to host."""
+    controller.connect.side_effect = HeosError()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=zeroconf_discovery_data
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    assert controller.connect.call_count == 1
+    assert controller.disconnect.call_count == 1
+
+
+async def test_zeroconf_discovery_updates(
+    hass: HomeAssistant,
+    zeroconf_discovery_data_bedroom: ZeroconfServiceInfo,
+    controller: MockHeos,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test discovery updates existing entry."""
+    config_entry.add_to_hass(hass)
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
+
+    host = HeosHost("Player", "Model", None, None, "127.0.0.2", NetworkType.WIRED, True)
+    controller.get_system_info.return_value = HeosSystem(None, host, [host])
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=zeroconf_discovery_data_bedroom,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"


### PR DESCRIPTION



## Proposed change
Currently Heos players are only discovered by SSDP, this adds Zeroconf support by utilizing the _heos-audio._tcp.local. name.
Many years ago the official Heos app didn't work across VLANs, not even with an mDNS reflector, as it used SSDP. But last time I checked (which is years ago) the app did work, without SSDP across VLANs, but with an mDNS reflector. And as a discovery only finds this used `_heos-audio._tcp.local.` name this must be what the app has been using as well.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
