### PR TITLE
Prefer source name in Music Assistant integration

### DIFF
--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -297,13 +297,13 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
         source_mappings: dict[str, str] = {}
         active_source_name: str | None = None
         for source in player.source_list:
+            if source.id == player.active_source:
+                active_source_name = source.name
             if source.passive:
                 # ignore passive sources because HA does not differentiate between
                 # active and passive sources
                 continue
             source_mappings[source.name] = source.id
-            if source.id == player.active_source:
-                active_source_name = source.name
         self._attr_source_list = list(source_mappings.keys())
         self._source_list_mapping = source_mappings
         self._attr_source = active_source_name

--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -301,7 +301,7 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
                 # ignore passive sources because HA does not differentiate between
                 # active and passive sources
                 continue
-            source_mappings[source.id] = source.name
+            source_mappings[source.name] = source.id
             if source.id == player.active_source:
                 active_source_name = source.name
         self._attr_source_list = list(source_mappings.keys())

--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -42,7 +42,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import ATTR_NAME, STATE_OFF
 from homeassistant.core import HomeAssistant, ServiceResponse, SupportsResponse
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,

--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -227,6 +227,7 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
         self._set_supported_features()
         self._attr_device_class = MediaPlayerDeviceClass.SPEAKER
         self._prev_time: float = 0
+        self._source_list_mapping: dict[str, str] = {}
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -292,10 +293,20 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
             self._attr_state = MediaPlayerState(player.state.value)
         else:
             self._attr_state = MediaPlayerState(STATE_OFF)
-        self._attr_source = player.active_source
-        self._attr_source_list = [
-            source.name for source in player.source_list if not source.passive
-        ]
+        # active source and source list (translate to HA source names)
+        source_mappings: dict[str, str] = {}
+        active_source_name: str | None = None
+        for source in player.source_list:
+            if source.passive:
+                # ignore passive sources because HA does not differentiate between
+                # active and passive sources
+                continue
+            source_mappings[source.id] = source.name
+            if source.id == player.active_source:
+                active_source_name = source.name
+        self._attr_source_list = list(source_mappings.keys())
+        self._source_list_mapping = source_mappings
+        self._attr_source = active_source_name
 
         group_members: list[str] = []
         if player.group_childs:
@@ -466,7 +477,12 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
     @catch_musicassistant_error
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
-        await self.mass.players.player_command_select_source(self.player_id, source)
+        source_id = self._source_list_mapping.get(source)
+        if source_id is None:
+            raise HomeAssistantError(
+                f"Source '{source}' not found for player {self.name}"
+            )
+        await self.mass.players.player_command_select_source(self.player_id, source_id)
 
     @catch_musicassistant_error
     async def _async_handle_play_media(

--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -479,7 +479,7 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
         """Select input source."""
         source_id = self._source_list_mapping.get(source)
         if source_id is None:
-            raise HomeAssistantError(
+            raise ServiceValidationError(
                 f"Source '{source}' not found for player {self.name}"
             )
         await self.mass.players.player_command_select_source(self.player_id, source_id)

--- a/tests/components/music_assistant/snapshots/test_media_player.ambr
+++ b/tests/components/music_assistant/snapshots/test_media_player.ambr
@@ -54,6 +54,7 @@
       'media_duration': 300,
       'media_position': 0,
       'media_title': 'Test Track',
+      'source': 'Spotify Connect',
       'supported_features': <MediaPlayerEntityFeature: 8320959>,
       'volume_level': 0.2,
     }),

--- a/tests/components/music_assistant/snapshots/test_media_player.ambr
+++ b/tests/components/music_assistant/snapshots/test_media_player.ambr
@@ -143,8 +143,8 @@
     'area_id': None,
     'capabilities': dict({
       'source_list': list([
-        '00:00:00:00:00:01',
-        'linein',
+        'Music Assistant Queue',
+        'Line-In',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -186,8 +186,8 @@
       'icon': 'mdi:speaker',
       'mass_player_type': 'player',
       'source_list': list([
-        '00:00:00:00:00:01',
-        'linein',
+        'Music Assistant Queue',
+        'Line-In',
       ]),
       'supported_features': <MediaPlayerEntityFeature: 8323007>,
     }),

--- a/tests/components/music_assistant/snapshots/test_media_player.ambr
+++ b/tests/components/music_assistant/snapshots/test_media_player.ambr
@@ -54,7 +54,6 @@
       'media_duration': 300,
       'media_position': 0,
       'media_title': 'Test Track',
-      'source': 'spotify',
       'supported_features': <MediaPlayerEntityFeature: 8320959>,
       'volume_level': 0.2,
     }),
@@ -126,7 +125,6 @@
       'media_title': 'November Rain',
       'repeat': 'all',
       'shuffle': True,
-      'source': 'test_group_player_1',
       'supported_features': <MediaPlayerEntityFeature: 8320959>,
       'volume_level': 0.06,
     }),
@@ -145,8 +143,8 @@
     'area_id': None,
     'capabilities': dict({
       'source_list': list([
-        'Music Assistant Queue',
-        'Line-In',
+        '00:00:00:00:00:01',
+        'linein',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -188,8 +186,8 @@
       'icon': 'mdi:speaker',
       'mass_player_type': 'player',
       'source_list': list([
-        'Music Assistant Queue',
-        'Line-In',
+        '00:00:00:00:00:01',
+        'linein',
       ]),
       'supported_features': <MediaPlayerEntityFeature: 8323007>,
     }),

--- a/tests/components/music_assistant/test_media_player.py
+++ b/tests/components/music_assistant/test_media_player.py
@@ -637,7 +637,7 @@ async def test_media_player_select_source_action(
         SERVICE_SELECT_SOURCE,
         {
             ATTR_ENTITY_ID: entity_id,
-            ATTR_INPUT_SOURCE: "linein",
+            ATTR_INPUT_SOURCE: "Line-In",
         },
         blocking=True,
     )


### PR DESCRIPTION

## Proposed change

Follow-up of #145619 
We need to translate the source ID into the name, because HA only uses a list if source names and has no relation with any source ID's.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
