### PR TITLE
Update fronius meter polling interval

### DIFF
--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -181,8 +181,8 @@ class FroniusLoggerUpdateCoordinator(FroniusCoordinatorBase):
 class FroniusMeterUpdateCoordinator(FroniusCoordinatorBase):
     """Query Fronius system meter endpoint and keep track of seen conditions."""
 
-    default_interval = timedelta(minutes=1)
-    error_interval = timedelta(minutes=10)
+    default_interval = timedelta(seconds=10)
+    error_interval = timedelta(minutes=3)
     valid_descriptions = METER_ENTITY_DESCRIPTIONS
 
     async def _update_method(self) -> dict[SolarNetId, Any]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The Fronius integration currently polls different endpoints at inconsistent intervals:
- Power flow data: every 10 seconds
- Meter data: every 60 seconds

This creates visual inconsistencies when using a [power dashboard](https://github.com/flixlix/power-flow-card-plus) where meter power values (grid consumption/production) lag 50 seconds behind inverter and battery power values, causing confusing displays where total power doesn't match component powers.

This change aligns the meter coordinator polling intervals with the power flow coordinator (10 seconds normal, 3 minutes on error) to provide consistent real-time dashboard behavior.

**Technical justification:** The Fronius Solar API supports up to 2 parallel realtime requests with a 4-second timeout between consecutive calls (as mentioned in #71213), so 10-second polling is well within API limits.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
- This PR fixes or closes issue: N/A
- This PR is related to issue:  N/A
- Link to documentation pull request:  
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.