### PR TITLE
Deprecate eddystone temperature integration

### DIFF
--- a/homeassistant/components/eddystone_temperature/__init__.py
+++ b/homeassistant/components/eddystone_temperature/__init__.py
@@ -1,1 +1,6 @@
 """The eddystone_temperature component."""
+
+DOMAIN = "eddystone_temperature"
+CONF_BEACONS = "beacons"
+CONF_INSTANCE = "instance"
+CONF_NAMESPACE = "namespace"

--- a/homeassistant/components/eddystone_temperature/sensor.py
+++ b/homeassistant/components/eddystone_temperature/sensor.py
@@ -23,17 +23,18 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, Event, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from . import CONF_BEACONS, CONF_INSTANCE, CONF_NAMESPACE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_BEACONS = "beacons"
 CONF_BT_DEVICE_ID = "bt_device_id"
-CONF_INSTANCE = "instance"
-CONF_NAMESPACE = "namespace"
+
 
 BEACON_SCHEMA = vol.Schema(
     {
@@ -58,6 +59,21 @@ def setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Validate configuration, create devices and start monitoring thread."""
+    create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_system_packages_yaml_integration_{DOMAIN}",
+        breaks_in_ha_version="2025.12.0",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_system_packages_yaml_integration",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Eddystone",
+        },
+    )
+
     bt_device_id: int = config[CONF_BT_DEVICE_ID]
 
     beacons: dict[str, dict[str, str]] = config[CONF_BEACONS]

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -533,6 +533,9 @@ babel==2.15.0
 # homeassistant.components.homekit
 base36==0.1.1
 
+# homeassistant.components.eddystone_temperature
+# beacontools[scan]==2.1.0
+
 # homeassistant.components.scrape
 beautifulsoup4==4.13.3
 

--- a/tests/components/eddystone_temperature/__init__.py
+++ b/tests/components/eddystone_temperature/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for eddystone temperature."""

--- a/tests/components/eddystone_temperature/test_sensor.py
+++ b/tests/components/eddystone_temperature/test_sensor.py
@@ -1,0 +1,45 @@
+"""Tests for eddystone temperature."""
+
+from unittest.mock import Mock, patch
+
+from homeassistant.components.eddystone_temperature import (
+    CONF_BEACONS,
+    CONF_INSTANCE,
+    CONF_NAMESPACE,
+    DOMAIN,
+)
+from homeassistant.components.sensor import DOMAIN as PLATFORM_DOMAIN
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+
+@patch.dict("sys.modules", beacontools=Mock())
+async def test_repair_issue_is_created(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test repair issue is created."""
+    assert await async_setup_component(
+        hass,
+        PLATFORM_DOMAIN,
+        {
+            PLATFORM_DOMAIN: [
+                {
+                    CONF_PLATFORM: DOMAIN,
+                    CONF_BEACONS: {
+                        "living_room": {
+                            CONF_NAMESPACE: "112233445566778899AA",
+                            CONF_INSTANCE: "000000000001",
+                        }
+                    },
+                }
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+    assert (
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_system_packages_yaml_integration_{DOMAIN}",
+    ) in issue_registry.issues


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Deprecate integration as additional system packages need to be installed, which are currently not installed in our docker container, which is used by all supported installation methods.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate integration as additional system packages need to be installed, which are currently not installed in our docker container, which is used by all supported installation methods.
Adding integration-specific system packages requires prior approval in an architecture discussion, and will only be considered if the use case is or is anticipated to be highly popular.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39299
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
