### PR TITLE
Add check for packages restricting Python version

### DIFF
--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -222,6 +222,15 @@ class Integration:
         """Add a warning."""
         self.warnings.append(Error(*args, **kwargs))
 
+    def add_warning_or_error(
+        self, warning_only: bool, *args: Any, **kwargs: Any
+    ) -> None:
+        """Add an error or a warning."""
+        if warning_only:
+            self.add_warning(*args, **kwargs)
+        else:
+            self.add_error(*args, **kwargs)
+
     def load_manifest(self) -> None:
         """Load manifest."""
         manifest_path = self.path / "manifest.json"

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -541,7 +541,7 @@ def get_requirements(integration: Integration, packages: set[str]) -> set[str]:
             continue
 
         if (
-            package in packages  # Top-level checks only only bleak is resolved
+            package in packages  # Top-level checks only util bleak is resolved
             and (requires_python := metadata(package)["Requires-Python"])
             and not all(
                 _is_dependency_version_range_valid(version_part, "SemVer")

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -541,7 +541,7 @@ def get_requirements(integration: Integration, packages: set[str]) -> set[str]:
             continue
 
         if (
-            package in packages  # Top-level checks only util bleak is resolved
+            package in packages  # Top-level checks only until bleak is resolved
             and (requires_python := metadata(package)["Requires-Python"])
             and not all(
                 _is_dependency_version_range_valid(version_part, "SemVer")

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -541,7 +541,7 @@ def get_requirements(integration: Integration, packages: set[str]) -> set[str]:
             continue
 
         if (
-            package in packages  # Top-level checks only
+            package in packages  # Top-level checks only only bleak is resolved
             and (requires_python := metadata(package)["Requires-Python"])
             and not all(
                 _is_dependency_version_range_valid(version_part, "SemVer")

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 from functools import cache
+from importlib.metadata import metadata
 import json
 import os
 import re
@@ -319,6 +320,33 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     },
 }
 
+PYTHON_VERSION_CHECK_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
+    # In the form dict("domain": {"package": {"dependency1", "dependency2"}})
+    # - domain is the integration domain
+    # - package is the package (can be transitive) referencing the dependency
+    # - dependencyX should be the name of the referenced dependency
+    "bluetooth": {
+        # https://github.com/hbldh/bleak/pull/1718 (not yet released)
+        "homeassistant": {"bleak"}
+    },
+    "eq3btsmart": {
+        # https://github.com/EuleMitKeule/eq3btsmart/releases/tag/2.0.0
+        "homeassistant": {"eq3btsmart"}
+    },
+    "homekit_controller": {
+        # https://github.com/Jc2k/aiohomekit/issues/456
+        "homeassistant": {"aiohomekit"}
+    },
+    "netatmo": {
+        # https://github.com/jabesq-org/pyatmo/pull/533 (not yet released)
+        "homeassistant": {"pyatmo"}
+    },
+    "python_script": {
+        # Security audits are needed for each Python version
+        "homeassistant": {"restrictedpython"}
+    },
+}
+
 
 def validate(integrations: dict[str, Integration], config: Config) -> None:
     """Handle requirements for integrations."""
@@ -489,6 +517,11 @@ def get_requirements(integration: Integration, packages: set[str]) -> set[str]:
     )
     needs_package_version_check_exception = False
 
+    python_version_check_exceptions = PYTHON_VERSION_CHECK_EXCEPTIONS.get(
+        integration.domain, {}
+    )
+    needs_python_version_check_exception = False
+
     while to_check:
         package = to_check.popleft()
 
@@ -507,22 +540,32 @@ def get_requirements(integration: Integration, packages: set[str]) -> set[str]:
                 )
             continue
 
+        if (
+            package in packages  # Top-level checks only
+            and (requires_python := metadata(package)["Requires-Python"])
+            and not all(
+                _is_dependency_version_range_valid(version_part, "SemVer")
+                for version_part in requires_python.split(",")
+            )
+        ):
+            needs_python_version_check_exception = True
+            integration.add_warning_or_error(
+                package in python_version_check_exceptions.get("homeassistant", set()),
+                "requirements",
+                f"Version restrictions for Python are too strict ({requires_python}) in {package}",
+            )
+
         dependencies: dict[str, str] = item["dependencies"]
         package_exceptions = forbidden_package_exceptions.get(package, set())
         for pkg, version in dependencies.items():
             if pkg.startswith("types-") or pkg in FORBIDDEN_PACKAGES:
                 reason = FORBIDDEN_PACKAGES.get(pkg, "not be a runtime dependency")
                 needs_forbidden_package_exceptions = True
-                if pkg in package_exceptions:
-                    integration.add_warning(
-                        "requirements",
-                        f"Package {pkg} should {reason} in {package}",
-                    )
-                else:
-                    integration.add_error(
-                        "requirements",
-                        f"Package {pkg} should {reason} in {package}",
-                    )
+                integration.add_warning_or_error(
+                    pkg in package_exceptions,
+                    "requirements",
+                    f"Package {pkg} should {reason} in {package}",
+                )
             if not check_dependency_version_range(
                 integration,
                 package,
@@ -545,6 +588,12 @@ def get_requirements(integration: Integration, packages: set[str]) -> set[str]:
             "requirements",
             f"Integration {integration.domain} version restrictions checks have been "
             "resolved, please remove from `PACKAGE_CHECK_VERSION_RANGE_EXCEPTIONS`",
+        )
+    if python_version_check_exceptions and not needs_python_version_check_exception:
+        integration.add_error(
+            "requirements",
+            f"Integration {integration.domain} version restrictions for Python have "
+            "been resolved, please remove from `PYTHON_VERSION_CHECK_EXCEPTIONS`",
         )
 
     return all_requirements
@@ -571,21 +620,16 @@ def check_dependency_version_range(
     ):
         return True
 
-    if pkg in package_exceptions:
-        integration.add_warning(
-            "requirements",
-            f"Version restrictions for {pkg} are too strict ({version}) in {source}",
-        )
-    else:
-        integration.add_error(
-            "requirements",
-            f"Version restrictions for {pkg} are too strict ({version}) in {source}",
-        )
+    integration.add_warning_or_error(
+        pkg in package_exceptions,
+        "requirements",
+        f"Version restrictions for {pkg} are too strict ({version}) in {source}",
+    )
     return False
 
 
 def _is_dependency_version_range_valid(version_part: str, convention: str) -> bool:
-    version_match = PIP_VERSION_RANGE_SEPARATOR.match(version_part)
+    version_match = PIP_VERSION_RANGE_SEPARATOR.match(version_part.strip())
     operator = version_match.group(1)
     version = version_match.group(2)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid unnecessary limits on Python in dependencies

```console
Integrations: 1360
Invalid integrations: 5

Found errors. Generating files canceled.

Integration bluetooth:
* [ERROR] [REQUIREMENTS] Version restrictions for Python are too strict (>=3.8,<3.14) in bleak

Integration eq3btsmart:
* [ERROR] [REQUIREMENTS] Version restrictions for Python are too strict (>=3.12,<3.14) in eq3btsmart

Integration homekit_controller:
* [ERROR] [REQUIREMENTS] Version restrictions for Python are too strict (>=3.10,<3.14) in aiohomekit

Integration netatmo:
* [ERROR] [REQUIREMENTS] Version restrictions for Python are too strict (<3.14,>=3.11) in pyatmo

Integration python_script:
* [ERROR] [REQUIREMENTS] Version restrictions for Python are too strict (>=3.9, <3.14) in restrictedpython
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
