### PR TITLE
Reolink fallback to download command for playback

### DIFF
--- a/homeassistant/components/reolink/views.py
+++ b/homeassistant/components/reolink/views.py
@@ -162,6 +162,8 @@ class PlaybackProxyView(HomeAssistantView):
             reolink_response.reason,
             response_headers,
         )
+        if "Content-Type" not in response_headers:
+            response_headers["Content-Type"] = reolink_response.content_type
         if response_headers["Content-Type"] == "apolication/octet-stream":
             response_headers["Content-Type"] = "application/octet-stream"
 

--- a/homeassistant/components/reolink/views.py
+++ b/homeassistant/components/reolink/views.py
@@ -130,12 +130,23 @@ class PlaybackProxyView(HomeAssistantView):
             "apolication/octet-stream",
         ]:
             err_str = f"Reolink playback expected video/mp4 but got {reolink_response.content_type}"
-            if reolink_response.content_type == "video/x-flv" and vod_type == VodRequestType.PLAYBACK.value:
+            if (
+                reolink_response.content_type == "video/x-flv"
+                and vod_type == VodRequestType.PLAYBACK.value
+            ):
                 # next time use DOWNLOAD immediately
                 self._vod_type = VodRequestType.DOWNLOAD.value
-                _LOGGER.debug("%s, retrying using download instead of playback cmd", err_str)
+                _LOGGER.debug(
+                    "%s, retrying using download instead of playback cmd", err_str
+                )
                 return await self.get(
-                    request, config_entry_id, channel, stream_res, self._vod_type, filename, retry
+                    request,
+                    config_entry_id,
+                    channel,
+                    stream_res,
+                    self._vod_type,
+                    filename,
+                    retry,
                 )
 
             _LOGGER.error(err_str)

--- a/homeassistant/components/reolink/views.py
+++ b/homeassistant/components/reolink/views.py
@@ -52,6 +52,7 @@ class PlaybackProxyView(HomeAssistantView):
             verify_ssl=False,
             ssl_cipher=SSLCipherList.INSECURE,
         )
+        self._vod_type: str | None = None
 
     async def get(
         self,
@@ -68,6 +69,8 @@ class PlaybackProxyView(HomeAssistantView):
 
         filename_decoded = urlsafe_b64decode(filename.encode("utf-8")).decode("utf-8")
         ch = int(channel)
+        if self._vod_type is not None:
+            vod_type = self._vod_type
         try:
             host = get_host(self.hass, config_entry_id)
         except Unresolvable:
@@ -127,6 +130,14 @@ class PlaybackProxyView(HomeAssistantView):
             "apolication/octet-stream",
         ]:
             err_str = f"Reolink playback expected video/mp4 but got {reolink_response.content_type}"
+            if reolink_response.content_type == "video/x-flv" and vod_type == VodRequestType.PLAYBACK.value:
+                # next time use DOWNLOAD immediately
+                self._vod_type = VodRequestType.DOWNLOAD.value
+                _LOGGER.debug("%s, retrying using download instead of playback cmd", err_str)
+                return await self.get(
+                    request, config_entry_id, channel, stream_res, self._vod_type, filename, retry
+                )
+
             _LOGGER.error(err_str)
             if reolink_response.content_type == "text/html":
                 text = await reolink_response.text()
@@ -140,7 +151,8 @@ class PlaybackProxyView(HomeAssistantView):
             reolink_response.reason,
             response_headers,
         )
-        response_headers["Content-Type"] = "video/mp4"
+        if response_headers["Content-Type"] == "apolication/octet-stream":
+            response_headers["Content-Type"] = "application/octet-stream"
 
         response = web.StreamResponse(
             status=reolink_response.status,

--- a/tests/components/reolink/test_views.py
+++ b/tests/components/reolink/test_views.py
@@ -58,17 +58,19 @@ def get_mock_session(
     return mock_session
 
 
+@pytest.mark.parametrize(("content_type"), [("video/mp4"), ("application/octet-stream"), ("apolication/octet-stream")])
 async def test_playback_proxy(
     hass: HomeAssistant,
     reolink_connect: MagicMock,
     config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
     caplog: pytest.LogCaptureFixture,
+    content_type: str,
 ) -> None:
     """Test successful playback proxy URL."""
     reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
 
-    mock_session = get_mock_session()
+    mock_session = get_mock_session(content_type=content_type)
 
     with patch(
         "homeassistant.components.reolink.views.async_get_clientsession",

--- a/tests/components/reolink/test_views.py
+++ b/tests/components/reolink/test_views.py
@@ -58,7 +58,10 @@ def get_mock_session(
     return mock_session
 
 
-@pytest.mark.parametrize(("content_type"), [("video/mp4"), ("application/octet-stream"), ("apolication/octet-stream")])
+@pytest.mark.parametrize(
+    ("content_type"),
+    [("video/mp4"), ("application/octet-stream"), ("apolication/octet-stream")],
+)
 async def test_playback_proxy(
     hass: HomeAssistant,
     reolink_connect: MagicMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the playback command returns the wrong content-type, fall back to the download command to get a mp4.
The latest firmware update of the "Reolink Duo 3V PoE" seems to have changed the return type of the playback command to "video/x-flv" just like what happend with the home hub during a firmware update.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/144001
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
