### PR TITLE
Add default sensor data for Tesla Wall Connector tests

### DIFF
--- a/tests/components/tesla_wall_connector/conftest.py
+++ b/tests/components/tesla_wall_connector/conftest.py
@@ -88,7 +88,23 @@ async def create_wall_connector_entry(
 
 def get_vitals_mock() -> Vitals:
     """Get mocked vitals object."""
-    return MagicMock(auto_spec=Vitals)
+    mock = MagicMock(auto_spec=Vitals)
+    mock.evse_state = 1
+    mock.handle_temp_c = 25.51
+    mock.pcba_temp_c = 30.5
+    mock.mcu_temp_c = 42.0
+    mock.grid_v = 230.15
+    mock.grid_hz = 50.021
+    mock.voltageA_v = 230.1
+    mock.voltageB_v = 231
+    mock.voltageC_v = 232.1
+    mock.currentA_a = 10
+    mock.currentB_a = 11.1
+    mock.currentC_a = 12
+    mock.session_energy_wh = 1234.56
+    mock.contactor_closed = False
+    mock.vehicle_connected = True
+    return mock
 
 
 def get_lifetime_mock() -> Lifetime:

--- a/tests/components/tesla_wall_connector/test_binary_sensor.py
+++ b/tests/components/tesla_wall_connector/test_binary_sensor.py
@@ -23,8 +23,6 @@ async def test_sensors(hass: HomeAssistant) -> None:
     ]
 
     mock_vitals_first_update = get_vitals_mock()
-    mock_vitals_first_update.contactor_closed = False
-    mock_vitals_first_update.vehicle_connected = True
 
     mock_vitals_second_update = get_vitals_mock()
     mock_vitals_second_update.contactor_closed = True

--- a/tests/components/tesla_wall_connector/test_init.py
+++ b/tests/components/tesla_wall_connector/test_init.py
@@ -5,13 +5,13 @@ from tesla_wall_connector.exceptions import WallConnectorConnectionError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .conftest import create_wall_connector_entry
+from .conftest import create_wall_connector_entry, get_vitals_mock
 
 
 async def test_init_success(hass: HomeAssistant) -> None:
     """Test setup and that we get the device info, including firmware version."""
 
-    entry = await create_wall_connector_entry(hass)
+    entry = await create_wall_connector_entry(hass, vitals_data=get_vitals_mock())
 
     assert entry.state is ConfigEntryState.LOADED
 
@@ -28,7 +28,7 @@ async def test_init_while_offline(hass: HomeAssistant) -> None:
 async def test_load_unload(hass: HomeAssistant) -> None:
     """Config entry can be unloaded."""
 
-    entry = await create_wall_connector_entry(hass)
+    entry = await create_wall_connector_entry(hass, vitals_data=get_vitals_mock())
 
     assert entry.state is ConfigEntryState.LOADED
 

--- a/tests/components/tesla_wall_connector/test_sensor.py
+++ b/tests/components/tesla_wall_connector/test_sensor.py
@@ -59,19 +59,6 @@ async def test_sensors(hass: HomeAssistant) -> None:
     ]
 
     mock_vitals_first_update = get_vitals_mock()
-    mock_vitals_first_update.evse_state = 1
-    mock_vitals_first_update.handle_temp_c = 25.51
-    mock_vitals_first_update.pcba_temp_c = 30.5
-    mock_vitals_first_update.mcu_temp_c = 42.0
-    mock_vitals_first_update.grid_v = 230.15
-    mock_vitals_first_update.grid_hz = 50.021
-    mock_vitals_first_update.voltageA_v = 230.1
-    mock_vitals_first_update.voltageB_v = 231
-    mock_vitals_first_update.voltageC_v = 232.1
-    mock_vitals_first_update.currentA_a = 10
-    mock_vitals_first_update.currentB_a = 11.1
-    mock_vitals_first_update.currentC_a = 12
-    mock_vitals_first_update.session_energy_wh = 1234.56
 
     mock_vitals_second_update = get_vitals_mock()
     mock_vitals_second_update.evse_state = 3


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The sensor platform is expecting the dict keys to be present, but the mock data was missing in the `test_init.py` tests. That was causing the sensor platform to throw (which would log an error). This PR properly populates the mock data.

In addition to making the test environment data consistent with the actual data, this is also required for https://github.com/home-assistant/core/pull/145013. Since the precision is always specified, the throw was hitting async_update_entity_options in _update_suggested_precision. Previously, async_update_entity_options was not called since the sensors had no precision specified.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
