### PR TITLE
Add range support to icon translations

### DIFF
--- a/homeassistant/components/sensor/icons.json
+++ b/homeassistant/components/sensor/icons.json
@@ -15,6 +15,22 @@
     "atmospheric_pressure": {
       "default": "mdi:thermometer-lines"
     },
+    "battery": {
+      "default": "mdi:battery-unknown",
+      "range": {
+        "0": "mdi:battery-alert",
+        "10": "mdi:battery-10",
+        "20": "mdi:battery-20",
+        "30": "mdi:battery-30",
+        "40": "mdi:battery-40",
+        "50": "mdi:battery-50",
+        "60": "mdi:battery-60",
+        "70": "mdi:battery-70",
+        "80": "mdi:battery-80",
+        "90": "mdi:battery-90",
+        "100": "mdi:battery"
+      }
+    },
     "blood_glucose_concentration": {
       "default": "mdi:spoon-sugar"
     },

--- a/script/hassfest/icons.py
+++ b/script/hassfest/icons.py
@@ -25,6 +25,16 @@ def icon_value_validator(value: Any) -> str:
     return str(value)
 
 
+def range_key_validator(value: str) -> str:
+    """Validate that range key value is numeric."""
+    try:
+        float(value)
+    except (TypeError, ValueError) as err:
+        raise vol.Invalid(f"Invalid range key '{value}', needs to be numeric.") from err
+
+    return value
+
+
 def require_default_icon_validator(value: dict) -> dict:
     """Validate that a default icon is set."""
     if "_" not in value:
@@ -44,6 +54,26 @@ def ensure_not_same_as_default(value: dict) -> dict:
                         f"The icon for state `{translation_key}.{state}` is the"
                         " same as the default icon and thus can be removed"
                     )
+
+    return value
+
+
+def ensure_range_is_sorted(value: dict) -> dict:
+    """Validate that range values are sorted in ascending order."""
+    for section_key, section in value.items():
+        # Only validate range if one exists and this is an icon definition
+        if ranges := section.get("range"):
+            try:
+                range_values = [float(key) for key in ranges]
+            except ValueError as err:
+                raise vol.Invalid(
+                    f"Range values for `{section_key}` must be numeric"
+                ) from err
+
+            if range_values != sorted(range_values):
+                raise vol.Invalid(
+                    f"Range values for `{section_key}` must be in ascending order"
+                )
 
     return value
 
@@ -100,19 +130,27 @@ def icon_schema(
         slug_validator=translation_key_validator,
     )
 
+    range_validator = cv.schema_with_slug_keys(
+        icon_value_validator,
+        slug_validator=range_key_validator,
+    )
+
     def icon_schema_slug(marker: type[vol.Marker]) -> dict[vol.Marker, Any]:
         return {
             marker("default"): icon_value_validator,
             vol.Optional("state"): state_validator,
+            vol.Optional("range"): range_validator,
             vol.Optional("state_attributes"): vol.All(
                 cv.schema_with_slug_keys(
                     {
                         marker("default"): icon_value_validator,
-                        marker("state"): state_validator,
+                        vol.Optional("state"): state_validator,
+                        vol.Optional("range"): range_validator,
                     },
                     slug_validator=translation_key_validator,
                 ),
                 ensure_not_same_as_default,
+                ensure_range_is_sorted,
             ),
         }
 
@@ -143,6 +181,7 @@ def icon_schema(
                     ),
                     require_default_icon_validator,
                     ensure_not_same_as_default,
+                    ensure_range_is_sorted,
                 )
             }
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add range support to icon translations, meaning we can now provide icons based on the numeric state through the icons translation files.

Implements the proposal from architectural discussion: https://github.com/home-assistant/architecture/discussions/1190

As an example, the battery sensor has been enriched with range definitions, for which I've adjusted and cleaned up the frontend.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2676
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/25541

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
