### PR TITLE
Allow base64_encode to support bytes and strings

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2577,9 +2577,11 @@ def from_hex(value: str) -> bytes:
     return bytes.fromhex(value)
 
 
-def base64_encode(value: str) -> str:
+def base64_encode(value: str | bytes) -> str:
     """Perform base64 encode."""
-    return base64.b64encode(value.encode("utf-8")).decode("utf-8")
+    if isinstance(value, str):
+        value = value.encode("utf-8")
+    return base64.b64encode(value).decode("utf-8")
 
 
 def base64_decode(value: str, encoding: str | None = "utf-8") -> str | bytes:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1640,12 +1640,16 @@ def test_from_hex(hass: HomeAssistant) -> None:
     )
 
 
-def test_base64_encode(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("value_template", "expected"),
+    [
+        ('{{ "homeassistant" | base64_encode }}', "aG9tZWFzc2lzdGFudA=="),
+        ("{{ int('0F010003', base=16) | pack('>I') | base64_encode }}", "DwEAAw=="),
+    ],
+)
+def test_base64_encode(hass: HomeAssistant, value_template: str, expected: str) -> None:
     """Test the base64_encode filter."""
-    assert (
-        template.Template('{{ "homeassistant" | base64_encode }}', hass).async_render()
-        == "aG9tZWFzc2lzdGFudA=="
-    )
+    assert template.Template(value_template, hass).async_render() == expected
 
 
 def test_base64_decode(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1645,6 +1645,7 @@ def test_from_hex(hass: HomeAssistant) -> None:
     [
         ('{{ "homeassistant" | base64_encode }}', "aG9tZWFzc2lzdGFudA=="),
         ("{{ int('0F010003', base=16) | pack('>I') | base64_encode }}", "DwEAAw=="),
+        ("{{ 'AA01000200150020' | from_hex | base64_encode }}", "qgEAAgAVACA="),
     ],
 )
 def test_base64_encode(hass: HomeAssistant, value_template: str, expected: str) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow base64_encode to support bytes.  Currently there is a gap in HA when converting HEX strings (common) to base64.  This is typically need for remotes like broadlink and other aspects of HA that require base64 strings.

If a user attempts to convert a hex string to base64, they have to know quite a bit about encoding.  [Which isn't easy.](https://community.home-assistant.io/t/convert-hex-string-to-base64/892265/8)

This PR is phase1 of a 2 updates.  This update specifically just allows base64_encode to accept bytes as an input.

Phase 2 -> https://github.com/home-assistant/core/pull/145229

This proposal changes this template:
```
{{ (int('0F010003', base=16) | pack(">I")).decode('utf-8') | base64_encode }}
```
To this:
```
{{ '0F010003' | fromhex | base64_encode }}
```
Which will easily work with hex strings.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39097
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
