### PR TITLE
Add Message Canceling to Pushover Integration 

### DIFF
--- a/homeassistant/components/pushover/const.py
+++ b/homeassistant/components/pushover/const.py
@@ -5,7 +5,6 @@ from typing import Final
 DOMAIN: Final = "pushover"
 DATA_HASS_CONFIG: Final = "pushover_hass_config"
 DEFAULT_NAME: Final = "Pushover"
-SERVICE_CANCEL: Final = "cancel"
 
 ATTR_ATTACHMENT: Final = "attachment"
 ATTR_URL: Final = "url"

--- a/homeassistant/components/pushover/const.py
+++ b/homeassistant/components/pushover/const.py
@@ -18,5 +18,8 @@ ATTR_EXPIRE: Final = "expire"
 ATTR_TTL: Final = "ttl"
 ATTR_DATA: Final = "data"
 ATTR_TIMESTAMP: Final = "timestamp"
+ATTR_TAGS: Final = "tags"
+
+CLEAR_NOTIFICATIONS_BY_TAGS: Final = "clear_notifications_by_tags"
 
 CONF_USER_KEY: Final = "user_key"

--- a/homeassistant/components/pushover/const.py
+++ b/homeassistant/components/pushover/const.py
@@ -5,6 +5,7 @@ from typing import Final
 DOMAIN: Final = "pushover"
 DATA_HASS_CONFIG: Final = "pushover_hass_config"
 DEFAULT_NAME: Final = "Pushover"
+SERVICE_CANCEL: Final = "cancel"
 
 ATTR_ATTACHMENT: Final = "attachment"
 ATTR_URL: Final = "url"
@@ -18,8 +19,7 @@ ATTR_EXPIRE: Final = "expire"
 ATTR_TTL: Final = "ttl"
 ATTR_DATA: Final = "data"
 ATTR_TIMESTAMP: Final = "timestamp"
+ATTR_TAG: Final = "tag"
 ATTR_TAGS: Final = "tags"
-
-CLEAR_NOTIFICATIONS_BY_TAGS: Final = "clear_notifications_by_tags"
 
 CONF_USER_KEY: Final = "user_key"

--- a/homeassistant/components/pushover/icons.json
+++ b/homeassistant/components/pushover/icons.json
@@ -1,0 +1,7 @@
+{
+  "services": {
+    "cancel": {
+      "service": "mdi:cancel"
+    }
+  }
+}

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -78,7 +78,7 @@ class PushoverNotificationService(BaseNotificationService):
             """Handle cancel notification message service calls."""
             kwargs = {}
             kwargs[ATTR_DATA] = service.data.get(ATTR_DATA)
-            await self.async_cancel(**kwargs)
+            await self.hass.async_add_executor_job(partial(self.cancel, **kwargs))
 
         hass.services.async_register(
             DOMAIN,
@@ -189,10 +189,3 @@ class PushoverNotificationService(BaseNotificationService):
             except BadAPIRequestError:
                 _LOGGER.exception("Error while trying to cancel receipt %s", receipt)
             del self.receipt_tags[receipt]
-
-    async def async_cancel(self, **kwargs):
-        """Cancel a notification.
-
-        This method must be run in the event loop.
-        """
-        await self.hass.async_add_executor_job(partial(self.cancel, **kwargs))

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -98,7 +98,7 @@ class PushoverNotificationService(BaseNotificationService):
         callback_url = data.get(ATTR_CALLBACK_URL)
         timestamp = data.get(ATTR_TIMESTAMP)
         sound = data.get(ATTR_SOUND)
-        html = 1 if data.get(ATTR_HTML, False) else 0
+        html = bool(data.get(ATTR_HTML, False))
         tags = data.get(ATTR_TAGS, [])
 
         if isinstance(tags, str):

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -43,9 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 SERVICE_CANCEL = "cancel"
 SERVICE_CANCEL_SCHEMA = vol.Schema(
     {
-        vol.Optional(ATTR_DATA): {
-            vol.Optional(ATTR_TAG): cv.string,
-        },
+        vol.Optional(ATTR_TAG): cv.string,
     }
 )
 
@@ -150,9 +148,8 @@ class PushoverNotificationService(BaseNotificationService):
             raise HomeAssistantError(str(err)) from err
 
     def cancel_message_service(self, service: ServiceCall):
-        """Cancel all notifications with a given tag."""
-        data = service.data.get(ATTR_DATA)
-        tag = data.get(ATTR_TAG) if data else ""
+        """Cancel all notifications with a given tag or all if no specific tag is given."""
+        tag = service.data.get(ATTR_TAG, "")
 
         if not self.receipt_tags:
             _LOGGER.debug("There are no notifications to be canceled")

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -17,6 +17,7 @@ from homeassistant.components.notify import (
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import (
@@ -35,14 +36,16 @@ from .const import (
     ATTR_URL_TITLE,
     CONF_USER_KEY,
     DOMAIN,
-    SERVICE_CANCEL,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-CANCEL_SERVICE_SCHEMA = vol.Schema(
+SERVICE_CANCEL = "cancel"
+SERVICE_CANCEL_SCHEMA = vol.Schema(
     {
-        vol.Optional(ATTR_DATA): dict,
+        vol.Optional(ATTR_DATA): {
+            vol.Optional(ATTR_TAG): cv.string,
+        },
     }
 )
 
@@ -77,7 +80,7 @@ class PushoverNotificationService(BaseNotificationService):
             DOMAIN,
             SERVICE_CANCEL,
             self.cancel_message_service,
-            schema=CANCEL_SERVICE_SCHEMA,
+            schema=SERVICE_CANCEL_SCHEMA,
         )
 
     def send_message(self, message: str = "", **kwargs: Any) -> None:

--- a/homeassistant/components/pushover/services.yaml
+++ b/homeassistant/components/pushover/services.yaml
@@ -1,0 +1,6 @@
+cancel:
+  fields:
+    data:
+      example: '{ "tag": "tagname" }'
+      selector:
+        object:

--- a/homeassistant/components/pushover/strings.json
+++ b/homeassistant/components/pushover/strings.json
@@ -24,5 +24,17 @@
         }
       }
     }
+  },
+  "services": {
+    "cancel": {
+      "name": "Cancel",
+      "description": "Cancels a pushover emergency notification.",
+      "fields": {
+        "data": {
+          "name": "Data",
+          "description": "Extended information of notification. Supports tag."
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/pushover/strings.json
+++ b/homeassistant/components/pushover/strings.json
@@ -27,7 +27,7 @@
   },
   "services": {
     "cancel": {
-      "name": "Cancel",
+      "name": "Cancel notification",
       "description": "Cancels a pushover emergency notification.",
       "fields": {
         "data": {

--- a/homeassistant/components/pushover/strings.json
+++ b/homeassistant/components/pushover/strings.json
@@ -28,7 +28,7 @@
   "services": {
     "cancel": {
       "name": "Cancel notification",
-      "description": "Cancels a pushover emergency notification.",
+      "description": "Cancels a Pushover emergency notification.",
       "fields": {
         "data": {
           "name": "Data",

--- a/tests/components/pushover/test_notify.py
+++ b/tests/components/pushover/test_notify.py
@@ -9,13 +9,13 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
+RECEIPT = "1758472711"
+
 
 @pytest.fixture(autouse=False)
 def mock_pushover():
     """Mock pushover."""
-    with patch(
-        "pushover_complete.PushoverAPI._generic_post", return_value={}
-    ) as mock_generic_post:
+    with patch("pushover_complete.PushoverAPI._generic_post") as mock_generic_post:
         yield mock_generic_post
 
 
@@ -23,7 +23,26 @@ def mock_pushover():
 def mock_send_message():
     """Patch PushoverAPI.send_message for TTL test."""
     with patch(
-        "homeassistant.components.pushover.notify.PushoverAPI.send_message"
+        "homeassistant.components.pushover.notify.PushoverAPI.send_message",
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_send_message_prio2():
+    """Patch PushoverAPI.send_message for cancel test."""
+    with patch(
+        "homeassistant.components.pushover.notify.PushoverAPI.send_message",
+        return_value={"receipt": RECEIPT},
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_cancel_receipt():
+    """Patch PushoverAPI.cancel_receipt for cancel test."""
+    with patch(
+        "homeassistant.components.pushover.notify.PushoverAPI.cancel_receipt"
     ) as mock:
         yield mock
 
@@ -69,3 +88,61 @@ async def test_send_message(
         html=0,
         ttl=900,
     )
+
+
+async def test_cancel_message(
+    hass: HomeAssistant,
+    mock_pushover: MagicMock,
+    mock_send_message_prio2: MagicMock,
+    mock_cancel_receipt: MagicMock,
+) -> None:
+    """Test cancelling a message."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "pushover",
+            "api_key": "API_KEY",
+            "user_key": "USER_KEY",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "notify",
+        "pushover",
+        {
+            "message": "Hello Emergency",
+            "data": {"ttl": 900, "priority": 2, "retry": 30, "tags": "tag1"},
+        },
+        blocking=True,
+    )
+
+    mock_send_message_prio2.assert_called_once_with(
+        user="USER_KEY",
+        message="Hello Emergency",
+        device="",
+        title="Home Assistant",
+        url=None,
+        url_title=None,
+        image=None,
+        priority=2,
+        retry=30,
+        expire=None,
+        callback_url=None,
+        timestamp=None,
+        sound=None,
+        html=0,
+        ttl=900,
+    )
+
+    await hass.services.async_call(
+        "pushover",
+        "cancel",
+        {"tag": "tag1"},
+        blocking=True,
+    )
+
+    mock_cancel_receipt.assert_called_once_with(RECEIPT)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Pushover service supports message priorities, where priority 2 messages represent "emergency messages" that are repeated until they are acknowledged by one of the recipients or they expire. Additionally, the Pushover API allows to early cancel such an emergency message by an ID the Pushover API returns when sending the message.

This PR adds the ability to use this emergency message canceling by storing the issued message ID ("receipt_id") with one or more tags provided with the message and exposing an action `pushover.cancel` that allows to cancel all previously sent messages with a specific tag. Calling the action without a tag will cancel all emergency messages at once.

An example use-case can be found in [Pushover cancel Alert](https://community.home-assistant.io/t/pushover-cancel-alert/873231).

Link to documentation PR: https://github.com/home-assistant/home-assistant.io/pull/40095

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
