### PR TITLE
Adjust ManualTriggerSensorEntity to handle timestamp device classes

### DIFF
--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -186,7 +186,8 @@ class CommandSensor(ManualTriggerSensorEntity):
                 self.entity_id, variables, None
             )
 
-        self._set_value_with_possible_timestamp(value, self.device_class, variables)
+        self._set_native_value_with_possible_timestamp(value)
+        self._process_manual_data(variables)
         self.async_write_ha_state()
 
     async def async_update(self) -> None:

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -10,8 +10,6 @@ from typing import Any
 
 from jsonpath import jsonpath
 
-from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.components.sensor.helpers import async_parse_date_datetime
 from homeassistant.const import (
     CONF_COMMAND,
     CONF_NAME,
@@ -188,17 +186,7 @@ class CommandSensor(ManualTriggerSensorEntity):
                 self.entity_id, variables, None
             )
 
-        if self.device_class not in {
-            SensorDeviceClass.DATE,
-            SensorDeviceClass.TIMESTAMP,
-        }:
-            self._attr_native_value = value
-        elif value is not None:
-            self._attr_native_value = async_parse_date_datetime(
-                value, self.entity_id, self.device_class
-            )
-
-        self._process_manual_data(variables)
+        self._set_value_with_possible_timestamp(value, self.device_class, variables)
         self.async_write_ha_state()
 
     async def async_update(self) -> None:

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -13,9 +13,7 @@ from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
     DOMAIN as SENSOR_DOMAIN,
     PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
-    SensorDeviceClass,
 )
-from homeassistant.components.sensor.helpers import async_parse_date_datetime
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_FORCE_UPDATE,
@@ -181,18 +179,5 @@ class RestSensor(ManualTriggerSensorEntity, RestEntity):
                 self.entity_id, variables, None
             )
 
-        if value is None or self.device_class not in (
-            SensorDeviceClass.DATE,
-            SensorDeviceClass.TIMESTAMP,
-        ):
-            self._attr_native_value = value
-            self._process_manual_data(variables)
-            self.async_write_ha_state()
-            return
-
-        self._attr_native_value = async_parse_date_datetime(
-            value, self.entity_id, self.device_class
-        )
-
-        self._process_manual_data(variables)
+        self._set_value_with_possible_timestamp(value, self.device_class, variables)
         self.async_write_ha_state()

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -179,5 +179,6 @@ class RestSensor(ManualTriggerSensorEntity, RestEntity):
                 self.entity_id, variables, None
             )
 
-        self._set_value_with_possible_timestamp(value, self.device_class, variables)
+        self._set_native_value_with_possible_timestamp(value)
+        self._process_manual_data(variables)
         self.async_write_ha_state()

--- a/homeassistant/components/scrape/sensor.py
+++ b/homeassistant/components/scrape/sensor.py
@@ -7,8 +7,7 @@ from typing import Any, cast
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import CONF_STATE_CLASS, SensorDeviceClass
-from homeassistant.components.sensor.helpers import async_parse_date_datetime
+from homeassistant.components.sensor import CONF_STATE_CLASS
 from homeassistant.const import (
     CONF_ATTRIBUTE,
     CONF_DEVICE_CLASS,
@@ -218,18 +217,7 @@ class ScrapeSensor(CoordinatorEntity[ScrapeCoordinator], ManualTriggerSensorEnti
                 self.entity_id, variables, None
             )
 
-        if self.device_class not in {
-            SensorDeviceClass.DATE,
-            SensorDeviceClass.TIMESTAMP,
-        }:
-            self._attr_native_value = value
-            self._process_manual_data(variables)
-            return
-
-        self._attr_native_value = async_parse_date_datetime(
-            value, self.entity_id, self.device_class
-        )
-        self._process_manual_data(variables)
+        self._set_value_with_possible_timestamp(value, self.device_class, variables)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/scrape/sensor.py
+++ b/homeassistant/components/scrape/sensor.py
@@ -217,7 +217,8 @@ class ScrapeSensor(CoordinatorEntity[ScrapeCoordinator], ManualTriggerSensorEnti
                 self.entity_id, variables, None
             )
 
-        self._set_value_with_possible_timestamp(value, self.device_class, variables)
+        self._set_native_value_with_possible_timestamp(value)
+        self._process_manual_data(variables)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/snmp/sensor.py
+++ b/homeassistant/components/snmp/sensor.py
@@ -217,8 +217,7 @@ class SnmpSensor(ManualTriggerSensorEntity):
                 self.entity_id, variables, STATE_UNKNOWN
             )
 
-        self._attr_native_value = value
-        self._process_manual_data(variables)
+        self._set_value_with_possible_timestamp(value, self.device_class, variables)
 
 
 class SnmpData:

--- a/homeassistant/components/snmp/sensor.py
+++ b/homeassistant/components/snmp/sensor.py
@@ -217,7 +217,8 @@ class SnmpSensor(ManualTriggerSensorEntity):
                 self.entity_id, variables, STATE_UNKNOWN
             )
 
-        self._set_value_with_possible_timestamp(value, self.device_class, variables)
+        self._set_native_value_with_possible_timestamp(value)
+        self._process_manual_data(variables)
 
 
 class SnmpData:

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -401,10 +401,12 @@ class SQLSensor(ManualTriggerSensorEntity):
         if data is not None and self._template is not None:
             variables = self._template_variables_with_value(data)
             if self._render_availability_template(variables):
-                self._attr_native_value = self._template.async_render_as_value_template(
+                _value = self._template.async_render_as_value_template(
                     self.entity_id, variables, None
                 )
-                self._process_manual_data(variables)
+                self._set_value_with_possible_timestamp(
+                    _value, self.device_class, variables
+                )
         else:
             self._attr_native_value = data
 

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -404,11 +404,10 @@ class SQLSensor(ManualTriggerSensorEntity):
                 _value = self._template.async_render_as_value_template(
                     self.entity_id, variables, None
                 )
-                self._set_native_value_with_possible_timestamp(value)
+                self._set_native_value_with_possible_timestamp(_value)
+                self._process_manual_data(variables)
         else:
             self._attr_native_value = data
-
-        self._process_manual_data(variables)
 
         if data is None:
             _LOGGER.warning("%s returned no results", self._query)

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -404,11 +404,11 @@ class SQLSensor(ManualTriggerSensorEntity):
                 _value = self._template.async_render_as_value_template(
                     self.entity_id, variables, None
                 )
-                self._set_value_with_possible_timestamp(
-                    _value, self.device_class, variables
-                )
+                self._set_native_value_with_possible_timestamp(value)
         else:
             self._attr_native_value = data
+
+        self._process_manual_data(variables)
 
         if data is None:
             _LOGGER.warning("%s returned no results", self._query)

--- a/homeassistant/helpers/trigger_template_entity.py
+++ b/homeassistant/helpers/trigger_template_entity.py
@@ -393,19 +393,13 @@ class ManualTriggerSensorEntity(ManualTriggerEntity, SensorEntity):
         self._attr_state_class = config.get(CONF_STATE_CLASS)
 
     @callback
-    def _set_value_with_possible_timestamp(
-        self,
-        value: Any,
-        device_class: SensorDeviceClass | None,
-        variables: dict[str, Any],
-    ) -> None:
-        """Set value with possible timestamp.
+    def _set_native_value_with_possible_timestamp(self, value: Any) -> None:
+        """Set native value with possible timestamp.
 
-        Implementing class should call this last in update method to set the value
-        and then render all templates.
-        Ex: _set_value_with_possible_timestamp(value, device_class, variables)
+        If self.device_class is `date` or `timestamp`,
+        it will try to parse the value to a date/datetime object.
         """
-        if device_class not in (
+        if self.device_class not in (
             SensorDeviceClass.DATE,
             SensorDeviceClass.TIMESTAMP,
         ):
@@ -414,5 +408,3 @@ class ManualTriggerSensorEntity(ManualTriggerEntity, SensorEntity):
             self._attr_native_value = async_parse_date_datetime(
                 value, self.entity_id, self.device_class
             )
-
-        super()._process_manual_data(variables)

--- a/tests/helpers/test_trigger_template_entity.py
+++ b/tests/helpers/test_trigger_template_entity.py
@@ -319,7 +319,7 @@ async def test_manual_trigger_sensor_entity_with_date(
     variables = entity._template_variables_with_value("2025-01-01T00:00:00+00:00")
     assert entity._render_availability_template(variables) is True
     assert entity.available is True
-    entity._set_value_with_possible_timestamp(
+    entity._set_native_value_with_possible_timestamp(
         entity.state, entity.device_class, variables
     )
     await hass.async_block_till_done()

--- a/tests/helpers/test_trigger_template_entity.py
+++ b/tests/helpers/test_trigger_template_entity.py
@@ -4,7 +4,10 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor.helpers import async_parse_date_datetime
 from homeassistant.const import (
+    CONF_DEVICE_CLASS,
     CONF_ICON,
     CONF_NAME,
     CONF_STATE,
@@ -20,6 +23,7 @@ from homeassistant.helpers.trigger_template_entity import (
     CONF_AVAILABILITY,
     CONF_PICTURE,
     ManualTriggerEntity,
+    ManualTriggerSensorEntity,
     ValueTemplate,
 )
 
@@ -288,3 +292,40 @@ async def test_trigger_template_complex(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert entity.some_other_key == {"test_key": "test_data"}
+
+
+async def test_manual_trigger_sensor_entity_with_date(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test manual trigger template entity when availability template isn't used."""
+    config = {
+        CONF_NAME: template.Template("test_entity", hass),
+        CONF_STATE: template.Template("{{ as_datetime(value) }}", hass),
+        CONF_DEVICE_CLASS: SensorDeviceClass.TIMESTAMP,
+    }
+
+    class TestEntity(ManualTriggerSensorEntity):
+        """Test entity class."""
+
+        extra_template_keys = (CONF_STATE,)
+
+        @property
+        def state(self) -> bool | None:
+            """Return extra attributes."""
+            return "2025-01-01T00:00:00+00:00"
+
+    entity = TestEntity(hass, config)
+    entity.entity_id = "test.entity"
+    variables = entity._template_variables_with_value("2025-01-01T00:00:00+00:00")
+    assert entity._render_availability_template(variables) is True
+    assert entity.available is True
+    entity._set_value_with_possible_timestamp(
+        entity.state, entity.device_class, variables
+    )
+    await hass.async_block_till_done()
+
+    assert entity.native_value == async_parse_date_datetime(
+        "2025-01-01T00:00:00+00:00", entity.entity_id, entity.device_class
+    )
+    assert entity.state == "2025-01-01T00:00:00+00:00"
+    assert entity.device_class == SensorDeviceClass.TIMESTAMP

--- a/tests/helpers/test_trigger_template_entity.py
+++ b/tests/helpers/test_trigger_template_entity.py
@@ -319,9 +319,7 @@ async def test_manual_trigger_sensor_entity_with_date(
     variables = entity._template_variables_with_value("2025-01-01T00:00:00+00:00")
     assert entity._render_availability_template(variables) is True
     assert entity.available is True
-    entity._set_native_value_with_possible_timestamp(
-        entity.state, entity.device_class, variables
-    )
+    entity._set_native_value_with_possible_timestamp(entity.state)
     await hass.async_block_till_done()
 
     assert entity.native_value == async_parse_date_datetime(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement new method `_set_value_with_possible_timestamp` in `ManualTriggerSensorEntity` that set the value considering when device class is `date` or `timestamp` and then render templates.

Avoids duplicate code in childs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143134
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 