### PR TITLE
Quantum Gateway device tracker tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1224,6 +1224,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/qnap_qsw/ @Noltari
 /tests/components/qnap_qsw/ @Noltari
 /homeassistant/components/quantum_gateway/ @cisasteelersfan
+/tests/components/quantum_gateway/ @cisasteelersfan
 /homeassistant/components/qvr_pro/ @oblogic7
 /homeassistant/components/qwikswitch/ @kellerza
 /tests/components/qwikswitch/ @kellerza

--- a/homeassistant/components/quantum_gateway/const.py
+++ b/homeassistant/components/quantum_gateway/const.py
@@ -1,0 +1,7 @@
+"""Constants for Quantum Gateway."""
+
+import logging
+
+LOGGER = logging.getLogger(__package__)
+
+DEFAULT_HOST = "myfiosgateway.com"

--- a/homeassistant/components/quantum_gateway/device_tracker.py
+++ b/homeassistant/components/quantum_gateway/device_tracker.py
@@ -39,7 +39,7 @@ def get_scanner(
 class QuantumGatewayDeviceScanner(DeviceScanner):
     """Class which queries a Quantum Gateway."""
 
-    def __init__(self, config):
+    def __init__(self, config) -> None:
         """Initialize the scanner."""
 
         self.host = config[CONF_HOST]

--- a/homeassistant/components/quantum_gateway/device_tracker.py
+++ b/homeassistant/components/quantum_gateway/device_tracker.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from quantum_gateway import QuantumGatewayScanner
 from requests.exceptions import RequestException
 import voluptuous as vol
@@ -18,9 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-_LOGGER = logging.getLogger(__name__)
-
-DEFAULT_HOST = "myfiosgateway.com"
+from .const import DEFAULT_HOST, LOGGER
 
 PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
     {
@@ -49,7 +45,7 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
         self.host = config[CONF_HOST]
         self.password = config[CONF_PASSWORD]
         self.use_https = config[CONF_SSL]
-        _LOGGER.debug("Initializing")
+        LOGGER.debug("Initializing")
 
         try:
             self.quantum = QuantumGatewayScanner(
@@ -58,10 +54,10 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
             self.success_init = self.quantum.success_init
         except RequestException:
             self.success_init = False
-            _LOGGER.error("Unable to connect to gateway. Check host")
+            LOGGER.error("Unable to connect to gateway. Check host")
 
         if not self.success_init:
-            _LOGGER.error("Unable to login to gateway. Check password and host")
+            LOGGER.error("Unable to login to gateway. Check password and host")
 
     def scan_devices(self):
         """Scan for new devices and return a list of found MACs."""
@@ -69,7 +65,7 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
         try:
             connected_devices = self.quantum.scan_devices()
         except RequestException:
-            _LOGGER.error("Unable to scan devices. Check connection to router")
+            LOGGER.error("Unable to scan devices. Check connection to router")
         return connected_devices
 
     def get_device_name(self, device):

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2125,6 +2125,9 @@ qingping-ble==0.10.0
 # homeassistant.components.qnap
 qnapstats==0.4.0
 
+# homeassistant.components.quantum_gateway
+quantum-gateway==0.0.8
+
 # homeassistant.components.radio_browser
 radios==0.3.2
 

--- a/tests/components/quantum_gateway/__init__.py
+++ b/tests/components/quantum_gateway/__init__.py
@@ -1,1 +1,22 @@
 """Tests for the quantum_gateway component."""
+
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_PLATFORM
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+
+async def setup_platform(hass: HomeAssistant) -> None:
+    """Set up the quantum_gateway integration."""
+    result = await async_setup_component(
+        hass,
+        DEVICE_TRACKER_DOMAIN,
+        {
+            DEVICE_TRACKER_DOMAIN: {
+                CONF_PLATFORM: "quantum_gateway",
+                CONF_PASSWORD: "fake_password",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert result

--- a/tests/components/quantum_gateway/__init__.py
+++ b/tests/components/quantum_gateway/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the quantum_gateway component."""

--- a/tests/components/quantum_gateway/conftest.py
+++ b/tests/components/quantum_gateway/conftest.py
@@ -1,0 +1,23 @@
+"""Fixtures for Quantum Gateway tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+async def mock_scanner() -> Generator[AsyncMock]:
+    """Mock QuantumGatewayScanner instance."""
+    with patch(
+        "homeassistant.components.quantum_gateway.device_tracker.QuantumGatewayScanner",
+        autospec=True,
+    ) as mock_scanner:
+        client = mock_scanner.return_value
+        client.success_init = True
+        client.scan_devices.return_value = ["ff:ff:ff:ff:ff:ff", "ff:ff:ff:ff:ff:fe"]
+        client.get_device_name.side_effect = {
+            "ff:ff:ff:ff:ff:ff": "",
+            "ff:ff:ff:ff:ff:fe": "desktop",
+        }.get
+        yield mock_scanner

--- a/tests/components/quantum_gateway/test_device_tracker.py
+++ b/tests/components/quantum_gateway/test_device_tracker.py
@@ -1,118 +1,46 @@
 """Tests for the quantum_gateway device tracker."""
 
-from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
 from requests import RequestException
 
-from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
-import homeassistant.components.quantum_gateway.device_tracker as quantum_gateway_device_tracker
-from homeassistant.const import CONF_PASSWORD, CONF_PLATFORM
+from homeassistant.const import STATE_HOME
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
+
+from . import setup_platform
 
 from tests.components.device_tracker.test_init import mock_yaml_devices  # noqa: F401
 
 
-@pytest.fixture
-def mocked_quantum_gateway_scanner():
-    """Mock for pyopnense.diagnostics."""
-    with mock.patch.object(
-        quantum_gateway_device_tracker, "QuantumGatewayScanner"
-    ) as mocked_scanner:
-        yield mocked_scanner
-
-
 @pytest.mark.usefixtures("yaml_devices")
-async def test_get_scanner(hass: HomeAssistant, mocked_quantum_gateway_scanner) -> None:
+async def test_get_scanner(hass: HomeAssistant, mock_scanner: AsyncMock) -> None:
     """Test creating a quantum gateway scanner."""
-    connected_devices = {
-        "ff:ff:ff:ff:ff:ff": "",
-        "ff:ff:ff:ff:ff:fe": "desktop",
-    }
-
-    mocked_quantum_gateway_scanner.configure_mock(
-        return_value=mock.Mock(
-            **{
-                "success_init": True,
-                "scan_devices.return_value": list(connected_devices.keys()),
-                "get_device_name.side_effect": connected_devices.get,
-            }
-        )
-    )
-
-    result = await async_setup_component(
-        hass,
-        DEVICE_TRACKER_DOMAIN,
-        {
-            DEVICE_TRACKER_DOMAIN: {
-                CONF_PLATFORM: "quantum_gateway",
-                CONF_PASSWORD: "fake_password",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    assert result
+    await setup_platform(hass)
 
     device_1 = hass.states.get("device_tracker.desktop")
     assert device_1 is not None
-    assert device_1.state == "home"
+    assert device_1.state == STATE_HOME
 
     device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
     assert device_2 is not None
-    assert device_2.state == "home"
+    assert device_2.state == STATE_HOME
 
 
 @pytest.mark.usefixtures("yaml_devices")
-async def test_get_scanner_error(
-    hass: HomeAssistant, mocked_quantum_gateway_scanner
-) -> None:
+async def test_get_scanner_error(hass: HomeAssistant, mock_scanner: AsyncMock) -> None:
     """Test failure when creating a quantum gateway scanner."""
-
-    mocked_quantum_gateway_scanner.configure_mock(side_effect=RequestException("Error"))
-
-    result = await async_setup_component(
-        hass,
-        DEVICE_TRACKER_DOMAIN,
-        {
-            DEVICE_TRACKER_DOMAIN: {
-                CONF_PLATFORM: "quantum_gateway",
-                CONF_PASSWORD: "fake_password",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    assert result
+    mock_scanner.side_effect = RequestException("Error")
+    await setup_platform(hass)
 
     assert "quantum_gateway.device_tracker" not in hass.config.components
 
 
 @pytest.mark.usefixtures("yaml_devices")
-async def test_scan_devices_error(
-    hass: HomeAssistant, mocked_quantum_gateway_scanner
-) -> None:
+async def test_scan_devices_error(hass: HomeAssistant, mock_scanner: AsyncMock) -> None:
     """Test failure when scanning devices."""
-    mocked_quantum_gateway_scanner.configure_mock(
-        return_value=mock.Mock(
-            **{
-                "success_init": True,
-                "scan_devices.side_effect": RequestException("Error"),
-            }
-        )
-    )
-
-    result = await async_setup_component(
-        hass,
-        DEVICE_TRACKER_DOMAIN,
-        {
-            DEVICE_TRACKER_DOMAIN: {
-                CONF_PLATFORM: "quantum_gateway",
-                CONF_PASSWORD: "fake_password",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    assert result
+    mock_scanner.return_value.scan_devices.side_effect = RequestException("Error")
+    await setup_platform(hass)
 
     assert "quantum_gateway.device_tracker" in hass.config.components
 

--- a/tests/components/quantum_gateway/test_device_tracker.py
+++ b/tests/components/quantum_gateway/test_device_tracker.py
@@ -1,0 +1,123 @@
+"""Tests for the quantum_gateway device tracker."""
+
+from unittest import mock
+
+import pytest
+from requests import RequestException
+
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
+import homeassistant.components.quantum_gateway.device_tracker as quantum_gateway_device_tracker
+from homeassistant.const import CONF_PASSWORD, CONF_PLATFORM
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.components.device_tracker.test_init import mock_yaml_devices  # noqa: F401
+
+
+@pytest.fixture
+def mocked_quantum_gateway_scanner():
+    """Mock for pyopnense.diagnostics."""
+    with mock.patch.object(
+        quantum_gateway_device_tracker, "QuantumGatewayScanner"
+    ) as mocked_scanner:
+        yield mocked_scanner
+
+
+@pytest.mark.usefixtures("yaml_devices")
+async def test_get_scanner(hass: HomeAssistant, mocked_quantum_gateway_scanner) -> None:
+    """Test creating a quantum gateway scanner."""
+    connected_devices = {
+        "ff:ff:ff:ff:ff:ff": "",
+        "ff:ff:ff:ff:ff:fe": "desktop",
+    }
+
+    mocked_quantum_gateway_scanner.configure_mock(
+        return_value=mock.Mock(
+            **{
+                "success_init": True,
+                "scan_devices.return_value": list(connected_devices.keys()),
+                "get_device_name.side_effect": connected_devices.get,
+            }
+        )
+    )
+
+    result = await async_setup_component(
+        hass,
+        DEVICE_TRACKER_DOMAIN,
+        {
+            DEVICE_TRACKER_DOMAIN: {
+                CONF_PLATFORM: "quantum_gateway",
+                CONF_PASSWORD: "fake_password",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert result
+
+    device_1 = hass.states.get("device_tracker.desktop")
+    assert device_1 is not None
+    assert device_1.state == "home"
+
+    device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
+    assert device_2 is not None
+    assert device_2.state == "home"
+
+
+@pytest.mark.usefixtures("yaml_devices")
+async def test_get_scanner_error(
+    hass: HomeAssistant, mocked_quantum_gateway_scanner
+) -> None:
+    """Test failure when creating a quantum gateway scanner."""
+
+    mocked_quantum_gateway_scanner.configure_mock(side_effect=RequestException("Error"))
+
+    result = await async_setup_component(
+        hass,
+        DEVICE_TRACKER_DOMAIN,
+        {
+            DEVICE_TRACKER_DOMAIN: {
+                CONF_PLATFORM: "quantum_gateway",
+                CONF_PASSWORD: "fake_password",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert result
+
+    assert "quantum_gateway.device_tracker" not in hass.config.components
+
+
+@pytest.mark.usefixtures("yaml_devices")
+async def test_scan_devices_error(
+    hass: HomeAssistant, mocked_quantum_gateway_scanner
+) -> None:
+    """Test failure when scanning devices."""
+    mocked_quantum_gateway_scanner.configure_mock(
+        return_value=mock.Mock(
+            **{
+                "success_init": True,
+                "scan_devices.side_effect": RequestException("Error"),
+            }
+        )
+    )
+
+    result = await async_setup_component(
+        hass,
+        DEVICE_TRACKER_DOMAIN,
+        {
+            DEVICE_TRACKER_DOMAIN: {
+                CONF_PLATFORM: "quantum_gateway",
+                CONF_PASSWORD: "fake_password",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert result
+
+    assert "quantum_gateway.device_tracker" in hass.config.components
+
+    device_1 = hass.states.get("device_tracker.desktop")
+    assert device_1 is None
+
+    device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
+    assert device_2 is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a PR to bring the Verizon Fios Quantum Gateway integration to 100% test coverage. The PR also includes a minor refactor of some `const`s to a central location.

The motivation behind these changes is to update the integration to use a config entry and config flow. The first step is adding some tests to make sure future changes don't break the integration!


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: n/a
- Link to developer documentation pull request: n/a
- Link to frontend pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
