### PR TITLE
Enhance Synology DSM handling of external USB drives

### DIFF
--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -518,21 +518,18 @@ class SynoDSMExternalUSBSensor(SynologyDSMDeviceEntity, SynoDSMSensor):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        found = False
         external_usb = self._api.external_usb
         assert external_usb is not None
         if "device" in self.entity_description.key:
             for device in external_usb.get_devices.values():
                 if device.device_name == self._device_id:
-                    found = True
-                    break
+                    return super().available
         elif "partition" in self.entity_description.key:
             for device in external_usb.get_devices.values():
                 for partition in device.device_partitions.values():
                     if partition.partition_title == self._device_id:
-                        found = True
-                        break
-        return found and super().available
+                        return super().available
+        return False
 
 
 class SynoDSMInfoSensor(SynoDSMSensor):

--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import cast
 
-from synology_dsm.api.core.external_usb import SynoCoreExternalUSB
+from synology_dsm.api.core.external_usb import (
+    SynoCoreExternalUSB,
+    SynoCoreExternalUSBDevice,
+)
 from synology_dsm.api.core.utilization import SynoCoreUtilization
 from synology_dsm.api.dsm.information import SynoDSMInformation
 from synology_dsm.api.storage.storage import SynoStorage
@@ -343,14 +346,42 @@ async def async_setup_entry(
     coordinator = data.coordinator_central
     storage = api.storage
     assert storage is not None
-    external_usb = api.external_usb
+    known_usb_devices: set[str] = set()
 
-    entities: list[
-        SynoDSMUtilSensor
-        | SynoDSMStorageSensor
-        | SynoDSMInfoSensor
-        | SynoDSMExternalUSBSensor
-    ] = [
+    def _check_usb_devices() -> None:
+        """Check for new USB devices during and after initial setup."""
+        if api.external_usb is not None and api.external_usb.get_devices:
+            current_usb_devices: set[str] = {
+                device.device_name for device in api.external_usb.get_devices.values()
+            }
+            new_usb_devices = current_usb_devices - known_usb_devices
+            if new_usb_devices:
+                known_usb_devices.update(new_usb_devices)
+                external_devices: list[SynoCoreExternalUSBDevice] = [
+                    device
+                    for device in api.external_usb.get_devices.values()
+                    if device.device_name in new_usb_devices
+                ]
+                new_usb_entities: list[SynoDSMExternalUSBSensor] = [
+                    SynoDSMExternalUSBSensor(
+                        api, coordinator, description, device.device_name
+                    )
+                    for device in entry.data.get(CONF_DEVICES, external_devices)
+                    for description in EXTERNAL_USB_DISK_SENSORS
+                ]
+                new_usb_entities.extend(
+                    [
+                        SynoDSMExternalUSBSensor(
+                            api, coordinator, description, partition.partition_title
+                        )
+                        for device in entry.data.get(CONF_DEVICES, external_devices)
+                        for partition in device.device_partitions.values()
+                        for description in EXTERNAL_USB_PARTITION_SENSORS
+                    ]
+                )
+                async_add_entities(new_usb_entities)
+
+    entities: list[SynoDSMUtilSensor | SynoDSMStorageSensor | SynoDSMInfoSensor] = [
         SynoDSMUtilSensor(api, coordinator, description)
         for description in UTILISATION_SENSORS
     ]
@@ -375,38 +406,15 @@ async def async_setup_entry(
             ]
         )
 
-    # Handle all external usb
-    if external_usb is not None and external_usb.get_devices:
-        entities.extend(
-            [
-                SynoDSMExternalUSBSensor(
-                    api, coordinator, description, device.device_name
-                )
-                for device in entry.data.get(
-                    CONF_DEVICES, external_usb.get_devices.values()
-                )
-                for description in EXTERNAL_USB_DISK_SENSORS
-            ]
-        )
-        entities.extend(
-            [
-                SynoDSMExternalUSBSensor(
-                    api, coordinator, description, partition.partition_title
-                )
-                for device in entry.data.get(
-                    CONF_DEVICES, external_usb.get_devices.values()
-                )
-                for partition in device.device_partitions.values()
-                for description in EXTERNAL_USB_PARTITION_SENSORS
-            ]
-        )
-
     entities.extend(
         [
             SynoDSMInfoSensor(api, coordinator, description)
             for description in INFORMATION_SENSORS
         ]
     )
+
+    _check_usb_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_check_usb_devices))
 
     async_add_entities(entities)
 

--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -523,6 +523,25 @@ class SynoDSMExternalUSBSensor(SynologyDSMDeviceEntity, SynoDSMSensor):
 
         return attr  # type: ignore[no-any-return]
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        found = False
+        external_usb = self._api.external_usb
+        assert external_usb is not None
+        if "device" in self.entity_description.key:
+            for device in external_usb.get_devices.values():
+                if device.device_name == self._device_id:
+                    found = True
+                    break
+        elif "partition" in self.entity_description.key:
+            for device in external_usb.get_devices.values():
+                for partition in device.device_partitions.values():
+                    if partition.partition_title == self._device_id:
+                        found = True
+                        break
+        return found and super().available
+
 
 class SynoDSMInfoSensor(SynoDSMSensor):
     """Representation a Synology information sensor."""

--- a/tests/components/synology_dsm/common.py
+++ b/tests/components/synology_dsm/common.py
@@ -112,6 +112,11 @@ def mock_dsm_storage_disks() -> list[SynoStorageDisk]:
     return [SynoStorageDisk(**disk_info) for disk_info in disks_data.values()]
 
 
+def mock_dsm_external_usb_devices_usb0() -> dict[str, SynoCoreExternalUSBDevice]:
+    """Mock SynologyDSM external USB device with no USB."""
+    return {}
+
+
 def mock_dsm_external_usb_devices_usb1() -> dict[str, SynoCoreExternalUSBDevice]:
     """Mock SynologyDSM external USB device with USB Disk 1."""
     return {

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -49,7 +49,9 @@ def mock_dsm_with_usb():
         dsm.storage = Mock(
             get_disk=mock_dsm_storage_get_disk,
             disks_ids=["sata1", "sata2", "sata3"],
+            disk_temp=Mock(return_value=42),
             get_volume=mock_dsm_storage_get_volume,
+            volume_disk_temp_avg=Mock(return_value=42),
             volume_size_used=Mock(return_value=12000138625024),
             volume_percentage_used=Mock(return_value=38),
             volumes_ids=["volume_1"],

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -48,10 +48,8 @@ def mock_dsm_with_usb():
         dsm.information = mock_dsm_information()
         dsm.storage = Mock(
             get_disk=mock_dsm_storage_get_disk,
-            disk_temp=Mock(return_value=32),
             disks_ids=["sata1", "sata2", "sata3"],
             get_volume=mock_dsm_storage_get_volume,
-            volume_disk_temp_avg=Mock(return_value=32),
             volume_size_used=Mock(return_value=12000138625024),
             volume_percentage_used=Mock(return_value=38),
             volumes_ids=["volume_1"],

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import (
+    mock_dsm_external_usb_devices_usb0,
     mock_dsm_external_usb_devices_usb1,
     mock_dsm_external_usb_devices_usb2,
     mock_dsm_information,
@@ -275,6 +276,72 @@ async def test_external_usb_new_device(
     for sensor_id, (expected_state, expected_attrs) in chain(
         expected_sensors_disk_1.items(), expected_sensors_disk_2.items()
     ):
+        sensor = hass.states.get(sensor_id)
+        assert sensor is not None
+        assert sensor.state == expected_state
+        for attr_key, attr_value in expected_attrs.items():
+            assert sensor.attributes[attr_key] == attr_value
+
+
+async def test_external_usb_availability(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    setup_dsm_with_usb: MagicMock,
+) -> None:
+    """Test Synology DSM USB availability."""
+
+    expected_sensors_disk_1_available = {
+        "sensor.nas_meontheinternet_com_usb_disk_1_status": ("normal", {}),
+        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_size": (
+            "14901.998046875",
+            {},
+        ),
+        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_used_space": (
+            "5803.1650390625",
+            {},
+        ),
+        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_used": (
+            "38.9",
+            {},
+        ),
+    }
+    expected_sensors_disk_1_unavailable = {
+        "sensor.nas_meontheinternet_com_usb_disk_1_status": ("unavailable", {}),
+        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_size": (
+            "unavailable",
+            {},
+        ),
+        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_used_space": (
+            "unavailable",
+            {},
+        ),
+        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_used": (
+            "unavailable",
+            {},
+        ),
+    }
+
+    # Initial check of existing sensors
+    for sensor_id, (
+        expected_state,
+        expected_attrs,
+    ) in expected_sensors_disk_1_available.items():
+        sensor = hass.states.get(sensor_id)
+        assert sensor is not None
+        assert sensor.state == expected_state
+        for attr_key, attr_value in expected_attrs.items():
+            assert sensor.attributes[attr_key] == attr_value
+
+    # Mock the get_devices method to simulate no USB devices being connected
+    setup_dsm_with_usb.external_usb.get_devices = mock_dsm_external_usb_devices_usb0()
+    # Coordinator refresh
+    await setup_dsm_with_usb.mock_entry.runtime_data.coordinator_central.async_request_refresh()
+    await hass.async_block_till_done()
+
+    for sensor_id, (
+        expected_state,
+        expected_attrs,
+    ) in expected_sensors_disk_1_unavailable.items():
         sensor = hass.states.get(sensor_id)
         assert sensor is not None
         assert sensor.state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This resolves some of the linked issue when connecting and ejecting external USB drives to the NAS where the availability does not change unless the integration is reloaded.  It adds the `available` property to external USB device entities to show as unavailable when ejected from the NAS.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #144575
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
