### PR TITLE
Use Platform constant in hue tests

### DIFF
--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import Mock
 
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.util.json import JsonArrayType
 
@@ -15,7 +16,7 @@ async def test_binary_sensors(
     """Test if all v2 binary_sensors get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "binary_sensor")
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
     # there shouldn't have been any requests at this point
     assert len(mock_bridge_v2.mock_requests) == 0
     # 5 binary_sensors should be created from test data
@@ -86,7 +87,7 @@ async def test_binary_sensor_add_update(
 ) -> None:
     """Test if binary_sensor get added/updated from events."""
     await mock_bridge_v2.api.load_test_data([FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY])
-    await setup_platform(hass, mock_bridge_v2, "binary_sensor")
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
 
     test_entity_id = "binary_sensor.hue_mocked_device_motion"
 

--- a/tests/components/hue/test_device_trigger_v1.py
+++ b/tests/components/hue/test_device_trigger_v1.py
@@ -7,6 +7,7 @@ from pytest_unordered import unordered
 from homeassistant.components import automation, hue
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.hue.v1 import device_trigger
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -27,7 +28,9 @@ async def test_get_triggers(
 ) -> None:
     """Test we get the expected triggers from a hue remote."""
     mock_bridge_v1.mock_sensor_responses.append(REMOTES_RESPONSE)
-    await setup_platform(hass, mock_bridge_v1, ["sensor", "binary_sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.SENSOR, Platform.BINARY_SENSOR]
+    )
 
     assert len(mock_bridge_v1.mock_requests) == 1
     # 2 remotes, just 1 battery sensor
@@ -98,7 +101,9 @@ async def test_if_fires_on_state_change(
 ) -> None:
     """Test for button press trigger firing."""
     mock_bridge_v1.mock_sensor_responses.append(REMOTES_RESPONSE)
-    await setup_platform(hass, mock_bridge_v1, ["sensor", "binary_sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.SENSOR, Platform.BINARY_SENSOR]
+    )
     assert len(mock_bridge_v1.mock_requests) == 1
     assert len(hass.states.async_all()) == 1
 

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -9,6 +9,7 @@ from homeassistant.components import hue
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.hue.v2.device import async_setup_devices
 from homeassistant.components.hue.v2.hue_event import async_setup_hue_events
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.json import JsonArrayType
@@ -23,7 +24,9 @@ async def test_hue_event(
 ) -> None:
     """Test hue button events."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
-    await setup_platform(hass, mock_bridge_v2, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v2, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
     await async_setup_devices(mock_bridge_v2)
     await async_setup_hue_events(mock_bridge_v2)
 
@@ -62,7 +65,9 @@ async def test_get_triggers(
 ) -> None:
     """Test we get the expected triggers from a hue remote."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
-    await setup_platform(hass, mock_bridge_v2, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v2, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
 
     # Get triggers for `Wall switch with 2 controls`
     hue_wall_switch_device = device_registry.async_get_device(

--- a/tests/components/hue/test_event.py
+++ b/tests/components/hue/test_event.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.util.json import JsonArrayType
 
@@ -15,7 +16,7 @@ async def test_event(
 ) -> None:
     """Test event entity for Hue integration."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
-    await setup_platform(hass, mock_bridge_v2, "event")
+    await setup_platform(hass, mock_bridge_v2, Platform.EVENT)
     # 7 entities should be created from test data
     assert len(hass.states.async_all()) == 7
 
@@ -69,7 +70,7 @@ async def test_event(
 async def test_sensor_add_update(hass: HomeAssistant, mock_bridge_v2: Mock) -> None:
     """Test Event entity for newly added Relative Rotary resource."""
     await mock_bridge_v2.api.load_test_data([FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY])
-    await setup_platform(hass, mock_bridge_v2, "event")
+    await setup_platform(hass, mock_bridge_v2, Platform.EVENT)
 
     test_entity_id = "event.hue_mocked_device_rotary"
 

--- a/tests/components/hue/test_light_v1.py
+++ b/tests/components/hue/test_light_v1.py
@@ -9,6 +9,7 @@ from homeassistant.components.hue.const import CONF_ALLOW_HUE_GROUPS
 from homeassistant.components.hue.v1 import light as hue_light
 from homeassistant.components.light import ColorMode
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import color as color_util
@@ -186,7 +187,7 @@ async def setup_bridge(hass: HomeAssistant, mock_bridge_v1: Mock) -> None:
     config_entry.mock_state(hass, ConfigEntryState.LOADED)
     mock_bridge_v1.config_entry = config_entry
     config_entry.runtime_data = mock_bridge_v1
-    await hass.config_entries.async_forward_entry_setups(config_entry, ["light"])
+    await hass.config_entries.async_forward_entry_setups(config_entry, [Platform.LIGHT])
     # To flush out the service call to update the group
     await hass.async_block_till_done()
 

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -7,7 +7,7 @@ from homeassistant.components.light import (
     DOMAIN as LIGHT_DOMAIN,
     ColorMode,
 )
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.util.json import JsonArrayType
@@ -22,7 +22,7 @@ async def test_lights(
     """Test if all v2 lights get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "light")
+    await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
     # there shouldn't have been any requests at this point
     assert len(mock_bridge_v2.mock_requests) == 0
     # 8 entities should be created from test data
@@ -90,7 +90,7 @@ async def test_light_turn_on_service(
     """Test calling the turn on service on a light."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "light")
+    await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
 
     test_light_id = "light.hue_light_with_color_temperature_only"
 
@@ -276,7 +276,7 @@ async def test_light_turn_off_service(
     """Test calling the turn off service on a light."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "light")
+    await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
 
     test_light_id = "light.hue_light_with_color_and_color_temperature_1"
 
@@ -364,7 +364,7 @@ async def test_light_added(hass: HomeAssistant, mock_bridge_v2: Mock) -> None:
     """Test new light added to bridge."""
     await mock_bridge_v2.api.load_test_data([FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY])
 
-    await setup_platform(hass, mock_bridge_v2, "light")
+    await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
 
     test_entity_id = "light.hue_mocked_device"
 
@@ -388,7 +388,7 @@ async def test_light_availability(
     """Test light availability property."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "light")
+    await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
 
     test_light_id = "light.hue_light_with_color_and_color_temperature_1"
 
@@ -423,7 +423,7 @@ async def test_grouped_lights(
     """Test if all v2 grouped lights get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "light")
+    await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
 
     # test if entities for hue groups are created and enabled by default
     for entity_id in ("light.test_zone", "light.test_room"):
@@ -657,7 +657,7 @@ async def test_light_turn_on_service_deprecation(
 
     test_light_id = "light.hue_light_with_color_temperature_only"
 
-    await setup_platform(hass, mock_bridge_v2, "light")
+    await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
 
     event = {
         "id": "3a6710fa-4474-4eba-b533-5e6e72968feb",

--- a/tests/components/hue/test_scene.py
+++ b/tests/components/hue/test_scene.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock
 
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.json import JsonArrayType
@@ -20,7 +20,7 @@ async def test_scene(
     """Test if (config) scenes get created."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "scene")
+    await setup_platform(hass, mock_bridge_v2, Platform.SCENE)
     # there shouldn't have been any requests at this point
     assert len(mock_bridge_v2.mock_requests) == 0
     # 3 entities should be created from test data
@@ -80,7 +80,7 @@ async def test_scene_turn_on_service(
     """Test calling the turn on service on a scene."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "scene")
+    await setup_platform(hass, mock_bridge_v2, Platform.SCENE)
 
     test_entity_id = "scene.test_room_regular_test_scene"
 
@@ -117,7 +117,7 @@ async def test_scene_advanced_turn_on_service(
     """Test calling the advanced turn on service on a scene."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "scene")
+    await setup_platform(hass, mock_bridge_v2, Platform.SCENE)
 
     test_entity_id = "scene.test_room_regular_test_scene"
 
@@ -154,7 +154,7 @@ async def test_scene_updates(
     """Test scene events from bridge."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "scene")
+    await setup_platform(hass, mock_bridge_v2, Platform.SCENE)
 
     test_entity_id = "scene.test_room_mocked_scene"
 

--- a/tests/components/hue/test_sensor_v1.py
+++ b/tests/components/hue/test_sensor_v1.py
@@ -8,7 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 from homeassistant.components import hue
 from homeassistant.components.hue.const import ATTR_HUE_EVENT
 from homeassistant.components.hue.v1 import sensor_base
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -285,7 +285,9 @@ SENSOR_RESPONSE = {
 async def test_no_sensors(hass: HomeAssistant, mock_bridge_v1: Mock) -> None:
     """Test the update_items function when no sensors are found."""
     mock_bridge_v1.mock_sensor_responses.append({})
-    await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
     assert len(mock_bridge_v1.mock_requests) == 1
     assert len(hass.states.async_all()) == 0
 
@@ -303,9 +305,11 @@ async def test_sensors_with_multiple_bridges(
         }
     )
     mock_bridge_v1.mock_sensor_responses.append(SENSOR_RESPONSE)
-    await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
     await setup_platform(
-        hass, mock_bridge_2, ["binary_sensor", "sensor"], "mock-bridge-2"
+        hass, mock_bridge_v1, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
+    await setup_platform(
+        hass, mock_bridge_2, [Platform.BINARY_SENSOR, Platform.SENSOR], "mock-bridge-2"
     )
 
     assert len(mock_bridge_v1.mock_requests) == 1
@@ -319,7 +323,9 @@ async def test_sensors(
 ) -> None:
     """Test the update_items function with some sensors."""
     mock_bridge_v1.mock_sensor_responses.append(SENSOR_RESPONSE)
-    await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
     assert len(mock_bridge_v1.mock_requests) == 1
     # 2 "physical" sensors with 3 virtual sensors each
     assert len(hass.states.async_all()) == 7
@@ -366,7 +372,9 @@ async def test_unsupported_sensors(hass: HomeAssistant, mock_bridge_v1: Mock) ->
     response_with_unsupported = dict(SENSOR_RESPONSE)
     response_with_unsupported["7"] = UNSUPPORTED_SENSOR
     mock_bridge_v1.mock_sensor_responses.append(response_with_unsupported)
-    await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
     assert len(mock_bridge_v1.mock_requests) == 1
     # 2 "physical" sensors with 3 virtual sensors each + 1 battery sensor
     assert len(hass.states.async_all()) == 7
@@ -376,7 +384,9 @@ async def test_new_sensor_discovered(hass: HomeAssistant, mock_bridge_v1: Mock) 
     """Test if 2nd update has a new sensor."""
     mock_bridge_v1.mock_sensor_responses.append(SENSOR_RESPONSE)
 
-    await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
     assert len(mock_bridge_v1.mock_requests) == 1
     assert len(hass.states.async_all()) == 7
 
@@ -410,7 +420,9 @@ async def test_sensor_removed(hass: HomeAssistant, mock_bridge_v1: Mock) -> None
     """Test if 2nd update has removed sensor."""
     mock_bridge_v1.mock_sensor_responses.append(SENSOR_RESPONSE)
 
-    await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
     assert len(mock_bridge_v1.mock_requests) == 1
     assert len(hass.states.async_all()) == 7
 
@@ -437,7 +449,9 @@ async def test_sensor_removed(hass: HomeAssistant, mock_bridge_v1: Mock) -> None
 async def test_update_timeout(hass: HomeAssistant, mock_bridge_v1: Mock) -> None:
     """Test bridge marked as not available if timeout error during update."""
     mock_bridge_v1.api.sensors.update = Mock(side_effect=TimeoutError)
-    await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
     assert len(mock_bridge_v1.mock_requests) == 0
     assert len(hass.states.async_all()) == 0
 
@@ -445,7 +459,9 @@ async def test_update_timeout(hass: HomeAssistant, mock_bridge_v1: Mock) -> None
 async def test_update_unauthorized(hass: HomeAssistant, mock_bridge_v1: Mock) -> None:
     """Test bridge marked as not authorized if unauthorized during update."""
     mock_bridge_v1.api.sensors.update = Mock(side_effect=aiohue.Unauthorized)
-    await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
     assert len(mock_bridge_v1.mock_requests) == 0
     assert len(hass.states.async_all()) == 0
     assert len(mock_bridge_v1.handle_unauthorized_error.mock_calls) == 1
@@ -462,7 +478,9 @@ async def test_hue_events(
 
     events = async_capture_events(hass, ATTR_HUE_EVENT)
 
-    await setup_platform(hass, mock_bridge_v1, ["binary_sensor", "sensor"])
+    await setup_platform(
+        hass, mock_bridge_v1, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
     assert len(mock_bridge_v1.mock_requests) == 1
     assert len(hass.states.async_all()) == 7
     assert len(events) == 0

--- a/tests/components/hue/test_sensor_v2.py
+++ b/tests/components/hue/test_sensor_v2.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 from homeassistant.components import hue
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -23,7 +24,7 @@ async def test_sensors(
     """Test if all v2 sensors get created with correct features."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "sensor")
+    await setup_platform(hass, mock_bridge_v2, Platform.SENSOR)
     # there shouldn't have been any requests at this point
     assert len(mock_bridge_v2.mock_requests) == 0
     # 6 entities should be created from test data
@@ -81,7 +82,7 @@ async def test_enable_sensor(
     assert await async_setup_component(hass, hue.DOMAIN, {}) is True
     await hass.async_block_till_done()
     await hass.config_entries.async_forward_entry_setups(
-        mock_config_entry_v2, ["sensor"]
+        mock_config_entry_v2, [Platform.SENSOR]
     )
 
     entity_id = "sensor.wall_switch_with_2_controls_zigbee_connectivity"
@@ -99,9 +100,11 @@ async def test_enable_sensor(
     assert updated_entry.disabled is False
 
     # reload platform and check if entity is correctly there
-    await hass.config_entries.async_forward_entry_unload(mock_config_entry_v2, "sensor")
+    await hass.config_entries.async_forward_entry_unload(
+        mock_config_entry_v2, Platform.SENSOR
+    )
     await hass.config_entries.async_forward_entry_setups(
-        mock_config_entry_v2, ["sensor"]
+        mock_config_entry_v2, [Platform.SENSOR]
     )
     await hass.async_block_till_done()
 
@@ -113,7 +116,7 @@ async def test_enable_sensor(
 async def test_sensor_add_update(hass: HomeAssistant, mock_bridge_v2: Mock) -> None:
     """Test if sensors get added/updated from events."""
     await mock_bridge_v2.api.load_test_data([FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY])
-    await setup_platform(hass, mock_bridge_v2, "sensor")
+    await setup_platform(hass, mock_bridge_v2, Platform.SENSOR)
 
     test_entity_id = "sensor.hue_mocked_device_temperature"
 

--- a/tests/components/hue/test_switch.py
+++ b/tests/components/hue/test_switch.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import Mock
 
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.util.json import JsonArrayType
 
@@ -15,7 +16,7 @@ async def test_switch(
     """Test if (config) switches get created."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "switch")
+    await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
     # there shouldn't have been any requests at this point
     assert len(mock_bridge_v2.mock_requests) == 0
     # 4 entities should be created from test data
@@ -42,7 +43,7 @@ async def test_switch_turn_on_service(
     """Test calling the turn on service on a switch."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "switch")
+    await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
 
     test_entity_id = "switch.hue_motion_sensor_motion_sensor_enabled"
 
@@ -66,7 +67,7 @@ async def test_switch_turn_off_service(
     """Test calling the turn off service on a switch."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
-    await setup_platform(hass, mock_bridge_v2, "switch")
+    await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
 
     test_entity_id = "switch.hue_motion_sensor_motion_sensor_enabled"
 
@@ -105,7 +106,7 @@ async def test_switch_added(hass: HomeAssistant, mock_bridge_v2: Mock) -> None:
     """Test new switch added to bridge."""
     await mock_bridge_v2.api.load_test_data([FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY])
 
-    await setup_platform(hass, mock_bridge_v2, "switch")
+    await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
 
     test_entity_id = "switch.hue_mocked_device_motion_sensor_enabled"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, spotted in #145788

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
