### PR TITLE
Bump cryptography to 45.0.1 and pyopenssl to 25.1.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -55,7 +55,7 @@ psutil-home-assistant==0.0.1
 PyJWT==2.10.1
 pymicro-vad==1.0.1
 PyNaCl==1.5.0
-pyOpenSSL==25.0.0
+pyOpenSSL==25.1.0
 pyserial==3.5
 pyspeex-noise==1.0.2
 python-slugify==8.0.4
@@ -142,10 +142,6 @@ pubnub!=6.4.0
 # Package's __init__.pyi stub has invalid syntax and breaks mypy
 # https://github.com/dahlia/iso4217/issues/16
 iso4217!=1.10.20220401
-
-# pyOpenSSL 24.0.0 or later required to avoid import errors when
-# cryptography 42.0.0 is installed with botocore
-pyOpenSSL>=24.0.0
 
 # protobuf must be in package constraints for the wheel
 # builder to build binary wheels

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -29,7 +29,7 @@ cached-ipaddress==0.10.0
 certifi>=2021.5.30
 ciso8601==2.3.2
 cronsim==2.6
-cryptography==44.0.1
+cryptography==45.0.1
 dbus-fast==2.43.0
 fnv-hash-fast==1.5.0
 go2rtc-client==0.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
   "cryptography==45.0.1",
   "Pillow==11.2.1",
   "propcache==0.3.1",
-  "pyOpenSSL==25.0.0",
+  "pyOpenSSL==25.1.0",
   "orjson==3.10.18",
   "packaging>=23.1",
   "psutil-home-assistant==0.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
   "numpy==2.2.2",
   "PyJWT==2.10.1",
   # PyJWT has loose dependency. We want the latest one.
-  "cryptography==44.0.1",
+  "cryptography==45.0.1",
   "Pillow==11.2.1",
   "propcache==0.3.1",
   "pyOpenSSL==25.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ PyJWT==2.10.1
 cryptography==45.0.1
 Pillow==11.2.1
 propcache==0.3.1
-pyOpenSSL==25.0.0
+pyOpenSSL==25.1.0
 orjson==3.10.18
 packaging>=23.1
 psutil-home-assistant==0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ lru-dict==1.3.0
 mutagen==1.47.0
 numpy==2.2.2
 PyJWT==2.10.1
-cryptography==44.0.1
+cryptography==45.0.1
 Pillow==11.2.1
 propcache==0.3.1
 pyOpenSSL==25.0.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -172,10 +172,6 @@ pubnub!=6.4.0
 # https://github.com/dahlia/iso4217/issues/16
 iso4217!=1.10.20220401
 
-# pyOpenSSL 24.0.0 or later required to avoid import errors when
-# cryptography 42.0.0 is installed with botocore
-pyOpenSSL>=24.0.0
-
 # protobuf must be in package constraints for the wheel
 # builder to build binary wheels
 protobuf==5.29.2


### PR DESCRIPTION
wheels: https://github.com/home-assistant/core/actions/runs/15088242009

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is nearly a 50% speed up for most use cases

details in https://github.com/pyca/cryptography/pull/12857

needs to be bump together

cryptography changelog: https://github.com/pyca/cryptography/compare/44.0.1...45.0.1
pyopenssl changelog: https://github.com/pyca/pyopenssl/compare/25.0.0...25.1.0

### Merging will **improve `aioesphomeapi` performances by 64.01%**

### Summary

`⚡ 5` improvements  
`✅ 5` untouched benchmarks  



### Benchmarks breakdown

|     | Benchmark | `BASE` | `HEAD` | Change |
| --- | --------- | ----------------------- | ------------------- | ------ |
| ⚡ | `` test_noise_messages[0] `` | 2.1 ms | 1.3 ms | +64.01% |
| ⚡ | `` test_noise_messages[1024] `` | 2.7 ms | 1.9 ms | +46.15% |
| ⚡ | `` test_noise_messages[128] `` | 2.3 ms | 1.5 ms | +54.85% |
| ⚡ | `` test_noise_messages[16384] `` | 15.9 ms | 15 ms | +5.69% |
| ⚡ | `` test_noise_messages[64] `` | 2.2 ms | 1.4 ms | +58.54% |


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
