### PR TITLE
Add advanced chat options to Ollama configuration

### DIFF
--- a/homeassistant/components/ollama/__init__.py
+++ b/homeassistant/components/ollama/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.util.ssl import get_default_context
 
 from .const import (
+    CONF_CHAT_OPTIONS,
     CONF_KEEP_ALIVE,
     CONF_MAX_HISTORY,
     CONF_MODEL,
@@ -28,6 +29,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 __all__ = [
+    "CONF_CHAT_OPTIONS",
     "CONF_KEEP_ALIVE",
     "CONF_MAX_HISTORY",
     "CONF_MODEL",

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -36,11 +36,13 @@ from homeassistant.helpers.selector import (
 from homeassistant.util.ssl import get_default_context
 
 from .const import (
+    CONF_CHAT_OPTIONS,
     CONF_KEEP_ALIVE,
     CONF_MAX_HISTORY,
     CONF_MODEL,
     CONF_NUM_CTX,
     CONF_PROMPT,
+    DEFAULT_CHAT_OPTIONS,
     DEFAULT_KEEP_ALIVE,
     DEFAULT_MAX_HISTORY,
     DEFAULT_MODEL,
@@ -280,6 +282,12 @@ def ollama_config_option_schema(
                 min=-1, max=sys.maxsize, step=1, mode=NumberSelectorMode.BOX
             )
         ),
+        vol.Optional(
+            CONF_CHAT_OPTIONS,
+            description={
+                "suggested_value": options.get(CONF_CHAT_OPTIONS, DEFAULT_CHAT_OPTIONS)
+            },
+        ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT, multiline=True)),
     }
 
 

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -287,7 +287,7 @@ def ollama_config_option_schema(
             description={
                 "suggested_value": options.get(CONF_CHAT_OPTIONS, DEFAULT_CHAT_OPTIONS)
             },
-        ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT, multiline=True)),
+        ): TemplateSelector(),
     }
 
 

--- a/homeassistant/components/ollama/const.py
+++ b/homeassistant/components/ollama/const.py
@@ -11,6 +11,9 @@ DEFAULT_KEEP_ALIVE = -1  # seconds. -1 = indefinite, 0 = never
 KEEP_ALIVE_FOREVER = -1
 DEFAULT_TIMEOUT = 5.0  # seconds
 
+CONF_CHAT_OPTIONS = "chat_options"
+DEFAULT_CHAT_OPTIONS = ""
+
 CONF_NUM_CTX = "num_ctx"
 DEFAULT_NUM_CTX = 8192
 MIN_NUM_CTX = 2048

--- a/homeassistant/components/ollama/strings.json
+++ b/homeassistant/components/ollama/strings.json
@@ -30,11 +30,13 @@
           "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
           "max_history": "Max history messages",
           "num_ctx": "Context window size",
-          "keep_alive": "Keep alive"
+          "keep_alive": "Keep alive",
+          "chat_options": "Chat options"
         },
         "data_description": {
           "prompt": "Instruct how the LLM should respond. This can be a template.",
           "keep_alive": "Duration in seconds for Ollama to keep model in memory. -1 = indefinite, 0 = never.",
+          "chat_options": "Ollama chat request API options (in YAML format), e.g. \"temperature: 0.5\". This is an advanced tuning option. Check the Ollama API description for details.",
           "num_ctx": "Maximum number of text tokens the model can process. Lower to reduce Ollama RAM, or increase for a large number of exposed entities."
         }
       }

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -177,7 +177,7 @@ async def test_options(
         ollama.CONF_PROMPT: "test prompt",
         ollama.CONF_MAX_HISTORY: 100,
         ollama.CONF_NUM_CTX: 32768,
-        ollama.CONF_CHAT_OPTIONS: "temperature: 0.65\nnum_thread: 8\n",
+        ollama.CONF_CHAT_OPTIONS: "temperature: 0.65\nnum_thread: 8",
     }
 
 

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -168,6 +168,7 @@ async def test_options(
             ollama.CONF_PROMPT: "test prompt",
             ollama.CONF_MAX_HISTORY: 100,
             ollama.CONF_NUM_CTX: 32768,
+            ollama.CONF_CHAT_OPTIONS: "temperature: 0.65\nnum_thread: 8\n",
         },
     )
     await hass.async_block_till_done()
@@ -176,6 +177,7 @@ async def test_options(
         ollama.CONF_PROMPT: "test prompt",
         ollama.CONF_MAX_HISTORY: 100,
         ollama.CONF_NUM_CTX: 32768,
+        ollama.CONF_CHAT_OPTIONS: "temperature: 0.65\nnum_thread: 8\n",
     }
 
 

--- a/tests/components/ollama/test_conversation.py
+++ b/tests/components/ollama/test_conversation.py
@@ -624,6 +624,27 @@ async def test_conversation_agent_with_assist(
     [
         ({}, {"num_ctx": 8192}),
         ({"num_ctx": 16384}, {"num_ctx": 16384}),
+        (
+            {ollama.CONF_CHAT_OPTIONS: "temperature: 0.65\nnum_thread: 10"},
+            {"num_ctx": 8192, "temperature": 0.65, "num_thread": 10},
+        ),
+        (
+            {
+                "num_ctx": 16384,
+                ollama.CONF_CHAT_OPTIONS: "temperature: 0.65\nnum_thread: 10",
+            },
+            {"num_ctx": 16384, "temperature": 0.65, "num_thread": 10},
+        ),
+        (
+            {
+                ollama.CONF_CHAT_OPTIONS: "num_ctx: 16384\ntemperature: 0.65\nnum_thread: 10"
+            },
+            {"num_ctx": 16384, "temperature": 0.65, "num_thread": 10},
+        ),
+        (
+            {ollama.CONF_CHAT_OPTIONS: "num_ctx: 16384\ninvalid_yaml\n"},
+            {"num_ctx": 8192},
+        ),
     ],
 )
 async def test_options(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds the option to set arbitrary chat API options for Ollama requests (using yaml syntax) to allow advanced tuning. E.g. this allows setting things like: 

```yaml
num_keep: 5
seed: 42
num_predict: 100
top_k: 20
top_p: 0.9
min_p: 0.0
typical_p: 0.7
repeat_last_n: 33
temperature: 0.8
repeat_penalty: 1.2
presence_penalty: 1.5
frequency_penalty: 1.0
penalize_newline: true
stop: ['\n' 'user:']
numa: false
num_ctx: 1024
num_batch: 2
num_gpu: 1
main_gpu: 0
use_mmap: true
num_thread: 8
```

While most of these options can be set using a model file, it may be more convenient if they can be set with the chat request instead. There are also options that are not accepted in a model file, e.g. `num_thread`, `main_gpu`, ... and in addition have no env/cli option either (e.g. `num_thread`).

Since these options may change (depending on the Ollama version) and are also only relevant for advanced use cases, I intentionally did not convert them into dedicated input fields.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Note: I've not added a documentation change after finding options are included automatically in `ollama.md`.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
