### PR TITLE
Add freebox port forwarding config switches

### DIFF
--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -10,6 +10,7 @@ from freebox_api.exceptions import InsufficientPermissionsError
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .router import FreeboxConfigEntry, FreeboxRouter
@@ -25,6 +26,16 @@ SWITCH_DESCRIPTIONS = [
     )
 ]
 
+PORT_FORWARDING_SWITCH_DESCRIPTIONS = [
+    SwitchEntityDescription(
+        key="port_forwarding",
+        name="Port Forwarding",
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:forwardburger",
+        entity_registry_enabled_default=False,
+    )
+]
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -33,10 +44,20 @@ async def async_setup_entry(
 ) -> None:
     """Set up the switch."""
     router = entry.runtime_data
-    entities = [
-        FreeboxSwitch(router, entity_description)
-        for entity_description in SWITCH_DESCRIPTIONS
-    ]
+    entities: list[SwitchEntity] = []
+    entities.extend(
+        [
+            FreeboxSwitch(router, entity_description)
+            for entity_description in SWITCH_DESCRIPTIONS
+        ]
+    )
+    for config in router.port_forwarding_config.values():
+        entities.extend(
+            [
+                FreeboxPortForwardingSwitch(router, config, entity_description)
+                for entity_description in PORT_FORWARDING_SWITCH_DESCRIPTIONS
+            ]
+        )
     async_add_entities(entities, True)
 
 
@@ -74,3 +95,57 @@ class FreeboxSwitch(SwitchEntity):
         """Get the state and update it."""
         data = await self._router.wifi.get_global_config()
         self._attr_is_on = bool(data["enabled"])
+
+
+class FreeboxPortForwardingSwitch(SwitchEntity):
+    """Representation of a freebox switch."""
+
+    def __init__(
+        self,
+        router: FreeboxRouter,
+        config: dict[str, Any],
+        entity_description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch."""
+        self.entity_description = entity_description
+        self._router = router
+        self._attr_device_info = router.device_info
+        self._attr_unique_id = f"{router.mac} {entity_description.name} {config['id']}"
+        self._attr_name = f"{entity_description.name} {config['id']}"
+        self._redir_id = config["id"]
+
+    async def _async_set_state(self, enabled: bool) -> None:
+        """Turn the switch on or off."""
+        try:
+            await self._router.port_forwarding.edit_port_forwarding_configuration(
+                self._redir_id, {"enabled": enabled}
+            )
+            await self._router.update_port_forwarding_configs()
+            await self.async_update()
+        except InsufficientPermissionsError as err:
+            raise HomeAssistantError(
+                "Home Assistant does not have permissions to modify the Freebox"
+                " settings. Please refer to documentation"
+            ) from err
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self._async_set_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self._async_set_state(False)
+
+    async def async_update(self) -> None:
+        """Get the state and update it."""
+        data = self._router.port_forwarding_config.get(self._redir_id, {})
+        self._attr_is_on = bool(data.get("enabled", False))
+        self._attr_extra_state_attributes = {
+            "comment": data.get("comment"),
+            "source": data.get("src_ip"),
+            "destination": data.get("lan_ip"),
+            "hostname": data.get("hostname"),
+            "port_start": data.get("wan_port_start"),
+            "port_end": data.get("wan_port_end"),
+            "port_destination": data.get("lan_port"),
+        }

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from freebox_api.exceptions import InsufficientPermissionsError
+from freebox_api.exceptions import HttpRequestError, InsufficientPermissionsError
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
@@ -127,6 +127,8 @@ class FreeboxPortForwardingSwitch(SwitchEntity):
                 "Home Assistant does not have permissions to modify the Freebox"
                 " settings. Please refer to documentation"
             ) from err
+        except HttpRequestError as err:
+            raise HomeAssistantError(err) from err
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""

--- a/tests/components/freebox/conftest.py
+++ b/tests/components/freebox/conftest.py
@@ -19,6 +19,7 @@ from .const import (
     DATA_LAN_GET_HOSTS_LIST_GUEST,
     DATA_LAN_GET_HOSTS_LIST_MODE_BRIDGE,
     DATA_LAN_GET_INTERFACES,
+    DATA_LAN_GET_PORT_FORWARDING_CONFIG_LIST,
     DATA_STORAGE_GET_DISKS,
     DATA_STORAGE_GET_RAIDS,
     DATA_SYSTEM_GET_CONFIG,
@@ -86,6 +87,9 @@ def mock_router(mock_device_registry_devices):
         # switch
         instance.wifi.get_global_config = AsyncMock(
             return_value=DATA_WIFI_GET_GLOBAL_CONFIG
+        )
+        instance.fw.get_all_port_forwarding_configuration = AsyncMock(
+            return_value=DATA_LAN_GET_PORT_FORWARDING_CONFIG_LIST
         )
         # home devices
         instance.home.get_home_nodes = AsyncMock(return_value=DATA_HOME_GET_NODES)

--- a/tests/components/freebox/const.py
+++ b/tests/components/freebox/const.py
@@ -23,6 +23,9 @@ DATA_STORAGE_GET_RAIDS = load_json_array_fixture("freebox/storage_get_raids.json
 DATA_WIFI_GET_GLOBAL_CONFIG = load_json_object_fixture(
     "freebox/wifi_get_global_config.json"
 )
+DATA_LAN_GET_PORT_FORWARDING_CONFIG_LIST = load_json_array_fixture(
+    "freebox/lan_get_port_forwarding_config_list.json"
+)
 
 # device_tracker
 DATA_LAN_GET_INTERFACES = load_json_array_fixture("freebox/lan_get_interfaces.json")

--- a/tests/components/freebox/fixtures/lan_get_port_forwarding_config_list.json
+++ b/tests/components/freebox/fixtures/lan_get_port_forwarding_config_list.json
@@ -1,0 +1,15 @@
+[
+  {
+    "enabled": true,
+    "comment": "port comment",
+    "id": 1,
+    "host": {},
+    "hostname": "android-c5fe44a2c27be1e2",
+    "lan_port": 69,
+    "wan_port_end": 69,
+    "wan_port_start": 69,
+    "lan_ip": "192.168.1.22",
+    "ip_proto": "tcp",
+    "src_ip": "8.8.8.8"
+  }
+]

--- a/tests/components/freebox/test_switch.py
+++ b/tests/components/freebox/test_switch.py
@@ -1,0 +1,50 @@
+"""Tests for the Freebox switches."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SERVICE_TOGGLE
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
+
+from .common import setup_platform
+
+
+async def test_port_forwarding(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, router: Mock
+) -> None:
+    """Test port forwarding switch."""
+    await setup_platform(hass, SWITCH_DOMAIN)
+
+    registry = er.async_get(hass)
+    entity_id = "switch.port_forwarding_1"
+
+    entity = registry.async_get(entity_id)
+    assert entity.disabled_by == "integration"
+
+    # Simulate enabling the switch
+    registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(entity.config_entry_id)
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == "on"
+
+    # Simulate toggling the switch
+    with patch(
+        "homeassistant.components.freebox.router.FreeboxRouter.port_forwarding"
+    ) as mock_service:
+        mock_service.edit_port_forwarding_configuration = AsyncMock()
+        mock_service.edit_port_forwarding_configuration.assert_not_called()
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TOGGLE,
+            service_data={
+                ATTR_ENTITY_ID: entity_id,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_service.edit_port_forwarding_configuration.assert_called_once_with(
+            1, {"enabled": False}
+        )

--- a/tests/components/freebox/test_switch.py
+++ b/tests/components/freebox/test_switch.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.entity_registry as er
 
 from .common import setup_platform
+from .const import DATA_LAN_GET_PORT_FORWARDING_CONFIG_LIST
 
 
 async def test_port_forwarding(
@@ -36,6 +37,9 @@ async def test_port_forwarding(
     ) as mock_service:
         mock_service.edit_port_forwarding_configuration = AsyncMock()
         mock_service.edit_port_forwarding_configuration.assert_not_called()
+        mock_service.get_all_port_forwarding_configuration = AsyncMock(
+            return_value=DATA_LAN_GET_PORT_FORWARDING_CONFIG_LIST
+        )
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TOGGLE,


### PR DESCRIPTION
## Proposed change

Freebox router API exposes port forwarding configuration.
This change map each port forwarding to switch entity (disabled by default).
With those switches, users can be able to disallow connection from the internet to their HomeAssistant instance.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
