### PR TITLE
Allow TTS streams to generate temporary media source IDs

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -20,9 +20,6 @@ import hass_nabucasa
 import voluptuous as vol
 
 from homeassistant.components import conversation, stt, tts, wake_word, websocket_api
-from homeassistant.components.tts import (
-    generate_media_source_id as tts_generate_media_source_id,
-)
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, MATCH_ALL
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -1276,26 +1273,10 @@ class PipelineRun:
             )
         )
 
-        try:
-            # Synthesize audio and get URL
-            tts_media_id = tts_generate_media_source_id(
-                self.hass,
-                tts_input,
-                engine=self.tts_stream.engine,
-                language=self.tts_stream.language,
-                options=self.tts_stream.options,
-            )
-        except Exception as src_error:
-            _LOGGER.exception("Unexpected error during text-to-speech")
-            raise TextToSpeechError(
-                code="tts-failed",
-                message="Unexpected error during text-to-speech",
-            ) from src_error
-
         self.tts_stream.async_set_message(tts_input)
 
         tts_output = {
-            "media_id": tts_media_id,
+            "media_id": self.tts_stream.media_source_id,
             "token": self.tts_stream.token,
             "url": self.tts_stream.url,
             "mime_type": self.tts_stream.content_type,

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -25,6 +25,9 @@ import voluptuous as vol
 
 from homeassistant.components import ffmpeg, websocket_api
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.media_source import (
+    generate_media_source_id as ms_generate_media_source_id,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, PLATFORM_FORMAT
 from homeassistant.core import (
@@ -58,6 +61,7 @@ from .const import (
     DEFAULT_CACHE_DIR,
     DEFAULT_TIME_MEMORY,
     DOMAIN,
+    MEDIA_SOURCE_STREAM_PATH,
     TtsAudioType,
 )
 from .entity import TextToSpeechEntity, TTSAudioRequest, TTSAudioResponse
@@ -273,9 +277,17 @@ async def async_get_media_source_audio(
     media_source_id: str,
 ) -> tuple[str, bytes]:
     """Get TTS audio as extension, data."""
+    manager = hass.data[DATA_TTS_MANAGER]
     parsed = parse_media_source_id(media_source_id)
-    stream = hass.data[DATA_TTS_MANAGER].async_create_result_stream(**parsed["options"])
-    stream.async_set_message(parsed["message"])
+    if "stream" in parsed:
+        stream = manager.async_get_result_stream(
+            parsed["stream"]  # type: ignore[typeddict-item]
+        )
+        if stream is None:
+            raise ValueError("Stream not found")
+    else:
+        stream = manager.async_create_result_stream(**parsed["options"])
+        stream.async_set_message(parsed["message"])
     data = b"".join([chunk async for chunk in stream.async_stream_result()])
     return stream.extension, data
 
@@ -477,6 +489,14 @@ class ResultStream:
     def url(self) -> str:
         """Get the URL to stream the result."""
         return f"/api/tts_proxy/{self.token}"
+
+    @cached_property
+    def media_source_id(self) -> str:
+        """Get the media source ID of this stream."""
+        return ms_generate_media_source_id(
+            DOMAIN,
+            f"{MEDIA_SOURCE_STREAM_PATH}/{self.token}",
+        )
 
     @cached_property
     def _result_cache(self) -> asyncio.Future[TTSCache]:

--- a/homeassistant/components/tts/const.py
+++ b/homeassistant/components/tts/const.py
@@ -30,4 +30,6 @@ DATA_COMPONENT: HassKey[EntityComponent[TextToSpeechEntity]] = HassKey(DOMAIN)
 
 DATA_TTS_MANAGER: HassKey[SpeechManager] = HassKey("tts_manager")
 
+MEDIA_SOURCE_STREAM_PATH = "-stream-"
+
 type TtsAudioType = tuple[str | None, bytes | None]

--- a/homeassistant/components/tts/media_source.py
+++ b/homeassistant/components/tts/media_source.py
@@ -19,7 +19,7 @@ from homeassistant.components.media_source import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DATA_COMPONENT, DATA_TTS_MANAGER, DOMAIN
+from .const import DATA_COMPONENT, DATA_TTS_MANAGER, DOMAIN, MEDIA_SOURCE_STREAM_PATH
 from .helper import get_engine_instance
 
 URL_QUERY_TTS_OPTIONS = "tts_options"
@@ -81,10 +81,22 @@ class ParsedMediaSourceId(TypedDict):
     message: str
 
 
+class ParsedMediaSourceStreamId(TypedDict):
+    """Parsed media source ID for a stream."""
+
+    stream: str
+
+
 @callback
-def parse_media_source_id(media_source_id: str) -> ParsedMediaSourceId:
+def parse_media_source_id(
+    media_source_id: str,
+) -> ParsedMediaSourceId | ParsedMediaSourceStreamId:
     """Turn a media source ID into options."""
     parsed = URL(media_source_id)
+
+    if parsed.path.startswith(f"{MEDIA_SOURCE_STREAM_PATH}/"):
+        return {"stream": parsed.path[len(MEDIA_SOURCE_STREAM_PATH) + 1 :]}
+
     if URL_QUERY_TTS_OPTIONS in parsed.query:
         try:
             options = json.loads(parsed.query[URL_QUERY_TTS_OPTIONS])
@@ -122,16 +134,23 @@ class TTSMediaSource(MediaSource):
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media to a url."""
+        manager = self.hass.data[DATA_TTS_MANAGER]
         try:
             parsed = parse_media_source_id(item.identifier)
-            stream = self.hass.data[DATA_TTS_MANAGER].async_create_result_stream(
-                **parsed["options"]
-            )
-            stream.async_set_message(parsed["message"])
+            if "stream" in parsed:
+                stream = manager.async_get_result_stream(
+                    parsed["stream"],  # type: ignore[typeddict-item]
+                )
+            else:
+                stream = manager.async_create_result_stream(**parsed["options"])
+                stream.async_set_message(parsed["message"])
         except Unresolvable:
             raise
         except HomeAssistantError as err:
             raise Unresolvable(str(err)) from err
+
+        if stream is None:
+            raise Unresolvable("Stream not found")
 
         return PlayMedia(stream.url, stream.content_type)
 

--- a/tests/components/assist_pipeline/snapshots/test_init.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_init.ambr
@@ -84,7 +84,7 @@
     dict({
       'data': dict({
         'tts_output': dict({
-          'media_id': "media-source://tts/tts.test?message=Sorry,+I+couldn't+understand+that&language=en_US&tts_options=%7B%7D",
+          'media_id': 'media-source://tts/-stream-/test_token.mp3',
           'mime_type': 'audio/mpeg',
           'token': 'test_token.mp3',
           'url': '/api/tts_proxy/test_token.mp3',
@@ -183,7 +183,7 @@
     dict({
       'data': dict({
         'tts_output': dict({
-          'media_id': "media-source://tts/test?message=Sorry,+I+couldn't+understand+that&language=en-US&tts_options=%7B%22voice%22:%22Arnold+Schwarzenegger%22%7D",
+          'media_id': 'media-source://tts/-stream-/test_token.mp3',
           'mime_type': 'audio/mpeg',
           'token': 'test_token.mp3',
           'url': '/api/tts_proxy/test_token.mp3',
@@ -282,7 +282,7 @@
     dict({
       'data': dict({
         'tts_output': dict({
-          'media_id': "media-source://tts/test?message=Sorry,+I+couldn't+understand+that&language=en-US&tts_options=%7B%22voice%22:%22Arnold+Schwarzenegger%22%7D",
+          'media_id': 'media-source://tts/-stream-/test_token.mp3',
           'mime_type': 'audio/mpeg',
           'token': 'test_token.mp3',
           'url': '/api/tts_proxy/test_token.mp3',
@@ -405,7 +405,7 @@
     dict({
       'data': dict({
         'tts_output': dict({
-          'media_id': "media-source://tts/tts.test?message=Sorry,+I+couldn't+understand+that&language=en_US&tts_options=%7B%7D",
+          'media_id': 'media-source://tts/-stream-/test_token.mp3',
           'mime_type': 'audio/mpeg',
           'token': 'test_token.mp3',
           'url': '/api/tts_proxy/test_token.mp3',

--- a/tests/components/assist_pipeline/snapshots/test_pipeline.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_pipeline.ambr
@@ -139,7 +139,7 @@
     dict({
       'data': dict({
         'tts_output': dict({
-          'media_id': 'media-source://tts/tts.test?message=hello,+how+are+you?&language=en_US&tts_options=%7B%7D',
+          'media_id': 'media-source://tts/-stream-/mocked-token.mp3',
           'mime_type': 'audio/mpeg',
           'token': 'mocked-token.mp3',
           'url': '/api/tts_proxy/mocked-token.mp3',

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -80,7 +80,7 @@
 # name: test_audio_pipeline.6
   dict({
     'tts_output': dict({
-      'media_id': "media-source://tts/tts.test?message=Sorry,+I+couldn't+understand+that&language=en_US&tts_options=%7B%7D",
+      'media_id': 'media-source://tts/-stream-/test_token.mp3',
       'mime_type': 'audio/mpeg',
       'token': 'test_token.mp3',
       'url': '/api/tts_proxy/test_token.mp3',
@@ -171,7 +171,7 @@
 # name: test_audio_pipeline_debug.6
   dict({
     'tts_output': dict({
-      'media_id': "media-source://tts/tts.test?message=Sorry,+I+couldn't+understand+that&language=en_US&tts_options=%7B%7D",
+      'media_id': 'media-source://tts/-stream-/test_token.mp3',
       'mime_type': 'audio/mpeg',
       'token': 'test_token.mp3',
       'url': '/api/tts_proxy/test_token.mp3',
@@ -274,7 +274,7 @@
 # name: test_audio_pipeline_with_enhancements.6
   dict({
     'tts_output': dict({
-      'media_id': "media-source://tts/tts.test?message=Sorry,+I+couldn't+understand+that&language=en_US&tts_options=%7B%7D",
+      'media_id': 'media-source://tts/-stream-/test_token.mp3',
       'mime_type': 'audio/mpeg',
       'token': 'test_token.mp3',
       'url': '/api/tts_proxy/test_token.mp3',
@@ -387,7 +387,7 @@
 # name: test_audio_pipeline_with_wake_word_no_timeout.8
   dict({
     'tts_output': dict({
-      'media_id': "media-source://tts/tts.test?message=Sorry,+I+couldn't+understand+that&language=en_US&tts_options=%7B%7D",
+      'media_id': 'media-source://tts/-stream-/test_token.mp3',
       'mime_type': 'audio/mpeg',
       'token': 'test_token.mp3',
       'url': '/api/tts_proxy/test_token.mp3',

--- a/tests/components/tts/test_media_source.py
+++ b/tests/components/tts/test_media_source.py
@@ -203,7 +203,7 @@ async def test_resolving(
     stream = MockResultStream(hass, "wav", b"")
     media = await media_source.async_resolve_media(hass, stream.media_source_id, None)
     assert media.url == stream.url
-    assert stream.content_type == stream.content_type
+    assert media.mime_type == stream.content_type
 
     with pytest.raises(media_source.Unresolvable):
         await media_source.async_resolve_media(

--- a/tests/components/tts/test_media_source.py
+++ b/tests/components/tts/test_media_source.py
@@ -17,6 +17,7 @@ from homeassistant.setup import async_setup_component
 
 from .common import (
     DEFAULT_LANG,
+    MockResultStream,
     MockTTSEntity,
     MockTTSProvider,
     mock_config_entry_setup,
@@ -197,6 +198,17 @@ async def test_resolving(
     assert message == "Bye World"
     assert language == "de_DE"
     assert mock_get_tts_audio.mock_calls[0][2]["options"] == {"voice": "Paulus"}
+
+    # Test with result stream
+    stream = MockResultStream(hass, "wav", b"")
+    media = await media_source.async_resolve_media(hass, stream.media_source_id, None)
+    assert media.url == stream.url
+    assert stream.content_type == stream.content_type
+
+    with pytest.raises(media_source.Unresolvable):
+        await media_source.async_resolve_media(
+            hass, "media-source://tts/-stream-/not-a-valid-token", None
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
TTS streams can now generate a media source ID that resolves to the stream. Currently Assist Pipeline generates a new media source ID, which is not mapped to the stream, which can cause speech to be resolved twice.

Note, this code is not used at all internally and better solution would be to stop generating the ID at all. However, the custom integration chime-tts still relies on it. I've asked them to migrate away in https://github.com/nimroddolev/chime_tts/issues/272 and plan on deprecating generating that ID in the future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
