### PR TITLE
Add `light` platform to `airq` integration to control the brightness of device's LEDs

### DIFF
--- a/homeassistant/components/airq/__init__.py
+++ b/homeassistant/components/airq/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from .const import CONF_CLIP_NEGATIVE, CONF_RETURN_AVERAGE
 from .coordinator import AirQCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.LIGHT, Platform.SENSOR]
 
 AirQConfigEntry = ConfigEntry[AirQCoordinator]
 

--- a/homeassistant/components/airq/coordinator.py
+++ b/homeassistant/components/airq/coordinator.py
@@ -75,6 +75,8 @@ class AirQCoordinator(DataUpdateCoordinator):
             return_average=self.return_average,
             clip_negative_values=self.clip_negative,
         )
+        data["brightness"] = await self.airq.get_current_brightness()
+
         if warming_up_sensors := identify_warming_up_sensors(data):
             _LOGGER.debug(
                 "Following sensors are still warming up: %s", warming_up_sensors

--- a/homeassistant/components/airq/light.py
+++ b/homeassistant/components/airq/light.py
@@ -74,15 +74,19 @@ class AirQLight(CoordinatorEntity, LightEntity):
 
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.device_id}_{description.key}"
+        self._update_attr()
+
+    def _update_attr(self) -> None:
+        led_value = self.entity_description.value(self.coordinator.data)
+        self._attr_is_on = bool(led_value)
+        if self._attr_is_on:
+            # do not update if off, to be able to restore the brightness once toggled on
+            self._attr_brightness = value_to_brightness(LED_VALUE_SCALE, led_value)
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle the LED value received from the coordinator."""
-        led_value = self.entity_description.value(self.coordinator.data)
-        assert led_value is not None
-        if is_on := (led_value > 0):
-            self._attr_brightness = value_to_brightness(LED_VALUE_SCALE, led_value)
-        self._attr_is_on = is_on
+        self._update_attr()
         super()._handle_coordinator_update()
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/airq/light.py
+++ b/homeassistant/components/airq/light.py
@@ -22,7 +22,8 @@ from homeassistant.util.color import brightness_to_value, value_to_brightness
 
 from . import AirQConfigEntry, AirQCoordinator
 
-LED_VALUE_SCALE = (1, 10)  # must not include 0 as 0 == off, thus must not be included
+LED_VALUE_SCALE = (1.0, 10.0)  # must not include 0 as 0 == off
+LED_VALUE_DEFAULT = 6.0
 BRIGHTNESS_DEFAULT = 153  # ~60%
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,13 +33,13 @@ _LOGGER = logging.getLogger(__name__)
 class AirQLightEntityDescription(LightEntityDescription):
     """Describes AirQ LED entity."""
 
-    value: Callable[[dict], float | int | None]
+    value: Callable[[dict], float]
 
 
 AIRQ_LIGHT_DESCRIPTION = AirQLightEntityDescription(
     key="airq_leds",
     translation_key="airq_leds",
-    value=lambda device: device.get("brightness"),
+    value=lambda device: device.get("brightness", LED_VALUE_DEFAULT),
 )
 
 

--- a/homeassistant/components/airq/light.py
+++ b/homeassistant/components/airq/light.py
@@ -87,7 +87,7 @@ class AirQLight(CoordinatorEntity, LightEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle the LED value received from the coordinator."""
         self._update_attr()
-        super()._handle_coordinator_update()
+        self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
@@ -102,11 +102,13 @@ class AirQLight(CoordinatorEntity, LightEntity):
         led_value = brightness_to_value(LED_VALUE_SCALE, brightness)
         _LOGGER.debug("Switching LED to value of %f", led_value)
         await self._device.set_current_brightness(led_value)
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
         self._attr_is_on = False
         await self._device.set_current_brightness(0)
+        self.async_write_ha_state()
 
     @property
     def _device(self) -> AirQ:

--- a/homeassistant/components/airq/light.py
+++ b/homeassistant/components/airq/light.py
@@ -1,0 +1,111 @@
+"""Definition of air-Q light platform (realised via AirQ LEDs)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from aioairq import AirQ
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ColorMode,
+    LightEntity,
+    LightEntityDescription,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.color import brightness_to_value, value_to_brightness
+
+from . import AirQConfigEntry, AirQCoordinator
+
+LED_VALUE_SCALE = (1, 10)  # must not include 0 as 0 == off, thus must not be included
+BRIGHTNESS_DEFAULT = 153  # ~60%
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class AirQLightEntityDescription(LightEntityDescription):
+    """Describes AirQ LED entity."""
+
+    value: Callable[[dict], float | int | None]
+
+
+AIRQ_LIGHT_DESCRIPTION = AirQLightEntityDescription(
+    key="airq_leds",
+    translation_key="airq_leds",
+    value=lambda device: device.get("brightness"),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: AirQConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up sensor entities based on a config entry."""
+
+    coordinator = entry.runtime_data
+    entities = [AirQLight(coordinator, AIRQ_LIGHT_DESCRIPTION)]
+
+    async_add_entities(entities)
+
+
+class AirQLight(CoordinatorEntity, LightEntity):
+    """Representation of the LEDs from a single AirQ."""
+
+    _attr_has_entity_name = True
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+    _attr_color_mode = ColorMode.BRIGHTNESS
+
+    def __init__(
+        self,
+        coordinator: AirQCoordinator,
+        description: AirQLightEntityDescription,
+    ) -> None:
+        """Initialize a single sensor."""
+        super().__init__(coordinator)
+        self.entity_description: AirQLightEntityDescription = description
+
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.device_id}_{description.key}"
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle the LED value received from the coordinator."""
+        led_value = self.entity_description.value(self.coordinator.data)
+        assert led_value is not None
+        if is_on := (led_value > 0):
+            self._attr_brightness = value_to_brightness(LED_VALUE_SCALE, led_value)
+        self._attr_is_on = is_on
+        super()._handle_coordinator_update()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the light."""
+        # if HA changes brightness, ATTR_BRIGHTNESS is in kwargs.
+        # otherwise restore to cached brightness or fall back to the default
+        brightness = (
+            kwargs.get(ATTR_BRIGHTNESS, self._attr_brightness) or BRIGHTNESS_DEFAULT
+        )
+        self._attr_brightness = brightness
+        self._attr_is_on = True
+
+        led_value = brightness_to_value(LED_VALUE_SCALE, brightness)
+        _LOGGER.debug("Switching LED to value of %f", led_value)
+        await self._device.set_current_brightness(led_value)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the light."""
+        self._attr_is_on = False
+        await self._device.set_current_brightness(0)
+
+    @property
+    def _device(self) -> AirQ:
+        """Return the device."""
+        # the following assertion pacifies mypy
+        assert isinstance(self.coordinator, AirQCoordinator)
+        return self.coordinator.airq

--- a/homeassistant/components/airq/manifest.json
+++ b/homeassistant/components/airq/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["aioairq"],
-  "requirements": ["aioairq==0.4.4"]
+  "requirements": ["aioairq==0.4.5"]
 }

--- a/homeassistant/components/airq/sensor.py
+++ b/homeassistant/components/airq/sensor.py
@@ -37,85 +37,85 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class AirQEntityDescription(SensorEntityDescription):
+class AirQSensorEntityDescription(SensorEntityDescription):
     """Describes AirQ sensor entity."""
 
     value: Callable[[dict], float | int | None]
 
 
 # Keys must match those in the data dictionary
-SENSOR_TYPES: list[AirQEntityDescription] = [
-    AirQEntityDescription(
+SENSOR_TYPES: list[AirQSensorEntityDescription] = [
+    AirQSensorEntityDescription(
         key="c2h4o",
         translation_key="acetaldehyde",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("c2h4o"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="nh3_MR100",
         translation_key="ammonia",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("nh3_MR100"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="ash3",
         translation_key="arsine",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("ash3"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="br2",
         translation_key="bromine",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("br2"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="ch4s",
         translation_key="methanethiol",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("ch4s"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="cl2_M20",
         translation_key="chlorine",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("cl2_M20"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="clo2",
         translation_key="chlorine_dioxide",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("clo2"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="co",
         translation_key="carbon_monoxide",
         native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("co"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="co2",
         device_class=SensorDeviceClass.CO2,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("co2"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="cs2",
         translation_key="carbon_disulfide",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("cs2"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="dewpt",
         translation_key="dew_point",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -123,189 +123,189 @@ SENSOR_TYPES: list[AirQEntityDescription] = [
         value=lambda data: data.get("dewpt"),
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="ethanol",
         translation_key="ethanol",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("ethanol"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="c2h4",
         translation_key="ethylene",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("c2h4"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="ch2o_M10",
         translation_key="formaldehyde",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("ch2o_M10"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="f2",
         translation_key="fluorine",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("f2"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="h2s",
         translation_key="hydrogen_sulfide",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("h2s"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="hcl",
         translation_key="hydrochloric_acid",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("hcl"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="hcn",
         translation_key="hydrogen_cyanide",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("hcn"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="hf",
         translation_key="hydrogen_fluoride",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("hf"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="health",
         translation_key="health_index",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("health", 0.0) / 10.0,
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="humidity",
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("humidity"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="humidity_abs",
         translation_key="absolute_humidity",
         native_unit_of_measurement=CONCENTRATION_GRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("humidity_abs"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="h2_M1000",
         translation_key="hydrogen",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("h2_M1000"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="h2o2",
         translation_key="hydrogen_peroxide",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("h2o2"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="ch4_MIPEX",
         translation_key="methane",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("ch4_MIPEX"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="n2o",
         device_class=SensorDeviceClass.NITROUS_OXIDE,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("n2o"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="no_M250",
         device_class=SensorDeviceClass.NITROGEN_MONOXIDE,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("no_M250"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="no2",
         device_class=SensorDeviceClass.NITROGEN_DIOXIDE,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("no2"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="acid_M100",
         translation_key="organic_acid",
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_BILLION,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("acid_M100"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="oxygen",
         translation_key="oxygen",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("oxygen"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="o3",
         device_class=SensorDeviceClass.OZONE,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("o3"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="performance",
         translation_key="performance_index",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("performance", 0.0) / 10.0,
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="ph3",
         translation_key="hydrogen_phosphide",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("ph3"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="pm1",
         device_class=SensorDeviceClass.PM1,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("pm1"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="pm2_5",
         device_class=SensorDeviceClass.PM25,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("pm2_5"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="pm10",
         device_class=SensorDeviceClass.PM10,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("pm10"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="pressure",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=UnitOfPressure.HPA,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("pressure"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="pressure_rel",
         translation_key="relative_pressure",
         native_unit_of_measurement=UnitOfPressure.HPA,
@@ -313,35 +313,35 @@ SENSOR_TYPES: list[AirQEntityDescription] = [
         value=lambda data: data.get("pressure_rel"),
         device_class=SensorDeviceClass.PRESSURE,
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="c3h8_MIPEX",
         translation_key="propane",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("c3h8_MIPEX"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="refigerant",
         translation_key="refigerant",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("refigerant"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="sih4",
         translation_key="silicon_hydride",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("sih4"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="so2",
         device_class=SensorDeviceClass.SULPHUR_DIOXIDE,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("so2"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="sound",
         translation_key="noise",
         native_unit_of_measurement=UnitOfSoundPressure.WEIGHTED_DECIBEL_A,
@@ -349,7 +349,7 @@ SENSOR_TYPES: list[AirQEntityDescription] = [
         value=lambda data: data.get("sound"),
         device_class=SensorDeviceClass.SOUND_PRESSURE,
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="sound_max",
         translation_key="maximum_noise",
         native_unit_of_measurement=UnitOfSoundPressure.WEIGHTED_DECIBEL_A,
@@ -357,28 +357,28 @@ SENSOR_TYPES: list[AirQEntityDescription] = [
         value=lambda data: data.get("sound_max"),
         device_class=SensorDeviceClass.SOUND_PRESSURE,
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="radon",
         translation_key="radon",
         native_unit_of_measurement=ACTIVITY_BECQUEREL_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("radon"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("temperature"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="tvoc",
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_BILLION,
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("tvoc"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="tvoc_ionsc",
         translation_key="industrial_volatile_organic_compounds",
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
@@ -386,7 +386,7 @@ SENSOR_TYPES: list[AirQEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data.get("tvoc_ionsc"),
     ),
-    AirQEntityDescription(
+    AirQSensorEntityDescription(
         key="virus",
         translation_key="virus_index",
         native_unit_of_measurement=PERCENTAGE,
@@ -434,11 +434,11 @@ class AirQSensor(CoordinatorEntity, SensorEntity):
     def __init__(
         self,
         coordinator: AirQCoordinator,
-        description: AirQEntityDescription,
+        description: AirQSensorEntityDescription,
     ) -> None:
         """Initialize a single sensor."""
         super().__init__(coordinator)
-        self.entity_description: AirQEntityDescription = description
+        self.entity_description: AirQSensorEntityDescription = description
 
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.device_id}_{description.key}"

--- a/homeassistant/components/airq/strings.json
+++ b/homeassistant/components/airq/strings.json
@@ -35,6 +35,11 @@
     }
   },
   "entity": {
+    "light": {
+      "airq_leds": {
+        "name": "LED"
+      }
+    },
     "sensor": {
       "acetaldehyde": {
         "name": "Acetaldehyde"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ aio-georss-gdacs==0.10
 aioacaia==0.1.14
 
 # homeassistant.components.airq
-aioairq==0.4.4
+aioairq==0.4.5
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.6.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -161,7 +161,7 @@ aio-georss-gdacs==0.10
 aioacaia==0.1.14
 
 # homeassistant.components.airq
-aioairq==0.4.4
+aioairq==0.4.5
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.6.12

--- a/tests/components/airq/common.py
+++ b/tests/components/airq/common.py
@@ -1,0 +1,18 @@
+"""Common methods used across tests for air-Q."""
+
+from aioairq import DeviceInfo
+
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
+
+TEST_USER_DATA = {
+    CONF_IP_ADDRESS: "192.168.0.0",
+    CONF_PASSWORD: "password",
+}
+TEST_DEVICE_INFO = DeviceInfo(
+    id="id",
+    name="airq_name",
+    model="model",
+    sw_version="sw",
+    hw_version="hw",
+)
+TEST_DEVICE_DATA = {"co2": 500.0, "Status": "OK", "brightness": 5}

--- a/tests/components/airq/conftest.py
+++ b/tests/components/airq/conftest.py
@@ -5,6 +5,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from homeassistant.components.airq.const import DOMAIN as AIRQ_DOMAIN
+from homeassistant.core import HomeAssistant
+
+from .common import TEST_DEVICE_INFO, TEST_USER_DATA
+
+from tests.common import MockConfigEntry
+
 
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock]:
@@ -13,3 +20,18 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         "homeassistant.components.airq.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture
+def airq_config_entry():
+    """Create a minimal MockConfigEntry."""
+    return MockConfigEntry(
+        domain=AIRQ_DOMAIN, data=TEST_USER_DATA, unique_id=TEST_DEVICE_INFO["id"]
+    )
+
+
+@pytest.fixture
+def registered_airq_config_entry(hass: HomeAssistant, airq_config_entry):
+    """Create & register a minimal MockConfigEntry."""
+    airq_config_entry.add_to_hass(hass)
+    return airq_config_entry

--- a/tests/components/airq/test_coordinator.py
+++ b/tests/components/airq/test_coordinator.py
@@ -59,6 +59,7 @@ async def test_logging_in_coordinator_first_update_data(
     with (
         patch("aioairq.AirQ.fetch_device_info", return_value=TEST_DEVICE_INFO),
         patch("aioairq.AirQ.get_latest_data", return_value=TEST_DEVICE_DATA),
+        patch("aioairq.AirQ.get_current_brightness", return_value=6.0),
     ):
         await coordinator._async_update_data()
 
@@ -94,6 +95,7 @@ async def test_logging_in_coordinator_subsequent_update_data(
     with (
         patch("aioairq.AirQ.fetch_device_info", return_value=TEST_DEVICE_INFO),
         patch("aioairq.AirQ.get_latest_data", return_value=TEST_DEVICE_DATA),
+        patch("aioairq.AirQ.get_current_brightness", return_value=6.0),
     ):
         await coordinator._async_update_data()
     # check that the name _is not_ missing
@@ -121,6 +123,7 @@ async def test_logging_when_warming_up_sensor_present(
             "aioairq.AirQ.get_latest_data",
             return_value=TEST_DEVICE_DATA | {"Status": STATUS_WARMUP},
         ),
+        patch("aioairq.AirQ.get_current_brightness", return_value=6.0),
     ):
         await coordinator._async_update_data()
     assert (

--- a/tests/components/airq/test_light.py
+++ b/tests/components/airq/test_light.py
@@ -1,0 +1,195 @@
+"""Test the LIGHT platform from air-Q integration."""
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.airq import AirQCoordinator
+from homeassistant.components.airq.light import (
+    BRIGHTNESS_DEFAULT,
+    LED_VALUE_SCALE,
+    AirQLight,
+    AirQLightEntityDescription,
+)
+from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode
+from homeassistant.core import HomeAssistant
+import homeassistant.util.color as color_util
+
+from .common import TEST_DEVICE_DATA, TEST_DEVICE_INFO
+
+ENTITY_ID = f"light.{TEST_DEVICE_INFO['name']}_led"
+
+
+@pytest.mark.asyncio
+async def test_entity_initialization(
+    hass: HomeAssistant, registered_airq_config_entry
+) -> None:
+    """Test the initialisation of AirQLight entity."""
+    coordinator = AirQCoordinator(hass, registered_airq_config_entry)
+    coordinator.data = TEST_DEVICE_DATA
+
+    description = AirQLightEntityDescription(
+        key="airq_leds",
+        translation_key="airq_leds",
+        value=lambda data: data.get("brightness"),
+    )
+    entity = AirQLight(coordinator, description)
+
+    assert entity.unique_id == f"{coordinator.device_id}_{description.key}"
+    assert entity.supported_color_modes == {ColorMode.BRIGHTNESS}
+    assert entity.color_mode == ColorMode.BRIGHTNESS
+
+
+@pytest.fixture
+def patch_aioairq_api(monkeypatch: pytest.MonkeyPatch) -> Callable[[float], None]:
+    """Patch all aioairq.AirQ calls.
+
+    Usage:
+        patch_aioairq_api(led_brightness=5)
+    """
+
+    def _patch(led_brightness: float) -> None:
+        monkeypatch.setattr(
+            "aioairq.AirQ.fetch_device_info",
+            AsyncMock(return_value=TEST_DEVICE_INFO),
+        )
+        monkeypatch.setattr(
+            "aioairq.AirQ.get_latest_data",
+            AsyncMock(return_value=TEST_DEVICE_DATA),
+        )
+        monkeypatch.setattr(
+            "aioairq.AirQ.get_current_brightness",
+            AsyncMock(return_value=led_brightness),
+        )
+
+    return _patch
+
+
+class LightEntityFactory(Protocol):
+    """Factory for creating AirQLight entities in Home Assistant.
+
+    This callable initializes an AirQLight entity at a given brightness,
+    sets up the underlying integration, and returns the HA entity object.
+    """
+
+    def __call__(self, *, led_brightness: float) -> Awaitable[AirQLight]:
+        """Build and return an AirQLight with a specified LED brightness.
+
+        Args:
+            led_brightness (float): The brightness level for the LED (0.0–10.0).
+
+        Returns:
+            Awaitable[AirQLight]: An awaitable which, when awaited, yields the created entity.
+
+        """
+        raise NotImplementedError
+
+
+@pytest.fixture
+def light_entity_factory(
+    hass: HomeAssistant,
+    registered_airq_config_entry,
+    patch_aioairq_api: Callable[[float], None],
+) -> LightEntityFactory:
+    """PyTest fixture returning a factory to spin up an AirQLight at a given brightness.
+
+    This wraps the HA setup calls so that tests can simply `await factory(...)`
+    to get a ready-to-use `AirQLight`.
+
+    Returns:
+        LightEntityFactory: A callable accepting `led_brightness` and producing the entity.
+
+    """
+
+    async def _create(led_brightness: float) -> AirQLight:
+        """Patch call to aioairq with requested led_brightness and add AirQLight to hass.
+
+        Args:
+            led_brightness (float): The target LED brightness for the new entity.
+
+        Returns:
+            AirQLight: The created Home Assistant light entity.
+
+        """
+        patch_aioairq_api(led_brightness)
+        await hass.config_entries.async_setup(registered_airq_config_entry.entry_id)
+        await hass.async_block_till_done()
+        return hass.data["light"].get_entity(ENTITY_ID)
+
+    return _create
+
+
+@pytest.mark.parametrize(
+    ("led_initial_brightness", "expected_on", "expected_brightness"),
+    [
+        (5.0, True, color_util.value_to_brightness(LED_VALUE_SCALE, 5)),
+        (0.0, False, None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_turn_off_on_cycle(
+    light_entity_factory: LightEntityFactory,
+    led_initial_brightness: float,
+    expected_on: bool,
+    expected_brightness: int,
+) -> None:
+    """Test toggling the entity off then on from various initial LED brightnesses.
+
+    Currently, if the device was added while being turned off, the entity will
+    turn it on to the default brightness value. In other cases, previous
+    brightness value will be restored.
+    """
+    light_entity = await light_entity_factory(led_brightness=led_initial_brightness)
+
+    # ensure initial state lines up
+    assert light_entity._attr_is_on == expected_on
+    assert light_entity._attr_brightness == expected_brightness
+
+    # turn off
+    with patch("aioairq.AirQ.set_current_brightness", return_value=None):
+        await light_entity.async_turn_off()
+    assert not light_entity._attr_is_on
+    # brightness attr sticks around even when off
+    assert light_entity._attr_brightness == expected_brightness
+
+    # turn back on without an explicit brightness
+    with patch("aioairq.AirQ.set_current_brightness", return_value=None):
+        await light_entity.async_turn_on()
+    assert light_entity._attr_is_on
+
+    # if initial was 0, fall back to BRIGHTNESS_DEFAULT
+    recovered_brightness = (
+        expected_brightness if led_initial_brightness else BRIGHTNESS_DEFAULT
+    )
+    assert light_entity._attr_brightness == recovered_brightness
+
+
+@pytest.mark.asyncio
+async def test_turn_on_with_explicit_brightness(
+    light_entity_factory: LightEntityFactory,
+) -> None:
+    """Test that async_turn_on properly uses ATTR_BRIGHTNESS argument."""
+    light_entity = await light_entity_factory(led_brightness=0.0)
+    target = 100
+    with patch("aioairq.AirQ.set_current_brightness", return_value=None):
+        await light_entity.async_turn_on(**{ATTR_BRIGHTNESS: target})
+    assert light_entity._attr_is_on
+    assert light_entity._attr_brightness == target
+
+
+@pytest.mark.asyncio
+async def test_brightness_change_in_ha_state(
+    hass: HomeAssistant, light_entity_factory: LightEntityFactory
+) -> None:
+    """Test that entity methods update the corresponding HA state too."""
+    light_entity = await light_entity_factory(led_brightness=0.0)
+    target_brightness = 100
+    with patch("aioairq.AirQ.set_current_brightness", return_value=None):
+        await light_entity.async_turn_on(**{ATTR_BRIGHTNESS: target_brightness})
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "on"
+    assert state.attributes["brightness"] == target_brightness


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Expose a single `light` entity for each `airq` device, allowing to toggle the LEDs on/off and to control their brightness.
[Diff](https://github.com/CorantGmbH/aioairq/compare/v0.4.4...v0.4.5) for the dependency upgrade, that permits the brightness control on the backend side.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39043
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
