### PR TITLE
Use async_load_json_(array/object)_fixture in async test functions

### DIFF
--- a/tests/components/aosmith/conftest.py
+++ b/tests/components/aosmith/conftest.py
@@ -20,7 +20,7 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 FIXTURE_USER_INPUT = {
     CONF_EMAIL: "testemail@example.com",
@@ -161,6 +161,7 @@ def get_devices_fixture_has_vacation_mode() -> bool:
 
 @pytest.fixture
 async def mock_client(
+    hass: HomeAssistant,
     get_devices_fixture_heat_pump: bool,
     get_devices_fixture_mode_pending: bool,
     get_devices_fixture_setpoint_pending: bool,
@@ -175,8 +176,8 @@ async def mock_client(
             has_vacation_mode=get_devices_fixture_has_vacation_mode,
         )
     ]
-    get_all_device_info_fixture = load_json_object_fixture(
-        "get_all_device_info.json", DOMAIN
+    get_all_device_info_fixture = await async_load_json_object_fixture(
+        hass, "get_all_device_info.json", DOMAIN
     )
 
     client_mock = MagicMock(AOSmithAPIClient)

--- a/tests/components/enigma2/test_init.py
+++ b/tests/components/enigma2/test_init.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import device_registry as dr
 
 from .conftest import TEST_REQUIRED
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 async def test_device_without_mac_address(
@@ -20,8 +20,8 @@ async def test_device_without_mac_address(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test that a device gets successfully registered when the device doesn't report a MAC address."""
-    openwebif_device_mock.get_about.return_value = load_json_object_fixture(
-        "device_about_without_mac.json", DOMAIN
+    openwebif_device_mock.get_about.return_value = await async_load_json_object_fixture(
+        hass, "device_about_without_mac.json", DOMAIN
     )
     entry = MockConfigEntry(
         domain=DOMAIN, data=TEST_REQUIRED, title="name", unique_id="123456"

--- a/tests/components/enigma2/test_media_player.py
+++ b/tests/components/enigma2/test_media_player.py
@@ -37,7 +37,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
 )
 
 
@@ -228,8 +228,10 @@ async def test_update_data_standby(
 ) -> None:
     """Test data handling."""
 
-    openwebif_device_mock.get_status_info.return_value = load_json_object_fixture(
-        "device_statusinfo_standby.json", DOMAIN
+    openwebif_device_mock.get_status_info.return_value = (
+        await async_load_json_object_fixture(
+            hass, "device_statusinfo_standby.json", DOMAIN
+        )
     )
     openwebif_device_mock.status = OpenWebIfStatus(
         currservice=OpenWebIfServiceEvent(), in_standby=True

--- a/tests/components/fyta/test_binary_sensor.py
+++ b/tests/components/fyta/test_binary_sensor.py
@@ -19,7 +19,7 @@ from . import setup_platform
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 
@@ -78,8 +78,16 @@ async def test_add_remove_entities(
     assert hass.states.get("binary_sensor.gummibaum_repotted").state == STATE_ON
 
     plants: dict[int, Plant] = {
-        0: Plant.from_dict(load_json_object_fixture("plant_status1.json", FYTA_DOMAIN)),
-        2: Plant.from_dict(load_json_object_fixture("plant_status3.json", FYTA_DOMAIN)),
+        0: Plant.from_dict(
+            await async_load_json_object_fixture(
+                hass, "plant_status1.json", FYTA_DOMAIN
+            )
+        ),
+        2: Plant.from_dict(
+            await async_load_json_object_fixture(
+                hass, "plant_status3.json", FYTA_DOMAIN
+            )
+        ),
     }
     mock_fyta_connector.update_all_plants.return_value = plants
     mock_fyta_connector.plant_list = {

--- a/tests/components/fyta/test_image.py
+++ b/tests/components/fyta/test_image.py
@@ -21,7 +21,7 @@ from . import setup_platform
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 from tests.typing import ClientSessionGenerator
@@ -83,8 +83,16 @@ async def test_add_remove_entities(
     assert hass.states.get("image.gummibaum_user_image") is not None
 
     plants: dict[int, Plant] = {
-        0: Plant.from_dict(load_json_object_fixture("plant_status1.json", FYTA_DOMAIN)),
-        2: Plant.from_dict(load_json_object_fixture("plant_status3.json", FYTA_DOMAIN)),
+        0: Plant.from_dict(
+            await async_load_json_object_fixture(
+                hass, "plant_status1.json", FYTA_DOMAIN
+            )
+        ),
+        2: Plant.from_dict(
+            await async_load_json_object_fixture(
+                hass, "plant_status3.json", FYTA_DOMAIN
+            )
+        ),
     }
     mock_fyta_connector.update_all_plants.return_value = plants
     mock_fyta_connector.plant_list = {
@@ -121,9 +129,15 @@ async def test_update_image(
 
     plants: dict[int, Plant] = {
         0: Plant.from_dict(
-            load_json_object_fixture("plant_status1_update.json", FYTA_DOMAIN)
+            await async_load_json_object_fixture(
+                hass, "plant_status1_update.json", FYTA_DOMAIN
+            )
         ),
-        2: Plant.from_dict(load_json_object_fixture("plant_status3.json", FYTA_DOMAIN)),
+        2: Plant.from_dict(
+            await async_load_json_object_fixture(
+                hass, "plant_status3.json", FYTA_DOMAIN
+            )
+        ),
     }
     mock_fyta_connector.update_all_plants.return_value = plants
     mock_fyta_connector.plant_list = {

--- a/tests/components/fyta/test_sensor.py
+++ b/tests/components/fyta/test_sensor.py
@@ -19,7 +19,7 @@ from . import setup_platform
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 
@@ -75,8 +75,16 @@ async def test_add_remove_entities(
     assert hass.states.get("sensor.gummibaum_plant_state").state == "doing_great"
 
     plants: dict[int, Plant] = {
-        0: Plant.from_dict(load_json_object_fixture("plant_status1.json", FYTA_DOMAIN)),
-        2: Plant.from_dict(load_json_object_fixture("plant_status3.json", FYTA_DOMAIN)),
+        0: Plant.from_dict(
+            await async_load_json_object_fixture(
+                hass, "plant_status1.json", FYTA_DOMAIN
+            )
+        ),
+        2: Plant.from_dict(
+            await async_load_json_object_fixture(
+                hass, "plant_status3.json", FYTA_DOMAIN
+            )
+        ),
     }
     mock_fyta_connector.update_all_plants.return_value = plants
     mock_fyta_connector.plant_list = {

--- a/tests/components/knocki/test_event.py
+++ b/tests/components/knocki/test_event.py
@@ -14,7 +14,11 @@ from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, load_json_array_fixture, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_array_fixture,
+    snapshot_platform,
+)
 
 
 async def test_entities(
@@ -91,7 +95,8 @@ async def test_adding_runtime_entities(
     add_trigger_function: Callable[[Event], None] = (
         mock_knocki_client.register_listener.call_args_list[0][0][1]
     )
-    trigger = Trigger.from_dict(load_json_array_fixture("triggers.json", DOMAIN)[0])
+    triggers = await async_load_json_array_fixture(hass, "triggers.json", DOMAIN)
+    trigger = Trigger.from_dict(triggers[0])
 
     add_trigger_function(Event(EventType.CREATED, trigger))
 
@@ -106,7 +111,9 @@ async def test_removing_runtime_entities(
     """Test we can create devices on runtime."""
     mock_knocki_client.get_triggers.return_value = [
         Trigger.from_dict(trigger)
-        for trigger in load_json_array_fixture("more_triggers.json", DOMAIN)
+        for trigger in await async_load_json_array_fixture(
+            hass, "more_triggers.json", DOMAIN
+        )
     ]
 
     await setup_integration(hass, mock_config_entry)
@@ -117,7 +124,8 @@ async def test_removing_runtime_entities(
     remove_trigger_function: Callable[[Event], Awaitable[None]] = (
         mock_knocki_client.register_listener.call_args_list[1][0][1]
     )
-    trigger = Trigger.from_dict(load_json_array_fixture("triggers.json", DOMAIN)[0])
+    triggers = await async_load_json_array_fixture(hass, "triggers.json", DOMAIN)
+    trigger = Trigger.from_dict(triggers[0])
 
     mock_knocki_client.get_triggers.return_value = [trigger]
 

--- a/tests/components/knx/conftest.py
+++ b/tests/components/knx/conftest.py
@@ -40,7 +40,11 @@ from homeassistant.setup import async_setup_component
 
 from . import KnxEntityGenerator
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_object_fixture,
+    load_json_object_fixture,
+)
 from tests.typing import WebSocketGenerator
 
 FIXTURE_PROJECT_DATA = load_json_object_fixture("project.json", KNX_DOMAIN)
@@ -110,8 +114,10 @@ class KNXTestKit:
             return DEFAULT
 
         if config_store_fixture:
-            self.hass_storage[KNX_CONFIG_STORAGE_KEY] = load_json_object_fixture(
-                config_store_fixture, KNX_DOMAIN
+            self.hass_storage[
+                KNX_CONFIG_STORAGE_KEY
+            ] = await async_load_json_object_fixture(
+                self.hass, config_store_fixture, KNX_DOMAIN
             )
 
         if add_entry_to_hass:

--- a/tests/components/linear_garage_door/test_cover.py
+++ b/tests/components/linear_garage_door/test_cover.py
@@ -22,7 +22,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 
@@ -106,7 +106,9 @@ async def test_update_cover_state(
     assert hass.states.get("cover.test_garage_1").state == CoverState.OPEN
     assert hass.states.get("cover.test_garage_2").state == CoverState.CLOSED
 
-    device_states = load_json_object_fixture("get_device_state_1.json", DOMAIN)
+    device_states = await async_load_json_object_fixture(
+        hass, "get_device_state_1.json", DOMAIN
+    )
     mock_linear.get_device_state.side_effect = lambda device_id: device_states[
         device_id
     ]

--- a/tests/components/linear_garage_door/test_light.py
+++ b/tests/components/linear_garage_door/test_light.py
@@ -27,7 +27,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 
@@ -112,7 +112,9 @@ async def test_update_light_state(
     assert hass.states.get("light.test_garage_1_light").state == STATE_ON
     assert hass.states.get("light.test_garage_2_light").state == STATE_OFF
 
-    device_states = load_json_object_fixture("get_device_state_1.json", DOMAIN)
+    device_states = await async_load_json_object_fixture(
+        hass, "get_device_state_1.json", DOMAIN
+    )
     mock_linear.get_device_state.side_effect = lambda device_id: device_states[
         device_id
     ]

--- a/tests/components/media_extractor/test_init.py
+++ b/tests/components/media_extractor/test_init.py
@@ -22,7 +22,7 @@ from homeassistant.setup import async_setup_component
 from . import YOUTUBE_EMPTY_PLAYLIST, YOUTUBE_PLAYLIST, YOUTUBE_VIDEO, MockYoutubeDL
 from .const import NO_FORMATS_RESPONSE, SOUNDCLOUD_TRACK
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 async def test_play_media_service_is_registered(hass: HomeAssistant) -> None:
@@ -253,8 +253,8 @@ async def test_query_error(
     with (
         patch(
             "homeassistant.components.media_extractor.YoutubeDL.extract_info",
-            return_value=load_json_object_fixture(
-                "media_extractor/youtube_1_info.json"
+            return_value=await async_load_json_object_fixture(
+                hass, "youtube_1_info.json", DOMAIN
             ),
         ),
         patch(

--- a/tests/components/melissa/conftest.py
+++ b/tests/components/melissa/conftest.py
@@ -4,24 +4,27 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from tests.common import load_json_object_fixture
+from homeassistant.components.melissa import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import async_load_json_object_fixture
 
 
 @pytest.fixture
-async def mock_melissa():
+async def mock_melissa(hass: HomeAssistant):
     """Mock the Melissa API."""
     with patch(
         "homeassistant.components.melissa.AsyncMelissa", autospec=True
     ) as mock_client:
         mock_client.return_value.async_connect = AsyncMock()
         mock_client.return_value.async_fetch_devices.return_value = (
-            load_json_object_fixture("fetch_devices.json", "melissa")
+            await async_load_json_object_fixture(hass, "fetch_devices.json", DOMAIN)
         )
-        mock_client.return_value.async_status.return_value = load_json_object_fixture(
-            "status.json", "melissa"
+        mock_client.return_value.async_status.return_value = (
+            await async_load_json_object_fixture(hass, "status.json", DOMAIN)
         )
         mock_client.return_value.async_cur_settings.return_value = (
-            load_json_object_fixture("cur_settings.json", "melissa")
+            await async_load_json_object_fixture(hass, "cur_settings.json", DOMAIN)
         )
 
         mock_client.return_value.STATE_OFF = 0

--- a/tests/components/miele/conftest.py
+++ b/tests/components/miele/conftest.py
@@ -18,7 +18,11 @@ from homeassistant.setup import async_setup_component
 from . import get_actions_callback, get_data_callback
 from .const import CLIENT_ID, CLIENT_SECRET
 
-from tests.common import MockConfigEntry, load_fixture, load_json_object_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_load_fixture,
+    async_load_json_object_fixture,
+)
 
 
 @pytest.fixture(name="expires_at")
@@ -75,9 +79,9 @@ def load_device_file() -> str:
 
 
 @pytest.fixture
-def device_fixture(load_device_file: str) -> MieleDevices:
+async def device_fixture(hass: HomeAssistant, load_device_file: str) -> MieleDevices:
     """Fixture for device."""
-    return load_json_object_fixture(load_device_file, DOMAIN)
+    return await async_load_json_object_fixture(hass, load_device_file, DOMAIN)
 
 
 @pytest.fixture(scope="package")
@@ -87,9 +91,9 @@ def load_action_file() -> str:
 
 
 @pytest.fixture
-def action_fixture(load_action_file: str) -> MieleAction:
+async def action_fixture(hass: HomeAssistant, load_action_file: str) -> MieleAction:
     """Fixture for action."""
-    return load_json_object_fixture(load_action_file, DOMAIN)
+    return await async_load_json_object_fixture(hass, load_action_file, DOMAIN)
 
 
 @pytest.fixture(scope="package")
@@ -99,9 +103,9 @@ def load_programs_file() -> str:
 
 
 @pytest.fixture
-def programs_fixture(load_programs_file: str) -> list[dict]:
+async def programs_fixture(hass: HomeAssistant, load_programs_file: str) -> list[dict]:
     """Fixture for available programs."""
-    return load_fixture(load_programs_file, DOMAIN)
+    return await async_load_fixture(hass, load_programs_file, DOMAIN)
 
 
 @pytest.fixture
@@ -172,7 +176,7 @@ async def push_data_and_actions(
     await data_callback(device_fixture)
     await hass.async_block_till_done()
 
-    act_file = load_json_object_fixture("4_actions.json", DOMAIN)
+    act_file = await async_load_json_object_fixture(hass, "4_actions.json", DOMAIN)
     action_callback = get_actions_callback(mock_miele_client)
     await action_callback(act_file)
     await hass.async_block_till_done()

--- a/tests/components/miele/test_init.py
+++ b/tests/components/miele/test_init.py
@@ -22,7 +22,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
 )
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import WebSocketGenerator
@@ -195,10 +195,10 @@ async def test_setup_all_platforms(
     assert hass.states.get("switch.washing_machine_power").state == "off"
 
     # Add two devices and let the clock tick for 130 seconds
-    freezer.tick(timedelta(seconds=130))
-    mock_miele_client.get_devices.return_value = load_json_object_fixture(
-        "5_devices.json", DOMAIN
+    mock_miele_client.get_devices.return_value = await async_load_json_object_fixture(
+        hass, "5_devices.json", DOMAIN
     )
+    freezer.tick(timedelta(seconds=130))
 
     async_fire_time_changed(hass)
     await hass.async_block_till_done()

--- a/tests/components/miele/test_vacuum.py
+++ b/tests/components/miele/test_vacuum.py
@@ -24,7 +24,11 @@ from homeassistant.helpers import entity_registry as er
 
 from . import get_actions_callback, get_data_callback
 
-from tests.common import MockConfigEntry, load_json_object_fixture, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_object_fixture,
+    snapshot_platform,
+)
 
 TEST_PLATFORM = VACUUM_DOMAIN
 ENTITY_ID = "vacuum.robot_vacuum_cleaner"
@@ -64,7 +68,9 @@ async def test_vacuum_states_api_push(
     await data_callback(device_fixture)
     await hass.async_block_till_done()
 
-    act_file = load_json_object_fixture("action_push_vacuum.json", DOMAIN)
+    act_file = await async_load_json_object_fixture(
+        hass, "action_push_vacuum.json", DOMAIN
+    )
     action_callback = get_actions_callback(mock_miele_client)
     await action_callback(act_file)
     await hass.async_block_till_done()

--- a/tests/components/nam/__init__.py
+++ b/tests/components/nam/__init__.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from homeassistant.components.nam.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 INCOMPLETE_NAM_DATA = {
     "software_version": "NAMF-2020-36",
@@ -24,7 +24,7 @@ async def init_integration(
         data={"host": "10.10.2.3"},
     )
 
-    nam_data = load_json_object_fixture("nam/nam_data.json")
+    nam_data = await async_load_json_object_fixture(hass, "nam_data.json", DOMAIN)
 
     if not co2_sensor:
         # Remove conc_co2_ppm value

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -28,7 +28,7 @@ from . import INCOMPLETE_NAM_DATA, init_integration
 
 from tests.common import (
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 
@@ -103,7 +103,7 @@ async def test_availability(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, exc: Exception
 ) -> None:
     """Ensure that we mark the entities unavailable correctly when device causes an error."""
-    nam_data = load_json_object_fixture("nam/nam_data.json")
+    nam_data = await async_load_json_object_fixture(hass, "nam_data.json", DOMAIN)
 
     await init_integration(hass)
 
@@ -147,7 +147,7 @@ async def test_availability(
 
 async def test_manual_update_entity(hass: HomeAssistant) -> None:
     """Test manual update entity via service homeasasistant/update_entity."""
-    nam_data = load_json_object_fixture("nam/nam_data.json")
+    nam_data = await async_load_json_object_fixture(hass, "nam_data.json", DOMAIN)
 
     await init_integration(hass)
 

--- a/tests/components/nice_go/test_cover.py
+++ b/tests/components/nice_go/test_cover.py
@@ -22,7 +22,11 @@ from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, load_json_object_fixture, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_object_fixture,
+    snapshot_platform,
+)
 
 
 async def test_covers(
@@ -104,9 +108,13 @@ async def test_update_cover_state(
     assert hass.states.get("cover.test_garage_1").state == CoverState.CLOSED
     assert hass.states.get("cover.test_garage_2").state == CoverState.OPEN
 
-    device_update = load_json_object_fixture("device_state_update.json", DOMAIN)
+    device_update = await async_load_json_object_fixture(
+        hass, "device_state_update.json", DOMAIN
+    )
     await mock_config_entry.runtime_data.on_data(device_update)
-    device_update_1 = load_json_object_fixture("device_state_update_1.json", DOMAIN)
+    device_update_1 = await async_load_json_object_fixture(
+        hass, "device_state_update_1.json", DOMAIN
+    )
     await mock_config_entry.runtime_data.on_data(device_update_1)
 
     assert hass.states.get("cover.test_garage_1").state == CoverState.OPENING

--- a/tests/components/nice_go/test_light.py
+++ b/tests/components/nice_go/test_light.py
@@ -20,7 +20,11 @@ from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, load_json_object_fixture, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_object_fixture,
+    snapshot_platform,
+)
 
 
 async def test_data(
@@ -84,9 +88,13 @@ async def test_update_light_state(
     assert hass.states.get("light.test_garage_2_light").state == STATE_OFF
     assert hass.states.get("light.test_garage_3_light") is None
 
-    device_update = load_json_object_fixture("device_state_update.json", DOMAIN)
+    device_update = await async_load_json_object_fixture(
+        hass, "device_state_update.json", DOMAIN
+    )
     await mock_config_entry.runtime_data.on_data(device_update)
-    device_update_1 = load_json_object_fixture("device_state_update_1.json", DOMAIN)
+    device_update_1 = await async_load_json_object_fixture(
+        hass, "device_state_update_1.json", DOMAIN
+    )
     await mock_config_entry.runtime_data.on_data(device_update_1)
 
     assert hass.states.get("light.test_garage_1_light").state == STATE_OFF

--- a/tests/components/opensky/conftest.py
+++ b/tests/components/opensky/conftest.py
@@ -18,8 +18,9 @@ from homeassistant.const import (
     CONF_RADIUS,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 @pytest.fixture
@@ -87,7 +88,7 @@ def mock_config_entry_authenticated() -> MockConfigEntry:
 
 
 @pytest.fixture
-async def opensky_client() -> AsyncGenerator[AsyncMock]:
+async def opensky_client(hass: HomeAssistant) -> AsyncGenerator[AsyncMock]:
     """Mock the OpenSky client."""
     with (
         patch(
@@ -101,7 +102,7 @@ async def opensky_client() -> AsyncGenerator[AsyncMock]:
     ):
         client = mock_client.return_value
         client.get_states.return_value = StatesResponse.from_api(
-            load_json_object_fixture("states.json", DOMAIN)
+            await async_load_json_object_fixture(hass, "states.json", DOMAIN)
         )
         client.is_authenticated = False
         yield client

--- a/tests/components/opensky/test_sensor.py
+++ b/tests/components/opensky/test_sensor.py
@@ -19,7 +19,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
 )
 
 
@@ -83,10 +83,10 @@ async def test_sensor_updating(
         assert events == snapshot
 
     opensky_client.get_states.return_value = StatesResponse.from_api(
-        load_json_object_fixture("states_1.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "states_1.json", DOMAIN)
     )
     await skip_time_and_check_events()
     opensky_client.get_states.return_value = StatesResponse.from_api(
-        load_json_object_fixture("states.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "states.json", DOMAIN)
     )
     await skip_time_and_check_events()

--- a/tests/components/overseerr/test_event.py
+++ b/tests/components/overseerr/test_event.py
@@ -19,7 +19,7 @@ from . import call_webhook, setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 from tests.typing import ClientSessionGenerator
@@ -42,7 +42,9 @@ async def test_entities(
 
     await call_webhook(
         hass,
-        load_json_object_fixture("webhook_request_automatically_approved.json", DOMAIN),
+        await async_load_json_object_fixture(
+            hass, "webhook_request_automatically_approved.json", DOMAIN
+        ),
         client,
     )
     await hass.async_block_till_done()
@@ -65,7 +67,9 @@ async def test_event_does_not_write_state(
 
     await call_webhook(
         hass,
-        load_json_object_fixture("webhook_request_automatically_approved.json", DOMAIN),
+        await async_load_json_object_fixture(
+            hass, "webhook_request_automatically_approved.json", DOMAIN
+        ),
         client,
     )
     await hass.async_block_till_done()

--- a/tests/components/overseerr/test_sensor.py
+++ b/tests/components/overseerr/test_sensor.py
@@ -11,7 +11,11 @@ from homeassistant.helpers import entity_registry as er
 
 from . import call_webhook, setup_integration
 
-from tests.common import MockConfigEntry, load_json_object_fixture, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_object_fixture,
+    snapshot_platform,
+)
 from tests.typing import ClientSessionGenerator
 
 
@@ -45,7 +49,9 @@ async def test_webhook_trigger_update(
 
     await call_webhook(
         hass,
-        load_json_object_fixture("webhook_request_automatically_approved.json", DOMAIN),
+        await async_load_json_object_fixture(
+            hass, "webhook_request_automatically_approved.json", DOMAIN
+        ),
         client,
     )
     await hass.async_block_till_done()

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -20,10 +20,11 @@ from samsungtvws.exceptions import ResponseError
 from samsungtvws.remote import ChannelEmitCommand
 
 from homeassistant.components.samsungtv.const import DOMAIN, WEBSOCKET_SSL_PORT
+from homeassistant.core import HomeAssistant
 
 from .const import SAMPLE_DEVICE_INFO_WIFI
 
-from tests.common import load_json_object_fixture
+from tests.common import async_load_json_object_fixture
 
 
 @pytest.fixture
@@ -174,7 +175,7 @@ def rest_api_fixture() -> Generator[Mock]:
 
 
 @pytest.fixture(name="rest_api_non_ssl_only")
-def rest_api_fixture_non_ssl_only() -> Generator[None]:
+def rest_api_fixture_non_ssl_only(hass: HomeAssistant) -> Generator[None]:
     """Patch the samsungtvws SamsungTVAsyncRest non-ssl only."""
 
     class MockSamsungTVAsyncRest:
@@ -189,7 +190,9 @@ def rest_api_fixture_non_ssl_only() -> Generator[None]:
             """Mock rest_device_info to fail for ssl and work for non-ssl."""
             if self.port == WEBSOCKET_SSL_PORT:
                 raise ResponseError
-            return load_json_object_fixture("device_info_UE48JU6400.json", DOMAIN)
+            return await async_load_json_object_fixture(
+                hass, "device_info_UE48JU6400.json", DOMAIN
+            )
 
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -68,7 +68,7 @@ from .const import (
     MOCK_SSDP_DATA_RENDERING_CONTROL_ST,
 )
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 RESULT_ALREADY_CONFIGURED = "already_configured"
 RESULT_ALREADY_IN_PROGRESS = "already_in_progress"
@@ -896,8 +896,8 @@ async def test_dhcp_wireless(hass: HomeAssistant) -> None:
 async def test_dhcp_wired(hass: HomeAssistant, rest_api: Mock) -> None:
     """Test starting a flow from dhcp."""
     # Even though it is named "wifiMac", it matches the mac of the wired connection
-    rest_api.rest_device_info.return_value = load_json_object_fixture(
-        "device_info_UE43LS003.json", DOMAIN
+    rest_api.rest_device_info.return_value = await async_load_json_object_fixture(
+        hass, "device_info_UE43LS003.json", DOMAIN
     )
     # confirm to add the entry
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/samsungtv/test_diagnostics.py
+++ b/tests/components/samsungtv/test_diagnostics.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from . import setup_samsungtv_entry
 from .const import ENTRYDATA_ENCRYPTED_WEBSOCKET, ENTRYDATA_WEBSOCKET
 
-from tests.common import load_json_object_fixture
+from tests.common import async_load_json_object_fixture
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
@@ -40,8 +40,8 @@ async def test_entry_diagnostics_encrypted(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
-    rest_api.rest_device_info.return_value = load_json_object_fixture(
-        "device_info_UE48JU6400.json", DOMAIN
+    rest_api.rest_device_info.return_value = await async_load_json_object_fixture(
+        hass, "device_info_UE48JU6400.json", DOMAIN
     )
     config_entry = await setup_samsungtv_entry(hass, ENTRYDATA_ENCRYPTED_WEBSOCKET)
 

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -31,7 +31,7 @@ from .const import (
     MOCK_SSDP_DATA_RENDERING_CONTROL_ST,
 )
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 @pytest.mark.parametrize(
@@ -65,8 +65,8 @@ async def test_setup_h_j_model(
     hass: HomeAssistant, rest_api: Mock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test Samsung TV integration is setup."""
-    rest_api.rest_device_info.return_value = load_json_object_fixture(
-        "device_info_UE48JU6400.json", DOMAIN
+    rest_api.rest_device_info.return_value = await async_load_json_object_fixture(
+        hass, "device_info_UE48JU6400.json", DOMAIN
     )
     entry = await setup_samsungtv_entry(
         hass, {**ENTRYDATA_WEBSOCKET, CONF_MODEL: "UE48JU6400"}

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -90,7 +90,7 @@ from .const import (
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
 )
 
 ENTITY_ID = f"{MP_DOMAIN}.mock_title"
@@ -708,8 +708,8 @@ async def test_turn_off_websocket(
     hass: HomeAssistant, remote_websocket: Mock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test for turn_off."""
-    remote_websocket.app_list_data = load_json_object_fixture(
-        "ws_installed_app_event.json", DOMAIN
+    remote_websocket.app_list_data = await async_load_json_object_fixture(
+        hass, "ws_installed_app_event.json", DOMAIN
     )
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -749,8 +749,8 @@ async def test_turn_off_websocket_frame(
     hass: HomeAssistant, remote_websocket: Mock, rest_api: Mock
 ) -> None:
     """Test for turn_off."""
-    rest_api.rest_device_info.return_value = load_json_object_fixture(
-        "device_info_UE43LS003.json", DOMAIN
+    rest_api.rest_device_info.return_value = await async_load_json_object_fixture(
+        hass, "device_info_UE43LS003.json", DOMAIN
     )
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -1173,8 +1173,8 @@ async def test_play_media_app(hass: HomeAssistant, remote_websocket: Mock) -> No
 @pytest.mark.usefixtures("rest_api")
 async def test_select_source_app(hass: HomeAssistant, remote_websocket: Mock) -> None:
     """Test for select_source."""
-    remote_websocket.app_list_data = load_json_object_fixture(
-        "ws_installed_app_event.json", DOMAIN
+    remote_websocket.app_list_data = await async_load_json_object_fixture(
+        hass, "ws_installed_app_event.json", DOMAIN
     )
     await setup_samsungtv_entry(hass, MOCK_CONFIGWS)
     remote_websocket.send_commands.reset_mock()

--- a/tests/components/shelly/test_devices.py
+++ b/tests/components/shelly/test_devices.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_registry import EntityRegistry
 
 from . import init_integration
 
-from tests.common import load_json_object_fixture
+from tests.common import async_load_json_object_fixture
 
 
 async def test_shelly_2pm_gen3_no_relay_names(
@@ -27,7 +27,7 @@ async def test_shelly_2pm_gen3_no_relay_names(
     This device has two relays/channels,we should get a main device and two sub
     devices.
     """
-    device_fixture = load_json_object_fixture("2pm_gen3.json", DOMAIN)
+    device_fixture = await async_load_json_object_fixture(hass, "2pm_gen3.json", DOMAIN)
     monkeypatch.setattr(mock_rpc_device, "shelly", device_fixture["shelly"])
     monkeypatch.setattr(mock_rpc_device, "status", device_fixture["status"])
     monkeypatch.setattr(mock_rpc_device, "config", device_fixture["config"])
@@ -110,7 +110,7 @@ async def test_shelly_2pm_gen3_relay_names(
     This device has two relays/channels,we should get a main device and two sub
     devices.
     """
-    device_fixture = load_json_object_fixture("2pm_gen3.json", DOMAIN)
+    device_fixture = await async_load_json_object_fixture(hass, "2pm_gen3.json", DOMAIN)
     device_fixture["config"]["switch:0"]["name"] = "Kitchen light"
     device_fixture["config"]["switch:1"]["name"] = "Living room light"
     monkeypatch.setattr(mock_rpc_device, "shelly", device_fixture["shelly"])
@@ -194,7 +194,9 @@ async def test_shelly_2pm_gen3_cover(
 
     With the cover profile we should only get the main device and no subdevices.
     """
-    device_fixture = load_json_object_fixture("2pm_gen3_cover.json", DOMAIN)
+    device_fixture = await async_load_json_object_fixture(
+        hass, "2pm_gen3_cover.json", DOMAIN
+    )
     monkeypatch.setattr(mock_rpc_device, "shelly", device_fixture["shelly"])
     monkeypatch.setattr(mock_rpc_device, "status", device_fixture["status"])
     monkeypatch.setattr(mock_rpc_device, "config", device_fixture["config"])
@@ -249,7 +251,9 @@ async def test_shelly_2pm_gen3_cover_with_name(
 
     With the cover profile we should only get the main device and no subdevices.
     """
-    device_fixture = load_json_object_fixture("2pm_gen3_cover.json", DOMAIN)
+    device_fixture = await async_load_json_object_fixture(
+        hass, "2pm_gen3_cover.json", DOMAIN
+    )
     device_fixture["config"]["cover:0"]["name"] = "Bedroom blinds"
     monkeypatch.setattr(mock_rpc_device, "shelly", device_fixture["shelly"])
     monkeypatch.setattr(mock_rpc_device, "status", device_fixture["status"])
@@ -305,7 +309,7 @@ async def test_shelly_pro_3em(
 
     We should get the main device and three subdevices, one subdevice per one phase.
     """
-    device_fixture = load_json_object_fixture("pro_3em.json", DOMAIN)
+    device_fixture = await async_load_json_object_fixture(hass, "pro_3em.json", DOMAIN)
     monkeypatch.setattr(mock_rpc_device, "shelly", device_fixture["shelly"])
     monkeypatch.setattr(mock_rpc_device, "status", device_fixture["status"])
     monkeypatch.setattr(mock_rpc_device, "config", device_fixture["config"])
@@ -376,7 +380,7 @@ async def test_shelly_pro_3em_with_emeter_name(
 
     We should get the main device and three subdevices, one subdevice per one phase.
     """
-    device_fixture = load_json_object_fixture("pro_3em.json", DOMAIN)
+    device_fixture = await async_load_json_object_fixture(hass, "pro_3em.json", DOMAIN)
     device_fixture["config"]["em:0"]["name"] = "Emeter name"
     monkeypatch.setattr(mock_rpc_device, "shelly", device_fixture["shelly"])
     monkeypatch.setattr(mock_rpc_device, "status", device_fixture["status"])

--- a/tests/components/smartthings/test_diagnostics.py
+++ b/tests/components/smartthings/test_diagnostics.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
     get_diagnostics_for_device,
@@ -31,7 +31,9 @@ async def test_config_entry_diagnostics(
 ) -> None:
     """Test generating diagnostics for a device entry."""
     mock_smartthings.get_raw_devices.return_value = [
-        load_json_object_fixture("devices/da_ac_rac_000001.json", DOMAIN)
+        await async_load_json_object_fixture(
+            hass, "devices/da_ac_rac_000001.json", DOMAIN
+        )
     ]
     await setup_integration(hass, mock_config_entry)
     assert (
@@ -51,12 +53,15 @@ async def test_device_diagnostics(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test generating diagnostics for a device entry."""
-    mock_smartthings.get_raw_device_status.return_value = load_json_object_fixture(
-        "device_status/da_ac_rac_000001.json", DOMAIN
+    mock_smartthings.get_raw_device_status.return_value = (
+        await async_load_json_object_fixture(
+            hass, "device_status/da_ac_rac_000001.json", DOMAIN
+        )
     )
-    mock_smartthings.get_raw_device.return_value = load_json_object_fixture(
-        "devices/da_ac_rac_000001.json", DOMAIN
-    )["items"][0]
+    device_items = await async_load_json_object_fixture(
+        hass, "devices/da_ac_rac_000001.json", DOMAIN
+    )
+    mock_smartthings.get_raw_device.return_value = device_items["items"][0]
     await setup_integration(hass, mock_config_entry)
 
     device = device_registry.async_get_device(

--- a/tests/components/smlight/test_button.py
+++ b/tests/components/smlight/test_button.py
@@ -17,7 +17,7 @@ from .conftest import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
 )
 
 
@@ -104,7 +104,7 @@ async def test_zigbee2_router_button(
     """Test creation of second radio router button (if available)."""
     mock_smlight_client.get_info.side_effect = None
     mock_smlight_client.get_info.return_value = Info.from_dict(
-        load_json_object_fixture("info-MR1.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
     )
     await setup_integration(hass, mock_config_entry)
 

--- a/tests/components/smlight/test_sensor.py
+++ b/tests/components/smlight/test_sensor.py
@@ -13,7 +13,11 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import setup_integration
 
-from tests.common import MockConfigEntry, load_json_object_fixture, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_load_json_object_fixture,
+    snapshot_platform,
+)
 
 pytestmark = [
     pytest.mark.usefixtures(
@@ -98,7 +102,7 @@ async def test_zigbee_type_sensors(
     """Test for zigbee type sensor with second radio."""
     mock_smlight_client.get_info.side_effect = None
     mock_smlight_client.get_info.return_value = Info.from_dict(
-        load_json_object_fixture("info-MR1.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
     )
     await setup_integration(hass, mock_config_entry)
 

--- a/tests/components/smlight/test_update.py
+++ b/tests/components/smlight/test_update.py
@@ -30,7 +30,7 @@ from .conftest import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 from tests.typing import WebSocketGenerator
@@ -154,7 +154,9 @@ async def test_update_zigbee2_firmware(
     mock_smlight_client: MagicMock,
 ) -> None:
     """Test update of zigbee2 firmware where available."""
-    mock_info = Info.from_dict(load_json_object_fixture("info-MR1.json", DOMAIN))
+    mock_info = Info.from_dict(
+        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
+    )
     mock_smlight_client.get_info.side_effect = None
     mock_smlight_client.get_info.return_value = mock_info
     await setup_integration(hass, mock_config_entry)
@@ -338,7 +340,7 @@ async def test_update_release_notes(
     """Test firmware release notes."""
     mock_smlight_client.get_info.side_effect = None
     mock_smlight_client.get_info.return_value = Info.from_dict(
-        load_json_object_fixture("info-MR1.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
     )
     await setup_integration(hass, mock_config_entry)
     ws_client = await hass_ws_client(hass)

--- a/tests/components/technove/test_sensor.py
+++ b/tests/components/technove/test_sensor.py
@@ -18,7 +18,7 @@ from . import setup_with_selected_platforms
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
 )
 
 
@@ -113,7 +113,7 @@ async def test_sensor_unknown_status(
     assert hass.states.get(entity_id).state == Status.PLUGGED_CHARGING.value
 
     mock_technove.update.return_value = Station(
-        load_json_object_fixture("station_bad_status.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "station_bad_status.json", DOMAIN)
     )
 
     freezer.tick(timedelta(minutes=5, seconds=1))

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.setup import async_setup_component
 from . import GATEWAY_ID, GATEWAY_ID1, GATEWAY_ID2
 from .common import CommandStore
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 async def test_entry_setup_unload(
@@ -118,7 +118,7 @@ async def test_migrate_config_entry_and_identifiers(
 
     gateway1 = mock_gateway_fixture(command_store, GATEWAY_ID1)
     command_store.register_device(
-        gateway1, load_json_object_fixture("bulb_w.json", DOMAIN)
+        gateway1, await async_load_json_object_fixture(hass, "bulb_w.json", DOMAIN)
     )
     config_entry1.add_to_hass(hass)
 

--- a/tests/components/twitch/test_sensor.py
+++ b/tests/components/twitch/test_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 
 from . import TwitchIterObject, get_generator_from_data, setup_integration
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 ENTITY_ID = "sensor.channel123"
 
@@ -72,8 +72,11 @@ async def test_oauth_with_sub(
     twitch_mock.return_value.get_followed_channels.return_value = TwitchIterObject(
         "empty_response.json", FollowedChannel
     )
+    subscription = await async_load_json_object_fixture(
+        hass, "check_user_subscription_2.json", DOMAIN
+    )
     twitch_mock.return_value.check_user_subscription.return_value = UserSubscription(
-        **load_json_object_fixture("check_user_subscription_2.json", DOMAIN)
+        **subscription
     )
     await setup_integration(hass, config_entry)
 

--- a/tests/components/webmin/conftest.py
+++ b/tests/components/webmin/conftest.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 TEST_USER_INPUT = {
     CONF_HOST: "192.168.1.1",
@@ -46,7 +46,8 @@ async def async_init_integration(
 
     with patch(
         "homeassistant.components.webmin.helpers.WebminInstance.update",
-        return_value=load_json_object_fixture(
+        return_value=await async_load_json_object_fixture(
+            hass,
             "webmin_update.json"
             if with_mac_address
             else "webmin_update_without_mac.json",

--- a/tests/components/webmin/test_config_flow.py
+++ b/tests/components/webmin/test_config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import TEST_USER_INPUT
 
-from tests.common import load_json_object_fixture
+from tests.common import async_load_json_object_fixture
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -42,7 +42,7 @@ async def test_form_user(
     """Test a successful user initiated flow."""
     with patch(
         "homeassistant.components.webmin.helpers.WebminInstance.update",
-        return_value=load_json_object_fixture(fixture, DOMAIN),
+        return_value=await async_load_json_object_fixture(hass, fixture, DOMAIN),
     ):
         result = await hass.config_entries.flow.async_configure(
             user_flow, TEST_USER_INPUT
@@ -96,7 +96,9 @@ async def test_form_user_errors(
 
     with patch(
         "homeassistant.components.webmin.helpers.WebminInstance.update",
-        return_value=load_json_object_fixture("webmin_update.json", DOMAIN),
+        return_value=await async_load_json_object_fixture(
+            hass, "webmin_update.json", DOMAIN
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_USER_INPUT
@@ -115,7 +117,9 @@ async def test_duplicate_entry(
     """Test a successful user initiated flow."""
     with patch(
         "homeassistant.components.webmin.helpers.WebminInstance.update",
-        return_value=load_json_object_fixture("webmin_update.json", DOMAIN),
+        return_value=await async_load_json_object_fixture(
+            hass, "webmin_update.json", DOMAIN
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             user_flow, TEST_USER_INPUT
@@ -128,7 +132,9 @@ async def test_duplicate_entry(
 
     with patch(
         "homeassistant.components.webmin.helpers.WebminInstance.update",
-        return_value=load_json_object_fixture("webmin_update.json", DOMAIN),
+        return_value=await async_load_json_object_fixture(
+            hass, "webmin_update.json", DOMAIN
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -42,7 +42,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_object_fixture,
+    async_load_json_object_fixture,
 )
 
 pytestmark = pytest.mark.usefixtures("init_integration")
@@ -202,7 +202,7 @@ async def test_dynamically_handle_segments(
 
     return_value = mock_wled.update.return_value
     mock_wled.update.return_value = WLEDDevice.from_dict(
-        load_json_object_fixture("rgb.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "rgb.json", DOMAIN)
     )
 
     freezer.tick(SCAN_INTERVAL)

--- a/tests/components/wled/test_number.py
+++ b/tests/components/wled/test_number.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from tests.common import async_fire_time_changed, load_json_object_fixture
+from tests.common import async_fire_time_changed, async_load_json_object_fixture
 
 pytestmark = pytest.mark.usefixtures("init_integration")
 
@@ -128,7 +128,7 @@ async def test_speed_dynamically_handle_segments(
     # Test adding a segment dynamically...
     return_value = mock_wled.update.return_value
     mock_wled.update.return_value = WLEDDevice.from_dict(
-        load_json_object_fixture("rgb.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "rgb.json", DOMAIN)
     )
 
     freezer.tick(SCAN_INTERVAL)

--- a/tests/components/wled/test_select.py
+++ b/tests/components/wled/test_select.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from tests.common import async_fire_time_changed, load_json_object_fixture
+from tests.common import async_fire_time_changed, async_load_json_object_fixture
 
 pytestmark = pytest.mark.usefixtures("init_integration")
 
@@ -130,7 +130,7 @@ async def test_color_palette_dynamically_handle_segments(
 
     return_value = mock_wled.update.return_value
     mock_wled.update.return_value = WLEDDevice.from_dict(
-        load_json_object_fixture("rgb.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "rgb.json", DOMAIN)
     )
 
     freezer.tick(SCAN_INTERVAL)

--- a/tests/components/wled/test_switch.py
+++ b/tests/components/wled/test_switch.py
@@ -21,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from tests.common import async_fire_time_changed, load_json_object_fixture
+from tests.common import async_fire_time_changed, async_load_json_object_fixture
 
 pytestmark = pytest.mark.usefixtures("init_integration")
 
@@ -144,7 +144,7 @@ async def test_switch_dynamically_handle_segments(
     # Test adding a segment dynamically...
     return_value = mock_wled.update.return_value
     mock_wled.update.return_value = WLEDDevice.from_dict(
-        load_json_object_fixture("rgb.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "rgb.json", DOMAIN)
     )
 
     freezer.tick(SCAN_INTERVAL)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as follow-up to #144534 and needed for #145709

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
