### PR TITLE
Add optional pet location select entity to Sure Petcare

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1546,8 +1546,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/sunricher_dali_center/ @niracler
 /tests/components/sunricher_dali_center/ @niracler
 /homeassistant/components/supla/ @mwegrzynek
-/homeassistant/components/surepetcare/ @benleb @danielhiversen
-/tests/components/surepetcare/ @benleb @danielhiversen
+/homeassistant/components/surepetcare/ @benleb @danielhiversen @zhephyr54
+/tests/components/surepetcare/ @benleb @danielhiversen @zhephyr54
 /homeassistant/components/swiss_hydrological_data/ @fabaff
 /homeassistant/components/swiss_public_transport/ @fabaff @miaucl
 /tests/components/swiss_public_transport/ @fabaff @miaucl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1546,8 +1546,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/sunricher_dali_center/ @niracler
 /tests/components/sunricher_dali_center/ @niracler
 /homeassistant/components/supla/ @mwegrzynek
-/homeassistant/components/surepetcare/ @benleb @danielhiversen @zhephyr54
-/tests/components/surepetcare/ @benleb @danielhiversen @zhephyr54
+/homeassistant/components/surepetcare/ @benleb @danielhiversen
+/tests/components/surepetcare/ @benleb @danielhiversen
 /homeassistant/components/swiss_hydrological_data/ @fabaff
 /homeassistant/components/swiss_public_transport/ @fabaff @miaucl
 /tests/components/swiss_public_transport/ @fabaff @miaucl

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -20,6 +20,7 @@ from .const import (
     ATTR_LOCATION,
     ATTR_LOCK_STATE,
     ATTR_PET_NAME,
+    CONF_CREATE_PET_SELECT,
     DOMAIN,
     SERVICE_SET_LOCK_STATE,
     SERVICE_SET_PET_LOCATION,
@@ -49,6 +50,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
+    if entry.data.get(CONF_CREATE_PET_SELECT):
+        PLATFORMS.append(Platform.SELECT)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     lock_state_service_schema = vol.Schema(

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -20,7 +20,6 @@ from .const import (
     ATTR_LOCATION,
     ATTR_LOCK_STATE,
     ATTR_PET_NAME,
-    CONF_CREATE_PET_SELECT,
     DOMAIN,
     SERVICE_SET_LOCK_STATE,
     SERVICE_SET_PET_LOCATION,
@@ -29,7 +28,7 @@ from .coordinator import SurePetcareDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.LOCK, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.LOCK, Platform.SELECT, Platform.SENSOR]
 SCAN_INTERVAL = timedelta(minutes=3)
 
 
@@ -50,8 +49,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    if entry.data.get(CONF_CREATE_PET_SELECT):
-        PLATFORMS.append(Platform.SELECT)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     lock_state_service_schema = vol.Schema(

--- a/homeassistant/components/surepetcare/config_flow.py
+++ b/homeassistant/components/surepetcare/config_flow.py
@@ -2,19 +2,38 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 import logging
-from typing import Any
+from typing import Any, cast
 
 import surepy
+from surepy.entities.devices import Flap
+from surepy.enums import EntityType
 from surepy.exceptions import SurePetcareAuthenticationError, SurePetcareError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import section
+from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+from homeassistant.helpers.typing import VolDictType
 
-from .const import DOMAIN, SURE_API_TIMEOUT
+from .const import (
+    CONF_CREATE_PET_SELECT,
+    CONF_FLAPS_MAPPINGS,
+    CONF_MANUALLY_SET_LOCATION,
+    CONF_PET_SELECT_OPTIONS,
+    DOMAIN,
+    SURE_API_TIMEOUT,
+)
+from .types import FlapMappings
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +41,7 @@ USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_CREATE_PET_SELECT): bool,
     }
 )
 
@@ -30,6 +50,11 @@ class SurePetCareConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Sure Petcare."""
 
     VERSION = 1
+    MINOR_VERSION = 1
+
+    _init_data: dict[str, Any] = {}
+    _flaps: list[Flap] = []
+    _areas: Iterable[ar.AreaEntry] = []
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -57,9 +82,13 @@ class SurePetCareConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
                 self._abort_if_unique_id_configured()
 
+                self._init_data = {**user_input, CONF_TOKEN: token}
+                if user_input[CONF_CREATE_PET_SELECT]:
+                    return await self.async_step_pet_select_config()
+
                 return self.async_create_entry(
                     title="Sure Petcare",
-                    data={**user_input, CONF_TOKEN: token},
+                    data=self._init_data,
                 )
 
         return self.async_show_form(
@@ -110,3 +139,187 @@ class SurePetCareConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
             errors=errors,
         )
+
+    async def async_step_pet_select_config(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the configuration for the pet location select entities."""
+        errors = {}
+
+        if user_input is not None:
+            errors = self._validate_pet_select_config_user_input(user_input)
+
+            if not errors:
+                config_entry_data = self._build_pet_select_config_entry(user_input)
+                return self.async_create_entry(
+                    title="Sure Petcare",
+                    data=config_entry_data,
+                )
+        else:
+            self._flaps = []
+            client = surepy.Surepy(
+                self._init_data[CONF_USERNAME],
+                self._init_data[CONF_PASSWORD],
+                auth_token=self._init_data[CONF_TOKEN],
+                api_timeout=SURE_API_TIMEOUT,
+                session=async_get_clientsession(self.hass),
+            )
+            try:
+                devices = await client.get_devices()
+            except SurePetcareAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except SurePetcareError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                self._flaps = [
+                    cast(Flap, device)
+                    for device in devices
+                    if device.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP]
+                ]
+
+            self._areas = await _get_areas(self.hass)
+
+        data_schema, description_placeholders = self._get_pet_select_config_schema(
+            user_input
+        )
+
+        return self.async_show_form(
+            step_id="pet_select_config",
+            data_schema=data_schema,
+            description_placeholders=description_placeholders,
+            errors=errors,
+        )
+
+    def _build_pet_select_config_entry(
+        self, user_input: dict[str, Any]
+    ) -> Mapping[str, Any]:
+        """Build the pet location select entity config entry."""
+        config_entry_data: dict[str, Any] = {}
+        config_entry_data.update(self._init_data)
+
+        config_entry_data[CONF_MANUALLY_SET_LOCATION] = user_input[
+            CONF_MANUALLY_SET_LOCATION
+        ]
+
+        flaps_mappings: dict[str, FlapMappings] = {}
+        selected_zones = set()
+        selected_zones.add(user_input[CONF_MANUALLY_SET_LOCATION]["entry"])
+        selected_zones.add(user_input[CONF_MANUALLY_SET_LOCATION]["exit"])
+
+        for idx, flap in enumerate(self._flaps):
+            flap_id = str(flap.id)
+            value = user_input[self._get_flap_static_key(idx)]
+            flaps_mappings[flap_id] = {
+                "entry": value["entry"],
+                "exit": value["exit"],
+            }
+            selected_zones.add(value["exit"])
+            selected_zones.add(value["entry"])
+
+        config_entry_data[CONF_FLAPS_MAPPINGS] = flaps_mappings
+        config_entry_data[CONF_PET_SELECT_OPTIONS] = sorted(selected_zones)
+
+        return config_entry_data
+
+    def _get_pet_select_config_schema(
+        self, default_input: dict[str, Any] | None
+    ) -> tuple[vol.Schema, dict[str, str]]:
+        """Return the schema for the pet location select entity config form.
+
+        Retain info already provided for future form views by setting them
+        as defaults in schema.
+        """
+        if default_input is None:
+            default_input = {}
+
+        areas_options = [area.name for area in self._areas]
+        options = [*areas_options, ""]
+        zones_selector = SelectSelector(
+            SelectSelectorConfig(
+                options=options,
+                mode=SelectSelectorMode.DROPDOWN,
+                multiple=False,
+                custom_value=True,
+            )
+        )
+
+        data_schema: VolDictType = {}
+        description_placeholders: dict[str, str] = {}
+        for idx, flap in enumerate(self._flaps):
+            flap_id = str(flap.id)
+            description_placeholders[f"flap_name_{idx + 1}"] = flap.name
+            flap_default_input = default_input.get(flap_id, {})
+            data_schema[vol.Required(self._get_flap_static_key(idx))] = section(
+                self._get_pet_select_config_section_schema(
+                    zones_selector,
+                    default_entry=flap_default_input.get("entry", ""),
+                    default_exit=flap_default_input.get("exit", ""),
+                ),
+                {"collapsed": False},
+            )
+
+        manual_default_input = default_input.get(CONF_MANUALLY_SET_LOCATION, {})
+        data_schema[vol.Required(CONF_MANUALLY_SET_LOCATION)] = section(
+            self._get_pet_select_config_section_schema(
+                zones_selector,
+                default_entry=manual_default_input.get("entry", ""),
+                default_exit=manual_default_input.get("exit", ""),
+            ),
+            {"collapsed": False},
+        )
+
+        return vol.Schema(data_schema), description_placeholders
+
+    def _get_flap_static_key(
+        self,
+        idx: int,
+    ) -> str:
+        """Return the static key for the flap at index idx."""
+        return f"flap_{idx + 1}"
+
+    def _get_pet_select_config_section_schema(
+        self,
+        zones_selector: SelectSelector,
+        default_entry: str = "",
+        default_exit: str = "",
+    ) -> vol.Schema:
+        """Return the schema for the flaps and manually set location sections of the pet location select entity config form."""
+        return vol.Schema(
+            {
+                vol.Required("exit", default=default_exit): zones_selector,
+                vol.Required("entry", default=default_entry): zones_selector,
+            }
+        )
+
+    def _validate_pet_select_config_user_input(
+        self,
+        user_input: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Validate user input for pet location select entity config step."""
+        errors = {}
+
+        manually_set_location = user_input[CONF_MANUALLY_SET_LOCATION]
+        if (
+            manually_set_location.get("entry").strip() == ""
+            or manually_set_location.get("exit").strip() == ""
+        ):
+            errors["base"] = "no_zones_selected"
+            return errors
+
+        for idx, _ in enumerate(self._flaps):
+            flap_static_key = self._get_flap_static_key(idx)
+            value = user_input[flap_static_key]
+            if value["entry"].strip() == "" or value["exit"].strip() == "":
+                errors[flap_static_key] = "no_zones_selected"
+                return errors
+
+        return errors
+
+
+async def _get_areas(hass: HomeAssistant) -> Iterable[ar.AreaEntry]:
+    """Retrieve all user-defined areas."""
+    area_reg = ar.async_get(hass)
+    return area_reg.async_list_areas()

--- a/homeassistant/components/surepetcare/const.py
+++ b/homeassistant/components/surepetcare/const.py
@@ -5,6 +5,10 @@ DOMAIN = "surepetcare"
 CONF_FEEDERS = "feeders"
 CONF_FLAPS = "flaps"
 CONF_PETS = "pets"
+CONF_CREATE_PET_SELECT = "create_pet_select"
+CONF_MANUALLY_SET_LOCATION = "manually_set_location"
+CONF_FLAPS_MAPPINGS = "flaps_mappings"
+CONF_PET_SELECT_OPTIONS = "pet_select_options"
 
 # sure petcare api
 SURE_API_TIMEOUT = 60

--- a/homeassistant/components/surepetcare/manifest.json
+++ b/homeassistant/components/surepetcare/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "surepetcare",
   "name": "Sure Petcare",
-  "codeowners": ["@benleb", "@danielhiversen"],
+  "codeowners": ["@benleb", "@danielhiversen", "@zhephyr54"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/surepetcare",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/surepetcare/select.py
+++ b/homeassistant/components/surepetcare/select.py
@@ -1,0 +1,138 @@
+"""Support for Sure PetCare Pets select entities."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from surepy.entities import SurepyEntity
+from surepy.entities.pet import Pet as SurepyPet
+from surepy.enums import EntityType, Location
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import (
+    CONF_FLAPS_MAPPINGS,
+    CONF_MANUALLY_SET_LOCATION,
+    CONF_PET_SELECT_OPTIONS,
+    DOMAIN,
+)
+from .coordinator import SurePetcareDataCoordinator
+from .entity import SurePetcareEntity
+from .types import FlapMappings
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Sure PetCare Pets select entities based on a config entry."""
+
+    coordinator: SurePetcareDataCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[PetSelect] = [
+        PetSelect(
+            surepy_entity.id,
+            coordinator,
+            entry.data[CONF_PET_SELECT_OPTIONS],
+            entry.data[CONF_FLAPS_MAPPINGS],
+            entry.data[CONF_MANUALLY_SET_LOCATION],
+        )
+        for surepy_entity in coordinator.data.values()
+        if surepy_entity.type == EntityType.PET
+    ]
+
+    async_add_entities(entities)
+
+
+class PetSelect(SurePetcareEntity, SelectEntity):
+    """Sure Petcare Pet select entity."""
+
+    _flaps_mappings: dict[str, FlapMappings] = {}
+    _manually_set_location_mappings: FlapMappings | None = None
+
+    def __init__(
+        self,
+        surepetcare_id: int,
+        coordinator: SurePetcareDataCoordinator,
+        options: list[str],
+        flaps_mappings: dict[str, FlapMappings],
+        manually_set_location_mappings: FlapMappings,
+    ) -> None:
+        """Initialize a Sure Petcare Pet select."""
+        self._attr_options = options
+        self._attr_current_option = None
+        self._flaps_mappings = flaps_mappings
+        self._manually_set_location_mappings = manually_set_location_mappings
+        self._attr_extra_state_attributes = {}
+
+        # Calling the SurePetcareEntity constructor last because it will call
+        # _update_attr which needs the above attributes to be set.
+        super().__init__(surepetcare_id, coordinator)
+        self._attr_name = self._device_name
+        self._attr_unique_id = self._device_id
+
+    @callback
+    def _update_attr(self, surepy_entity: SurepyEntity) -> None:
+        """Get the latest data and update the state."""
+        surepy_entity = cast(SurepyPet, surepy_entity)
+
+        position = surepy_entity._data.get("position", {})  # noqa: SLF001
+        device_id = position.get("device_id")
+        device_id_str = str(device_id) if device_id is not None else None
+        user_id = position.get("user_id")
+        user_id_str = str(user_id) if user_id is not None else None
+
+        location = surepy_entity.location
+
+        state_attr = self._attr_extra_state_attributes
+        # If the pet location has not changed and the last update was manual,
+        # don't update the state.
+        if (
+            state_attr.get("last_update_type") == "manual"
+            and location.since == state_attr.get("since")
+            and location.where == state_attr.get("where")
+            and device_id_str == state_attr.get("last_seen_device_id")
+        ):
+            return
+
+        self._attr_current_option = self._get_pet_location_zone(
+            device_id_str, user_id_str, Location(location.where)
+        )
+        self._attr_extra_state_attributes = {
+            "since": location.since,
+            "where": location.where,
+            "last_seen_device_id": device_id_str,
+            "last_update_type": "auto",
+        }
+
+    def _get_pet_location_zone(
+        self, device_id: str | None, user_id: str | None, location: Location
+    ) -> str:
+        """Get the pet location zone."""
+        mappings = None
+        if device_id is None and user_id is not None:
+            mappings = self._manually_set_location_mappings
+        elif device_id is not None:
+            mappings = self._flaps_mappings.get(device_id)
+
+        location_zone = "unknown"
+        if mappings is not None:
+            if location == Location.INSIDE:
+                location_zone = mappings["entry"]
+            elif location == Location.OUTSIDE:
+                location_zone = mappings["exit"]
+
+        return location_zone
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        if option not in self._attr_options:
+            raise ValueError(f"Invalid option for {self.entity_id}: {option}")
+
+        self._attr_current_option = option
+        self._attr_extra_state_attributes["last_update_type"] = "manual"
+        self.async_write_ha_state()

--- a/homeassistant/components/surepetcare/select.py
+++ b/homeassistant/components/surepetcare/select.py
@@ -14,6 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
+    CONF_CREATE_PET_SELECT,
     CONF_FLAPS_MAPPINGS,
     CONF_MANUALLY_SET_LOCATION,
     CONF_PET_SELECT_OPTIONS,
@@ -31,15 +32,18 @@ async def async_setup_entry(
 ) -> None:
     """Set up Sure PetCare Pets select entities based on a config entry."""
 
+    if entry.options.get(CONF_CREATE_PET_SELECT) is False:
+        return
+
     coordinator: SurePetcareDataCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     entities: list[PetSelect] = [
         PetSelect(
             surepy_entity.id,
             coordinator,
-            entry.data[CONF_PET_SELECT_OPTIONS],
-            entry.data[CONF_FLAPS_MAPPINGS],
-            entry.data[CONF_MANUALLY_SET_LOCATION],
+            entry.options[CONF_PET_SELECT_OPTIONS],
+            entry.options[CONF_FLAPS_MAPPINGS],
+            entry.options[CONF_MANUALLY_SET_LOCATION],
         )
         for surepy_entity in coordinator.data.values()
         if surepy_entity.type == EntityType.PET
@@ -49,7 +53,7 @@ async def async_setup_entry(
 
 
 class PetSelect(SurePetcareEntity, SelectEntity):
-    """Sure Petcare Pet select entity."""
+    """Sure Petcare Pet select entity representing a pet's location."""
 
     _flaps_mappings: dict[str, FlapMappings] = {}
     _manually_set_location_mappings: FlapMappings | None = None

--- a/homeassistant/components/surepetcare/strings.json
+++ b/homeassistant/components/surepetcare/strings.json
@@ -8,11 +8,7 @@
       "user": {
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "create_pet_select": "Create a select entity for each pet's location"
-        },
-        "data_description": {
-          "create_pet_select": "This is especially useful if you have multiple flaps that do not directly lead outside"
+          "password": "[%key:common::config_flow::data::password%]"
         }
       },
       "reauth_confirm": {
@@ -21,76 +17,34 @@
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
         }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "create_pet_select": "Create a pet location select entity for each pet"
+        },
+        "data_description": {
+          "create_pet_select": "This will create a select entity for each pet representing its current location. This is especially useful if you have multiple flaps that do not directly lead outside and the existing binary sensors can't accurately reflect your pets' locations."
+        }
       },
       "pet_select_config": {
-        "title": "Pet flaps' entry/exit to zones mapping",
-        "description": "Link your pet flaps' entry and exit points to the desired zones. You can either select one of your areas or enter a custom zone name.",
+        "title": "Map flap entry/exit to zones",
+        "description": "Choose in which zone your pet should be reported after it enters or exits a flap. You can either select one of your areas or enter a custom zone name. This controls how the integration determines and reports a pet's location when the flap records an entry or an exit.",
         "sections": {
           "flap_1": {
             "name": "Flap \"{flap_name_1}\"",
-            "data": {
-              "entry": "[%key:component::surepetcare::common::flap_entry%]",
-              "exit": "[%key:component::surepetcare::common::flap_exit%]"
-            }
-          },
-          "flap_2": {
-            "name": "Flap \"{flap_name_2}\"",
-            "data": {
-              "entry": "[%key:component::surepetcare::common::flap_entry%]",
-              "exit": "[%key:component::surepetcare::common::flap_exit%]"
-            }
-          },
-          "flap_3": {
-            "name": "Flap \"{flap_name_3}\"",
-            "data": {
-              "entry": "[%key:component::surepetcare::common::flap_entry%]",
-              "exit": "[%key:component::surepetcare::common::flap_exit%]"
-            }
-          },
-          "flap_4": {
-            "name": "Flap \"{flap_name_4}\"",
-            "data": {
-              "entry": "[%key:component::surepetcare::common::flap_entry%]",
-              "exit": "[%key:component::surepetcare::common::flap_exit%]"
-            }
-          },
-          "flap_5": {
-            "name": "Flap \"{flap_name_5}\"",
-            "data": {
-              "entry": "[%key:component::surepetcare::common::flap_entry%]",
-              "exit": "[%key:component::surepetcare::common::flap_exit%]"
-            }
-          },
-          "flap_6": {
-            "name": "Flap \"{flap_name_6}\"",
-            "data": {
-              "entry": "[%key:component::surepetcare::common::flap_entry%]",
-              "exit": "[%key:component::surepetcare::common::flap_exit%]"
-            }
-          },
-          "flap_7": {
-            "name": "Flap \"{flap_name_7}\"",
-            "data": {
-              "entry": "[%key:component::surepetcare::common::flap_entry%]",
-              "exit": "[%key:component::surepetcare::common::flap_exit%]"
-            }
-          },
-          "flap_8": {
-            "name": "Flap \"{flap_name_8}\"",
-            "data": {
-              "entry": "[%key:component::surepetcare::common::flap_entry%]",
-              "exit": "[%key:component::surepetcare::common::flap_exit%]"
-            }
-          },
-          "flap_9": {
-            "name": "Flap \"{flap_name_9}\"",
-            "data": {
-              "entry": "[%key:component::surepetcare::common::flap_entry%]",
-              "exit": "[%key:component::surepetcare::common::flap_exit%]"
-            }
-          },
-          "flap_10": {
-            "name": "Flap \"{flap_name_10}\"",
             "data": {
               "entry": "[%key:component::surepetcare::common::flap_entry%]",
               "exit": "[%key:component::surepetcare::common::flap_exit%]"
@@ -112,10 +66,6 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "no_zones_selected": "Please select or enter a zone for each entry and exit."
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "services": {

--- a/homeassistant/components/surepetcare/strings.json
+++ b/homeassistant/components/surepetcare/strings.json
@@ -1,10 +1,18 @@
 {
+  "common": {
+    "flap_entry": "Entry",
+    "flap_exit": "Exit"
+  },
   "config": {
     "step": {
       "user": {
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "create_pet_select": "Create a select entity for each pet's location"
+        },
+        "data_description": {
+          "create_pet_select": "This is especially useful if you have multiple flaps that do not directly lead outside"
         }
       },
       "reauth_confirm": {
@@ -13,12 +21,97 @@
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "pet_select_config": {
+        "title": "Pet flaps' entry/exit to zones mapping",
+        "description": "Link your pet flaps' entry and exit points to the desired zones. You can either select one of your areas or enter a custom zone name.",
+        "sections": {
+          "flap_1": {
+            "name": "Flap \"{flap_name_1}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "flap_2": {
+            "name": "Flap \"{flap_name_2}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "flap_3": {
+            "name": "Flap \"{flap_name_3}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "flap_4": {
+            "name": "Flap \"{flap_name_4}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "flap_5": {
+            "name": "Flap \"{flap_name_5}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "flap_6": {
+            "name": "Flap \"{flap_name_6}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "flap_7": {
+            "name": "Flap \"{flap_name_7}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "flap_8": {
+            "name": "Flap \"{flap_name_8}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "flap_9": {
+            "name": "Flap \"{flap_name_9}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "flap_10": {
+            "name": "Flap \"{flap_name_10}\"",
+            "data": {
+              "entry": "[%key:component::surepetcare::common::flap_entry%]",
+              "exit": "[%key:component::surepetcare::common::flap_exit%]"
+            }
+          },
+          "manually_set_location": {
+            "name": "Manually set location",
+            "description": "When the pet location is changed manually through the Sure Petcare app",
+            "data": {
+              "exit": "Outside",
+              "entry": "Inside"
+            }
+          }
+        }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "no_zones_selected": "Please select or enter a zone for each entry and exit."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",

--- a/homeassistant/components/surepetcare/types.py
+++ b/homeassistant/components/surepetcare/types.py
@@ -1,0 +1,10 @@
+"""Type definitions for Sure PetCare."""
+
+from typing import TypedDict
+
+
+class FlapMappings(TypedDict):
+    """A TypedDict representing the mapping of entry and exit for a flap."""
+
+    entry: str
+    exit: str

--- a/tests/components/surepetcare/__init__.py
+++ b/tests/components/surepetcare/__init__.py
@@ -85,5 +85,3 @@ MOCK_API_DATA = {
     "devices": [MOCK_HUB, MOCK_CAT_FLAP, MOCK_PET_FLAP, MOCK_FEEDER, MOCK_FELAQUA],
     "pets": [MOCK_PET],
 }
-
-MOCK_HASS_AREAS = ["Garage", "Hall"]

--- a/tests/components/surepetcare/__init__.py
+++ b/tests/components/surepetcare/__init__.py
@@ -77,7 +77,7 @@ MOCK_PET = {
     "id": 24680,
     "household_id": HOUSEHOLD_ID,
     "name": "Pet",
-    "position": {"since": "2020-08-23T23:10:50", "where": 1},
+    "position": {"since": "2020-08-23T23:10:50", "where": 1, "device_id": 13576},
     "status": {},
 }
 
@@ -85,3 +85,5 @@ MOCK_API_DATA = {
     "devices": [MOCK_HUB, MOCK_CAT_FLAP, MOCK_PET_FLAP, MOCK_FEEDER, MOCK_FELAQUA],
     "pets": [MOCK_PET],
 }
+
+MOCK_HASS_AREAS = ["Garage", "Hall"]

--- a/tests/components/surepetcare/conftest.py
+++ b/tests/components/surepetcare/conftest.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import pytest
-from surepy import MESTART_RESOURCE
+from surepy.const import MESTART_RESOURCE
 
 from homeassistant.components.surepetcare.const import (
     CONF_CREATE_PET_SELECT,
@@ -15,7 +15,7 @@ from homeassistant.components.surepetcare.const import (
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from . import MOCK_API_DATA, MOCK_HASS_AREAS
+from . import MOCK_API_DATA
 
 from tests.common import MockConfigEntry
 
@@ -54,13 +54,17 @@ async def mock_config_entry_setup(
     data = {
         CONF_USERNAME: "test-username",
         CONF_PASSWORD: "test-password",
-        CONF_CREATE_PET_SELECT: False,
         CONF_TOKEN: "token",
         "feeders": [12345],
         "flaps": [13579, 13576],
         "pets": [24680],
     }
-    with_pet_select_data = {
+
+    options = {
+        CONF_CREATE_PET_SELECT: False,
+    }
+
+    with_pet_select_options = {
         CONF_CREATE_PET_SELECT: True,
         CONF_MANUALLY_SET_LOCATION: {"entry": "Home", "exit": "Outside"},
         CONF_FLAPS_MAPPINGS: {
@@ -73,20 +77,11 @@ async def mock_config_entry_setup(
             "Outside",
         ],
     }
-    merged_data = {**data, **with_pet_select_data} if with_pet_select else data
-    entry = MockConfigEntry(domain=DOMAIN, data=merged_data)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=data,
+        options=options if not with_pet_select else with_pet_select_options,
+    )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     return entry
-
-
-@pytest.fixture
-def mock_get_areas():
-    """Patch the _get_areas function."""
-    with patch(
-        "homeassistant.components.surepetcare.config_flow._get_areas",
-        return_value=[
-            type("AreaEntry", (), {"name": name}) for name in MOCK_HASS_AREAS
-        ],
-    ) as patched:
-        yield patched

--- a/tests/components/surepetcare/conftest.py
+++ b/tests/components/surepetcare/conftest.py
@@ -5,44 +5,88 @@ from unittest.mock import patch
 import pytest
 from surepy import MESTART_RESOURCE
 
-from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.components.surepetcare.const import (
+    CONF_CREATE_PET_SELECT,
+    CONF_FLAPS_MAPPINGS,
+    CONF_MANUALLY_SET_LOCATION,
+    CONF_PET_SELECT_OPTIONS,
+    DOMAIN,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from . import MOCK_API_DATA
+from . import MOCK_API_DATA, MOCK_HASS_AREAS
 
 from tests.common import MockConfigEntry
-
-
-async def _mock_call(method, resource):
-    if method == "GET" and resource == MESTART_RESOURCE:
-        return {"data": MOCK_API_DATA}
-    return None
 
 
 @pytest.fixture
 async def surepetcare():
     """Mock the SurePetcare for easier testing."""
+    current_response = {"data": MOCK_API_DATA}
+
+    async def _mock_call(method, resource):
+        if method == "GET" and resource == MESTART_RESOURCE:
+            return current_response
+        return None
+
+    def set_call_response(response_data):
+        nonlocal current_response
+        current_response = response_data
+
     with patch("surepy.SureAPIClient", autospec=True) as mock_client_class:
         client = mock_client_class.return_value
         client.resources = {}
         client.call = _mock_call
         client.get_token.return_value = "token"
+        client.set_call_response = set_call_response
         yield client
 
 
 @pytest.fixture
-async def mock_config_entry_setup(hass: HomeAssistant) -> MockConfigEntry:
+async def mock_config_entry_setup(
+    hass: HomeAssistant, request: pytest.FixtureRequest
+) -> MockConfigEntry:
     """Help setting up a mocked config entry."""
+    params = getattr(request, "param", {})
+    with_pet_select = params.get("with_pet_select", False)
+
     data = {
         CONF_USERNAME: "test-username",
         CONF_PASSWORD: "test-password",
+        CONF_CREATE_PET_SELECT: False,
         CONF_TOKEN: "token",
         "feeders": [12345],
         "flaps": [13579, 13576],
         "pets": [24680],
     }
-    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    with_pet_select_data = {
+        CONF_CREATE_PET_SELECT: True,
+        CONF_MANUALLY_SET_LOCATION: {"entry": "Home", "exit": "Outside"},
+        CONF_FLAPS_MAPPINGS: {
+            "13579": {"entry": "Garage", "exit": "Outside"},
+            "13576": {"entry": "Home", "exit": "Garage"},
+        },
+        CONF_PET_SELECT_OPTIONS: [
+            "Garage",
+            "Home",
+            "Outside",
+        ],
+    }
+    merged_data = {**data, **with_pet_select_data} if with_pet_select else data
+    entry = MockConfigEntry(domain=DOMAIN, data=merged_data)
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     return entry
+
+
+@pytest.fixture
+def mock_get_areas():
+    """Patch the _get_areas function."""
+    with patch(
+        "homeassistant.components.surepetcare.config_flow._get_areas",
+        return_value=[
+            type("AreaEntry", (), {"name": name}) for name in MOCK_HASS_AREAS
+        ],
+    ) as patched:
+        yield patched

--- a/tests/components/surepetcare/test_config_flow.py
+++ b/tests/components/surepetcare/test_config_flow.py
@@ -21,7 +21,6 @@ from tests.common import MockConfigEntry
 INPUT_DATA = {
     "username": "test-username",
     "password": "test-password",
-    "create_pet_select": False,
 }
 
 
@@ -43,7 +42,6 @@ async def test_form(hass: HomeAssistant, surepetcare: NonCallableMagicMock) -> N
             {
                 "username": "test-username",
                 "password": "test-password",
-                "create_pet_select": False,
             },
         )
         await hass.async_block_till_done()
@@ -53,7 +51,6 @@ async def test_form(hass: HomeAssistant, surepetcare: NonCallableMagicMock) -> N
     assert result2["data"] == {
         "username": "test-username",
         "password": "test-password",
-        "create_pet_select": False,
         "token": "token",
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -74,7 +71,6 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
             {
                 "username": "test-username",
                 "password": "test-password",
-                "create_pet_select": False,
             },
         )
 
@@ -97,7 +93,6 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
             {
                 "username": "test-username",
                 "password": "test-password",
-                "create_pet_select": False,
             },
         )
 
@@ -120,7 +115,6 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
             {
                 "username": "test-username",
                 "password": "test-password",
-                "create_pet_select": False,
             },
         )
 
@@ -137,7 +131,6 @@ async def test_flow_entry_already_exists(
         data={
             "username": "test-username",
             "password": "test-password",
-            "create_pet_select": False,
         },
         unique_id="test-username",
     )
@@ -153,70 +146,11 @@ async def test_flow_entry_already_exists(
             data={
                 "username": "test-username",
                 "password": "test-password",
-                "create_pet_select": False,
             },
         )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-
-
-async def test_form_step_pet_select_config(
-    hass: HomeAssistant,
-    surepetcare: NonCallableMagicMock,
-    mock_get_areas,
-) -> None:
-    """Test we get the pet select config form."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    user_input = {
-        CONF_USERNAME: "test-username",
-        CONF_PASSWORD: "test-password",
-        CONF_CREATE_PET_SELECT: True,
-    }
-
-    with patch(
-        "homeassistant.components.surepetcare.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input
-        )
-
-        assert result2["type"] == FlowResultType.FORM
-        assert result2["step_id"] == "pet_select_config"
-
-        pet_select_input = {
-            "flap_1": {"entry": "Garage", "exit": "Outside"},
-            "flap_2": {"entry": "Home", "exit": "Garage"},
-            CONF_MANUALLY_SET_LOCATION: {"entry": "Home", "exit": "Outside"},
-        }
-
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"], pet_select_input
-        )
-
-        assert result3["type"] == FlowResultType.CREATE_ENTRY
-        assert result3["title"] == "Sure Petcare"
-        assert result3["data"] == {
-            CONF_USERNAME: "test-username",
-            CONF_PASSWORD: "test-password",
-            CONF_CREATE_PET_SELECT: True,
-            CONF_TOKEN: "token",
-            CONF_MANUALLY_SET_LOCATION: {"entry": "Home", "exit": "Outside"},
-            CONF_FLAPS_MAPPINGS: {
-                "13579": {"entry": "Garage", "exit": "Outside"},
-                "13576": {"entry": "Home", "exit": "Garage"},
-            },
-            CONF_PET_SELECT_OPTIONS: [
-                "Garage",
-                "Home",
-                "Outside",
-            ],
-        }
-        assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_reauthentication(
@@ -346,3 +280,69 @@ async def test_reauthentication_unknown_failure(hass: HomeAssistant) -> None:
     assert result2["step_id"] == "reauth_confirm"
     assert result["type"] is FlowResultType.FORM
     assert result2["errors"]["base"] == "unknown"
+
+
+async def test_options_step_pet_select_config(
+    hass: HomeAssistant, surepetcare: NonCallableMagicMock
+) -> None:
+    """Test we get the pet select config form."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+            CONF_TOKEN: "token",
+        },
+        unique_id="test-username",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    user_input = {
+        CONF_CREATE_PET_SELECT: True,
+    }
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert entry.options == {}
+
+    with patch(
+        "homeassistant.components.airnow.async_setup_entry",
+        return_value=True,
+    ):
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input
+        )
+
+        assert result2["type"] == FlowResultType.FORM
+        assert result2["step_id"] == "pet_select_config"
+
+        pet_select_input = {
+            "flap_1": {"entry": "Garage", "exit": "Outside"},
+            "flap_2": {"entry": "Home", "exit": "Garage"},
+            CONF_MANUALLY_SET_LOCATION: {"entry": "Home", "exit": "Outside"},
+        }
+
+        result3 = await hass.config_entries.options.async_configure(
+            result2["flow_id"], pet_select_input
+        )
+
+        assert result3["type"] == FlowResultType.CREATE_ENTRY
+        assert entry.options == {
+            CONF_CREATE_PET_SELECT: True,
+            CONF_MANUALLY_SET_LOCATION: {"entry": "Home", "exit": "Outside"},
+            CONF_FLAPS_MAPPINGS: {
+                "13579": {"entry": "Garage", "exit": "Outside"},
+                "13576": {"entry": "Home", "exit": "Garage"},
+            },
+            CONF_PET_SELECT_OPTIONS: [
+                "Garage",
+                "Home",
+                "Outside",
+            ],
+        }

--- a/tests/components/surepetcare/test_select.py
+++ b/tests/components/surepetcare/test_select.py
@@ -1,4 +1,4 @@
-"""The tests for the Sure Petcare binary sensor platform."""
+"""The tests for the Sure Petcare select platform."""
 
 import pytest
 

--- a/tests/components/surepetcare/test_select.py
+++ b/tests/components/surepetcare/test_select.py
@@ -1,0 +1,261 @@
+"""The tests for the Sure Petcare binary sensor platform."""
+
+import pytest
+
+from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import HOUSEHOLD_ID, MOCK_API_DATA, MOCK_PET
+
+from tests.common import MockConfigEntry
+
+EXPECTED_ENTITY_IDS = {
+    "select.pet": f"{HOUSEHOLD_ID}-24680",
+}
+
+
+async def test_no_select(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry_setup: MockConfigEntry,
+) -> None:
+    """Test that no select is created if not configured."""
+    state_entity_ids = hass.states.async_entity_ids()
+
+    for entity_id in EXPECTED_ENTITY_IDS.items():
+        assert entity_id not in state_entity_ids
+
+
+@pytest.mark.parametrize(
+    "mock_config_entry_setup",
+    [
+        {
+            "with_pet_select": True,
+        }
+    ],
+    indirect=True,
+)
+async def test_select(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    surepetcare,
+    mock_config_entry_setup: MockConfigEntry,
+) -> None:
+    """Test the generation of unique ids."""
+    state_entity_ids = hass.states.async_entity_ids()
+
+    for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():
+        assert entity_id in state_entity_ids
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state == "Home"
+
+        attr = state.attributes
+        assert attr["options"] == [
+            "Garage",
+            "Home",
+            "Outside",
+        ]
+        assert attr["last_seen_device_id"] == "13576"
+        assert attr["last_update_type"] == "auto"
+        entity = entity_registry.async_get(entity_id)
+        assert entity.unique_id == unique_id
+
+
+@pytest.mark.parametrize(
+    "mock_config_entry_setup",
+    [
+        {
+            "with_pet_select": True,
+        }
+    ],
+    indirect=True,
+)
+async def test_select_then_location_change(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry_setup: MockConfigEntry,
+) -> None:
+    """Test that select state changes when location changes."""
+
+    state = hass.states.get("select.pet")
+    assert state.state == "Home"
+
+    surepetcare.set_call_response(
+        {
+            "data": {
+                **MOCK_API_DATA,
+                "pets": [
+                    {
+                        **MOCK_PET,
+                        "position": {
+                            "since": "2020-08-23T23:30:00",
+                            "where": 1,
+                            "device_id": 13579,
+                        },
+                    }
+                ],
+            }
+        }
+    )
+
+    coordinator = hass.data[DOMAIN][mock_config_entry_setup.entry_id]
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    # select state should change because the mock surepetcare api
+    # response has changed.
+    state = hass.states.get("select.pet")
+    assert state.state == "Garage"
+
+
+@pytest.mark.parametrize(
+    "mock_config_entry_setup",
+    [
+        {
+            "with_pet_select": True,
+        }
+    ],
+    indirect=True,
+)
+async def test_select_app_manually_set_location(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry_setup: MockConfigEntry,
+) -> None:
+    """Test that select state is correct when the location is manually set through the app."""
+
+    state = hass.states.get("select.pet")
+    assert state.state == "Home"
+
+    surepetcare.set_call_response(
+        {
+            "data": {
+                **MOCK_API_DATA,
+                "pets": [
+                    {
+                        **MOCK_PET,
+                        "position": {
+                            "since": "2020-08-23T23:30:00",
+                            "where": 2,
+                            "user_id": 1,
+                        },
+                    }
+                ],
+            }
+        }
+    )
+
+    coordinator = hass.data[DOMAIN][mock_config_entry_setup.entry_id]
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    # select state should change because the mock surepetcare api
+    # response has changed.
+    state = hass.states.get("select.pet")
+    assert state.state == "Outside"
+
+
+@pytest.mark.parametrize(
+    "mock_config_entry_setup",
+    [
+        {
+            "with_pet_select": True,
+        }
+    ],
+    indirect=True,
+)
+async def test_select_manual_update(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry_setup: MockConfigEntry,
+) -> None:
+    """Test select manual update."""
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        service_data={"option": "Garage"},
+        blocking=True,
+        target={"entity_id": "select.pet"},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.pet")
+    assert state.state == "Garage"
+
+    attr = state.attributes
+    assert attr["last_update_type"] == "manual"
+
+    coordinator = hass.data[DOMAIN][mock_config_entry_setup.entry_id]
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    # select state should not change because it was set manually
+    # and the mock surepetcare api response has not changed.
+    state = hass.states.get("select.pet")
+    assert state.state == "Garage"
+
+    attr = state.attributes
+    assert attr["last_update_type"] == "manual"
+
+
+@pytest.mark.parametrize(
+    "mock_config_entry_setup",
+    [
+        {
+            "with_pet_select": True,
+        }
+    ],
+    indirect=True,
+)
+async def test_select_manual_update_then_location_change(
+    hass: HomeAssistant,
+    surepetcare,
+    mock_config_entry_setup: MockConfigEntry,
+) -> None:
+    """Test that select state changes when location changes after manual update."""
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        service_data={"option": "Outside"},
+        blocking=True,
+        target={"entity_id": "select.pet"},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.pet")
+    assert state.state == "Outside"
+
+    attr = state.attributes
+    assert attr["last_update_type"] == "manual"
+
+    surepetcare.set_call_response(
+        {
+            "data": {
+                **MOCK_API_DATA,
+                "pets": [
+                    {
+                        **MOCK_PET,
+                        "position": {
+                            "since": "2020-08-23T23:30:00",
+                            "where": 1,
+                            "device_id": 13579,
+                        },
+                    }
+                ],
+            }
+        }
+    )
+
+    coordinator = hass.data[DOMAIN][mock_config_entry_setup.entry_id]
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
+
+    # select state should change because the mock surepetcare api
+    # response has changed.
+    state = hass.states.get("select.pet")
+    assert state.state == "Garage"
+
+    attr = state.attributes
+    assert attr["last_update_type"] == "auto"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new option in the config flow to create an additional select entity for each pet's location. This is particularly useful for users with multiple flaps that do not directly lead outside. In such setups, the Home/Away status reported by the Sure Petcare app will be wrong if the last used flap does not lead outside. This feature aims to work around that limitation.

![select_pet_location_schema](https://github.com/user-attachments/assets/64151e06-ec09-46e5-85fb-7e4046fa52ce)
\* "Couloir" (my flap name) = Hall in english

When enabled, the user is asked to map each pet flap’s entry and exit sides to a zone (Home Assistant areas are suggested by default but custom inputs are allowed). These mappings are then used to determine each pet’s precise location and allow the user to manually change it via the select entity if needed. If the state is manually changed, it will not be automatically updated again until the pet’s location changes compared to the last recorded one.

This feature is entirely optional and does not affect the behavior of the existing pet binary sensors. While changing a pet’s location via the Sure Petcare app will update the select entity state, manually changing the select entity state from Home Assistant will not alter the actual Home/Away status in Sure Petcare.

![pet_location_select](https://github.com/user-attachments/assets/97ffd8e1-e26d-4033-9eb0-0eb2d5d3e704)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39070
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
