### PR TITLE
Fix Reolink setup when ONVIF push is unsupported

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -581,7 +581,12 @@ class ReolinkHost:
             )
             return
 
-        await self._api.subscribe(self._webhook_url)
+        try:
+            await self._api.subscribe(self._webhook_url)
+        except NotSupportedError as err:
+            self._onvif_push_supported = False
+            _LOGGER.debug(err)
+            return
 
         _LOGGER.debug(
             "Host %s: subscribed successfully to webhook %s",
@@ -602,7 +607,7 @@ class ReolinkHost:
             return  # API is shutdown, no need to subscribe
 
         try:
-            if self._onvif_push_supported and not self._api.baichuan.events_active:
+            if self._onvif_push_supported and not self._api.baichuan.events_active and self._cancel_tcp_push_check is None:
                 await self._renew(SubType.push)
 
             if self._onvif_long_poll_supported and self._long_poll_task is not None:

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -607,7 +607,11 @@ class ReolinkHost:
             return  # API is shutdown, no need to subscribe
 
         try:
-            if self._onvif_push_supported and not self._api.baichuan.events_active and self._cancel_tcp_push_check is None:
+            if (
+                self._onvif_push_supported
+                and not self._api.baichuan.events_active
+                and self._cancel_tcp_push_check is None
+            ):
                 await self._renew(SubType.push)
 
             if self._onvif_long_poll_supported and self._long_poll_task is not None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
On very old Reolink models like the RLC-423, ONVIF push is not supported.
When the TCP push also fails, this could lead to the following unexpected exception blocking startup.

```
2025-05-10 20:10:21.209 ERROR (MainThread) [homeassistant.components.reolink] Unexpected error fetching reolink.RLC-423 data
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 380, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 281, in _async_update_data
    return await self.update_method()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/reolink/__init__.py", line 149, in async_device_config_update
    await host.renew()
  File "/usr/src/homeassistant/homeassistant/components/reolink/host.py", line 605, in renew
    await self._renew(SubType.push)
  File "/usr/src/homeassistant/homeassistant/components/reolink/host.py", line 636, in _renew
    await self.subscribe()
  File "/usr/src/homeassistant/homeassistant/components/reolink/host.py", line 583, in subscribe
    await self._api.subscribe(self._webhook_url)
  File "/usr/local/lib/python3.13/site-packages/reolink_aio/api.py", line 6247, in subscribe
    raise err
  File "/usr/local/lib/python3.13/site-packages/reolink_aio/api.py", line 6245, in subscribe
    response = await self.subscription_send(headers, xml)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/reolink_aio/api.py", line 6206, in subscription_send
    raise NotSupportedError(
    ...<2 lines>...
    )
reolink_aio.exceptions.NotSupportedError: Host 192.168.0.194:443: subscription request got HTTP status response 400: Bad Request with 'SOAP-ENV:Fault' as response text
```

This PR ensures the proper checks are in place to prevent such errors:
- Do not renew the ONVIF push subscription while we are still waiting to see if TCP push succeeds.
- If at a later time ONVIF push is subscribed for the first time and the response is that it is unsupported, properly mark it as unsupported so it does not keep checking and does not throw this unexpected exception.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/starkillerOG/reolink_aio/issues/110
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
