### PR TITLE
Pin rpds-py to 0.24.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -217,3 +217,8 @@ aiofiles>=24.1.0
 # https://github.com/aio-libs/multidict/issues/1134
 # https://github.com/aio-libs/multidict/issues/1131
 multidict>=6.4.2
+
+# rpds-py > 0.25.0 requires cargo 1.84.0
+# Stable Alpine current only ships cargo 1.83.0
+# No wheels upstream available for armhf & armv7
+rpds-py==0.24.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -246,6 +246,11 @@ aiofiles>=24.1.0
 # https://github.com/aio-libs/multidict/issues/1134
 # https://github.com/aio-libs/multidict/issues/1131
 multidict>=6.4.2
+
+# rpds-py > 0.25.0 requires cargo 1.84.0
+# Stable Alpine current only ships cargo 1.83.0
+# No wheels upstream available for armhf & armv7
+rpds-py==0.24.0
 """
 
 GENERATED_MESSAGE = (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pins rpds-py to 0.24.0

Current wheels errors this fixes:

```
Collecting rpds-py>=0.7.1 (from jsonschema~=4.14->matrix-nio==0.25.2->-r /tmp/wheels_requirement.txt (line 22))
  Downloading rpds_py-0.25.0.tar.gz (26 kB)
  Installing build dependencies ... 25l- \ | / - done
25h  Getting requirements to build wheel ... 25ldone
25h  Preparing metadata (pyproject.toml) ... 25l- \ | / - \ error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [36 lines of output]
          Updating crates.io index
       Downloading crates ...
        Downloaded archery v1.2.1
        Downloaded once_cell v1.21.3
        Downloaded unindent v0.2.4
        Downloaded unicode-ident v1.0.18
        Downloaded shlex v1.3.0
        Downloaded pyo3-macros v0.25.0
        Downloaded cc v1.2.22
        Downloaded pyo3-build-config v0.25.0
        Downloaded triomphe v0.1.14
        Downloaded quote v1.0.40
        Downloaded proc-macro2 v1.0.95
        Downloaded portable-atomic v1.11.0
        Downloaded indoc v2.0.6
        Downloaded libc v0.2.172
        Downloaded autocfg v1.4.0
        Downloaded pyo3-macros-backend v0.25.0
        Downloaded pyo3-ffi v0.25.0
        Downloaded pyo3 v0.25.0
        Downloaded syn v2.0.101
        Downloaded rpds v1.1.1
      error: failed to parse manifest at `/root/.cargo/registry/src/index.crates.io-1cd66030c949c28d/rpds-1.1.1/Cargo.toml`
      
      Caused by:
        feature `edition2024` is required
      
        The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
        Consider trying a newer version of Cargo (this may require the nightly release).
        See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
      💥 maturin failed
        Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
        Caused by: `cargo metadata` exited with an error:
      Error running maturin: Command '['maturin', 'pep517', 'write-dist-info', '--metadata-directory', '/tmp/pip-modern-metadata-85quflq5', '--interpreter', '/usr/local/bin/python']' returned non-zero exit status 1.
      Checking for Rust toolchain....
      Running `maturin pep517 write-dist-info --metadata-directory /tmp/pip-modern-metadata-85quflq5 --interpreter /usr/local/bin/python`
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```

It needs cargo 1.84.0 to build, but our current Alpine version has 1.83.0 available.
Upstream doesn't provide wheels for armhf & armv7, causing the wheels building to fail.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
