### PR TITLE
feat: Add a priority attribute to notifications on notify

### DIFF
--- a/homeassistant/components/demo/notify.py
+++ b/homeassistant/components/demo/notify.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.notify import (
     DOMAIN as NOTIFY_DOMAIN,
     NotifyEntity,
@@ -43,7 +45,12 @@ class DemoNotifyEntity(NotifyEntity):
             name=device_name,
         )
 
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
+    async def async_send_message(
+        self,
+        message: str,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Send a message to a user."""
         event_notification = {"message": message}
         if title is not None:

--- a/homeassistant/components/fully_kiosk/notify.py
+++ b/homeassistant/components/fully_kiosk/notify.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from fullykiosk import FullyKioskError
 
@@ -65,7 +66,12 @@ class FullyNotifyEntity(FullyKioskEntity, NotifyEntity):
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.data['deviceID']}-{description.key}"
 
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
+    async def async_send_message(
+        self,
+        message: str,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Send a message."""
         try:
             await self.coordinator.fully.sendCommand(

--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -171,7 +171,12 @@ class NotifyGroup(GroupEntity, NotifyEntity):
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
         self._attr_unique_id = unique_id
 
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
+    async def async_send_message(
+        self,
+        message: str,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Send a message to all members of the group."""
         await self.hass.services.async_call(
             NOTIFY_DOMAIN,

--- a/homeassistant/components/kitchen_sink/notify.py
+++ b/homeassistant/components/kitchen_sink/notify.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components import persistent_notification
 from homeassistant.components.notify import NotifyEntity, NotifyEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -57,7 +59,12 @@ class DemoNotify(NotifyEntity):
         )
         self._attr_name = entity_name
 
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
+    async def async_send_message(
+        self,
+        message: str,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Send out a persistent notification."""
         persistent_notification.async_create(
             self.hass, message, title or "Demo notification"

--- a/homeassistant/components/knx/notify.py
+++ b/homeassistant/components/knx/notify.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from xknx import XKNX
 from xknx.devices import Notification as XknxNotification
 
@@ -53,6 +55,11 @@ class KNXNotify(KnxYamlEntity, NotifyEntity):
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_unique_id = str(self._device.remote_value.group_address)
 
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
+    async def async_send_message(
+        self,
+        message: str,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Send a notification to knx bus."""
         await self._device.set(message)

--- a/homeassistant/components/mqtt/notify.py
+++ b/homeassistant/components/mqtt/notify.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import voluptuous as vol
 
 from homeassistant.components import notify
@@ -77,7 +79,12 @@ class MqttNotify(MqttEntity, NotifyEntity):
     async def _subscribe_topics(self) -> None:
         """(Re)Subscribe to topics."""
 
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
+    async def async_send_message(
+        self,
+        message: str,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Send a message."""
         payload = self._command_template(message)
         await self.async_publish_with_config(self._config[CONF_COMMAND_TOPIC], payload)

--- a/homeassistant/components/notify/const.py
+++ b/homeassistant/components/notify/const.py
@@ -20,6 +20,12 @@ ATTR_RECIPIENTS = "recipients"
 # Title of notification
 ATTR_TITLE = "title"
 
+# Metadata of a notification
+ATTR_METADATA = "metadata"
+
+# Priority of a notification. An integer between 1 (lowest) and 5 (highest).
+ATTR_PRIORITY = "priority"
+
 DOMAIN = "notify"
 
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/notify/services.yaml
+++ b/homeassistant/components/notify/services.yaml
@@ -36,6 +36,13 @@ send_message:
       filter:
         supported_features:
           - notify.NotifyEntityFeature.TITLE
+    metadata:
+      required: false
+      selector:
+        object:
+      filter:
+        supported_features:
+          - notify.NotifyEntityFeature.METADATA
 
 persistent_notification:
   fields:

--- a/homeassistant/components/notify/strings.json
+++ b/homeassistant/components/notify/strings.json
@@ -39,6 +39,10 @@
         "title": {
           "name": "Title",
           "description": "Title for your notification message."
+        },
+        "metadata": {
+          "name": "Metadata",
+          "description": "Attributes of the notification other than the content (title and message)."
         }
       }
     },

--- a/homeassistant/components/tibber/notify.py
+++ b/homeassistant/components/tibber/notify.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from tibber import Tibber
 
 from homeassistant.components.notify import (
@@ -37,7 +39,12 @@ class TibberNotificationEntity(NotifyEntity):
         """Initialize Tibber notify entity."""
         self._attr_unique_id = unique_id
 
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
+    async def async_send_message(
+        self,
+        message: str,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Send a message to Tibber devices."""
         tibber_connection: Tibber = self.hass.data[DOMAIN]
         try:

--- a/tests/components/group/test_notify.py
+++ b/tests/components/group/test_notify.py
@@ -302,7 +302,12 @@ class MockNotifyEntity(MockEntity, NotifyEntity):
         super().__init__(**values)
         self.send_message_mock_calls = MagicMock()
 
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
+    async def async_send_message(
+        self,
+        message: str,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Send a notification message."""
         self.send_message_mock_calls(message, title=title)
 

--- a/tests/components/ntfy/snapshots/test_notify.ambr
+++ b/tests/components/ntfy/snapshots/test_notify.ambr
@@ -27,7 +27,7 @@
     'original_name': None,
     'platform': 'ntfy',
     'previous_unique_id': None,
-    'supported_features': <NotifyEntityFeature: 1>,
+    'supported_features': <NotifyEntityFeature: 3>,
     'translation_key': 'publish',
     'unique_id': '123456789_ABCDEF_publish',
     'unit_of_measurement': None,
@@ -37,7 +37,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'mytopic',
-      'supported_features': <NotifyEntityFeature: 1>,
+      'supported_features': <NotifyEntityFeature: 3>,
     }),
     'context': <ANY>,
     'entity_id': 'notify.mytopic',


### PR DESCRIPTION
## Proposed change
### The problem
Pretty much all messaging systems in general, including notifications, has the concept of proirity. examples:
- Notifications on Android.
- Notifications on iOS.
- Emails (as in "important" or not)

This affects how the user on such systems get alerted (or not).

### The approach
Thinking of a notification as consisting of two category of information; content and metadata, we can argue that:
- title and message attributes are content.
- priority is a metadata.

.. And anticipating the need for future other metadata, I chose to introduce a new `metadata` dict parameter to the `*_send_message` methods. Yet, I don't want it to be an open ended unmanaged bag of key-value pairs, so, I opted to dictating a schema that explicity allows certain keys (currently, obviously, the `priority` key).

### Fist use case
Using ntfy component to publish notifications with priorities.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
