### PR TITLE
Add read_only selectors to Statistics Options Flow

### DIFF
--- a/homeassistant/components/statistics/config_flow.py
+++ b/homeassistant/components/statistics/config_flow.py
@@ -106,6 +106,17 @@ DATA_SCHEMA_SETUP = vol.Schema(
 )
 DATA_SCHEMA_OPTIONS = vol.Schema(
     {
+        vol.Optional(CONF_ENTITY_ID): EntitySelector(
+            EntitySelectorConfig(read_only=True)
+        ),
+        vol.Optional(CONF_STATE_CHARACTERISTIC): SelectSelector(
+            SelectSelectorConfig(
+                options=list(STATS_BINARY_SUPPORT) + list(STATS_NUMERIC_SUPPORT),
+                translation_key=CONF_STATE_CHARACTERISTIC,
+                mode=SelectSelectorMode.DROPDOWN,
+                read_only=True,
+            )
+        ),
         vol.Optional(CONF_SAMPLES_MAX_BUFFER_SIZE): NumberSelector(
             NumberSelectorConfig(min=0, step=1, mode=NumberSelectorMode.BOX)
         ),

--- a/homeassistant/components/statistics/config_flow.py
+++ b/homeassistant/components/statistics/config_flow.py
@@ -111,7 +111,9 @@ DATA_SCHEMA_OPTIONS = vol.Schema(
         ),
         vol.Optional(CONF_STATE_CHARACTERISTIC): SelectSelector(
             SelectSelectorConfig(
-                options=list(STATS_BINARY_SUPPORT) + list(STATS_NUMERIC_SUPPORT),
+                options=list(
+                    set(list(STATS_BINARY_SUPPORT) + list(STATS_NUMERIC_SUPPORT))
+                ),
                 translation_key=CONF_STATE_CHARACTERISTIC,
                 mode=SelectSelectorMode.DROPDOWN,
                 read_only=True,

--- a/homeassistant/components/statistics/strings.json
+++ b/homeassistant/components/statistics/strings.json
@@ -32,6 +32,8 @@
       "options": {
         "description": "Read the documentation for further details on how to configure the statistics sensor using these options.",
         "data": {
+          "entity_id": "[%key:component::statistics::config::step::user::data::entity_id%]",
+          "state_characteristic": "[%key:component::statistics::config::step::state_characteristic::data::state_characteristic%]",
           "sampling_size": "Sampling size",
           "max_age": "Max age",
           "keep_last_sample": "Keep last sample",
@@ -39,6 +41,8 @@
           "precision": "Precision"
         },
         "data_description": {
+          "entity_id": "[%key:component::statistics::config::step::user::data_description::entity_id%]",
+          "state_characteristic": "[%key:component::statistics::config::step::state_characteristic::data_description::state_characteristic%]",
           "sampling_size": "Maximum number of source sensor measurements stored.",
           "max_age": "Maximum age of source sensor measurements stored.",
           "keep_last_sample": "Defines whether the most recent sampled value should be preserved regardless of the 'Max age' setting.",
@@ -60,6 +64,8 @@
       "init": {
         "description": "[%key:component::statistics::config::step::options::description%]",
         "data": {
+          "entity_id": "[%key:component::statistics::config::step::user::data::entity_id%]",
+          "state_characteristic": "[%key:component::statistics::config::step::state_characteristic::data::state_characteristic%]",
           "sampling_size": "[%key:component::statistics::config::step::options::data::sampling_size%]",
           "max_age": "[%key:component::statistics::config::step::options::data::max_age%]",
           "keep_last_sample": "[%key:component::statistics::config::step::options::data::keep_last_sample%]",
@@ -67,6 +73,8 @@
           "precision": "[%key:component::statistics::config::step::options::data::precision%]"
         },
         "data_description": {
+          "entity_id": "[%key:component::statistics::config::step::user::data_description::entity_id%]",
+          "state_characteristic": "[%key:component::statistics::config::step::state_characteristic::data_description::state_characteristic%]",
           "sampling_size": "[%key:component::statistics::config::step::options::data_description::sampling_size%]",
           "max_age": "[%key:component::statistics::config::step::options::data_description::max_age%]",
           "keep_last_sample": "[%key:component::statistics::config::step::options::data_description::keep_last_sample%]",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Similar to #129456 .

The data_description on entity selector looks missing but that seems to be an unrelated frontend bug. 

![image](https://github.com/user-attachments/assets/f56f69dc-0dbc-44be-84fd-b203fd19791b)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
