### PR TITLE
Translate raised exceptions for Squeezebox

### DIFF
--- a/homeassistant/components/squeezebox/browse_media.py
+++ b/homeassistant/components/squeezebox/browse_media.py
@@ -317,10 +317,10 @@ async def build_item_response(
     if children is None:
         raise BrowseError(
             translation_domain=DOMAIN,
-            translation_key="browse_search_media_not_found",
+            translation_key="browse_media_not_found",
             translation_placeholders={
-                "search_type": f"{search_type}",
-                "search_id": f"{search_id}",
+                "type": str(search_type),
+                "id": str(search_id),
             },
         )
 
@@ -409,7 +409,7 @@ async def generate_playlist(
             translation_domain=DOMAIN,
             translation_key="browse_media_type_not_supported",
             translation_placeholders={
-                "media_type": f"{media_type}",
+                "media_type": str(media_type),
             },
         )
 
@@ -429,7 +429,7 @@ async def generate_playlist(
         translation_domain=DOMAIN,
         translation_key="browse_media_not_found",
         translation_placeholders={
-            "media_type": f"{media_type}",
-            "media_id": f"{media_id}",
+            "type": str(media_type),
+            "id": str(media_id),
         },
     )

--- a/homeassistant/components/squeezebox/browse_media.py
+++ b/homeassistant/components/squeezebox/browse_media.py
@@ -19,7 +19,7 @@ from homeassistant.components.media_player import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import is_internal_request
 
-from .const import UNPLAYABLE_TYPES
+from .const import DOMAIN, UNPLAYABLE_TYPES
 
 LIBRARY = [
     "favorites",
@@ -315,7 +315,14 @@ async def build_item_response(
             children.append(child_media)
 
     if children is None:
-        raise BrowseError(f"Media not found: {search_type} / {search_id}")
+        raise BrowseError(
+            translation_domain=DOMAIN,
+            translation_key="browse_search_media_not_found",
+            translation_placeholders={
+                "search_type": f"{search_type}",
+                "search_id": f"{search_id}",
+            },
+        )
 
     assert media_class["item"] is not None
     if not search_id:
@@ -398,7 +405,13 @@ async def generate_playlist(
     media_id = payload["search_id"]
 
     if media_type not in browse_media.squeezebox_id_by_type:
-        raise BrowseError(f"Media type not supported: {media_type}")
+        raise BrowseError(
+            translation_domain=DOMAIN,
+            translation_key="browse_media_type_not_supported",
+            translation_placeholders={
+                "media_type": f"{media_type}",
+            },
+        )
 
     browse_id = (browse_media.squeezebox_id_by_type[media_type], media_id)
     if media_type.startswith("app-"):
@@ -412,4 +425,11 @@ async def generate_playlist(
     if result and "items" in result:
         items: list = result["items"]
         return items
-    raise BrowseError(f"Media not found: {media_type} / {media_id}")
+    raise BrowseError(
+        translation_domain=DOMAIN,
+        translation_key="browse_media_not_found",
+        translation_placeholders={
+            "media_type": f"{media_type}",
+            "media_id": f"{media_id}",
+        },
+    )

--- a/homeassistant/components/squeezebox/coordinator.py
+++ b/homeassistant/components/squeezebox/coordinator.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from . import SqueezeboxConfigEntry
 
 from .const import (
+    DOMAIN,
     PLAYER_UPDATE_INTERVAL,
     SENSOR_UPDATE_INTERVAL,
     SIGNAL_PLAYER_REDISCOVERED,
@@ -65,7 +66,10 @@ class LMSStatusDataUpdateCoordinator(DataUpdateCoordinator):
             data: dict | None = await self.lms.async_prepared_status()
 
         if not data:
-            raise UpdateFailed("No data from status poll")
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="coordinator_no_data",
+            )
         _LOGGER.debug("Raw serverstatus %s=%s", self.lms.name, data)
 
         return data

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -474,7 +474,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
                     translation_domain=DOMAIN,
                     translation_key="invalid_announce_media_type",
                     translation_placeholders={
-                        "media_type": f"{media_type}",
+                        "media_type": str(media_type),
                     },
                 )
 
@@ -487,7 +487,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
                     translation_domain=DOMAIN,
                     translation_key="invalid_announce_volume",
                     translation_placeholders={
-                        "announce_volume": f"{ATTR_ANNOUNCE_VOLUME}",
+                        "announce_volume": ATTR_ANNOUNCE_VOLUME,
                     },
                 ) from None
             else:
@@ -500,7 +500,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
                     translation_domain=DOMAIN,
                     translation_key="invalid_announce_timeout",
                     translation_placeholders={
-                        "announce_timeout": f"{ATTR_ANNOUNCE_TIMEOUT}",
+                        "announce_timeout": ATTR_ANNOUNCE_TIMEOUT,
                     },
                 ) from None
             else:
@@ -610,7 +610,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
                     translation_domain=DOMAIN,
                     translation_key="join_cannot_find_other_player",
                     translation_placeholders={
-                        "other_player_entity_id": f"{other_player_entity_id}"
+                        "other_player_entity_id": str(other_player_entity_id)
                     },
                 )
             if other_player_id := other_player.unique_id:
@@ -620,7 +620,7 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
                     translation_domain=DOMAIN,
                     translation_key="join_cannot_join_unknown_player",
                     translation_placeholders={
-                        "other_player_entity_id": f"{other_player_entity_id}"
+                        "other_player_entity_id": str(other_player_entity_id)
                     },
                 )
 

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -471,7 +471,11 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         if announce:
             if media_type not in MediaType.MUSIC:
                 raise ServiceValidationError(
-                    "Announcements must have media type of 'music'.  Playlists are not supported"
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_announce_media_type",
+                    translation_placeholders={
+                        "media_type": f"{media_type}",
+                    },
                 )
 
             extra = kwargs.get(ATTR_MEDIA_EXTRA, {})
@@ -480,7 +484,11 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
                 announce_volume = get_announce_volume(extra)
             except ValueError:
                 raise ServiceValidationError(
-                    f"{ATTR_ANNOUNCE_VOLUME} must be a number greater than 0 and less than or equal to 1"
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_announce_volume",
+                    translation_placeholders={
+                        "announce_volume": f"{ATTR_ANNOUNCE_VOLUME}",
+                    },
                 ) from None
             else:
                 self._player.set_announce_volume(announce_volume)
@@ -489,7 +497,11 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
                 announce_timeout = get_announce_timeout(extra)
             except ValueError:
                 raise ServiceValidationError(
-                    f"{ATTR_ANNOUNCE_TIMEOUT} must be a whole number greater than 0"
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_announce_timeout",
+                    translation_placeholders={
+                        "announce_timeout": f"{ATTR_ANNOUNCE_TIMEOUT}",
+                    },
                 ) from None
             else:
                 self._player.set_announce_timeout(announce_timeout)
@@ -595,13 +607,21 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
             other_player = ent_reg.async_get(other_player_entity_id)
             if other_player is None:
                 raise ServiceValidationError(
-                    f"Could not find player with entity_id {other_player_entity_id}"
+                    translation_domain=DOMAIN,
+                    translation_key="join_cannot_find_other_player",
+                    translation_placeholders={
+                        "other_player_entity_id": f"{other_player_entity_id}"
+                    },
                 )
             if other_player_id := other_player.unique_id:
                 await self._player.async_sync(other_player_id)
             else:
                 raise ServiceValidationError(
-                    f"Could not join unknown player {other_player_entity_id}"
+                    translation_domain=DOMAIN,
+                    translation_key="join_cannot_join_unknown_player",
+                    translation_placeholders={
+                        "other_player_entity_id": f"{other_player_entity_id}"
+                    },
                 )
 
     async def async_unjoin_player(self) -> None:

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -149,5 +149,37 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "invalid_announce_media_type": {
+      "message": "Announcements must have media type of music. {media_type} is not a supported type."
+    },
+    "invalid_announce_volume": {
+      "message": "{announce_volume} must be a number greater than 0 and less than or equal to 1."
+    },
+    "invalid_announce_timeout": {
+      "message": "{announce_timeout} must be a number greater than 0."
+    },
+    "join_cannot_find_other_player": {
+      "message": "Could not find player with entity_id {other_player_entity_id}."
+    },
+    "join_cannot_join_unknown_player": {
+      "message": "Could not join unknown player {other_player_entity_id}."
+    },
+    "coordinator_no_data": {
+      "message": "No data from status poll."
+    },
+    "browse_search_media_not_found": {
+      "message": "Media not found: {search_type} / {search_id}."
+    },
+    "browse_media_not_found": {
+      "message": "Media not found: {media_type} / {media_id}"
+    },
+    "browse_media_type_not_supported": {
+      "message": "Media type not supported: {media_type}."
+    },
+    "update_restart_failed": {
+      "message": "Error trying to update LMS Plugins: Restart failed."
+    }
   }
 }

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -152,7 +152,7 @@
   },
   "exceptions": {
     "invalid_announce_media_type": {
-      "message": "Announcements must have media type of music. {media_type} is not a supported type."
+      "message": "Only type 'music' can be played as announcement (received type {media_type})."
     },
     "invalid_announce_volume": {
       "message": "{announce_volume} must be a number greater than 0 and less than or equal to 1."
@@ -169,11 +169,8 @@
     "coordinator_no_data": {
       "message": "No data from status poll."
     },
-    "browse_search_media_not_found": {
-      "message": "Media not found: {search_type} / {search_id}."
-    },
     "browse_media_not_found": {
-      "message": "Media not found: {media_type} / {media_id}."
+      "message": "Media not found: {type} / {id}."
     },
     "browse_media_type_not_supported": {
       "message": "Media type not supported: {media_type}."

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -173,7 +173,7 @@
       "message": "Media not found: {search_type} / {search_id}."
     },
     "browse_media_not_found": {
-      "message": "Media not found: {media_type} / {media_id}"
+      "message": "Media not found: {media_type} / {media_id}."
     },
     "browse_media_type_not_supported": {
       "message": "Media type not supported: {media_type}."

--- a/homeassistant/components/squeezebox/update.py
+++ b/homeassistant/components/squeezebox/update.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.event import async_call_later
 
 from . import SqueezeboxConfigEntry
 from .const import (
+    DOMAIN,
     SERVER_MODEL,
     STATUS_QUERY_VERSION,
     STATUS_UPDATE_NEWPLUGINS,
@@ -158,7 +159,8 @@ class ServerStatusUpdatePlugins(ServerStatusUpdate):
             self.restart_triggered = False
             self.async_write_ha_state()
             raise HomeAssistantError(
-                "Error trying to update LMS Plugins: Restart failed"
+                translation_domain=DOMAIN,
+                translation_key="update_restart_failed",
             )
 
     async def _async_update_catchall(self, now: datetime | None = None) -> None:


### PR DESCRIPTION


## Proposed change
Add translations for raised exceptions across Squeezebox platforms

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
