### PR TITLE
Bump ZHA to 0.0.59

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.57"],
+  "requirements": ["zha==0.0.59"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -11,7 +11,6 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.typing import UndefinedType
 
 from .entity import ZHAEntity
 from .helpers import (
@@ -45,17 +44,6 @@ async def async_setup_entry(
 
 class ZhaNumber(ZHAEntity, RestoreNumber):
     """Representation of a ZHA Number entity."""
-
-    @property
-    def name(self) -> str | UndefinedType | None:
-        """Return the name of the number entity."""
-        if (description := self.entity_data.entity.description) is None:
-            return super().name
-
-        # The name of this entity is reported by the device itself.
-        # For backwards compatibility, we keep the same format as before. This
-        # should probably be changed in the future to omit the prefix.
-        return f"{super().name} {description}"
 
     @property
     def native_value(self) -> float | None:

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1137,6 +1137,9 @@
       },
       "external_temperature_sensor_value": {
         "name": "External temperature sensor value"
+      },
+      "update_frequency": {
+        "name": "Update frequency"
       }
     },
     "select": {
@@ -1367,6 +1370,9 @@
       },
       "alarm_sound_mode": {
         "name": "Alarm sound mode"
+      },
+      "external_switch_type": {
+        "name": "External switch type"
       }
     },
     "sensor": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3177,7 +3177,7 @@ zeroconf==0.147.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.57
+zha==0.0.59
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2579,7 +2579,7 @@ zeroconf==0.147.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.57
+zha==0.0.59
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.63.0

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -75,7 +75,7 @@ def update_attribute_cache(cluster):
         attrs.append(make_attribute(attrid, value))
 
     hdr = make_zcl_header(zcl_f.GeneralCommand.Report_Attributes)
-    hdr.frame_control.disable_default_response = True
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
     msg = zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Report_Attributes].schema(
         attribute_reports=attrs
     )
@@ -119,7 +119,7 @@ async def send_attributes_report(
     )
 
     hdr = make_zcl_header(zcl_f.GeneralCommand.Report_Attributes)
-    hdr.frame_control.disable_default_response = True
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
     cluster.handle_message(hdr, msg)
     await hass.async_block_till_done()
 

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -92,7 +92,7 @@ async def test_number(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None
 
     assert (
         hass.states.get(entity_id).attributes.get("friendly_name")
-        == "FakeManufacturer FakeModel Number PWM1"
+        == "FakeManufacturer FakeModel PWM1"
     )
 
     # change value from device

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -62,10 +62,10 @@ async def async_test_temperature(hass: HomeAssistant, cluster: Cluster, entity_i
 async def async_test_pressure(hass: HomeAssistant, cluster: Cluster, entity_id: str):
     """Test pressure sensor."""
     await send_attributes_report(hass, cluster, {1: 1, 0: 1000, 2: 10000})
-    assert_state(hass, entity_id, "1000.0", UnitOfPressure.HPA)
+    assert_state(hass, entity_id, "1000", UnitOfPressure.HPA)
 
     await send_attributes_report(hass, cluster, {0: 1000, 20: -1, 16: 10000})
-    assert_state(hass, entity_id, "1000.0", UnitOfPressure.HPA)
+    assert_state(hass, entity_id, "1000", UnitOfPressure.HPA)
 
 
 async def async_test_illuminance(hass: HomeAssistant, cluster: Cluster, entity_id: str):
@@ -211,17 +211,17 @@ async def async_test_em_power_factor(
     # update divisor cached value
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 1})
     await send_attributes_report(hass, cluster, {0: 1, 0x0510: 100, 10: 1000})
-    assert_state(hass, entity_id, "100.0", PERCENTAGE)
+    assert_state(hass, entity_id, "100", PERCENTAGE)
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0510: 99, 10: 1000})
-    assert_state(hass, entity_id, "99.0", PERCENTAGE)
+    assert_state(hass, entity_id, "99", PERCENTAGE)
 
     await send_attributes_report(hass, cluster, {"ac_power_divisor": 10})
     await send_attributes_report(hass, cluster, {0: 1, 0x0510: 100, 10: 5000})
-    assert_state(hass, entity_id, "100.0", PERCENTAGE)
+    assert_state(hass, entity_id, "100", PERCENTAGE)
 
     await send_attributes_report(hass, cluster, {0: 1, 0x0510: 99, 10: 5000})
-    assert_state(hass, entity_id, "99.0", PERCENTAGE)
+    assert_state(hass, entity_id, "99", PERCENTAGE)
 
 
 async def async_test_em_rms_current(
@@ -317,7 +317,7 @@ async def async_test_pi_heating_demand(
     await send_attributes_report(
         hass, cluster, {Thermostat.AttributeDefs.pi_heating_demand.id: 1}
     )
-    assert_state(hass, entity_id, "1.0", "%")
+    assert_state(hass, entity_id, "1", "%")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [0.0.59](https://github.com/zigpy/zha/releases/tag/0.0.59), including [0.0.58](https://github.com/zigpy/zha/releases/tag/0.0.58) changes (full diff: https://github.com/zigpy/zha/compare/0.0.57...0.0.59).
These dependency upgrades are bundled with it: 

- `zha-quirks` [0.0.138](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.138)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.137...0.0.138

- `zigpy` [0.80.1](https://github.com/zigpy/zigpy/releases/tag/0.80.1), including [0.80.0](https://github.com/zigpy/zigpy/releases/tag/0.80.0) changes, including [0.79.1](https://github.com/zigpy/zigpy/releases/tag/0.79.1) changes
full diff: https://github.com/zigpy/zigpy/compare/0.79.0...0.80.1

- `zigpy-deconz` [0.25.0](https://github.com/zigpy/zigpy-deconz/releases/tag/0.25.0)
full diff: https://github.com/zigpy/zigpy-deconz/compare/0.24.2...0.25.0


This ZHA release adds support for automatically discovering entities from the `AnalogInput` cluster, allowing for easier implementation of DIY-Zigbee devices, similar to ESPHome. Furthermore, the `number` platform has been improved to align with other platforms.
A small issue, introduced with the added precision in ZHA 0.0.57, where sensor state incapable of precision with decimal places sent from ZHA to HA was always converted to a float, instead of staying an integer, leading to some state unexpectedly being `100.0` instead of `100`, for example, was fixed as well.
 
This zigpy release improves quirk processing and fixes some datatypes.
This zigpy-deconz release fixes an issue where retries were still present in both the radio library and zigpy itself.
This zha-quirks release also adds a few entities via the quirks v2 API. The entity names are added to `strings.json`.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
