### PR TITLE
Cleanup wrongly combined Reolink devices

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -364,53 +364,90 @@ def migrate_entity_ids(
     devices = dr.async_entries_for_config_entry(device_reg, config_entry_id)
     ch_device_ids = {}
     for device in devices:
-        (device_uid, ch, is_chime) = get_device_uid_and_ch(device, host)
+        for dev_id in device.identifiers:
+            (device_uid, ch, is_chime) = get_device_uid_and_ch(dev_id, host)
+            if not device_uid:
+                continue
 
-        if host.api.supported(None, "UID") and device_uid[0] != host.unique_id:
-            if ch is None:
-                new_device_id = f"{host.unique_id}"
-            else:
-                new_device_id = f"{host.unique_id}_{device_uid[1]}"
-            _LOGGER.debug(
-                "Updating Reolink device UID from %s to %s", device_uid, new_device_id
-            )
-            new_identifiers = {(DOMAIN, new_device_id)}
-            device_reg.async_update_device(device.id, new_identifiers=new_identifiers)
-
-        if ch is None or is_chime:
-            continue  # Do not consider the NVR itself or chimes
-
-        # Check for wrongfully added MAC of the NVR/Hub to the camera
-        # Can be removed in HA 2025.12
-        host_connnection = (CONNECTION_NETWORK_MAC, host.api.mac_address)
-        if host_connnection in device.connections:
-            new_connections = device.connections.copy()
-            new_connections.remove(host_connnection)
-            device_reg.async_update_device(device.id, new_connections=new_connections)
-
-        ch_device_ids[device.id] = ch
-        if host.api.supported(ch, "UID") and device_uid[1] != host.api.camera_uid(ch):
-            if host.api.supported(None, "UID"):
-                new_device_id = f"{host.unique_id}_{host.api.camera_uid(ch)}"
-            else:
-                new_device_id = f"{device_uid[0]}_{host.api.camera_uid(ch)}"
-            _LOGGER.debug(
-                "Updating Reolink device UID from %s to %s", device_uid, new_device_id
-            )
-            new_identifiers = {(DOMAIN, new_device_id)}
-            existing_device = device_reg.async_get_device(identifiers=new_identifiers)
-            if existing_device is None:
+            if host.api.supported(None, "UID") and device_uid[0] != host.unique_id:
+                if ch is None:
+                    new_device_id = f"{host.unique_id}"
+                else:
+                    new_device_id = f"{host.unique_id}_{device_uid[1]}"
+                _LOGGER.debug(
+                    "Updating Reolink device UID from %s to %s",
+                    device_uid,
+                    new_device_id,
+                )
+                new_identifiers = {(DOMAIN, new_device_id)}
                 device_reg.async_update_device(
                     device.id, new_identifiers=new_identifiers
                 )
-            else:
-                _LOGGER.warning(
-                    "Reolink device with uid %s already exists, "
-                    "removing device with uid %s",
-                    new_device_id,
-                    device_uid,
+
+            if ch is None or is_chime:
+                continue  # Do not consider the NVR itself or chimes
+
+            # Check for wrongfully combined host with NVR entities in one device
+            # Can be removed in HA 2025.12
+            if (DOMAIN, host.unique_id) in device.identifiers:
+                new_identifiers = device.identifiers.copy()
+                for old_id in device.identifiers:
+                    if old_id[0] == DOMAIN and old_id[1] != host.unique_id:
+                        new_identifiers.remove(old_id)
+                _LOGGER.debug(
+                    "Updating Reolink device identifiers from %s to %s",
+                    device.identifiers,
+                    new_identifiers,
                 )
-                device_reg.async_remove_device(device.id)
+                device_reg.async_update_device(
+                    device.id, new_identifiers=new_identifiers
+                )
+                break
+
+            # Check for wrongfully added MAC of the NVR/Hub to the camera
+            # Can be removed in HA 2025.12
+            host_connnection = (CONNECTION_NETWORK_MAC, host.api.mac_address)
+            if host_connnection in device.connections:
+                new_connections = device.connections.copy()
+                new_connections.remove(host_connnection)
+                _LOGGER.debug(
+                    "Updating Reolink device connections from %s to %s",
+                    device.connections,
+                    new_connections,
+                )
+                device_reg.async_update_device(
+                    device.id, new_connections=new_connections
+                )
+
+            ch_device_ids[device.id] = ch
+            if host.api.supported(ch, "UID") and device_uid[1] != host.api.camera_uid(
+                ch
+            ):
+                if host.api.supported(None, "UID"):
+                    new_device_id = f"{host.unique_id}_{host.api.camera_uid(ch)}"
+                else:
+                    new_device_id = f"{device_uid[0]}_{host.api.camera_uid(ch)}"
+                _LOGGER.debug(
+                    "Updating Reolink device UID from %s to %s",
+                    device_uid,
+                    new_device_id,
+                )
+                new_identifiers = {(DOMAIN, new_device_id)}
+                existing_device = device_reg.async_get_device(
+                    identifiers=new_identifiers
+                )
+                if existing_device is None:
+                    device_reg.async_update_device(
+                        device.id, new_identifiers=new_identifiers
+                    )
+                else:
+                    _LOGGER.warning(
+                        "Reolink device with uid %s already exists, "
+                        "removing device with uid %s",
+                        new_device_id,
+                        device_uid,
+                    )
+                    device_reg.async_remove_device(device.id)
 
     entity_reg = er.async_get(hass)
     entities = er.async_entries_for_config_entry(entity_reg, config_entry_id)

--- a/homeassistant/components/reolink/util.py
+++ b/homeassistant/components/reolink/util.py
@@ -76,13 +76,18 @@ def get_store(hass: HomeAssistant, config_entry_id: str) -> Store[str]:
 
 
 def get_device_uid_and_ch(
-    device: dr.DeviceEntry, host: ReolinkHost
+    device: dr.DeviceEntry | tuple[str, str], host: ReolinkHost
 ) -> tuple[list[str], int | None, bool]:
     """Get the channel and the split device_uid from a reolink DeviceEntry."""
     device_uid = []
     is_chime = False
 
-    for dev_id in device.identifiers:
+    if isinstance(device, dr.DeviceEntry):
+        dev_ids = device.identifiers
+    else:
+        dev_ids = {device}
+
+    for dev_id in dev_ids:
         if dev_id[0] == DOMAIN:
             device_uid = dev_id[1].split("_")
             if device_uid[0] == host.unique_id:

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -630,7 +630,7 @@ async def test_cleanup_mac_connection(
     domain = Platform.SWITCH
 
     dev_entry = device_registry.async_get_or_create(
-        identifiers={(DOMAIN, dev_id)},
+        identifiers={(DOMAIN, dev_id), ("OTHER_INTEGRATION", "SOME_ID")},
         connections={(CONNECTION_NETWORK_MAC, TEST_MAC)},
         config_entry_id=config_entry.entry_id,
         disabled_by=None,
@@ -660,6 +660,66 @@ async def test_cleanup_mac_connection(
     device = device_registry.async_get_device(identifiers={(DOMAIN, dev_id)})
     assert device
     assert device.connections == set()
+
+    reolink_connect.baichuan.mac_address.return_value = TEST_MAC_CAM
+
+
+async def test_cleanup_combined_with_NVR(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test cleanup of the device registry if IPC camera device was combined with the NVR device."""
+    reolink_connect.channels = [0]
+    reolink_connect.baichuan.mac_address.return_value = None
+    entity_id = f"{TEST_UID}_{TEST_UID_CAM}_record_audio"
+    dev_id = f"{TEST_UID}_{TEST_UID_CAM}"
+    domain = Platform.SWITCH
+    start_identifiers = {
+        (DOMAIN, dev_id),
+        (DOMAIN, TEST_UID),
+        ("OTHER_INTEGRATION", "SOME_ID"),
+    }
+
+    dev_entry = device_registry.async_get_or_create(
+        identifiers=start_identifiers,
+        connections={(CONNECTION_NETWORK_MAC, TEST_MAC)},
+        config_entry_id=config_entry.entry_id,
+        disabled_by=None,
+    )
+
+    entity_registry.async_get_or_create(
+        domain=domain,
+        platform=DOMAIN,
+        unique_id=entity_id,
+        config_entry=config_entry,
+        suggested_object_id=entity_id,
+        disabled_by=None,
+        device_id=dev_entry.id,
+    )
+
+    assert entity_registry.async_get_entity_id(domain, DOMAIN, entity_id)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, dev_id)})
+    assert device
+    assert device.identifiers == start_identifiers
+
+    # setup CH 0 and host entities/device
+    with patch("homeassistant.components.reolink.PLATFORMS", [domain]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id(domain, DOMAIN, entity_id)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, dev_id)})
+    assert device
+    assert device.identifiers == {(DOMAIN, dev_id)}
+    host_device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_UID)})
+    assert host_device
+    assert host_device.identifiers == {
+        (DOMAIN, TEST_UID),
+        ("OTHER_INTEGRATION", "SOME_ID"),
+    }
 
     reolink_connect.baichuan.mac_address.return_value = TEST_MAC_CAM
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup wrongly combined Reolink devices, followup to PR https://github.com/home-assistant/core/pull/144554
There was an aditional way in which the registry could be messed up:
Multiple IPC cams could be combined with the NVR/Home Hub device due to the wrong identical MAC.
This PR cleans up that mess.

Tested locally on my dev enviroment in which I perpusely messed up my device registry by first reverting to HA 2025.4.0 with a clean install, then adding the NVR, then updating to the code of this PR to have it cleaned up correctly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/143578 fixes https://github.com/home-assistant/core/issues/142434 fixes https://github.com/home-assistant/core/issues/143287
- This PR is related to issue: https://github.com/home-assistant/core/issues/144478
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
