### PR TITLE
Add MockDhcpServiceInfo common test helper

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -98,7 +98,6 @@ from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
 )
 from homeassistant.helpers.json import JSONEncoder, _orjson_default_encoder, json_dumps
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util, ulid as ulid_util, uuid as uuid_util
 from homeassistant.util.async_ import (
@@ -1954,26 +1953,3 @@ def get_schema_suggested_value(schema: vol.Schema, key: str) -> Any | None:
                 return None
             return schema_key.description["suggested_value"]
     return None
-
-
-class MockDhcpServiceInfo(DhcpServiceInfo):
-    """Mocked DHCP service info."""
-
-    def __init__(self, ip: str, hostname: str, macaddress: str) -> None:
-        """Initialize the mock service info."""
-        # Historically, the MAC address was formatted without colons
-        # and since all consumers of this data are expecting it to be
-        # formatted without colons we will continue to do so
-        super().__init__(
-            ip=ip,
-            hostname=hostname,
-            macaddress=dr.format_mac(macaddress).replace(":", ""),
-        )
-
-    async def start_discovery_flow(
-        self, hass: HomeAssistant, domain: str
-    ) -> ConfigFlowResult:
-        """Start a reauthentication flow."""
-        return await hass.config_entries.flow.async_init(
-            domain, context={"source": config_entries.SOURCE_DHCP}, data=self
-        )

--- a/tests/components/airthings/test_config_flow.py
+++ b/tests/components/airthings/test_config_flow.py
@@ -10,9 +10,8 @@ from homeassistant.components.airthings.const import CONF_SECRET, DOMAIN
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, MockDhcpServiceInfo
 
 TEST_DATA = {
     CONF_ID: "client_id",
@@ -20,17 +19,17 @@ TEST_DATA = {
 }
 
 DHCP_SERVICE_INFO = [
-    DhcpServiceInfo(
+    MockDhcpServiceInfo(
         hostname="airthings-view",
         ip="192.168.1.100",
         macaddress="00:00:00:00:00:00",
     ),
-    DhcpServiceInfo(
+    MockDhcpServiceInfo(
         hostname="airthings-hub",
         ip="192.168.1.101",
         macaddress="D0:14:11:90:00:00",
     ),
-    DhcpServiceInfo(
+    MockDhcpServiceInfo(
         hostname="airthings-hub",
         ip="192.168.1.102",
         macaddress="70:B3:D5:2A:00:00",
@@ -147,15 +146,11 @@ async def test_flow_entry_already_exists(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize("dhcp_service_info", DHCP_SERVICE_INFO)
 async def test_dhcp_flow(
-    hass: HomeAssistant, dhcp_service_info: DhcpServiceInfo
+    hass: HomeAssistant, dhcp_service_info: MockDhcpServiceInfo
 ) -> None:
     """Test the DHCP discovery flow."""
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        data=dhcp_service_info,
-        context={"source": config_entries.SOURCE_DHCP},
-    )
+    result = await dhcp_service_info.start_discovery_flow(hass, DOMAIN)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"

--- a/tests/components/airthings/test_config_flow.py
+++ b/tests/components/airthings/test_config_flow.py
@@ -11,7 +11,8 @@ from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from tests.common import MockConfigEntry, MockDhcpServiceInfo
+from tests.common import MockConfigEntry
+from tests.service_info import MockDhcpServiceInfo
 
 TEST_DATA = {
     CONF_ID: "client_id",

--- a/tests/components/airthings/test_config_flow.py
+++ b/tests/components/airthings/test_config_flow.py
@@ -151,7 +151,11 @@ async def test_dhcp_flow(
 ) -> None:
     """Test the DHCP discovery flow."""
 
-    result = await dhcp_service_info.start_discovery_flow(hass, DOMAIN)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=dhcp_service_info,
+        context={"source": config_entries.SOURCE_DHCP},
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -11,15 +11,12 @@ from aioairzone.exceptions import (
     SystemOutOfRange,
 )
 
-from homeassistant import config_entries
 from homeassistant.components.airzone.config_flow import short_mac
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .util import (
     CONFIG,
@@ -31,12 +28,12 @@ from .util import (
     USER_INPUT,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, MockDhcpServiceInfo
 
-DHCP_SERVICE_INFO = DhcpServiceInfo(
+DHCP_SERVICE_INFO = MockDhcpServiceInfo(
     hostname="airzone",
     ip="192.168.1.100",
-    macaddress=dr.format_mac("E84F25000000").replace(":", ""),
+    macaddress="E84F25000000",
 )
 
 TEST_ID = 1
@@ -204,11 +201,7 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.AirzoneLocalApi.get_version",
         return_value=HVAC_VERSION_MOCK,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            data=DHCP_SERVICE_INFO,
-            context={"source": config_entries.SOURCE_DHCP},
-        )
+        result = await DHCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
@@ -262,11 +255,7 @@ async def test_dhcp_flow_error(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.AirzoneLocalApi.get_version",
         side_effect=AirzoneError,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            data=DHCP_SERVICE_INFO,
-            context={"source": config_entries.SOURCE_DHCP},
-        )
+        result = await DHCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
@@ -279,11 +268,7 @@ async def test_dhcp_connection_error(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.AirzoneLocalApi.get_version",
         return_value=HVAC_VERSION_MOCK,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            data=DHCP_SERVICE_INFO,
-            context={"source": config_entries.SOURCE_DHCP},
-        )
+        result = await DHCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
@@ -355,11 +340,7 @@ async def test_dhcp_invalid_system_id(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.AirzoneLocalApi.get_version",
         return_value=HVAC_VERSION_MOCK,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            data=DHCP_SERVICE_INFO,
-            context={"source": config_entries.SOURCE_DHCP},
-        )
+        result = await DHCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -28,7 +28,8 @@ from .util import (
     USER_INPUT,
 )
 
-from tests.common import MockConfigEntry, MockDhcpServiceInfo
+from tests.common import MockConfigEntry
+from tests.service_info import MockDhcpServiceInfo
 
 DHCP_SERVICE_INFO = MockDhcpServiceInfo(
     hostname="airzone",

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -11,6 +11,7 @@ from aioairzone.exceptions import (
     SystemOutOfRange,
 )
 
+from homeassistant import config_entries
 from homeassistant.components.airzone.config_flow import short_mac
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
@@ -202,7 +203,11 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.AirzoneLocalApi.get_version",
         return_value=HVAC_VERSION_MOCK,
     ):
-        result = await DHCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DHCP_SERVICE_INFO,
+            context={"source": config_entries.SOURCE_DHCP},
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
@@ -256,7 +261,11 @@ async def test_dhcp_flow_error(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.AirzoneLocalApi.get_version",
         side_effect=AirzoneError,
     ):
-        result = await DHCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DHCP_SERVICE_INFO,
+            context={"source": config_entries.SOURCE_DHCP},
+        )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
@@ -269,7 +278,11 @@ async def test_dhcp_connection_error(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.AirzoneLocalApi.get_version",
         return_value=HVAC_VERSION_MOCK,
     ):
-        result = await DHCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DHCP_SERVICE_INFO,
+            context={"source": config_entries.SOURCE_DHCP},
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
@@ -341,7 +354,11 @@ async def test_dhcp_invalid_system_id(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.AirzoneLocalApi.get_version",
         return_value=HVAC_VERSION_MOCK,
     ):
-        result = await DHCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DHCP_SERVICE_INFO,
+            context={"source": config_entries.SOURCE_DHCP},
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -22,7 +22,8 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .mock_data import MOCK_CONFIG, NETWORK_INFO, ROBOROCK_RRUID, USER_DATA, USER_EMAIL
 
-from tests.common import MockConfigEntry, MockDhcpServiceInfo
+from tests.common import MockConfigEntry
+from tests.service_info import MockDhcpServiceInfo
 
 DNCP_SERVICE_INFO = MockDhcpServiceInfo(
     ip=NETWORK_INFO.ip,

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -25,12 +25,6 @@ from .mock_data import MOCK_CONFIG, NETWORK_INFO, ROBOROCK_RRUID, USER_DATA, USE
 from tests.common import MockConfigEntry
 from tests.service_info import MockDhcpServiceInfo
 
-DNCP_SERVICE_INFO = MockDhcpServiceInfo(
-    ip=NETWORK_INFO.ip,
-    macaddress=NETWORK_INFO.mac,
-    hostname="roborock-vacuum-a72",
-)
-
 
 @pytest.fixture
 def cleanup_map_storage():
@@ -352,7 +346,15 @@ async def test_discovery_not_setup(
     with (
         patch("homeassistant.components.roborock.async_setup_entry", return_value=True),
     ):
-        result = await DNCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=MockDhcpServiceInfo(
+                ip=NETWORK_INFO.ip,
+                macaddress=NETWORK_INFO.mac,
+                hostname="roborock-vacuum-a72",
+            ),
+        )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "user"
         with patch(
@@ -389,7 +391,15 @@ async def test_discovery_already_setup(
     """Handle aborting if the device is already setup."""
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
     await hass.async_block_till_done()
-    result = await DNCP_SERVICE_INFO.start_discovery_flow(hass, DOMAIN)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data=MockDhcpServiceInfo(
+            ip=NETWORK_INFO.ip,
+            macaddress=NETWORK_INFO.mac,
+            hostname="roborock-vacuum-a72",
+        ),
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/wmspro/test_config_flow.py
+++ b/tests/components/wmspro/test_config_flow.py
@@ -5,15 +5,14 @@ from unittest.mock import AsyncMock, patch
 import aiohttp
 
 from homeassistant.components.wmspro.const import DOMAIN
-from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER, ConfigEntryState
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from . import setup_config_entry
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, MockDhcpServiceInfo
 
 
 async def test_config_flow(
@@ -49,12 +48,10 @@ async def test_config_flow_from_dhcp(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_hub_refresh: AsyncMock
 ) -> None:
     """Test we can handle DHCP discovery to create a config entry."""
-    info = DhcpServiceInfo(
+    info = MockDhcpServiceInfo(
         ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_DHCP}, data=info
-    )
+    result = await info.start_discovery_flow(hass, DOMAIN)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -108,12 +105,10 @@ async def test_config_flow_from_dhcp_add_mac(
     assert len(mock_setup_entry.mock_calls) == 1
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id is None
 
-    info = DhcpServiceInfo(
+    info = MockDhcpServiceInfo(
         ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_DHCP}, data=info
-    )
+    result = await info.start_discovery_flow(hass, DOMAIN)
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
@@ -125,12 +120,10 @@ async def test_config_flow_from_dhcp_ip_update(
     mock_hub_refresh: AsyncMock,
 ) -> None:
     """Test we can use DHCP discovery to update IP in a config entry."""
-    info = DhcpServiceInfo(
+    info = MockDhcpServiceInfo(
         ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_DHCP}, data=info
-    )
+    result = await info.start_discovery_flow(hass, DOMAIN)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -153,12 +146,10 @@ async def test_config_flow_from_dhcp_ip_update(
     assert len(mock_setup_entry.mock_calls) == 1
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
 
-    info = DhcpServiceInfo(
+    info = MockDhcpServiceInfo(
         ip="5.6.7.8", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_DHCP}, data=info
-    )
+    result = await info.start_discovery_flow(hass, DOMAIN)
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
@@ -171,12 +162,10 @@ async def test_config_flow_from_dhcp_no_update(
     mock_hub_refresh: AsyncMock,
 ) -> None:
     """Test we do not use DHCP discovery to overwrite hostname with IP in config entry."""
-    info = DhcpServiceInfo(
+    info = MockDhcpServiceInfo(
         ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_DHCP}, data=info
-    )
+    result = await info.start_discovery_flow(hass, DOMAIN)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -199,12 +188,10 @@ async def test_config_flow_from_dhcp_no_update(
     assert len(mock_setup_entry.mock_calls) == 1
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
 
-    info = DhcpServiceInfo(
+    info = MockDhcpServiceInfo(
         ip="5.6.7.8", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_DHCP}, data=info
-    )
+    result = await info.start_discovery_flow(hass, DOMAIN)
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"

--- a/tests/components/wmspro/test_config_flow.py
+++ b/tests/components/wmspro/test_config_flow.py
@@ -12,7 +12,8 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from . import setup_config_entry
 
-from tests.common import MockConfigEntry, MockDhcpServiceInfo
+from tests.common import MockConfigEntry
+from tests.service_info import MockDhcpServiceInfo
 
 
 async def test_config_flow(

--- a/tests/components/wmspro/test_config_flow.py
+++ b/tests/components/wmspro/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import aiohttp
 
 from homeassistant.components.wmspro.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
+from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -52,7 +52,9 @@ async def test_config_flow_from_dhcp(
     info = MockDhcpServiceInfo(
         ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await info.start_discovery_flow(hass, DOMAIN)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -109,7 +111,9 @@ async def test_config_flow_from_dhcp_add_mac(
     info = MockDhcpServiceInfo(
         ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await info.start_discovery_flow(hass, DOMAIN)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
@@ -124,7 +128,9 @@ async def test_config_flow_from_dhcp_ip_update(
     info = MockDhcpServiceInfo(
         ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await info.start_discovery_flow(hass, DOMAIN)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -150,7 +156,9 @@ async def test_config_flow_from_dhcp_ip_update(
     info = MockDhcpServiceInfo(
         ip="5.6.7.8", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await info.start_discovery_flow(hass, DOMAIN)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
@@ -166,7 +174,9 @@ async def test_config_flow_from_dhcp_no_update(
     info = MockDhcpServiceInfo(
         ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await info.start_discovery_flow(hass, DOMAIN)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -192,7 +202,9 @@ async def test_config_flow_from_dhcp_no_update(
     info = MockDhcpServiceInfo(
         ip="5.6.7.8", hostname="webcontrol", macaddress="00:11:22:33:44:55"
     )
-    result = await info.start_discovery_flow(hass, DOMAIN)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"

--- a/tests/service_info.py
+++ b/tests/service_info.py
@@ -1,0 +1,32 @@
+"""Service info test helpers."""
+
+from __future__ import annotations
+
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+
+
+class MockDhcpServiceInfo(DhcpServiceInfo):
+    """Mocked DHCP service info."""
+
+    def __init__(self, ip: str, hostname: str, macaddress: str) -> None:
+        """Initialize the mock service info."""
+        # Historically, the MAC address was formatted without colons
+        # and since all consumers of this data are expecting it to be
+        # formatted without colons we will continue to do so
+        super().__init__(
+            ip=ip,
+            hostname=hostname,
+            macaddress=dr.format_mac(macaddress).replace(":", ""),
+        )
+
+    async def start_discovery_flow(
+        self, hass: HomeAssistant, domain: str
+    ) -> ConfigFlowResult:
+        """Start a reauthentication flow."""
+        return await hass.config_entries.flow.async_init(
+            domain, context={"source": config_entries.SOURCE_DHCP}, data=self
+        )

--- a/tests/service_info.py
+++ b/tests/service_info.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
@@ -21,12 +18,4 @@ class MockDhcpServiceInfo(DhcpServiceInfo):
             ip=ip,
             hostname=hostname,
             macaddress=dr.format_mac(macaddress).replace(":", ""),
-        )
-
-    async def start_discovery_flow(
-        self, hass: HomeAssistant, domain: str
-    ) -> ConfigFlowResult:
-        """Start a reauthentication flow."""
-        return await hass.config_entries.flow.async_init(
-            domain, context={"source": config_entries.SOURCE_DHCP}, data=self
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Whilst reviewing #110599, I looked at existing DhcpServiceInfo tests and realised that quite a few did not set the MAC address correctly (lowercase without colons)

This adds a new `MockDhcpServiceInfo` helper which formats the mac address accordingly, with an extra method to start the discovery flow

I think all integrations would benefit from this new helper - but I've selected just four to highlight the benefits

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
