### PR TITLE
Fix stale options in here_travel_time

### DIFF
--- a/homeassistant/components/here_travel_time/__init__.py
+++ b/homeassistant/components/here_travel_time/__init__.py
@@ -5,26 +5,13 @@ from __future__ import annotations
 from homeassistant.const import CONF_API_KEY, CONF_MODE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.start import async_at_started
-from homeassistant.util import dt as dt_util
 
-from .const import (
-    CONF_ARRIVAL_TIME,
-    CONF_DEPARTURE_TIME,
-    CONF_DESTINATION_ENTITY_ID,
-    CONF_DESTINATION_LATITUDE,
-    CONF_DESTINATION_LONGITUDE,
-    CONF_ORIGIN_ENTITY_ID,
-    CONF_ORIGIN_LATITUDE,
-    CONF_ORIGIN_LONGITUDE,
-    CONF_ROUTE_MODE,
-    TRAVEL_MODE_PUBLIC,
-)
+from .const import TRAVEL_MODE_PUBLIC
 from .coordinator import (
     HereConfigEntry,
     HERERoutingDataUpdateCoordinator,
     HERETransitDataUpdateCoordinator,
 )
-from .model import HERETravelTimeConfig
 
 PLATFORMS = [Platform.SENSOR]
 
@@ -33,29 +20,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: HereConfigEntry) 
     """Set up HERE Travel Time from a config entry."""
     api_key = config_entry.data[CONF_API_KEY]
 
-    arrival = dt_util.parse_time(config_entry.options.get(CONF_ARRIVAL_TIME, ""))
-    departure = dt_util.parse_time(config_entry.options.get(CONF_DEPARTURE_TIME, ""))
-
-    here_travel_time_config = HERETravelTimeConfig(
-        destination_latitude=config_entry.data.get(CONF_DESTINATION_LATITUDE),
-        destination_longitude=config_entry.data.get(CONF_DESTINATION_LONGITUDE),
-        destination_entity_id=config_entry.data.get(CONF_DESTINATION_ENTITY_ID),
-        origin_latitude=config_entry.data.get(CONF_ORIGIN_LATITUDE),
-        origin_longitude=config_entry.data.get(CONF_ORIGIN_LONGITUDE),
-        origin_entity_id=config_entry.data.get(CONF_ORIGIN_ENTITY_ID),
-        travel_mode=config_entry.data[CONF_MODE],
-        route_mode=config_entry.options[CONF_ROUTE_MODE],
-        arrival=arrival,
-        departure=departure,
-    )
-
     cls: type[HERETransitDataUpdateCoordinator | HERERoutingDataUpdateCoordinator]
     if config_entry.data[CONF_MODE] in {TRAVEL_MODE_PUBLIC, "publicTransportTimeTable"}:
         cls = HERETransitDataUpdateCoordinator
     else:
         cls = HERERoutingDataUpdateCoordinator
 
-    data_coordinator = cls(hass, config_entry, api_key, here_travel_time_config)
+    data_coordinator = cls(hass, config_entry, api_key)
     config_entry.runtime_data = data_coordinator
 
     async def _async_update_at_start(_: HomeAssistant) -> None:

--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -26,7 +26,7 @@ from here_transit import (
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfLength
+from homeassistant.const import CONF_MODE, UnitOfLength
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.location import find_coordinates
@@ -34,8 +34,21 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import DistanceConverter
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, ROUTE_MODE_FASTEST
-from .model import HERETravelTimeConfig, HERETravelTimeData
+from .const import (
+    CONF_ARRIVAL_TIME,
+    CONF_DEPARTURE_TIME,
+    CONF_DESTINATION_ENTITY_ID,
+    CONF_DESTINATION_LATITUDE,
+    CONF_DESTINATION_LONGITUDE,
+    CONF_ORIGIN_ENTITY_ID,
+    CONF_ORIGIN_LATITUDE,
+    CONF_ORIGIN_LONGITUDE,
+    CONF_ROUTE_MODE,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    ROUTE_MODE_FASTEST,
+)
+from .model import HERETravelTimeAPIParams, HERETravelTimeData
 
 BACKOFF_MULTIPLIER = 1.1
 
@@ -47,7 +60,7 @@ type HereConfigEntry = ConfigEntry[
 
 
 class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator[HERETravelTimeData]):
-    """here_routing DataUpdateCoordinator."""
+    """HERETravelTime DataUpdateCoordinator for the routing API."""
 
     config_entry: HereConfigEntry
 
@@ -56,7 +69,6 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator[HERETravelTimeData]
         hass: HomeAssistant,
         config_entry: HereConfigEntry,
         api_key: str,
-        config: HERETravelTimeConfig,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -67,41 +79,34 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator[HERETravelTimeData]
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
         self._api = HERERoutingApi(api_key)
-        self.config = config
 
     async def _async_update_data(self) -> HERETravelTimeData:
         """Get the latest data from the HERE Routing API."""
-        origin, destination, arrival, departure = prepare_parameters(
-            self.hass, self.config
-        )
-
-        route_mode = (
-            RoutingMode.FAST
-            if self.config.route_mode == ROUTE_MODE_FASTEST
-            else RoutingMode.SHORT
-        )
+        params = prepare_parameters(self.hass, self.config_entry)
 
         _LOGGER.debug(
             (
                 "Requesting route for origin: %s, destination: %s, route_mode: %s,"
                 " mode: %s, arrival: %s, departure: %s"
             ),
-            origin,
-            destination,
-            route_mode,
-            TransportMode(self.config.travel_mode),
-            arrival,
-            departure,
+            params.origin,
+            params.destination,
+            params.route_mode,
+            TransportMode(params.travel_mode),
+            params.arrival,
+            params.departure,
         )
 
         try:
             response = await self._api.route(
-                transport_mode=TransportMode(self.config.travel_mode),
-                origin=here_routing.Place(origin[0], origin[1]),
-                destination=here_routing.Place(destination[0], destination[1]),
-                routing_mode=route_mode,
-                arrival_time=arrival,
-                departure_time=departure,
+                transport_mode=TransportMode(params.travel_mode),
+                origin=here_routing.Place(params.origin[0], params.origin[1]),
+                destination=here_routing.Place(
+                    params.destination[0], params.destination[1]
+                ),
+                routing_mode=params.route_mode,
+                arrival_time=params.arrival,
+                departure_time=params.departure,
                 return_values=[Return.POLYINE, Return.SUMMARY],
                 spans=[Spans.NAMES],
             )
@@ -175,7 +180,7 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator[HERETravelTimeData]
 class HERETransitDataUpdateCoordinator(
     DataUpdateCoordinator[HERETravelTimeData | None]
 ):
-    """HERETravelTime DataUpdateCoordinator."""
+    """HERETravelTime DataUpdateCoordinator for the transit API."""
 
     config_entry: HereConfigEntry
 
@@ -184,7 +189,6 @@ class HERETransitDataUpdateCoordinator(
         hass: HomeAssistant,
         config_entry: HereConfigEntry,
         api_key: str,
-        config: HERETravelTimeConfig,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -195,32 +199,31 @@ class HERETransitDataUpdateCoordinator(
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
         self._api = HERETransitApi(api_key)
-        self.config = config
 
     async def _async_update_data(self) -> HERETravelTimeData | None:
         """Get the latest data from the HERE Routing API."""
-        origin, destination, arrival, departure = prepare_parameters(
-            self.hass, self.config
-        )
+        params = prepare_parameters(self.hass, self.config_entry)
 
         _LOGGER.debug(
             (
                 "Requesting transit route for origin: %s, destination: %s, arrival: %s,"
                 " departure: %s"
             ),
-            origin,
-            destination,
-            arrival,
-            departure,
+            params.origin,
+            params.destination,
+            params.arrival,
+            params.departure,
         )
         try:
             response = await self._api.route(
-                origin=here_transit.Place(latitude=origin[0], longitude=origin[1]),
-                destination=here_transit.Place(
-                    latitude=destination[0], longitude=destination[1]
+                origin=here_transit.Place(
+                    latitude=params.origin[0], longitude=params.origin[1]
                 ),
-                arrival_time=arrival,
-                departure_time=departure,
+                destination=here_transit.Place(
+                    latitude=params.destination[0], longitude=params.destination[1]
+                ),
+                arrival_time=params.arrival,
+                departure_time=params.departure,
                 return_values=[
                     here_transit.Return.POLYLINE,
                     here_transit.Return.TRAVEL_SUMMARY,
@@ -285,8 +288,8 @@ class HERETransitDataUpdateCoordinator(
 
 def prepare_parameters(
     hass: HomeAssistant,
-    config: HERETravelTimeConfig,
-) -> tuple[list[str], list[str], str | None, str | None]:
+    config_entry: HereConfigEntry,
+) -> HERETravelTimeAPIParams:
     """Prepare parameters for the HERE api."""
 
     def _from_entity_id(entity_id: str) -> list[str]:
@@ -305,32 +308,55 @@ def prepare_parameters(
         return formatted_coordinates
 
     # Destination
-    if config.destination_entity_id is not None:
-        destination = _from_entity_id(config.destination_entity_id)
+    if (
+        destination_entity_id := config_entry.data.get(CONF_DESTINATION_ENTITY_ID)
+    ) is not None:
+        destination = _from_entity_id(str(destination_entity_id))
     else:
         destination = [
-            str(config.destination_latitude),
-            str(config.destination_longitude),
+            str(config_entry.data[CONF_DESTINATION_LATITUDE]),
+            str(config_entry.data[CONF_DESTINATION_LONGITUDE]),
         ]
 
     # Origin
-    if config.origin_entity_id is not None:
-        origin = _from_entity_id(config.origin_entity_id)
+    if (origin_entity_id := config_entry.data.get(CONF_ORIGIN_ENTITY_ID)) is not None:
+        origin = _from_entity_id(str(origin_entity_id))
     else:
         origin = [
-            str(config.origin_latitude),
-            str(config.origin_longitude),
+            str(config_entry.data[CONF_ORIGIN_LATITUDE]),
+            str(config_entry.data[CONF_ORIGIN_LONGITUDE]),
         ]
 
     # Arrival/Departure
-    arrival: str | None = None
-    departure: str | None = None
-    if config.arrival is not None:
-        arrival = next_datetime(config.arrival).isoformat()
-    if config.departure is not None:
-        departure = next_datetime(config.departure).isoformat()
+    arrival: datetime | None = None
+    if (
+        conf_arrival := dt_util.parse_time(
+            config_entry.options.get(CONF_ARRIVAL_TIME, "")
+        )
+    ) is not None:
+        arrival = next_datetime(conf_arrival)
+    departure: datetime | None = None
+    if (
+        conf_departure := dt_util.parse_time(
+            config_entry.options.get(CONF_DEPARTURE_TIME, "")
+        )
+    ) is not None:
+        departure = next_datetime(conf_departure)
 
-    return (origin, destination, arrival, departure)
+    route_mode = (
+        RoutingMode.FAST
+        if config_entry.options[CONF_ROUTE_MODE] == ROUTE_MODE_FASTEST
+        else RoutingMode.SHORT
+    )
+
+    return HERETravelTimeAPIParams(
+        destination=destination,
+        origin=origin,
+        travel_mode=config_entry.data[CONF_MODE],
+        route_mode=route_mode,
+        arrival=arrival,
+        departure=departure,
+    )
 
 
 def build_hass_attribution(sections: list[dict[str, Any]]) -> str | None:

--- a/homeassistant/components/here_travel_time/model.py
+++ b/homeassistant/components/here_travel_time/model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import time
+from datetime import datetime
 from typing import TypedDict
 
 
@@ -21,16 +21,12 @@ class HERETravelTimeData(TypedDict):
 
 
 @dataclass
-class HERETravelTimeConfig:
-    """Configuration for HereTravelTimeDataUpdateCoordinator."""
+class HERETravelTimeAPIParams:
+    """Configuration for polling the HERE API."""
 
-    destination_latitude: float | None
-    destination_longitude: float | None
-    destination_entity_id: str | None
-    origin_latitude: float | None
-    origin_longitude: float | None
-    origin_entity_id: str | None
+    destination: list[str]
+    origin: list[str]
     travel_mode: str
     route_mode: str
-    arrival: time | None
-    departure: time | None
+    arrival: datetime | None
+    departure: datetime | None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Changing the option "Route Mode" did not take effect until after a ConfigEntry reload. The reason was that `HereTravelTimeConfig` was populated at ConfigEntry creation and did not get updated when the options changed.

Moving the whole parameter building logic to the coordinator always builds them just before the API request from the current values of `config_entry.data` and `config_entry.options`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
