### PR TITLE
Add entities to tuya pet feeder (cwwsq)

### DIFF
--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -144,6 +144,11 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
             translation_key="feeding",
             on_value="feeding",
         ),
+        TuyaBinarySensorEntityDescription(
+            key=DPCode.CHARGE_STATE,
+            translation_key="charge_state",
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
     ),
     # Human Presence Sensor
     # https://developer.tuya.com/en/docs/iot/categoryhps?id=Kaiuz42yhn1hs

--- a/homeassistant/components/tuya/button.py
+++ b/homeassistant/components/tuya/button.py
@@ -54,6 +54,15 @@ BUTTONS: dict[str, tuple[ButtonEntityDescription, ...]] = {
             translation_key="snooze",
         ),
     ),
+     # Smart Pet Feeder
+    # https://developer.tuya.com/en/docs/iot/categorycwwsq?id=Kaiuz2b6vydld
+    "cwwsq": ( 
+        ButtonEntityDescription(
+            key=DPCode.MEAL_PLAN,
+            translation_key="meal_plan",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
 }
 
 

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -132,6 +132,7 @@ class DPCode(StrEnum):
     BRIGHTNESS_MIN_2 = "brightness_min_2"
     BRIGHTNESS_MIN_3 = "brightness_min_3"
     C_F = "c_f"  # Temperature unit switching
+    CHARGE_STATE = "charge_state"
     CH2O_STATE = "ch2o_state"
     CH2O_VALUE = "ch2o_value"
     CH4_SENSOR_STATE = "ch4_sensor_state"
@@ -225,6 +226,7 @@ class DPCode(StrEnum):
     MACH_OPERATE = "mach_operate"
     MANUAL_FEED = "manual_feed"
     MATERIAL = "material"  # Material
+    MEAL_PLAN = "meal_plan"
     MODE = "mode"  # Working mode / Mode
     MOODLIGHTING = "moodlighting"  # Mood light
     MOTION_RECORD = "motion_record"

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -304,6 +304,12 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
             translation_key="last_amount",
             state_class=SensorStateClass.MEASUREMENT,
         ),
+        TuyaSensorEntityDescription( #Not supported yet until RAW is a valid input
+            key=DPCode.MEAL_PLAN,
+            translation_key="meal_plan",
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
+        *BATTERY_SENSORS,
     ),
     # Air Quality Monitor
     # https://developer.tuya.com/en/docs/iot/hjjcy?id=Kbeoad8y1nnlv

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -56,6 +56,9 @@
       },
       "tilt": {
         "name": "Tilt"
+      },
+      "charge_state": {
+        "name": "Charge state"
       }
     },
     "button": {
@@ -76,6 +79,9 @@
       },
       "snooze": {
         "name": "Snooze"
+      },
+      "meal_plan": {
+        "name": "Meal plan"
       }
     },
     "cover": {
@@ -520,6 +526,9 @@
       "remaining_time": {
         "name": "Remaining time"
       },
+      "meal_plan": {
+        "name": "Meal plan"
+      },
       "methane": {
         "name": "[%key:component::tuya::entity::binary_sensor::methane::name%]"
       },
@@ -849,6 +858,9 @@
       },
       "sterilization": {
         "name": "Sterilization"
+      },
+      "light": {
+        "name": "Light"
       }
     }
   }

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -79,6 +79,11 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
             translation_key="slow_feed",
             entity_category=EntityCategory.CONFIG,
         ),
+        SwitchEntityDescription(
+            key=DPCode.LIGHT,
+            translation_key="light",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
     # Pet Water Feeder
     # https://developer.tuya.com/en/docs/iot/f?id=K9gf46aewxem5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added functionality to Tuya pet feeder [cwwsq](https://developer.tuya.com/en/docs/iot/categorycwwsq?id=Kaiuz2b6vydld).

There is a question if meal_plan will work since Tuya integration does not support RAW format from other entities than ElectricityTypeData if not subkey is implemented. If any suggestion for workaround I would appreciate it.

Another note is how the Tuya integration can send update on RAW data. I created a button that I will add data to but seem to be a poor solution.

Example of data from the logs:
```
 [homeassistant.components.tuya] Received update for device bfd0273e59494eb34esvrx: {'meal_plan': 'fwQAAgF/BgABAH8JAAIBfwwAAQB/DwACAX8VAAIBfxcAAQAIEgABAQ==', 'manual_feed': 1, 'factory_reset': False, 'battery_percentage': 90, 'charge_state': False, 'feed_report': 2, 'light': True} (updated properties: ['meal_plan'])
 
2025-05-12 12:00:43.068 DEBUG (paho-mqtt-client-cloud_628543bf4809a49d2935b386a2741e47) [homeassistant.components.tuya] 
Received update for device bfd0273e59494eb34esvrx: {'meal_plan': 'fwQAAgF/BgABAH8JAAIBfwwAAQB/DwACAX8VAAIBfxcAAQAIEgABAQ==', 'manual_feed': 1, 'factory_reset': False, 'battery_percentage': 90, 'charge_state': False, 'feed_report': 2, 'light': True} (updated properties: ['meal_plan'])
 ```

![image](https://github.com/user-attachments/assets/e717bdc8-dd00-4145-8331-2eaa62645539)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://community.home-assistant.io/t/cat-feeder-cleverio-pf100-cwwsq-missing-entities/888441
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
