### PR TITLE
Fix history_stats with sliding window that ends before now

### DIFF
--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -137,13 +137,11 @@ class HistoryStats:
                 return self._state
         else:
             await self._async_history_from_db(
-                current_period_start_timestamp, current_period_end_timestamp
+                current_period_start_timestamp, now_timestamp
             )
             if event and (new_state := event.data["new_state"]) is not None:
-                if (
-                    current_period_start_timestamp
-                    <= floored_timestamp(new_state.last_changed)
-                    <= current_period_end_timestamp
+                if current_period_start_timestamp <= floored_timestamp(
+                    new_state.last_changed
                 ):
                     self._history_current_period.append(
                         HistoryState(new_state.state, new_state.last_changed_timestamp)

--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -222,7 +222,7 @@ class HistoryStats:
             current_state_matches = history_state.state in self._entity_states
             state_change_timestamp = history_state.last_changed
 
-            if state_change_timestamp > end_timestamp:
+            if math.floor(state_change_timestamp) > end_timestamp:
                 break
 
             if math.floor(state_change_timestamp) > now_timestamp:

--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -88,6 +88,11 @@ class HistoryStats:
         utc_now = dt_util.utcnow()
         now_timestamp = floored_timestamp(utc_now)
 
+        # If we end up querying data from the recorder when we get triggered by a new state
+        # change event, it is possible this function could be reentered a second time before
+        # the first recorder query returns. In that case a second recorder query will be done
+        # and we need to hold the new event so that we can append it after the second query.
+        # Otherwise the event will be dropped.
         if event:
             self._pending_events.append(event)
 
@@ -159,7 +164,7 @@ class HistoryStats:
             self._has_recorder_data = True
 
         if self._query_count == 0:
-            self._pending_events = []
+            self._pending_events.clear()
 
         seconds_matched, match_count = self._async_compute_seconds_and_changes(
             now_timestamp,

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -1664,7 +1664,7 @@ async def test_state_change_during_window_rollover(
                         "entity_id": "binary_sensor.state",
                         "name": "sensor1",
                         "state": "on",
-                        "start": "{{ today_at() }}",
+                        "start": "{{ today_at('12:00') if now().hour == 1 else today_at() }}",
                         "end": "{{ now() }}",
                         "type": "time",
                     }
@@ -1679,7 +1679,7 @@ async def test_state_change_during_window_rollover(
     assert hass.states.get("sensor.sensor1").state == "11.0"
 
     # Advance 59 minutes, to record the last minute update just before midnight, just like a real system would do.
-    t2 = start_time + timedelta(minutes=59, microseconds=300)
+    t2 = start_time + timedelta(minutes=59, microseconds=300)  # 23:59
     with freeze_time(t2):
         async_fire_time_changed(hass, t2)
         await hass.async_block_till_done()
@@ -1688,7 +1688,7 @@ async def test_state_change_during_window_rollover(
 
     # One minute has passed and the time has now rolled over into a new day, resetting the recorder window.
     # The sensor will be ON since midnight.
-    t3 = t2 + timedelta(minutes=1)
+    t3 = t2 + timedelta(minutes=1)  # 00:01
     with freeze_time(t3):
         # The sensor turns off around this time, before the sensor does its normal polled update.
         hass.states.async_set("binary_sensor.state", "off")
@@ -1697,12 +1697,68 @@ async def test_state_change_during_window_rollover(
     assert hass.states.get("sensor.sensor1").state == "0.0"
 
     # More time passes, and the history stats does a polled update again. It should be 0 since the sensor has been off since midnight.
-    t4 = t3 + timedelta(minutes=10)
+    # Turn the sensor back on.
+    t4 = t3 + timedelta(minutes=10)  # 00:10
     with freeze_time(t4):
         async_fire_time_changed(hass, t4)
         await hass.async_block_till_done()
+        hass.states.async_set("binary_sensor.state", "on")
+        await hass.async_block_till_done()
 
     assert hass.states.get("sensor.sensor1").state == "0.0"
+
+    # Due to time change, start time has now moved into the future. Turn off the sensor.
+    t5 = t4 + timedelta(hours=1)  # 01:10
+    with freeze_time(t5):
+        hass.states.async_set("binary_sensor.state", "off")
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("sensor.sensor1").state == STATE_UNKNOWN
+
+    # Start time has moved back to start of today. Turn the sensor on at the same time it is recomputed
+    # Should query the recorder this time due to start time moving backwards in time.
+    t6 = t5 + timedelta(hours=1)  # 02:10
+
+    def _fake_states_t6(*args, **kwargs):
+        return {
+            "binary_sensor.state": [
+                ha.State(
+                    "binary_sensor.state",
+                    "off",
+                    last_changed=t6.replace(hour=0, minute=0, second=0, microsecond=0),
+                ),
+                ha.State(
+                    "binary_sensor.state",
+                    "on",
+                    last_changed=t6.replace(hour=0, minute=10, second=0, microsecond=0),
+                ),
+                ha.State(
+                    "binary_sensor.state",
+                    "off",
+                    last_changed=t6.replace(hour=1, minute=10, second=0, microsecond=0),
+                ),
+            ]
+        }
+
+    with (
+        patch(
+            "homeassistant.components.recorder.history.state_changes_during_period",
+            _fake_states_t6,
+        ),
+        freeze_time(t6),
+    ):
+        hass.states.async_set("binary_sensor.state", "on")
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("sensor.sensor1").state == "1.0"
+
+    # Another hour passes since the re-query. Total 'On' time should be 2 hours (00:10-1:10, 2:10-now (3:10))
+    t7 = t6 + timedelta(hours=1)  # 03:10
+    with freeze_time(t7):
+        async_fire_time_changed(hass, t7)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.sensor1").state == "2.0"
 
 
 @pytest.mark.parametrize("time_zone", ["Europe/Berlin", "America/Chicago", "US/Hawaii"])

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -1969,7 +1969,7 @@ async def test_history_stats_handles_floored_timestamps(
         await async_update_entity(hass, "sensor.sensor1")
         await hass.async_block_till_done()
 
-    assert last_times == (start_time, start_time + timedelta(hours=2))
+    assert last_times == (start_time, start_time)
 
 
 async def test_unique_id(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
If history stats gets a state update but the current window ends prior to now, we should still store the state change, such that when time passes and that event slides into the active window we will have it available for calculation. 

Regression caused from previous bugfix #143279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #145112
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
