### PR TITLE
Bump python-linkplay to v0.2.8

### DIFF
--- a/homeassistant/components/linkplay/manifest.json
+++ b/homeassistant/components/linkplay/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["linkplay"],
-  "requirements": ["python-linkplay==0.2.7"],
+  "requirements": ["python-linkplay==0.2.8"],
   "zeroconf": ["_linkplay._tcp.local."]
 }

--- a/homeassistant/components/linkplay/manifest.json
+++ b/homeassistant/components/linkplay/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["linkplay"],
-  "requirements": ["python-linkplay==0.2.5"],
+  "requirements": ["python-linkplay==0.2.7"],
   "zeroconf": ["_linkplay._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2446,7 +2446,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.10.2
 
 # homeassistant.components.linkplay
-python-linkplay==0.2.7
+python-linkplay==0.2.8
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2446,7 +2446,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.10.2
 
 # homeassistant.components.linkplay
-python-linkplay==0.2.5
+python-linkplay==0.2.7
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1989,7 +1989,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.10.2
 
 # homeassistant.components.linkplay
-python-linkplay==0.2.5
+python-linkplay==0.2.7
 
 # homeassistant.components.matter
 python-matter-server==7.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1989,7 +1989,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.10.2
 
 # homeassistant.components.linkplay
-python-linkplay==0.2.7
+python-linkplay==0.2.8
 
 # homeassistant.components.matter
 python-matter-server==7.0.0


### PR DESCRIPTION
## Proposed change
This dependency brings three things: 
* <s>We no longer fetch the player status during discovery, hopefully reducing the number of calls further to address that WiiM devices are going offline when too many calls are made during the same time. WiiM support is blaming this integration for sending out too many http calls at the same time, and suggests people to not use it if they want their device to remain online.</s>
* There's now a warning logged when your device is not in the project list, a list that maps a project to a manufacturer and a product name. This may raise the number of issues, since people will be asked to report, but it also makes clear to the maintainers what kind of devices exist in the wild that use this integration and may bring up more documentation.
* Includes changes to control the audio mode for https://github.com/home-assistant/core/pull/143329 

Changelog: 
* https://github.com/Velleman/python-linkplay/releases/tag/v0.2.6
* https://github.com/Velleman/python-linkplay/releases/tag/v0.2.7
* https://github.com/Velleman/python-linkplay/releases/tag/v0.2.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
