### PR TITLE
handle an alarm trigger while in triggered state

### DIFF
--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -353,6 +353,8 @@ class ManualAlarm(AlarmControlPanelEntity, RestoreEntity):
         No code needed, a trigger time of zero for the current state
         disables the alarm.
         """
+        if self._state == AlarmControlPanelState.TRIGGERED:
+            return
         if not self._trigger_time_by_state[self._active_state]:
             return
         self._async_update_state(AlarmControlPanelState.TRIGGERED)

--- a/tests/components/manual/test_alarm_control_panel.py
+++ b/tests/components/manual/test_alarm_control_panel.py
@@ -1561,3 +1561,29 @@ async def test_invalid_arming_states(hass: HomeAssistant) -> None:
 
     state = hass.states.get("alarm_control_panel.test")
     assert state is None
+
+
+async def test_trigger_while_triggered(hass: HomeAssistant) -> None:
+    """Trigger while triggered."""
+    assert await async_setup_component(
+        hass,
+        alarm_control_panel.DOMAIN,
+        {
+            "alarm_control_panel": {
+                "platform": "manual",
+                "delay_time": 0,
+                "name": "test",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_id = "alarm_control_panel.test"
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    assert hass.states.get(entity_id).state == AlarmControlPanelState.TRIGGERED
+
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
+
+    assert hass.states.get(entity_id).state == AlarmControlPanelState.TRIGGERED


### PR DESCRIPTION
I noticed the following exception is recurrent in my logs.

>       if not self._trigger_time_by_state[self._active_state]:
E       KeyError: <AlarmControlPanelState.TRIGGERED: 'triggered'>

homeassistant/components/manual/alarm_control_panel.py:356: KeyError

## Proposed change
The logs had this recurrent exception, it's harmless so this is just to cleanup the logfile.

Beware: this has never been tested on a real HA instance, it was only tested with pytest on the new test introduced which reproduces the issue.

A better approach (which I would have preferred from the beginning) might be re-extend the trigger time at every extra trigger, but that could be considered a breaking change, this one changes nothing besides preventing the exception from flooding the logs.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.