### PR TITLE
Mark all _FUNCTION_MATCH as mandatory in pylint plugin

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -278,6 +278,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 2: "ClientCredential",
             },
             return_type="AbstractOAuth2Implementation",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_get_authorization_server",
@@ -285,6 +286,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 0: "HomeAssistant",
             },
             return_type="AuthorizationServer",
+            mandatory=True,
         ),
     ],
     "backup": [
@@ -294,6 +296,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 0: "HomeAssistant",
             },
             return_type=None,
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_post_backup",
@@ -301,6 +304,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 0: "HomeAssistant",
             },
             return_type=None,
+            mandatory=True,
         ),
     ],
     "cast": [
@@ -311,6 +315,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "str",
             },
             return_type="list[BrowseMedia]",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_browse_media",
@@ -321,6 +326,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 3: "str",
             },
             return_type=["BrowseMedia", "BrowseMedia | None"],
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_play_media",
@@ -332,6 +338,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 4: "str",
             },
             return_type="bool",
+            mandatory=True,
         ),
     ],
     "config_flow": [
@@ -341,6 +348,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 0: "HomeAssistant",
             },
             return_type="bool",
+            mandatory=True,
         ),
     ],
     "device_action": [
@@ -351,6 +359,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigType",
             },
             return_type="ConfigType",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_call_action_from_config",
@@ -361,6 +370,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 3: "Context | None",
             },
             return_type=None,
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_get_action_capabilities",
@@ -369,6 +379,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigType",
             },
             return_type="dict[str, Schema]",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_get_actions",
@@ -377,6 +388,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "str",
             },
             return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
+            mandatory=True,
         ),
     ],
     "device_condition": [
@@ -387,6 +399,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigType",
             },
             return_type="ConfigType",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_condition_from_config",
@@ -395,6 +408,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigType",
             },
             return_type="ConditionCheckerType",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_get_condition_capabilities",
@@ -403,6 +417,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigType",
             },
             return_type="dict[str, Schema]",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_get_conditions",
@@ -411,6 +426,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "str",
             },
             return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
+            mandatory=True,
         ),
     ],
     "device_tracker": [
@@ -423,6 +439,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 3: "DiscoveryInfoType | None",
             },
             return_type="bool",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_setup_scanner",
@@ -433,6 +450,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 3: "DiscoveryInfoType | None",
             },
             return_type="bool",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="get_scanner",
@@ -442,6 +460,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
             },
             return_type=["DeviceScanner", None],
             has_async_counterpart=True,
+            mandatory=True,
         ),
     ],
     "device_trigger": [
@@ -452,6 +471,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigType",
             },
             return_type="ConfigType",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_attach_trigger",
@@ -462,6 +482,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 3: "TriggerInfo",
             },
             return_type="CALLBACK_TYPE",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_get_trigger_capabilities",
@@ -470,6 +491,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigType",
             },
             return_type="dict[str, Schema]",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_get_triggers",
@@ -478,6 +500,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "str",
             },
             return_type=["list[dict[str, str]]", "list[dict[str, Any]]"],
+            mandatory=True,
         ),
     ],
     "diagnostics": [
@@ -488,6 +511,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 1: "ConfigEntry",
             },
             return_type="Mapping[str, Any]",
+            mandatory=True,
         ),
         TypeHintMatch(
             function_name="async_get_device_diagnostics",
@@ -497,6 +521,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
                 2: "DeviceEntry",
             },
             return_type="Mapping[str, Any]",
+            mandatory=True,
         ),
     ],
     "notify": [
@@ -509,6 +534,7 @@ _FUNCTION_MATCH: dict[str, list[TypeHintMatch]] = {
             },
             return_type=["BaseNotificationService", None],
             has_async_counterpart=True,
+            mandatory=True,
         ),
     ],
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mark top level module functions as mandatory in all platforms

As follow-up to https://github.com/home-assistant/core/pull/139730

Type hints have already been added in previous PRs - so no code changes needed in the components. It's just preventing new ones from creeping in.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
