### PR TITLE
Bump pymodbus to 3.9.2

### DIFF
--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "iot_class": "local_polling",
   "loggers": ["pymodbus"],
-  "requirements": ["pymodbus==3.8.3"]
+  "requirements": ["pymodbus==3.9.1"]
 }

--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "iot_class": "local_polling",
   "loggers": ["pymodbus"],
-  "requirements": ["pymodbus==3.9.1"]
+  "requirements": ["pymodbus==3.9.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2147,7 +2147,7 @@ pymitv==1.4.3
 pymochad==0.2.0
 
 # homeassistant.components.modbus
-pymodbus==3.9.1
+pymodbus==3.9.2
 
 # homeassistant.components.monoprice
 pymonoprice==0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2147,7 +2147,7 @@ pymitv==1.4.3
 pymochad==0.2.0
 
 # homeassistant.components.modbus
-pymodbus==3.8.3
+pymodbus==3.9.1
 
 # homeassistant.components.monoprice
 pymonoprice==0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1780,7 +1780,7 @@ pymiele==0.5.2
 pymochad==0.2.0
 
 # homeassistant.components.modbus
-pymodbus==3.8.3
+pymodbus==3.9.1
 
 # homeassistant.components.monoprice
 pymonoprice==0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1780,7 +1780,7 @@ pymiele==0.5.2
 pymochad==0.2.0
 
 # homeassistant.components.modbus
-pymodbus==3.9.1
+pymodbus==3.9.2
 
 # homeassistant.components.monoprice
 pymonoprice==0.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Possible breaking change: [Since at least pymodbus version 2.x, e.g. read_coils have returned bit coils in wrong order](https://github.com/pymodbus-dev/pymodbus/pull/2627)

The slave address 0 is now allowed only if the device answers with the same id 0. (see [Release notes v. 3.8.6](https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.8.6) )
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The PR updates pymodbus aligning it at the last available release. 
List of changes:
[Release notes v. 3.8.3](https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.8.3)
[Release notes v. 3.8.4](https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.8.4)
[Release notes v. 3.8.5](https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.8.5)
[Release notes v. 3.8.6](https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.8.6)
[Release notes v. 3.9.0](https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.9.0)
[Release notes v. 3.9.1](https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.9.1)
[Release notes v. 3.9.2](https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.9.2)

Current version 3.8.2 seems to be releated to some issues opened (#138077 , #141459)

I'm using the version 3.9.2 currently at my production environment  since 1 month ago, but additional tests in different environment are appreciated.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #138077 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
