### PR TITLE
Sort usb ports in Z-Wave flow so unknown devices are last

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -154,7 +154,7 @@ def get_usb_ports() -> dict[str, str]:
     return dict(
         sorted(
             port_descriptions.items(),
-            key=lambda x: (x[1].startswith("n/a"), x[1].lower()),
+            key=lambda x: x[1].lower().startswith("n/a"),
         )
     )
 

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -149,7 +149,14 @@ def get_usb_ports() -> dict[str, str]:
             pid,
         )
         port_descriptions[dev_path] = human_name
-    return port_descriptions
+
+    # Sort the dictionary by description, putting "n/a" last
+    return dict(
+        sorted(
+            port_descriptions.items(),
+            key=lambda x: (x[1].lower() == "n/a", x[1].lower()),
+        )
+    )
 
 
 async def async_get_usb_ports(hass: HomeAssistant) -> dict[str, str]:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -154,7 +154,7 @@ def get_usb_ports() -> dict[str, str]:
     return dict(
         sorted(
             port_descriptions.items(),
-            key=lambda x: (x[1].lower() == "n/a", x[1].lower()),
+            key=lambda x: (x[1].startswith("n/a"), x[1].lower()),
         )
     )
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -17,7 +17,7 @@ from zwave_js_server.exceptions import FailedCommand
 from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.zwave_js.config_flow import TITLE
+from homeassistant.components.zwave_js.config_flow import TITLE, get_usb_ports
 from homeassistant.components.zwave_js.const import ADDON_SLUG, CONF_USB_PATH, DOMAIN
 from homeassistant.components.zwave_js.helpers import SERVER_VERSION_TIMEOUT
 from homeassistant.core import HomeAssistant
@@ -4661,3 +4661,31 @@ async def test_configure_addon_usb_ports_failure(
         )
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "usb_ports_failed"
+
+
+async def test_get_usb_ports_sorting(hass: HomeAssistant) -> None:
+    """Test that get_usb_ports sorts ports with 'n/a' descriptions last."""
+    mock_ports = [
+        ListPortInfo("/dev/ttyUSB0"),
+        ListPortInfo("/dev/ttyUSB1"),
+        ListPortInfo("/dev/ttyUSB2"),
+        ListPortInfo("/dev/ttyUSB3"),
+    ]
+    mock_ports[0].description = "n/a"
+    mock_ports[1].description = "Device A"
+    mock_ports[2].description = "n/a"
+    mock_ports[3].description = "Device B"
+
+    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
+        result = get_usb_ports()
+
+        descriptions = list(result.values())
+
+        # Verify that descriptions containing "n/a" are at the end
+        assert all("n/a" in desc for desc in descriptions[-2:])
+
+        assert not descriptions[0].startswith("n/a")
+        assert not descriptions[1].startswith("n/a")
+
+        assert "Device A" in descriptions[0]
+        assert "Device B" in descriptions[1]

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -4673,7 +4673,7 @@ async def test_get_usb_ports_sorting(hass: HomeAssistant) -> None:
     ]
     mock_ports[0].description = "n/a"
     mock_ports[1].description = "Device A"
-    mock_ports[2].description = "n/a"
+    mock_ports[2].description = "N/A"
     mock_ports[3].description = "Device B"
 
     with patch("serial.tools.list_ports.comports", return_value=mock_ports):
@@ -4682,10 +4682,10 @@ async def test_get_usb_ports_sorting(hass: HomeAssistant) -> None:
         descriptions = list(result.values())
 
         # Verify that descriptions containing "n/a" are at the end
-        assert all("n/a" in desc for desc in descriptions[-2:])
 
-        assert not descriptions[0].startswith("n/a")
-        assert not descriptions[1].startswith("n/a")
-
-        assert "Device A" in descriptions[0]
-        assert "Device B" in descriptions[1]
+        assert descriptions == [
+            "Device A - /dev/ttyUSB1, s/n: n/a",
+            "Device B - /dev/ttyUSB3, s/n: n/a",
+            "n/a - /dev/ttyUSB0, s/n: n/a",
+            "N/A - /dev/ttyUSB2, s/n: n/a",
+        ]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removing such ports seems risky so just put them at the bottom of the list for now

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/zwave-js/backlog/issues/62
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
