### PR TITLE
Miele consumption sensors consistent behavior with RestoreSensor

### DIFF
--- a/tests/components/miele/fixtures/laundry_scenario/001_off.json
+++ b/tests/components/miele/fixtures/laundry_scenario/001_off.json
@@ -1,0 +1,272 @@
+{
+  "DummyWasher": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 1,
+        "value_localized": "Washing machine"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "32",
+        "techType": "WCR870",
+        "matNumber": "10979100",
+        "swids": [
+          "5836",
+          "20457",
+          "20449",
+          "25260",
+          "20450",
+          "5013",
+          "25314",
+          "25205",
+          "25313",
+          "25191"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK057",
+        "releaseVersion": "08.32"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 1,
+        "value_localized": "Off",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 0],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": true,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": false,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [0, 0],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": null,
+        "value_localized": null,
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": null,
+      "batteryLevel": null
+    }
+  },
+  "DummyDryer": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 2,
+        "value_localized": "Tumble dryer"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "13",
+        "techType": "TCJ690WP",
+        "matNumber": "10979980",
+        "swids": [
+          "5213",
+          "25359",
+          "25360",
+          "25002",
+          "20456",
+          "25213",
+          "5136",
+          "20445",
+          "25234",
+          "4174"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK037",
+        "releaseVersion": "04.05"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 1,
+        "value_localized": "Off",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 0],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": true,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [0, 55],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": null,
+        "value_localized": null,
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": null,
+      "batteryLevel": null
+    }
+  }
+}

--- a/tests/components/miele/fixtures/laundry_scenario/002_washing.json
+++ b/tests/components/miele/fixtures/laundry_scenario/002_washing.json
@@ -1,0 +1,283 @@
+{
+  "DummyWasher": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 1,
+        "value_localized": "Washing machine"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "32",
+        "techType": "WCR870",
+        "matNumber": "10979100",
+        "swids": [
+          "5836",
+          "20457",
+          "20449",
+          "25260",
+          "20450",
+          "5013",
+          "25314",
+          "25205",
+          "25313",
+          "25191"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK057",
+        "releaseVersion": "08.32"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 3,
+        "value_localized": "Minimum iron",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 5,
+        "value_localized": "In use",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 1,
+        "value_localized": "Program",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 260,
+        "value_localized": "Main wash",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [1, 45],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": 3000,
+          "value_localized": 30.0,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": false,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [0, 12],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": 1200,
+        "value_localized": "1200",
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": {
+        "currentWaterConsumption": {
+          "unit": "l",
+          "value": 7.0
+        },
+        "currentEnergyConsumption": {
+          "unit": "kWh",
+          "value": 0.1
+        },
+        "waterForecast": 0.3,
+        "energyForecast": 0.3
+      },
+      "batteryLevel": null
+    }
+  },
+  "DummyDryer": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 2,
+        "value_localized": "Tumble dryer"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "13",
+        "techType": "TCJ690WP",
+        "matNumber": "10979980",
+        "swids": [
+          "5213",
+          "25359",
+          "25360",
+          "25002",
+          "20456",
+          "25213",
+          "5136",
+          "20445",
+          "25234",
+          "4174"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK037",
+        "releaseVersion": "04.05"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 1,
+        "value_localized": "Off",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 0],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": true,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [0, 55],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": null,
+        "value_localized": null,
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": null,
+      "batteryLevel": null
+    }
+  }
+}

--- a/tests/components/miele/fixtures/laundry_scenario/003_rinse_hold.json
+++ b/tests/components/miele/fixtures/laundry_scenario/003_rinse_hold.json
@@ -1,0 +1,283 @@
+{
+  "DummyWasher": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 1,
+        "value_localized": "Washing machine"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "32",
+        "techType": "WCR870",
+        "matNumber": "10979100",
+        "swids": [
+          "5836",
+          "20457",
+          "20449",
+          "25260",
+          "20450",
+          "5013",
+          "25314",
+          "25205",
+          "25313",
+          "25191"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK057",
+        "releaseVersion": "08.32"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 3,
+        "value_localized": "Minimum iron",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 11,
+        "value_localized": "Rinse hold",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 1,
+        "value_localized": "Program",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 262,
+        "value_localized": "Rinse hold",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 8],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": 3000,
+          "value_localized": 30.0,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": false,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [1, 49],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": 1200,
+        "value_localized": "1200",
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": {
+        "currentWaterConsumption": {
+          "unit": "l",
+          "value": 41.0
+        },
+        "currentEnergyConsumption": {
+          "unit": "kWh",
+          "value": 0.3
+        },
+        "waterForecast": 0.3,
+        "energyForecast": 0.3
+      },
+      "batteryLevel": null
+    }
+  },
+  "DummyDryer": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 2,
+        "value_localized": "Tumble dryer"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "13",
+        "techType": "TCJ690WP",
+        "matNumber": "10979980",
+        "swids": [
+          "5213",
+          "25359",
+          "25360",
+          "25002",
+          "20456",
+          "25213",
+          "5136",
+          "20445",
+          "25234",
+          "4174"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK037",
+        "releaseVersion": "04.05"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 1,
+        "value_localized": "Off",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 0,
+        "value_localized": "",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 0],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": true,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [0, 55],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": null,
+        "value_localized": null,
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": null,
+      "batteryLevel": null
+    }
+  }
+}

--- a/tests/components/miele/fixtures/laundry_scenario/004_wash_end.json
+++ b/tests/components/miele/fixtures/laundry_scenario/004_wash_end.json
@@ -38,8 +38,8 @@
         "key_localized": "Program name"
       },
       "status": {
-        "value_raw": 11,
-        "value_localized": "Rinse hold",
+        "value_raw": 7,
+        "value_localized": "Finished",
         "key_localized": "status"
       },
       "programType": {
@@ -48,11 +48,11 @@
         "key_localized": "Program type"
       },
       "programPhase": {
-        "value_raw": 262,
-        "value_localized": "Rinse hold",
+        "value_raw": 267,
+        "value_localized": "Anti-crease",
         "key_localized": "Program phase"
       },
-      "remainingTime": [0, 8],
+      "remainingTime": [0, 0],
       "startTime": [0, 0],
       "targetTemperature": [
         {
@@ -112,7 +112,7 @@
       },
       "ambientLight": null,
       "light": null,
-      "elapsedTime": [1, 49],
+      "elapsedTime": [0, 0],
       "spinningSpeed": {
         "unit": "rpm",
         "value_raw": 1200,

--- a/tests/components/miele/fixtures/laundry_scenario/005_drying.json
+++ b/tests/components/miele/fixtures/laundry_scenario/005_drying.json
@@ -1,0 +1,294 @@
+{
+  "DummyWasher": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 1,
+        "value_localized": "Washing machine"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "32",
+        "techType": "WCR870",
+        "matNumber": "10979100",
+        "swids": [
+          "5836",
+          "20457",
+          "20449",
+          "25260",
+          "20450",
+          "5013",
+          "25314",
+          "25205",
+          "25313",
+          "25191"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK057",
+        "releaseVersion": "08.32"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 3,
+        "value_localized": "Minimum iron",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 3,
+        "value_localized": "Programme selected",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 1,
+        "value_localized": "Program",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 256,
+        "value_localized": "",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [1, 59],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": 4000,
+          "value_localized": 40.0,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": true,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": false,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [0, 0],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": 1200,
+        "value_localized": "1200",
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": {
+        "currentWaterConsumption": {
+          "unit": "l",
+          "value": 52.0
+        },
+        "currentEnergyConsumption": {
+          "unit": "kWh",
+          "value": 0.3
+        },
+        "waterForecast": 0.3,
+        "energyForecast": 0.3
+      },
+      "batteryLevel": null
+    }
+  },
+  "DummyDryer": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 2,
+        "value_localized": "Tumble dryer"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "13",
+        "techType": "TCJ690WP",
+        "matNumber": "10979980",
+        "swids": [
+          "5213",
+          "25359",
+          "25360",
+          "25002",
+          "20456",
+          "25213",
+          "5136",
+          "20445",
+          "25234",
+          "4174"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK037",
+        "releaseVersion": "04.05"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 3,
+        "value_localized": "Minimum iron",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 5,
+        "value_localized": "In use",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 3,
+        "value_localized": "Automatic programme",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 514,
+        "value_localized": "Drying",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 49],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": true,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [0, 20],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": null,
+        "value_localized": null,
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": 2,
+        "value_localized": "Normal",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": {
+        "currentWaterConsumption": {
+          "unit": "l",
+          "value": 0.0
+        },
+        "currentEnergyConsumption": {
+          "unit": "kWh",
+          "value": 0.1
+        },
+        "waterForecast": 0.0,
+        "energyForecast": 0.7
+      },
+      "batteryLevel": null
+    }
+  }
+}

--- a/tests/components/miele/fixtures/laundry_scenario/006_drying_end.json
+++ b/tests/components/miele/fixtures/laundry_scenario/006_drying_end.json
@@ -1,0 +1,294 @@
+{
+  "DummyWasher": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 1,
+        "value_localized": "Washing machine"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "32",
+        "techType": "WCR870",
+        "matNumber": "10979100",
+        "swids": [
+          "5836",
+          "20457",
+          "20449",
+          "25260",
+          "20450",
+          "5013",
+          "25314",
+          "25205",
+          "25313",
+          "25191"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK057",
+        "releaseVersion": "08.32"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 1,
+        "value_localized": "Cottons",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 5,
+        "value_localized": "In use",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 1,
+        "value_localized": "Program",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 260,
+        "value_localized": "Main wash",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 56],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": 6000,
+          "value_localized": 60.0,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": false,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [1, 26],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": 1600,
+        "value_localized": "1600",
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": {
+        "currentWaterConsumption": {
+          "unit": "l",
+          "value": 7.0
+        },
+        "currentEnergyConsumption": {
+          "unit": "kWh",
+          "value": 0.6
+        },
+        "waterForecast": 0.3,
+        "energyForecast": 0.5
+      },
+      "batteryLevel": null
+    }
+  },
+  "DummyDryer": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 2,
+        "value_localized": "Tumble dryer"
+      },
+      "deviceName": "",
+      "protocolVersion": 4,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "13",
+        "techType": "TCJ690WP",
+        "matNumber": "10979980",
+        "swids": [
+          "5213",
+          "25359",
+          "25360",
+          "25002",
+          "20456",
+          "25213",
+          "5136",
+          "20445",
+          "25234",
+          "4174"
+        ]
+      },
+      "xkmIdentLabel": {
+        "techType": "EK037",
+        "releaseVersion": "04.05"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": 3,
+        "value_localized": "Minimum iron",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 7,
+        "value_localized": "Finished",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": 3,
+        "value_localized": "Automatic programme",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": 522,
+        "value_localized": "Finished",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [0, 0],
+      "startTime": [0, 0],
+      "targetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTargetTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "temperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        },
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "coreTemperature": [
+        {
+          "value_raw": -32768,
+          "value_localized": null,
+          "unit": "Celsius"
+        }
+      ],
+      "signalInfo": false,
+      "signalFailure": false,
+      "signalDoor": false,
+      "remoteEnable": {
+        "fullRemoteControl": true,
+        "smartGrid": true,
+        "mobileStart": false
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [1, 18],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": null,
+        "value_localized": null,
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": 2,
+        "value_localized": "Normal",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": {
+        "currentWaterConsumption": {
+          "unit": "l",
+          "value": 0.0
+        },
+        "currentEnergyConsumption": {
+          "unit": "kWh",
+          "value": 0.5
+        },
+        "waterForecast": 0.0,
+        "energyForecast": 0.7
+      },
+      "batteryLevel": null
+    }
+  }
+}

--- a/tests/components/miele/mocks.py
+++ b/tests/components/miele/mocks.py
@@ -1,0 +1,66 @@
+"""Mocks for the miele component."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.miele.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry, load_json_object_fixture
+
+
+async def mock_sensor_transitions(
+    hass: HomeAssistant,
+    mock_miele_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_name: str,
+    json_sequence: list[str],
+    expected_sensor_states: dict[str, list[str]],
+) -> None:
+    """Fixture for setting up parametrized tests for transitions between appliance status."""
+
+    num_steps = len(json_sequence) + 1  # +1 for the initial fixture
+
+    # check that all expected sensor states have the same number of steps
+    for sensor_suffix, states in expected_sensor_states.items():
+        assert len(states) == num_steps, (
+            f"Inconsistent number of steps for sensor '{sensor_suffix}'"
+        )
+
+    # for the initial state loaded from the fixture
+    step_index = 0
+    check_sensor_state(hass, device_name, expected_sensor_states, 0)
+
+    # for each additional step in the sequence, load the corresponding JSON file
+    for step_index, json_file in enumerate(json_sequence, start=1):
+        # load the JSON file for the current step and force update of sensors
+        mock_miele_client.get_devices.return_value = load_json_object_fixture(
+            json_file, DOMAIN
+        )
+        await hass.config_entries.async_reload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # check that the state of each sensor matches the expected state
+        check_sensor_state(hass, device_name, expected_sensor_states, step_index)
+
+
+def check_sensor_state(
+    hass: HomeAssistant,
+    device_name: str,
+    expected_sensor_states: dict[str, list[str]],
+    step_index: int,
+):
+    """Check the state of each sensor matches the expected state."""
+
+    for sensor_suffix, expected_states in expected_sensor_states.items():
+        sensor_entity = (
+            f"sensor.{device_name}"
+            if sensor_suffix == ""
+            else f"sensor.{device_name}_{sensor_suffix}"
+        )
+        state = hass.states.get(sensor_entity)
+        expected = expected_states[step_index]
+
+        assert state is not None, f"Missing entity: {sensor_entity}"
+        assert state.state == expected, (
+            f"[{sensor_entity}] Step {step_index + 1}: got {state.state}, expected {expected}"
+        )

--- a/tests/components/miele/test_sensor.py
+++ b/tests/components/miele/test_sensor.py
@@ -46,7 +46,6 @@ async def test_hob_sensor_states(
 
 @pytest.mark.parametrize("load_device_file", ["laundry_scenario/001_off.json"])
 @pytest.mark.parametrize("platforms", [(SENSOR_DOMAIN,)])
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
     ("device_name", "json_sequence", "expected_sensor_states"),
     [
@@ -106,7 +105,6 @@ async def test_hob_sensor_states(
 async def test_laundry_scenario(
     hass: HomeAssistant,
     mock_miele_client: MagicMock,
-    entity_registry: er.EntityRegistry,
     setup_platform: None,
     mock_config_entry: MockConfigEntry,
     device_name: str,

--- a/tests/components/miele/test_sensor.py
+++ b/tests/components/miele/test_sensor.py
@@ -54,18 +54,29 @@ async def test_hob_sensor_states(
             [
                 "laundry_scenario/002_washing.json",
                 "laundry_scenario/003_rinse_hold.json",
+                "laundry_scenario/004_wash_end.json",
             ],
             {
-                "": ["off", "in_use", "rinse_hold"],
-                "program": ["no_program", "minimum_iron", "minimum_iron"],
-                "program_phase": ["not_running", "main_wash", "rinse_hold"],
-                # "target_temperature": ["unknown", "30", "30"],
-                "spin_speed": ["unknown", "1200", "1200"],
-                "remaining_time": ["0", "105", "8"],
+                "": ["off", "in_use", "rinse_hold", "program_ended"],
+                "program": [
+                    "no_program",
+                    "minimum_iron",
+                    "minimum_iron",
+                    "minimum_iron",
+                ],
+                "program_phase": [
+                    "not_running",
+                    "main_wash",
+                    "rinse_hold",
+                    "anti_crease",
+                ],
+                # "target_temperature": ["unknown", "30", "30", "30"],
+                "spin_speed": ["unknown", "1200", "1200", "1200"],
+                "remaining_time": ["0", "105", "8", "0"],
                 # OFF -> elapsed forced to 0 (some devices continue reporting last value of last cycle)
                 # IN_USE -> elapsed time from API (normal case)
                 # PROGRAM_ENDED -> elapsed time kept from last program (some devices immediately go to 0)
-                "elapsed_time": ["0", "12", "109"],
+                "elapsed_time": ["0", "12", "109", "109"],
             },
         ),
         (

--- a/tests/components/miele/test_sensor.py
+++ b/tests/components/miele/test_sensor.py
@@ -87,17 +87,18 @@ async def test_hob_sensor_states(
             "tumble_dryer",
             [
                 "laundry_scenario/005_drying.json",
+                "laundry_scenario/006_drying_end.json",
             ],
             {
-                "": ["off", "in_use"],
-                "program": ["no_program", "minimum_iron"],
-                "program_phase": ["not_running", "drying"],
-                "drying_step": ["unknown", "normal"],
-                "remaining_time": ["0", "49"],
+                "": ["off", "in_use", "program_ended"],
+                "program": ["no_program", "minimum_iron", "minimum_iron"],
+                "program_phase": ["not_running", "drying", "finished"],
+                "drying_step": ["unknown", "normal", "normal"],
+                "remaining_time": ["0", "49", "0"],
                 # OFF -> elapsed forced to 0 (some devices continue reporting last value of last cycle)
                 # IN_USE -> elapsed time from API (normal case)
                 # PROGRAM_ENDED -> elapsed time kept from last program (some devices immediately go to 0)
-                "elapsed_time": ["0", "20"],
+                "elapsed_time": ["0", "20", "20"],
             },
         ),
     ],

--- a/tests/components/miele/test_sensor.py
+++ b/tests/components/miele/test_sensor.py
@@ -9,6 +9,8 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from .mocks import mock_sensor_transitions
+
 from tests.common import MockConfigEntry, snapshot_platform
 
 
@@ -39,3 +41,67 @@ async def test_hob_sensor_states(
     """Test sensor state."""
 
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
+
+
+@pytest.mark.parametrize("load_device_file", ["laundry_scenario/001_off.json"])
+@pytest.mark.parametrize("platforms", [(SENSOR_DOMAIN,)])
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    ("device_name", "json_sequence", "expected_sensor_states"),
+    [
+        (
+            "washing_machine",
+            [
+                "laundry_scenario/002_washing.json",
+                "laundry_scenario/003_rinse_hold.json",
+            ],
+            {
+                "": ["off", "in_use", "rinse_hold"],
+                "program": ["no_program", "minimum_iron", "minimum_iron"],
+                "program_phase": ["not_running", "main_wash", "rinse_hold"],
+                # "target_temperature": ["unknown", "30", "30"],
+                "spin_speed": ["unknown", "1200", "1200"],
+                "remaining_time": ["0", "105", "8"],
+                # OFF -> elapsed forced to 0 (some devices continue reporting last value of last cycle)
+                # IN_USE -> elapsed time from API (normal case)
+                # PROGRAM_ENDED -> elapsed time kept from last program (some devices immediately go to 0)
+                "elapsed_time": ["0", "12", "109"],
+            },
+        ),
+        (
+            "tumble_dryer",
+            [],
+            {
+                "": ["off"],
+                "program": ["no_program"],
+                "program_phase": ["not_running"],
+                "drying_step": ["unknown"],
+                "remaining_time": ["0"],
+                # OFF -> elapsed forced to 0 (some devices continue reporting last value of last cycle)
+                # IN_USE -> elapsed time from API (normal case)
+                # PROGRAM_ENDED -> elapsed time kept from last program (some devices immediately go to 0)
+                "elapsed_time": ["0"],
+            },
+        ),
+    ],
+)
+async def test_laundry_scenario(
+    hass: HomeAssistant,
+    mock_miele_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+    setup_platform: None,
+    mock_config_entry: MockConfigEntry,
+    device_name: str,
+    json_sequence: list[str],
+    expected_sensor_states: dict[str, list[str]],
+) -> None:
+    """Parametrized test for verifying sensor state transitions for laundry devices."""
+
+    await mock_sensor_transitions(
+        hass,
+        mock_miele_client,
+        mock_config_entry,
+        device_name,
+        json_sequence,
+        expected_sensor_states,
+    )

--- a/tests/components/miele/test_sensor.py
+++ b/tests/components/miele/test_sensor.py
@@ -5,13 +5,14 @@ from unittest.mock import MagicMock
 import pytest
 from syrupy import SnapshotAssertion
 
+from homeassistant.components.miele.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .mocks import mock_sensor_transitions
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, load_json_object_fixture, snapshot_platform
 
 
 @pytest.mark.parametrize("platforms", [(SENSOR_DOMAIN,)])
@@ -55,11 +56,13 @@ async def test_hob_sensor_states(
                 "laundry_scenario/002_washing.json",
                 "laundry_scenario/003_rinse_hold.json",
                 "laundry_scenario/004_wash_end.json",
+                "laundry_scenario/005_drying.json",  # washer remains programmed while starting dryer
             ],
             {
-                "": ["off", "in_use", "rinse_hold", "program_ended"],
+                "": ["off", "in_use", "rinse_hold", "program_ended", "programmed"],
                 "program": [
                     "no_program",
+                    "minimum_iron",
                     "minimum_iron",
                     "minimum_iron",
                     "minimum_iron",
@@ -69,29 +72,33 @@ async def test_hob_sensor_states(
                     "main_wash",
                     "rinse_hold",
                     "anti_crease",
+                    "not_running",
                 ],
-                # "target_temperature": ["unknown", "30", "30", "30"],
-                "spin_speed": ["unknown", "1200", "1200", "1200"],
-                "remaining_time": ["0", "105", "8", "0"],
+                # "target_temperature": ["unknown", "30", "30", "30", "40"],
+                "spin_speed": ["unknown", "1200", "1200", "1200", "1200"],
+                "remaining_time": ["0", "105", "8", "0", "119"],
                 # OFF -> elapsed forced to 0 (some devices continue reporting last value of last cycle)
                 # IN_USE -> elapsed time from API (normal case)
                 # PROGRAM_ENDED -> elapsed time kept from last program (some devices immediately go to 0)
-                "elapsed_time": ["0", "12", "109", "109"],
+                # PROGRAMMED -> elapsed time from API (normal case)
+                "elapsed_time": ["0", "12", "109", "109", "0"],
             },
         ),
         (
             "tumble_dryer",
-            [],
+            [
+                "laundry_scenario/005_drying.json",
+            ],
             {
-                "": ["off"],
-                "program": ["no_program"],
-                "program_phase": ["not_running"],
-                "drying_step": ["unknown"],
-                "remaining_time": ["0"],
+                "": ["off", "in_use"],
+                "program": ["no_program", "minimum_iron"],
+                "program_phase": ["not_running", "drying"],
+                "drying_step": ["unknown", "normal"],
+                "remaining_time": ["0", "49"],
                 # OFF -> elapsed forced to 0 (some devices continue reporting last value of last cycle)
                 # IN_USE -> elapsed time from API (normal case)
                 # PROGRAM_ENDED -> elapsed time kept from last program (some devices immediately go to 0)
-                "elapsed_time": ["0"],
+                "elapsed_time": ["0", "20"],
             },
         ),
     ],
@@ -116,3 +123,37 @@ async def test_laundry_scenario(
         json_sequence,
         expected_sensor_states,
     )
+
+
+@pytest.mark.parametrize("load_device_file", ["laundry_scenario/003_rinse_hold.json"])
+@pytest.mark.parametrize("platforms", [(SENSOR_DOMAIN,)])
+async def test_elapsed_time_sensor_restored(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_miele_client: MagicMock,
+    setup_platform: None,
+) -> None:
+    """Test that elapsed time returns the restored value when program ended."""
+
+    entity_id = "sensor.washing_machine_elapsed_time"
+
+    assert hass.states.get(entity_id).state == "109"
+
+    # load device when status is PROGRAM_ENDED and elapsed time reported by API is 0
+    mock_miele_client.get_devices.return_value = load_json_object_fixture(
+        "laundry_scenario/004_wash_end.json", DOMAIN
+    )
+
+    # unload config entry and reload to make sure that the state is restored
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "unavailable"
+
+    await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # check that elapsed time is the one restored and not the value reported by API (0)
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "109"


### PR DESCRIPTION
## Proposed change
Miele API is returning inconsistent values for current consumption sensors.
In particular:
- some devices continue reporting the consumed energy/water until a new program cycle starts
- when starting a new program cycle, the API may start returning "0" after some seconds that the cycle has started

Proposed change is to make consumption sensors extend `MieleRestoreSensor` class and:
- reset last cached value (-1) when the appliance is in an idle state (including, on, off, programmed, etc.), returning 0 as consumed energy/water
- if last cached value is in reset value (-1), API is reporting a value > 0 and appliance has started (considering also paused state, as fully-integrated dishwashers start from pause state until the door is closed), then continue reporting 0
- otherwise, as the API starts reporting 0, cached value is updated to the API value and returned (so, as it increases, it is returned, since the previous points checks for the reset value -1).

This PR is based on `RestoreSensor` already added in https://github.com/home-assistant/core/pull/145093 and it must be reviewed after that PR.

**The PR is a draft for now and I still have to add some test scenario for specific API glitches.**

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. 

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
