### PR TITLE
Fix mapping from program_phase to vacuum_activity for Miele integration

### DIFF
--- a/homeassistant/components/miele/vacuum.py
+++ b/homeassistant/components/miele/vacuum.py
@@ -141,21 +141,21 @@ async def async_setup_entry(
 
 
 VACUUM_PHASE_TO_ACTIVITY = {
-    MieleVacuumStateCode.idle: VacuumActivity.IDLE,
-    MieleVacuumStateCode.docked: VacuumActivity.DOCKED,
-    MieleVacuumStateCode.cleaning: VacuumActivity.CLEANING,
-    MieleVacuumStateCode.going_to_target_area: VacuumActivity.CLEANING,
-    MieleVacuumStateCode.returning: VacuumActivity.RETURNING,
-    MieleVacuumStateCode.wheel_lifted: VacuumActivity.ERROR,
-    MieleVacuumStateCode.dirty_sensors: VacuumActivity.ERROR,
-    MieleVacuumStateCode.dust_box_missing: VacuumActivity.ERROR,
-    MieleVacuumStateCode.blocked_drive_wheels: VacuumActivity.ERROR,
-    MieleVacuumStateCode.blocked_brushes: VacuumActivity.ERROR,
-    MieleVacuumStateCode.check_dust_box_and_filter: VacuumActivity.ERROR,
-    MieleVacuumStateCode.internal_fault_reboot: VacuumActivity.ERROR,
-    MieleVacuumStateCode.blocked_front_wheel: VacuumActivity.ERROR,
-    MieleVacuumStateCode.paused: VacuumActivity.PAUSED,
-    MieleVacuumStateCode.remote_controlled: VacuumActivity.PAUSED,
+    MieleVacuumStateCode.idle.value: VacuumActivity.IDLE,
+    MieleVacuumStateCode.docked.value: VacuumActivity.DOCKED,
+    MieleVacuumStateCode.cleaning.value: VacuumActivity.CLEANING,
+    MieleVacuumStateCode.going_to_target_area.value: VacuumActivity.CLEANING,
+    MieleVacuumStateCode.returning.value: VacuumActivity.RETURNING,
+    MieleVacuumStateCode.wheel_lifted.value: VacuumActivity.ERROR,
+    MieleVacuumStateCode.dirty_sensors.value: VacuumActivity.ERROR,
+    MieleVacuumStateCode.dust_box_missing.value: VacuumActivity.ERROR,
+    MieleVacuumStateCode.blocked_drive_wheels.value: VacuumActivity.ERROR,
+    MieleVacuumStateCode.blocked_brushes.value: VacuumActivity.ERROR,
+    MieleVacuumStateCode.check_dust_box_and_filter.value: VacuumActivity.ERROR,
+    MieleVacuumStateCode.internal_fault_reboot.value: VacuumActivity.ERROR,
+    MieleVacuumStateCode.blocked_front_wheel.value: VacuumActivity.ERROR,
+    MieleVacuumStateCode.paused.value: VacuumActivity.PAUSED,
+    MieleVacuumStateCode.remote_controlled.value: VacuumActivity.PAUSED,
 }
 
 
@@ -171,7 +171,7 @@ class MieleVacuum(MieleEntity, StateVacuumEntity):
     def activity(self) -> VacuumActivity | None:
         """Return activity."""
         return VACUUM_PHASE_TO_ACTIVITY.get(
-            MieleVacuumStateCode(self.device.state_program_phase)
+            MieleVacuumStateCode(self.device.state_program_phase).value
         )
 
     @property

--- a/tests/components/miele/fixtures/vacuum_device.json
+++ b/tests/components/miele/fixtures/vacuum_device.json
@@ -15,7 +15,10 @@
         "matNumber": "11686510",
         "swids": ["<swid1>", "<swid2>", "<swid3>", "<...>"]
       },
-      "xkmIdentLabel": { "techType": "", "releaseVersion": "" }
+      "xkmIdentLabel": {
+        "techType": "",
+        "releaseVersion": ""
+      }
     },
     "state": {
       "ProgramID": {
@@ -34,9 +37,7 @@
         "key_localized": "Program type"
       },
       "programPhase": {
-        "xvalue_raw": 5889,
-        "zvalue_raw": 5904,
-        "value_raw": 5893,
+        "value_raw": 5889,
         "value_localized": "in the base station",
         "key_localized": "Program phase"
       },

--- a/tests/components/miele/snapshots/test_vacuum.ambr
+++ b/tests/components/miele/snapshots/test_vacuum.ambr
@@ -58,6 +58,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'paused',
+    'state': 'cleaning',
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix bug that caused vacuum activity to always show Paused.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
