### PR TITLE
Ensure that OpenAI tool call deltas have a role

### DIFF
--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -141,6 +141,11 @@ async def _transform_stream(
             if isinstance(event.item, ResponseOutputMessage):
                 yield {"role": event.item.role}
             elif isinstance(event.item, ResponseFunctionToolCall):
+                # OpenAI has tool calls as individual events
+                # while HA puts tool calls inside the assistant message.
+                # We turn them into individual assistant content for HA
+                # to ensure that tools are called as soon as possible.
+                yield {"role": "assistant"}
                 current_tool_call = event.item
         elif isinstance(event, ResponseOutputItemDoneEvent):
             item = event.item.model_dump()

--- a/tests/components/openai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/openai_conversation/snapshots/test_conversation.ambr
@@ -17,6 +17,20 @@
           }),
           'tool_name': 'test_tool',
         }),
+      ]),
+    }),
+    dict({
+      'agent_id': 'conversation.openai',
+      'role': 'tool_result',
+      'tool_call_id': 'call_call_1',
+      'tool_name': 'test_tool',
+      'tool_result': 'value1',
+    }),
+    dict({
+      'agent_id': 'conversation.openai',
+      'content': None,
+      'role': 'assistant',
+      'tool_calls': list([
         dict({
           'id': 'call_call_2',
           'tool_args': dict({
@@ -29,16 +43,44 @@
     dict({
       'agent_id': 'conversation.openai',
       'role': 'tool_result',
-      'tool_call_id': 'call_call_1',
+      'tool_call_id': 'call_call_2',
       'tool_name': 'test_tool',
-      'tool_result': 'value1',
+      'tool_result': 'value2',
+    }),
+    dict({
+      'agent_id': 'conversation.openai',
+      'content': 'Cool',
+      'role': 'assistant',
+      'tool_calls': None,
+    }),
+  ])
+# ---
+# name: test_function_call_without_reasoning
+  list([
+    dict({
+      'content': 'Please call the test function',
+      'role': 'user',
+    }),
+    dict({
+      'agent_id': 'conversation.openai',
+      'content': None,
+      'role': 'assistant',
+      'tool_calls': list([
+        dict({
+          'id': 'call_call_1',
+          'tool_args': dict({
+            'param1': 'call1',
+          }),
+          'tool_name': 'test_tool',
+        }),
+      ]),
     }),
     dict({
       'agent_id': 'conversation.openai',
       'role': 'tool_result',
-      'tool_call_id': 'call_call_2',
+      'tool_call_id': 'call_call_1',
       'tool_name': 'test_tool',
-      'tool_result': 'value2',
+      'tool_result': 'value1',
     }),
     dict({
       'agent_id': 'conversation.openai',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The conversation chat log only accepts deltas with role="assistant". Therefore it was missing a check that the first delta that comes in has a role. This check was added.

Found out while solving this bug in OpenAI;

In Home Assistant, the conversation chat log assistant content class contains both content and tool calls. In the OpenAI responses API, tool calls and content are in different objects. This allows tool calls to be called as they come in, instead of waiting until all tool calls are done rendering. 

This behavior wasn't correctly supported in Home Assistant, and we would not include a role if the first message that came in from OpenAI was a tool call.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
