### PR TITLE
Use async_load_fixture in async test functions (a)

### DIFF
--- a/tests/components/agent_dvr/__init__.py
+++ b/tests/components/agent_dvr/__init__.py
@@ -4,7 +4,7 @@ from homeassistant.components.agent_dvr.const import DOMAIN, SERVER_URL
 from homeassistant.const import CONF_HOST, CONF_PORT, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, async_load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 CONF_DATA = {
@@ -34,12 +34,12 @@ async def init_integration(
 
     aioclient_mock.get(
         "http://example.local:8090/command.cgi?cmd=getStatus",
-        text=load_fixture("agent_dvr/status.json"),
+        text=await async_load_fixture(hass, "status.json", DOMAIN),
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
     aioclient_mock.get(
         "http://example.local:8090/command.cgi?cmd=getObjects",
-        text=load_fixture("agent_dvr/objects.json"),
+        text=await async_load_fixture(hass, "objects.json", DOMAIN),
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
     entry = create_entry(hass)

--- a/tests/components/agent_dvr/test_config_flow.py
+++ b/tests/components/agent_dvr/test_config_flow.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from homeassistant.components.agent_dvr import config_flow
-from homeassistant.components.agent_dvr.const import SERVER_URL
+from homeassistant.components.agent_dvr.const import DOMAIN, SERVER_URL
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
@@ -11,7 +10,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from . import init_integration
 
-from tests.common import load_fixture
+from tests.common import async_load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
@@ -20,7 +19,7 @@ pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 async def test_show_user_form(hass: HomeAssistant) -> None:
     """Test that the user set up form is served."""
     result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
+        DOMAIN,
         context={"source": SOURCE_USER},
     )
 
@@ -35,7 +34,7 @@ async def test_user_device_exists_abort(
     await init_integration(hass, aioclient_mock)
 
     result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
+        DOMAIN,
         context={"source": SOURCE_USER},
         data={CONF_HOST: "example.local", CONF_PORT: 8090},
     )
@@ -51,7 +50,7 @@ async def test_connection_error(
     aioclient_mock.get("http://example.local:8090/command.cgi?cmd=getStatus", text="")
 
     result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
+        DOMAIN,
         context={"source": SOURCE_USER},
         data={CONF_HOST: "example.local", CONF_PORT: 8090},
     )
@@ -67,18 +66,18 @@ async def test_full_user_flow_implementation(
     """Test the full manual user flow from start to finish."""
     aioclient_mock.get(
         "http://example.local:8090/command.cgi?cmd=getStatus",
-        text=load_fixture("agent_dvr/status.json"),
+        text=await async_load_fixture(hass, "status.json", DOMAIN),
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
 
     aioclient_mock.get(
         "http://example.local:8090/command.cgi?cmd=getObjects",
-        text=load_fixture("agent_dvr/objects.json"),
+        text=await async_load_fixture(hass, "objects.json", DOMAIN),
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
 
     result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
+        DOMAIN,
         context={"source": SOURCE_USER},
     )
 
@@ -95,5 +94,5 @@ async def test_full_user_flow_implementation(
     assert result["title"] == "DESKTOP"
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
-    entries = hass.config_entries.async_entries(config_flow.DOMAIN)
+    entries = hass.config_entries.async_entries(DOMAIN)
     assert entries[0].unique_id == "c0715bba-c2d0-48ef-9e3e-bc81c9ea4447"

--- a/tests/components/airgradient/test_button.py
+++ b/tests/components/airgradient/test_button.py
@@ -20,7 +20,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_fixture,
+    async_load_fixture,
     snapshot_platform,
 )
 
@@ -81,7 +81,7 @@ async def test_cloud_creates_no_button(
     assert len(hass.states.async_all()) == 0
 
     mock_cloud_airgradient_client.get_config.return_value = Config.from_json(
-        load_fixture("get_config_local.json", DOMAIN)
+        await async_load_fixture(hass, "get_config_local.json", DOMAIN)
     )
 
     freezer.tick(timedelta(minutes=5))
@@ -91,7 +91,7 @@ async def test_cloud_creates_no_button(
     assert len(hass.states.async_all()) == 2
 
     mock_cloud_airgradient_client.get_config.return_value = Config.from_json(
-        load_fixture("get_config_cloud.json", DOMAIN)
+        await async_load_fixture(hass, "get_config_cloud.json", DOMAIN)
     )
 
     freezer.tick(timedelta(minutes=5))

--- a/tests/components/airgradient/test_number.py
+++ b/tests/components/airgradient/test_number.py
@@ -24,7 +24,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_fixture,
+    async_load_fixture,
     snapshot_platform,
 )
 
@@ -83,7 +83,7 @@ async def test_cloud_creates_no_number(
     assert len(hass.states.async_all()) == 0
 
     mock_cloud_airgradient_client.get_config.return_value = Config.from_json(
-        load_fixture("get_config_local.json", DOMAIN)
+        await async_load_fixture(hass, "get_config_local.json", DOMAIN)
     )
 
     freezer.tick(timedelta(minutes=5))
@@ -93,7 +93,7 @@ async def test_cloud_creates_no_number(
     assert len(hass.states.async_all()) == 2
 
     mock_cloud_airgradient_client.get_config.return_value = Config.from_json(
-        load_fixture("get_config_cloud.json", DOMAIN)
+        await async_load_fixture(hass, "get_config_cloud.json", DOMAIN)
     )
 
     freezer.tick(timedelta(minutes=5))

--- a/tests/components/airgradient/test_select.py
+++ b/tests/components/airgradient/test_select.py
@@ -23,7 +23,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_fixture,
+    async_load_fixture,
     snapshot_platform,
 )
 
@@ -77,7 +77,7 @@ async def test_cloud_creates_no_number(
     assert len(hass.states.async_all()) == 1
 
     mock_cloud_airgradient_client.get_config.return_value = Config.from_json(
-        load_fixture("get_config_local.json", DOMAIN)
+        await async_load_fixture(hass, "get_config_local.json", DOMAIN)
     )
 
     freezer.tick(timedelta(minutes=5))
@@ -87,7 +87,7 @@ async def test_cloud_creates_no_number(
     assert len(hass.states.async_all()) == 7
 
     mock_cloud_airgradient_client.get_config.return_value = Config.from_json(
-        load_fixture("get_config_cloud.json", DOMAIN)
+        await async_load_fixture(hass, "get_config_cloud.json", DOMAIN)
     )
 
     freezer.tick(timedelta(minutes=5))

--- a/tests/components/airgradient/test_sensor.py
+++ b/tests/components/airgradient/test_sensor.py
@@ -18,7 +18,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_fixture,
+    async_load_fixture,
     snapshot_platform,
 )
 
@@ -46,14 +46,14 @@ async def test_create_entities(
 ) -> None:
     """Test creating entities."""
     mock_airgradient_client.get_current_measures.return_value = Measures.from_json(
-        load_fixture("measures_after_boot.json", DOMAIN)
+        await async_load_fixture(hass, "measures_after_boot.json", DOMAIN)
     )
     with patch("homeassistant.components.airgradient.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
 
     assert len(hass.states.async_all()) == 0
     mock_airgradient_client.get_current_measures.return_value = Measures.from_json(
-        load_fixture("current_measures_indoor.json", DOMAIN)
+        await async_load_fixture(hass, "current_measures_indoor.json", DOMAIN)
     )
     freezer.tick(timedelta(minutes=1))
     async_fire_time_changed(hass)

--- a/tests/components/airgradient/test_switch.py
+++ b/tests/components/airgradient/test_switch.py
@@ -25,7 +25,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_fixture,
+    async_load_fixture,
     snapshot_platform,
 )
 
@@ -83,7 +83,7 @@ async def test_cloud_creates_no_switch(
     assert len(hass.states.async_all()) == 0
 
     mock_cloud_airgradient_client.get_config.return_value = Config.from_json(
-        load_fixture("get_config_local.json", DOMAIN)
+        await async_load_fixture(hass, "get_config_local.json", DOMAIN)
     )
 
     freezer.tick(timedelta(minutes=5))
@@ -93,7 +93,7 @@ async def test_cloud_creates_no_switch(
     assert len(hass.states.async_all()) == 1
 
     mock_cloud_airgradient_client.get_config.return_value = Config.from_json(
-        load_fixture("get_config_cloud.json", DOMAIN)
+        await async_load_fixture(hass, "get_config_cloud.json", DOMAIN)
     )
 
     freezer.tick(timedelta(minutes=5))

--- a/tests/components/airly/__init__.py
+++ b/tests/components/airly/__init__.py
@@ -3,7 +3,7 @@
 from homeassistant.components.airly.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, async_load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 API_NEAREST_URL = "https://airapi.airly.eu/v2/measurements/nearest?lat=123.000000&lng=456.000000&maxDistanceKM=5.000000"
@@ -34,7 +34,9 @@ async def init_integration(
     )
 
     aioclient_mock.get(
-        API_POINT_URL, text=load_fixture("valid_station.json", DOMAIN), headers=HEADERS
+        API_POINT_URL,
+        text=await async_load_fixture(hass, "valid_station.json", DOMAIN),
+        headers=HEADERS,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/airly/test_config_flow.py
+++ b/tests/components/airly/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from . import API_NEAREST_URL, API_POINT_URL
 
-from tests.common import MockConfigEntry, load_fixture, patch
+from tests.common import MockConfigEntry, async_load_fixture, patch
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 CONFIG = {
@@ -55,7 +55,9 @@ async def test_invalid_location(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that errors are shown when location is invalid."""
-    aioclient_mock.get(API_POINT_URL, text=load_fixture("no_station.json", "airly"))
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "no_station.json", DOMAIN)
+    )
 
     aioclient_mock.get(
         API_NEAREST_URL,
@@ -74,9 +76,13 @@ async def test_invalid_location_for_point_and_nearest(
 ) -> None:
     """Test an abort when the location is wrong for the point and nearest methods."""
 
-    aioclient_mock.get(API_POINT_URL, text=load_fixture("no_station.json", "airly"))
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "no_station.json", DOMAIN)
+    )
 
-    aioclient_mock.get(API_NEAREST_URL, text=load_fixture("no_station.json", "airly"))
+    aioclient_mock.get(
+        API_NEAREST_URL, text=await async_load_fixture(hass, "no_station.json", DOMAIN)
+    )
 
     with patch("homeassistant.components.airly.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
@@ -91,7 +97,9 @@ async def test_duplicate_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that errors are shown when duplicates are added."""
-    aioclient_mock.get(API_POINT_URL, text=load_fixture("valid_station.json", "airly"))
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "valid_station.json", DOMAIN)
+    )
     MockConfigEntry(domain=DOMAIN, unique_id="123-456", data=CONFIG).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -106,7 +114,9 @@ async def test_create_entry(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that the user step works."""
-    aioclient_mock.get(API_POINT_URL, text=load_fixture("valid_station.json", "airly"))
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "valid_station.json", DOMAIN)
+    )
 
     with patch("homeassistant.components.airly.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
@@ -126,10 +136,13 @@ async def test_create_entry_with_nearest_method(
 ) -> None:
     """Test that the user step works with nearest method."""
 
-    aioclient_mock.get(API_POINT_URL, text=load_fixture("no_station.json", "airly"))
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "no_station.json", DOMAIN)
+    )
 
     aioclient_mock.get(
-        API_NEAREST_URL, text=load_fixture("valid_station.json", "airly")
+        API_NEAREST_URL,
+        text=await async_load_fixture(hass, "valid_station.json", DOMAIN),
     )
 
     with patch("homeassistant.components.airly.async_setup_entry", return_value=True):

--- a/tests/components/airly/test_init.py
+++ b/tests/components/airly/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import API_POINT_URL, init_integration
 
-from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
+from tests.common import MockConfigEntry, async_fire_time_changed, async_load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -69,7 +69,9 @@ async def test_config_without_unique_id(
         },
     )
 
-    aioclient_mock.get(API_POINT_URL, text=load_fixture("valid_station.json", "airly"))
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "valid_station.json", DOMAIN)
+    )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state is ConfigEntryState.LOADED
@@ -92,7 +94,9 @@ async def test_config_with_turned_off_station(
         },
     )
 
-    aioclient_mock.get(API_POINT_URL, text=load_fixture("no_station.json", "airly"))
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "no_station.json", DOMAIN)
+    )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state is ConfigEntryState.SETUP_RETRY
@@ -124,7 +128,7 @@ async def test_update_interval(
 
     aioclient_mock.get(
         API_POINT_URL,
-        text=load_fixture("valid_station.json", "airly"),
+        text=await async_load_fixture(hass, "valid_station.json", DOMAIN),
         headers=HEADERS,
     )
     entry.add_to_hass(hass)
@@ -159,7 +163,7 @@ async def test_update_interval(
 
     aioclient_mock.get(
         "https://airapi.airly.eu/v2/measurements/point?lat=66.660000&lng=111.110000",
-        text=load_fixture("valid_station.json", "airly"),
+        text=await async_load_fixture(hass, "valid_station.json", DOMAIN),
         headers=HEADERS,
     )
     entry.add_to_hass(hass)
@@ -216,7 +220,9 @@ async def test_migrate_device_entry(
         },
     )
 
-    aioclient_mock.get(API_POINT_URL, text=load_fixture("valid_station.json", "airly"))
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "valid_station.json", DOMAIN)
+    )
     config_entry.add_to_hass(hass)
 
     device_entry = device_registry.async_get_or_create(

--- a/tests/components/airly/test_sensor.py
+++ b/tests/components/airly/test_sensor.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from airly.exceptions import AirlyError
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.airly.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -15,7 +16,7 @@ from homeassistant.util.dt import utcnow
 
 from . import API_POINT_URL, init_integration
 
-from tests.common import async_fire_time_changed, load_fixture
+from tests.common import async_fire_time_changed, async_load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -62,7 +63,9 @@ async def test_availability(
     assert state.state == STATE_UNAVAILABLE
 
     aioclient_mock.clear_requests()
-    aioclient_mock.get(API_POINT_URL, text=load_fixture("valid_station.json", "airly"))
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "valid_station.json", DOMAIN)
+    )
     future = utcnow() + timedelta(minutes=120)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as follow-up to #144534 and needed for #145709

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
