### PR TITLE
Catch blocking version pinning in dependencies early

### DIFF
--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -286,12 +286,12 @@ def _is_dependency_version_range_valid(version_part: str, convention: str) -> bo
         # Lower version binding and version exclusion are fine
         return True
 
-    if operator == "==":
-        # Explicit version with wildcard is allowed only on major version
-        # e.g. ==1.* is allowed, but ==1.2.* is not
-        return version.endswith(".*") and version.count(".") == 1
-
     if convention == "SemVer":
+        if operator == "==":
+            # Explicit version with wildcard is allowed only on major version
+            # e.g. ==1.* is allowed, but ==1.2.* is not
+            return version.endswith(".*") and version.count(".") == 1
+
         awesome = AwesomeVersion(version)
         if operator in ("<", "<="):
             # Upper version binding only allowed on major version

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -22,6 +22,18 @@ from script.gen_requirements_all import (
 
 from .model import Config, Integration
 
+PACKAGE_CHECK_VERSION_RANGE = {
+    "aiohttp": "SemVer",
+    "attrs": "CalVer",
+    "grpcio": "SemVer",
+    "mashumaro": "SemVer",
+    "pydantic": "SemVer",
+    "pyjwt": "SemVer",
+    "pytz": "CalVer",
+    "typing_extensions": "SemVer",
+    "yarl": "SemVer",
+}
+
 PACKAGE_REGEX = re.compile(
     r"^(?:--.+\s)?([-_,\.\w\d\[\]]+)(==|>=|<=|~=|!=|<|>|===)*(.*)$"
 )
@@ -176,7 +188,7 @@ def get_pipdeptree() -> dict[str, dict[str, Any]]:
             "key": "flake8-docstrings",
             "package_name": "flake8-docstrings",
             "installed_version": "1.5.0"
-            "dependencies": {"flake8"}
+            "dependencies": {"flake8": ">=1.2.3, <4.5.0"}
         }
     }
     """
@@ -192,7 +204,9 @@ def get_pipdeptree() -> dict[str, dict[str, Any]]:
     ):
         deptree[item["package"]["key"]] = {
             **item["package"],
-            "dependencies": {dep["key"] for dep in item["dependencies"]},
+            "dependencies": {
+                dep["key"]: dep["required_version"] for dep in item["dependencies"]
+            },
         }
     return deptree
 
@@ -223,8 +237,8 @@ def get_requirements(integration: Integration, packages: set[str]) -> set[str]:
                 )
             continue
 
-        dependencies: set[str] = item["dependencies"]
-        for pkg in dependencies:
+        dependencies: dict[str, str] = item["dependencies"]
+        for pkg, version in dependencies.items():
             if pkg.startswith("types-") or pkg in FORBIDDEN_PACKAGES:
                 if package in FORBIDDEN_PACKAGE_EXCEPTIONS:
                     integration.add_warning(
@@ -236,10 +250,60 @@ def get_requirements(integration: Integration, packages: set[str]) -> set[str]:
                         "requirements",
                         f"Package {pkg} should not be a runtime dependency in {package}",
                     )
+            check_dependency_version_range(integration, package, pkg, version)
 
         to_check.extend(dependencies)
 
     return all_requirements
+
+
+def check_dependency_version_range(
+    integration: Integration, source: str, pkg: str, version: str
+) -> None:
+    """Check requirement version range.
+
+    We want to avoid upper version bounds that are too strict for common packages.
+    """
+    if version == "Any" or (convention := PACKAGE_CHECK_VERSION_RANGE.get(pkg)) is None:
+        return
+
+    if not all(
+        _is_dependency_version_range_valid(version_part, convention)
+        for version_part in version.split(";", 1)[0].split(",")
+    ):
+        integration.add_error(
+            "requirements",
+            f"Version restrictions for {pkg} are too strict ({version}) in {source}",
+        )
+
+
+def _is_dependency_version_range_valid(version_part: str, convention: str) -> bool:
+    version_match = PIP_VERSION_RANGE_SEPARATOR.match(version_part)
+    operator = version_match.group(1)
+    version = version_match.group(2)
+
+    if operator in (">", ">=", "!="):
+        # Lower version binding and version exclusion are fine
+        return True
+
+    if operator == "==":
+        # Explicit version with wildcard is allowed only on major version
+        # e.g. ==1.* is allowed, but ==1.2.* is not
+        return version.endswith(".*") and version.count(".") == 1
+
+    if convention == "SemVer":
+        awesome = AwesomeVersion(version)
+        if operator in ("<", "<="):
+            # Upper version binding only allowed on major version
+            # e.g. <=3 is allowed, but <=3.1 is not
+            return awesome.section(1) == 0 and awesome.section(2) == 0
+
+        if operator == "~=":
+            # Compatible release operator is only allowed on major or minor version
+            # e.g. ~=1.2 is allowed, but ~=1.2.3 is not
+            return awesome.section(2) == 0
+
+    return False
 
 
 def install_requirements(integration: Integration, requirements: set[str]) -> bool:

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -24,7 +24,8 @@ from .model import Config, Integration
 
 PACKAGE_CHECK_VERSION_RANGE = {
     "aiohttp": "SemVer",
-    "attrs": "CalVer",
+    # https://github.com/iMicknl/python-overkiz-api/issues/1644
+    # "attrs": "CalVer"
     "grpcio": "SemVer",
     "mashumaro": "SemVer",
     "pydantic": "SemVer",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump of aiohttp to 3.12.0b0 (in https://github.com/home-assistant/core/pull/145358) is blocked because a dependency (igloohome-api) has restictions on aiohttp (`aiohttp~=3.11.10` -  https://github.com/keithle888/igloohome-api/pull/4)

This aims to prevent new issues by catching these early, preventing "igloohome-api" from being accepted in the first place until the restrictions are lifted

```console
Integration igloohome:
* [ERROR] [REQUIREMENTS] Version restrictions for aiohttp are too strict (~=3.11.10) in igloohome-api
* [ERROR] [REQUIREMENTS] Version restrictions for pyjwt are too strict (~=2.10.1) in igloohome-api

Integration overkiz:
* [ERROR] [REQUIREMENTS] Version restrictions for attrs are too strict (>=21.2,<26.0) in pyoverkiz
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
