### PR TITLE
Option to remove reasoning from Ollama responses

### DIFF
--- a/homeassistant/components/ollama/__init__.py
+++ b/homeassistant/components/ollama/__init__.py
@@ -21,6 +21,8 @@ from .const import (
     CONF_MODEL,
     CONF_NUM_CTX,
     CONF_PROMPT,
+    CONF_REASONING_END,
+    CONF_REASONING_START,
     DEFAULT_TIMEOUT,
     DOMAIN,
 )
@@ -33,6 +35,8 @@ __all__ = [
     "CONF_MODEL",
     "CONF_NUM_CTX",
     "CONF_PROMPT",
+    "CONF_REASONING_END",
+    "CONF_REASONING_START",
     "CONF_URL",
     "DOMAIN",
 ]

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -41,6 +41,8 @@ from .const import (
     CONF_MODEL,
     CONF_NUM_CTX,
     CONF_PROMPT,
+    CONF_REASONING_END,
+    CONF_REASONING_START,
     DEFAULT_KEEP_ALIVE,
     DEFAULT_MAX_HISTORY,
     DEFAULT_MODEL,
@@ -280,6 +282,18 @@ def ollama_config_option_schema(
                 min=-1, max=sys.maxsize, step=1, mode=NumberSelectorMode.BOX
             )
         ),
+        vol.Optional(
+            CONF_REASONING_START,
+            description={
+                "suggested_value": options.get(CONF_REASONING_START, "<think>")
+            },
+        ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
+        vol.Optional(
+            CONF_REASONING_END,
+            description={
+                "suggested_value": options.get(CONF_REASONING_END, "</think>")
+            },
+        ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
     }
 
 

--- a/homeassistant/components/ollama/const.py
+++ b/homeassistant/components/ollama/const.py
@@ -4,6 +4,8 @@ DOMAIN = "ollama"
 
 CONF_MODEL = "model"
 CONF_PROMPT = "prompt"
+CONF_REASONING_START = "reasoning_start"
+CONF_REASONING_END = "reasoning_end"
 
 CONF_KEEP_ALIVE = "keep_alive"
 DEFAULT_KEEP_ALIVE = -1  # seconds. -1 = indefinite, 0 = never
@@ -120,6 +122,7 @@ MODEL_NAMES = [  # https://ollama.com/library
     "qwen2.5-coder",
     "qwen2.5",
     "qwen2",
+    "qwen3",
     "reader-lm",
     "reflection",
     "samantha-mistral",

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -168,6 +168,8 @@ async def test_options(
             ollama.CONF_PROMPT: "test prompt",
             ollama.CONF_MAX_HISTORY: 100,
             ollama.CONF_NUM_CTX: 32768,
+            ollama.CONF_REASONING_START: "test start",
+            ollama.CONF_REASONING_END: "test end",
         },
     )
     await hass.async_block_till_done()
@@ -176,6 +178,8 @@ async def test_options(
         ollama.CONF_PROMPT: "test prompt",
         ollama.CONF_MAX_HISTORY: 100,
         ollama.CONF_NUM_CTX: 32768,
+        ollama.CONF_REASONING_START: "test start",
+        ollama.CONF_REASONING_END: "test end",
     }
 
 


### PR DESCRIPTION
Adds a user option that allows a user to define reasoning start and end tags (defaulting to `<think>` and `</think>` respectively). This is the default for Qwen3, which is also added to the model list.

## Proposed change
Allow users to utilize thinking models in Home Assistant.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140003
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
