### PR TITLE
Add environment variables for command line arguments

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -92,19 +92,26 @@ def get_arguments() -> argparse.Namespace:
         "-c",
         "--config",
         metavar="path_to_config_dir",
-        default=config_util.get_default_config_dir(),
+        default=os.environ.get("HA_CONFIG", config_util.get_default_config_dir()),
         help="Directory that contains the Home Assistant configuration",
     )
     parser.add_argument(
         "--recovery-mode",
         action="store_true",
+        default=config_util.get_environ_bool("HA_RECOVERY_MODE"),
         help="Start Home Assistant in recovery mode",
     )
     parser.add_argument(
-        "--debug", action="store_true", help="Start Home Assistant in debug mode"
+        "--debug",
+        action="store_true",
+        default=config_util.get_environ_bool("HA_DEBUG"),
+        help="Start Home Assistant in debug mode",
     )
     parser.add_argument(
-        "--open-ui", action="store_true", help="Open the webinterface in a browser"
+        "--open-ui",
+        action="store_true",
+        default=config_util.get_environ_bool("HA_OPEN_UI"),
+        help="Open the webinterface in a browser",
     )
 
     skip_pip_group = parser.add_mutually_exclusive_group()
@@ -122,22 +129,29 @@ def get_arguments() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Enable verbose logging to file."
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=config_util.get_environ_bool("HA_VERBOSE"),
+        help="Enable verbose logging to file.",
     )
     parser.add_argument(
         "--log-rotate-days",
         type=int,
-        default=None,
+        default=config_util.get_environ_int("HA_LOG_ROTATE_DAYS"),
         help="Enables daily log rotation and keeps up to the specified days",
     )
     parser.add_argument(
         "--log-file",
         type=str,
-        default=None,
+        default=os.environ.get("HA_LOG_FILE"),
         help="Log file to write to.  If not set, CONFIG/home-assistant.log is used",
     )
     parser.add_argument(
-        "--log-no-color", action="store_true", help="Disable color logs"
+        "--log-no-color",
+        action="store_true",
+        default=config_util.get_environ_bool("HA_LOG_NO_COLOR"),
+        help="Disable color logs",
     )
     parser.add_argument(
         "--script", nargs=argparse.REMAINDER, help="Run one of the embedded scripts"
@@ -145,6 +159,7 @@ def get_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--ignore-os-check",
         action="store_true",
+        default=config_util.get_environ_bool("HA_IGNORE_OS_CHECK"),
         help="Skips validation of operating system",
     )
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1350,3 +1350,25 @@ async def async_enable_safe_mode(hass: HomeAssistant) -> None:
         Path(hass.config.path(SAFE_MODE_FILENAME)).touch()
 
     await hass.async_add_executor_job(_enable_safe_mode)
+
+
+def get_environ_bool(key: str) -> bool:
+    """Get bool from environment variable."""
+
+    value = os.environ.get(key)
+    if value is None:
+        return False
+    if value.lower() in ["t", "true", "y", "yes"]:
+        return True
+    if value.lower() in ["f", "false", "n", "no"]:
+        return False
+    raise ValueError(f"Unable to parse '{value}' to bool")
+
+
+def get_environ_int(key: str) -> int | None:
+    """Get int from environment variable."""
+
+    value = os.environ.get(key)
+    if value is None:
+        return None
+    return int(value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1788,3 +1788,36 @@ async def test_loading_platforms_gathers(hass: HomeAssistant) -> None:
         ("platform_int", "sensor"),
         ("platform_int2", "sensor"),
     ]
+
+
+def test_get_environ_bool() -> None:
+    """Test getting boolean from environment variable."""
+
+    assert config_util.get_environ_bool("NOT_DEFINED") is False
+
+    os.environ["DEFINED"] = "y"
+    assert config_util.get_environ_bool("DEFINED") is True
+
+    os.environ["DEFINED"] = "yes"
+    assert config_util.get_environ_bool("DEFINED") is True
+
+    os.environ["DEFINED"] = "true"
+    assert config_util.get_environ_bool("DEFINED") is True
+
+    os.environ["DEFINED"] = "n"
+    assert config_util.get_environ_bool("DEFINED") is False
+
+    os.environ["DEFINED"] = "no"
+    assert config_util.get_environ_bool("DEFINED") is False
+
+    os.environ["DEFINED"] = "false"
+    assert config_util.get_environ_bool("DEFINED") is False
+
+
+def test_get_environ_int() -> None:
+    """Test getting int from environment variable."""
+
+    assert config_util.get_environ_int("NOT_DEFINED") is None
+
+    os.environ["DEFINED"] = "10"
+    assert config_util.get_environ_int("DEFINED") == 10


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This feature is proposed mainly to allow to inject configuration into the docker executable of Home Assistant. This is done by adding environment variable for all command line arguments.

Sources of motivation for the change:

- https://community.home-assistant.io/t/how-do-i-pass-the-log-file-option-into-the-home-assistant-docker-container/225958
- https://community.home-assistant.io/t/how-to-redirect-home-assistant-log-from-docker-to-var-log/206377/8
- https://community.home-assistant.io/t/move-logfiles-into-subfolder-config-logs/72439/2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request:
  - https://github.com/home-assistant/home-assistant.io/pull/39088
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
