### PR TITLE
Not valid hvac modes now fails in Climate

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -27,7 +27,6 @@ from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.temperature import display_temp as show_temp
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.loader import async_suggest_report_issue
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.unit_conversion import TemperatureConverter
 

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -535,26 +535,6 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             return
         modes_str: str = ", ".join(modes) if modes else ""
         translation_key = f"not_valid_{mode_type}_mode"
-        if mode_type == "hvac":
-            report_issue = async_suggest_report_issue(
-                self.hass,
-                integration_domain=self.platform.platform_name,
-                module=type(self).__module__,
-            )
-            _LOGGER.warning(
-                (
-                    "%s::%s sets the hvac_mode %s which is not "
-                    "valid for this entity with modes: %s. "
-                    "This will stop working in 2025.4 and raise an error instead. "
-                    "Please %s"
-                ),
-                self.platform.platform_name,
-                self.__class__.__name__,
-                mode,
-                modes_str,
-                report_issue,
-            )
-            return
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key=translation_key,

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -258,6 +258,9 @@
     "not_valid_preset_mode": {
       "message": "Preset mode {mode} is not valid. Valid preset modes are: {modes}."
     },
+    "not_valid_hvac_mode": {
+      "message": "Hvac mode {mode} is not valid. Valid hvac modes are: {modes}."
+    },
     "not_valid_swing_mode": {
       "message": "Swing mode {mode} is not valid. Valid swing modes are: {modes}."
     },

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -259,7 +259,7 @@
       "message": "Preset mode {mode} is not valid. Valid preset modes are: {modes}."
     },
     "not_valid_hvac_mode": {
-      "message": "Hvac mode {mode} is not valid. Valid hvac modes are: {modes}."
+      "message": "HVAC mode {mode} is not valid. Valid HVAC modes are: {modes}."
     },
     "not_valid_swing_mode": {
       "message": "Swing mode {mode} is not valid. Valid swing modes are: {modes}."

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -164,8 +164,6 @@ class DeconzThermostat(DeconzDevice[Thermostat], ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode not in self._attr_hvac_modes:
-            raise ValueError(f"Unsupported HVAC mode {hvac_mode}")
 
         if len(self._attr_hvac_modes) == 2:  # Only allow turn on and off thermostat
             await self.hub.api.sensors.thermostat.set_config(

--- a/homeassistant/components/freedompro/climate.py
+++ b/homeassistant/components/freedompro/climate.py
@@ -125,8 +125,6 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Async function to set mode to climate."""
-        if hvac_mode not in SUPPORTED_HVAC_MODES:
-            raise ValueError(f"Got unsupported hvac_mode {hvac_mode}")
 
         payload = {"heatingCoolingState": HVAC_INVERT_MAP[hvac_mode]}
         await put_state(

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -216,8 +216,6 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode not in self.hvac_modes:
-            return
 
         if hvac_mode == HVACMode.AUTO:
             await self._device.set_control_mode_async(HMIP_AUTOMATIC_CM)

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -133,8 +133,6 @@ class MaxCubeClimate(ClimateEntity):
             self._set_target(MAX_DEVICE_MODE_MANUAL, temp)
         elif hvac_mode == HVACMode.AUTO:
             self._set_target(MAX_DEVICE_MODE_AUTOMATIC, None)
-        else:
-            raise ValueError(f"unsupported HVAC mode {hvac_mode}")
 
     def _set_target(self, mode: int | None, temp: float | None) -> None:
         """Set the mode and/or temperature of the thermostat.

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -267,8 +267,6 @@ class ThermostatEntity(ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode not in self.hvac_modes:
-            raise ValueError(f"Unsupported hvac_mode '{hvac_mode}'")
         api_mode = THERMOSTAT_INV_MODE_MAP[hvac_mode]
         trait = self._device.traits[ThermostatModeTrait.NAME]
         try:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -15,7 +15,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN, MASTER_THERMOSTATS
@@ -216,17 +215,6 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the hvac mode."""
-        if hvac_mode not in self.hvac_modes:
-            hvac_modes = ", ".join(self.hvac_modes)
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="unsupported_hvac_mode_requested",
-                translation_placeholders={
-                    "hvac_mode": hvac_mode,
-                    "hvac_modes": hvac_modes,
-                },
-            )
-
         if hvac_mode == self.hvac_mode:
             return
 

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -316,9 +316,6 @@
     },
     "unsupported_firmware": {
       "message": "[%key:component::plugwise::config::error::unsupported%]"
-    },
-    "unsupported_hvac_mode_requested": {
-      "message": "Unsupported mode {hvac_mode} requested, valid modes are: {hvac_modes}."
     }
   }
 }

--- a/homeassistant/components/tesla_fleet/climate.py
+++ b/homeassistant/components/tesla_fleet/climate.py
@@ -164,12 +164,6 @@ class TeslaFleetClimateEntity(TeslaFleetVehicleEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the climate mode and state."""
-        if hvac_mode not in self.hvac_modes:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="invalid_hvac_mode",
-                translation_placeholders={"hvac_mode": hvac_mode},
-            )
         if hvac_mode == HVACMode.OFF:
             await self.async_turn_off()
         else:

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -573,9 +573,6 @@
     "invalid_cop_temp": {
       "message": "Cabin overheat protection does not support that temperature."
     },
-    "invalid_hvac_mode": {
-      "message": "Climate mode {hvac_mode} is not supported."
-    },
     "missing_temperature": {
       "message": "Temperature is required for this action."
     },

--- a/homeassistant/components/tplink/climate.py
+++ b/homeassistant/components/tplink/climate.py
@@ -21,11 +21,10 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import PRECISION_TENTHS, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import TPLinkConfigEntry, legacy_device_id
-from .const import DOMAIN, UNIT_MAPPING
+from .const import UNIT_MAPPING
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
     CoordinatedTPLinkModuleEntity,
@@ -161,14 +160,6 @@ class TPLinkClimateEntity(CoordinatedTPLinkModuleEntity, ClimateEntity):
             await self._thermostat_module.set_state(True)
         elif hvac_mode is HVACMode.OFF:
             await self._thermostat_module.set_state(False)
-        else:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="unsupported_mode",
-                translation_placeholders={
-                    "mode": hvac_mode,
-                },
-            )
 
     @async_refresh_after
     async def async_turn_on(self) -> None:

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -487,9 +487,6 @@
     "unexpected_device": {
       "message": "Unexpected device found at {host}; expected {expected}, found {found}"
     },
-    "unsupported_mode": {
-      "message": "Tried to set unsupported mode: {mode}"
-    },
     "invalid_alarm_duration": {
       "message": "Invalid duration {duration} available: 1-{duration_max}s"
     }

--- a/homeassistant/components/whirlpool/climate.py
+++ b/homeassistant/components/whirlpool/climate.py
@@ -130,9 +130,7 @@ class AirConEntity(WhirlpoolEntity, ClimateEntity):
             await self._appliance.set_power_on(False)
             return
 
-        if not (mode := HVAC_MODE_TO_AIRCON_MODE.get(hvac_mode)):
-            raise ValueError(f"Invalid hvac mode {hvac_mode}")
-
+        mode = HVAC_MODE_TO_AIRCON_MODE.get(hvac_mode)
         await self._appliance.set_mode(mode)
         if not self._appliance.get_power_on():
             await self._appliance.set_power_on(True)

--- a/homeassistant/components/whirlpool/climate.py
+++ b/homeassistant/components/whirlpool/climate.py
@@ -130,7 +130,7 @@ class AirConEntity(WhirlpoolEntity, ClimateEntity):
             await self._appliance.set_power_on(False)
             return
 
-        mode = HVAC_MODE_TO_AIRCON_MODE.get(hvac_mode)
+        mode = HVAC_MODE_TO_AIRCON_MODE[hvac_mode]
         await self._appliance.set_mode(mode)
         if not self._appliance.get_power_on():
             await self._appliance.set_power_on(True)

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -492,8 +492,6 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if (hvac_mode_id := self._hvac_modes.get(hvac_mode)) is None:
-            raise ValueError(f"Received an invalid hvac mode: {hvac_mode}")
 
         if not self._current_mode:
             # Thermostat(valve) has no support for setting a mode, so we make it a no-op
@@ -503,7 +501,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         # can set it again when turning the device back on.
         if hvac_mode == HVACMode.OFF and self._current_mode.value != ThermostatMode.OFF:
             self._last_hvac_mode_id_before_off = self._current_mode.value
-        await self._async_set_value(self._current_mode, hvac_mode_id)
+        await self._async_set_value(self._current_mode, self._hvac_modes.get(hvac_mode))
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -501,7 +501,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         # can set it again when turning the device back on.
         if hvac_mode == HVACMode.OFF and self._current_mode.value != ThermostatMode.OFF:
             self._last_hvac_mode_id_before_off = self._current_mode.value
-        await self._async_set_value(self._current_mode, self._hvac_modes.get(hvac_mode))
+        await self._async_set_value(self._current_mode, self._hvac_modes[hvac_mode])
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""

--- a/tests/components/advantage_air/test_climate.py
+++ b/tests/components/advantage_air/test_climate.py
@@ -177,7 +177,7 @@ async def test_climate_myzone_zone(
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVACMode.FAN_ONLY},
+        {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVACMode.HEAT_COOL},
         blocking=True,
     )
     mock_update.assert_called_once()

--- a/tests/components/balboa/test_climate.py
+++ b/tests/components/balboa/test_climate.py
@@ -127,9 +127,6 @@ async def test_spa_hvac_action(
     state = await _patch_spa_heatstate(hass, client, 1)
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
 
-    state = await _patch_spa_heatstate(hass, client, 2)
-    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
-
 
 async def test_spa_preset_modes(
     hass: HomeAssistant, client: MagicMock, integration: MockConfigEntry

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -325,7 +325,7 @@ async def test_mode_validation(
 
     with pytest.raises(
         ServiceValidationError,
-        match="Hvac mode auto is not valid. Valid hvac modes are: off, heat",
+        match="HVAC mode auto is not valid. Valid HVAC modes are: off, heat",
     ) as exc:
         await hass.services.async_call(
             DOMAIN,
@@ -337,7 +337,7 @@ async def test_mode_validation(
             blocking=True,
         )
     assert (
-        str(exc.value) == "Hvac mode auto is not valid. Valid hvac modes are: off, heat"
+        str(exc.value) == "HVAC mode auto is not valid. Valid HVAC modes are: off, heat"
     )
     assert exc.value.translation_key == "not_valid_hvac_mode"
 

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -323,22 +323,23 @@ async def test_mode_validation(
     assert state.attributes.get(ATTR_SWING_MODE) == "off"
     assert state.attributes.get(ATTR_SWING_HORIZONTAL_MODE) == "off"
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {
-            "entity_id": "climate.test",
-            "hvac_mode": "auto",
-        },
-        blocking=True,
-    )
-
+    with pytest.raises(
+        ServiceValidationError,
+        match="Hvac mode auto is not valid. Valid hvac modes are: off, heat",
+    ) as exc:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {
+                "entity_id": "climate.test",
+                "hvac_mode": "auto",
+            },
+            blocking=True,
+        )
     assert (
-        "MockClimateEntity sets the hvac_mode auto which is not valid "
-        "for this entity with modes: off, heat. This will stop working "
-        "in 2025.4 and raise an error instead. "
-        "Please" in caplog.text
+        str(exc.value) == "Hvac mode auto is not valid. Valid hvac modes are: off, heat"
     )
+    assert exc.value.translation_key == "not_valid_hvac_mode"
 
     with pytest.raises(
         ServiceValidationError,

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -136,7 +136,7 @@ async def test_simple_climate_device(
 
     # Service set HVAC mode to unsupported value
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
@@ -239,7 +239,7 @@ async def test_climate_device_without_cooling_support(
 
     # Service set HVAC mode to unsupported value
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,

--- a/tests/components/freedompro/test_climate.py
+++ b/tests/components/freedompro/test_climate.py
@@ -19,6 +19,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -135,7 +136,7 @@ async def test_climate_set_unsupported_hvac_mode(
     assert entry
     assert entry.unique_id == uid
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -651,7 +651,7 @@ async def test_holidy_summer_mode(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Hvac mode heat is not valid. Valid hvac modes are: off",
+        match="HVAC mode heat is not valid. Valid HVAC modes are: off",
     ):
         await hass.services.async_call(
             "climate",

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -651,7 +651,7 @@ async def test_holidy_summer_mode(
 
     with pytest.raises(
         HomeAssistantError,
-        match="HVAC mode heat is not valid. Valid HVAC modes are: off",
+        match="Can't change settings while holiday or summer mode is active on the device",
     ):
         await hass.services.async_call(
             "climate",

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -651,7 +651,7 @@ async def test_holidy_summer_mode(
 
     with pytest.raises(
         HomeAssistantError,
-        match="Can't change settings while holiday or summer mode is active on the device",
+        match="Hvac mode heat is not valid. Valid hvac modes are: off",
     ):
         await hass.services.async_call(
             "climate",

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -896,7 +896,7 @@ async def test_heating_cooling_switch_toggles_when_outside_min_cycle_duration(
         "expected_triggered_service_call",
     ),
     [
-        (True, HVACMode.COOL, False, 30, 25, HVACMode.HEAT, SERVICE_TURN_ON),
+        (True, HVACMode.COOL, False, 30, 25, HVACMode.COOL, SERVICE_TURN_ON),
         (True, HVACMode.COOL, True, 25, 30, HVACMode.OFF, SERVICE_TURN_OFF),
         (False, HVACMode.HEAT, False, 25, 30, HVACMode.HEAT, SERVICE_TURN_ON),
         (False, HVACMode.HEAT, True, 30, 25, HVACMode.OFF, SERVICE_TURN_OFF),

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -205,13 +205,14 @@ async def test_hmip_heating_group_heat(
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == HVACMode.AUTO
 
-    # hvac mode "dry" is not available. expect a valueerror.
-    await hass.services.async_call(
-        "climate",
-        "set_hvac_mode",
-        {"entity_id": entity_id, "hvac_mode": "dry"},
-        blocking=True,
-    )
+    # hvac mode "dry" is not available.
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": entity_id, "hvac_mode": "dry"},
+            blocking=True,
+        )
 
     assert len(hmip_device.mock_calls) == service_call_counter + 24
     # Only fire event from last async_manipulate_test_data available.

--- a/tests/components/maxcube/test_maxcube_climate.py
+++ b/tests/components/maxcube/test_maxcube_climate.py
@@ -179,7 +179,7 @@ async def test_thermostat_set_invalid_hvac_mode(
     hass: HomeAssistant, cube: MaxCube, thermostat: MaxThermostat
 ) -> None:
     """Set hvac mode to heat."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -407,13 +407,6 @@ async def test_turn_on_and_off_optimistic_with_power_command(
         ),
         (
             help_custom_config(
-                climate.DOMAIN, DEFAULT_CONFIG, ({"modes": ["off", "dry"]},)
-            ),
-            None,
-            "off",
-        ),
-        (
-            help_custom_config(
                 climate.DOMAIN, DEFAULT_CONFIG, ({"modes": ["off", "cool"]},)
             ),
             "cool",

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -520,7 +520,7 @@ async def test_thermostat_invalid_hvac_mode(
     assert thermostat.state == HVACMode.OFF
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         await common.async_set_hvac_mode(hass, HVACMode.DRY)
 
     assert thermostat.state == HVACMode.OFF
@@ -1396,7 +1396,7 @@ async def test_thermostat_unexpected_hvac_status(
     assert ATTR_FAN_MODE not in thermostat.attributes
     assert ATTR_FAN_MODES not in thermostat.attributes
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         await common.async_set_hvac_mode(hass, HVACMode.DRY)
     assert thermostat.state == HVACMode.OFF
 

--- a/tests/components/nibe_heatpump/test_climate.py
+++ b/tests/components/nibe_heatpump/test_climate.py
@@ -297,7 +297,6 @@ async def test_set_temperature_unsupported_cooling(
     [
         (Model.S320, "s1", "climate.climate_system_s1"),
         (Model.F1155, "s2", "climate.climate_system_s2"),
-        (Model.F730, "s1", "climate.climate_system_s1"),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -244,7 +244,7 @@ async def test_adam_climate_entity_climate_changes(
 
     with pytest.raises(
         ServiceValidationError,
-        match="Hvac mode dry is not valid. Valid hvac modes are: auto, heat",
+        match="HVAC mode dry is not valid. Valid HVAC modes are: auto, heat",
     ):
         await hass.services.async_call(
             CLIMATE_DOMAIN,

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -242,7 +242,10 @@ async def test_adam_climate_entity_climate_changes(
         "c50f167537524366a5af7aa3942feb1e", HVACMode.OFF
     )
 
-    with pytest.raises(ServiceValidationError, match="valid modes are"):
+    with pytest.raises(
+        ServiceValidationError,
+        match="Hvac mode dry is not valid. Valid hvac modes are: auto, heat",
+    ):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,

--- a/tests/components/tesla_fleet/test_climate.py
+++ b/tests/components/tesla_fleet/test_climate.py
@@ -402,7 +402,7 @@ async def test_climate_noscope(
 
     with pytest.raises(
         ServiceValidationError,
-        match="Hvac mode off is not valid. Valid hvac modes are: heat_cool",
+        match="HVAC mode off is not valid. Valid HVAC modes are: heat_cool",
     ):
         await hass.services.async_call(
             CLIMATE_DOMAIN,

--- a/tests/components/tesla_fleet/test_climate.py
+++ b/tests/components/tesla_fleet/test_climate.py
@@ -401,7 +401,8 @@ async def test_climate_noscope(
     entity_id = "climate.test_climate"
 
     with pytest.raises(
-        ServiceValidationError, match="Climate mode off is not supported"
+        ServiceValidationError,
+        match="Hvac mode off is not valid. Valid hvac modes are: heat_cool",
     ):
         await hass.services.async_call(
             CLIMATE_DOMAIN,

--- a/tests/components/tplink/test_climate.py
+++ b/tests/components/tplink/test_climate.py
@@ -161,7 +161,7 @@ async def test_set_hvac_mode(
     )
     therm_module.set_state.assert_called_with(True)
 
-    msg = "Hvac mode dry is not valid. Valid hvac modes are: heat, off"
+    msg = "HVAC mode dry is not valid. Valid HVAC modes are: heat, off"
     with pytest.raises(ServiceValidationError, match=msg):
         await hass.services.async_call(
             CLIMATE_DOMAIN,

--- a/tests/components/tplink/test_climate.py
+++ b/tests/components/tplink/test_climate.py
@@ -161,7 +161,7 @@ async def test_set_hvac_mode(
     )
     therm_module.set_state.assert_called_with(True)
 
-    msg = "Tried to set unsupported mode: dry"
+    msg = "Hvac mode dry is not valid. Valid hvac modes are: heat, off"
     with pytest.raises(ServiceValidationError, match=msg):
         await hass.services.async_call(
             CLIMATE_DOMAIN,

--- a/tests/components/whirlpool/test_climate.py
+++ b/tests/components/whirlpool/test_climate.py
@@ -300,7 +300,7 @@ async def test_service_hvac_mode_turn_on(
         (
             SERVICE_SET_HVAC_MODE,
             {ATTR_HVAC_MODE: HVACMode.DRY},
-            ValueError,
+            ServiceValidationError,
         ),
         (
             SERVICE_SET_FAN_MODE,

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -522,20 +522,28 @@ async def test_set_hvac_mode(
     state = hass.states.get(entity_id)
     assert state.state == HVACMode.OFF
 
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: hvac_mode},
-        blocking=True,
-    )
-    state = hass.states.get(entity_id)
     if sys_mode is not None:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: hvac_mode},
+            blocking=True,
+        )
+        state = hass.states.get(entity_id)
         assert state.state == hvac_mode
         assert thrm_cluster.write_attributes.call_count == 1
         assert thrm_cluster.write_attributes.call_args[0][0] == {
             "system_mode": sys_mode
         }
     else:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                CLIMATE_DOMAIN,
+                SERVICE_SET_HVAC_MODE,
+                {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: hvac_mode},
+                blocking=True,
+            )
+        state = hass.states.get(entity_id)
         assert thrm_cluster.write_attributes.call_count == 0
         assert state.state == HVACMode.OFF
 

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -264,7 +264,7 @@ async def test_thermostat_v2(
     client.async_send_command.reset_mock()
 
     # Test setting invalid hvac mode
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
@@ -574,7 +574,7 @@ async def test_setpoint_thermostat(
     )
 
     # Test setting illegal mode raises an error
-    with pytest.raises(ValueError):
+    with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Setting hvac mode which was not included in the hvac modes previously gave a warning. This will now fail (has been deprecated 12 months).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See breaking.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
