### PR TITLE
Remove confirm screen after Z-Wave usb discovery

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -444,7 +444,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             # at least for a short time.
             return self.async_abort(reason="already_in_progress")
         if current_config_entries := self._async_current_entries(include_ignore=False):
-            config_entry = next(
+            self._reconfigure_config_entry = next(
                 (
                     entry
                     for entry in current_config_entries
@@ -452,7 +452,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 ),
                 None,
             )
-            if not config_entry:
+            if not self._reconfigure_config_entry:
                 return self.async_abort(reason="addon_required")
 
         vid = discovery_info.vid
@@ -503,17 +503,7 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {CONF_NAME: title}
 
         self._usb_discovery = True
-        if current_config_entries := self._async_current_entries(include_ignore=False):
-            self._reconfigure_config_entry = next(
-                (
-                    entry
-                    for entry in current_config_entries
-                    if entry.data.get(CONF_USE_ADDON)
-                ),
-                None,
-            )
-            if not self._reconfigure_config_entry:
-                return self.async_abort(reason="addon_required")
+        if current_config_entries:
             return await self.async_step_intent_migrate()
 
         return await self.async_step_installation_type()

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -170,8 +170,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    _title: str
-
     def __init__(self) -> None:
         """Set up flow instance."""
         self.s0_legacy_key: str | None = None
@@ -503,18 +501,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             title = human_name.split(" - ")[0].strip()
         self.context["title_placeholders"] = {CONF_NAME: title}
-        self._title = title
-        return await self.async_step_usb_confirm()
-
-    async def async_step_usb_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle USB Discovery confirmation."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="usb_confirm",
-                description_placeholders={CONF_NAME: self._title},
-            )
 
         self._usb_discovery = True
         if current_config_entries := self._async_current_entries(include_ignore=False):

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -98,9 +98,6 @@
       "start_addon": {
         "title": "The Z-Wave add-on is starting."
       },
-      "usb_confirm": {
-        "description": "Do you want to set up {name} with the Z-Wave add-on?"
-      },
       "zeroconf_confirm": {
         "description": "Do you want to add the Z-Wave Server with home ID {home_id} found at {url} to Home Assistant?",
         "title": "Discovered Z-Wave Server"

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -585,8 +585,8 @@ async def test_abort_hassio_discovery_with_existing_flow(hass: HomeAssistant) ->
         context={"source": config_entries.SOURCE_USB},
         data=USB_DISCOVERY_INFO,
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "usb_confirm"
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "installation_type"
 
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -664,13 +664,8 @@ async def test_usb_discovery(
         context={"source": config_entries.SOURCE_USB},
         data=usb_discovery_info,
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "usb_confirm"
-    assert result["description_placeholders"] == {"name": discovery_name}
+
     assert mock_usb_serial_by_id.call_count == 1
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "installation_type"
     assert result["menu_options"] == ["intent_recommended", "intent_custom"]
@@ -771,12 +766,8 @@ async def test_usb_discovery_addon_not_running(
         context={"source": config_entries.SOURCE_USB},
         data=USB_DISCOVERY_INFO,
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "usb_confirm"
+
     assert mock_usb_serial_by_id.call_count == 2
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "installation_type"
 
@@ -932,12 +923,8 @@ async def test_usb_discovery_migration(
         context={"source": config_entries.SOURCE_USB},
         data=USB_DISCOVERY_INFO,
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "usb_confirm"
+
     assert mock_usb_serial_by_id.call_count == 2
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "intent_migrate"
 
@@ -1063,12 +1050,8 @@ async def test_usb_discovery_migration_restore_driver_ready_timeout(
         context={"source": config_entries.SOURCE_USB},
         data=USB_DISCOVERY_INFO,
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "usb_confirm"
+
     assert mock_usb_serial_by_id.call_count == 2
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "intent_migrate"
 
@@ -1366,16 +1349,16 @@ async def test_usb_discovery_with_existing_usb_flow(hass: HomeAssistant) -> None
         data=first_usb_info,
     )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "usb_confirm"
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "installation_type"
 
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USB},
         data=USB_DISCOVERY_INFO,
     )
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "usb_confirm"
+    assert result2["type"] is FlowResultType.MENU
+    assert result2["step_id"] == "installation_type"
 
     usb_flows_in_progress = hass.config_entries.flow.async_progress_by_handler(
         DOMAIN, match_context={"source": config_entries.SOURCE_USB}
@@ -1405,53 +1388,6 @@ async def test_abort_usb_discovery_addon_required(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_USB},
         data=USB_DISCOVERY_INFO,
     )
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "addon_required"
-
-
-@pytest.mark.usefixtures(
-    "supervisor",
-    "addon_running",
-)
-async def test_abort_usb_discovery_confirm_addon_required(
-    hass: HomeAssistant,
-    addon_options: dict[str, Any],
-    mock_usb_serial_by_id: MagicMock,
-) -> None:
-    """Test usb discovery confirm aborted when existing entry not using add-on."""
-    addon_options["device"] = "/dev/another_device"
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "url": "ws://localhost:3000",
-            "usb_path": "/dev/another_device",
-            "use_addon": True,
-        },
-        title=TITLE,
-        unique_id="1234",
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_USB},
-        data=USB_DISCOVERY_INFO,
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "usb_confirm"
-    assert mock_usb_serial_by_id.call_count == 2
-
-    hass.config_entries.async_update_entry(
-        entry,
-        data={
-            **entry.data,
-            "use_addon": False,
-        },
-    )
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "addon_required"
 
@@ -4635,13 +4571,8 @@ async def test_recommended_usb_discovery(
         context={"source": config_entries.SOURCE_USB},
         data=usb_discovery_info,
     )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "usb_confirm"
-    assert result["description_placeholders"] == {"name": discovery_name}
+
     assert mock_usb_serial_by_id.call_count == 1
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "installation_type"
     assert result["menu_options"] == ["intent_recommended", "intent_custom"]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/92
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
