### PR TITLE
Add Leneda integration - base functionality

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -862,6 +862,8 @@ build.json @home-assistant/supervisor
 /tests/components/led_ble/ @bdraco
 /homeassistant/components/lektrico/ @lektrico
 /tests/components/lektrico/ @lektrico
+/homeassistant/components/leneda/ @fedus
+/tests/components/leneda/ @fedus
 /homeassistant/components/letpot/ @jpelgrom
 /tests/components/letpot/ @jpelgrom
 /homeassistant/components/lg_netcast/ @Drafteed @splinter98

--- a/homeassistant/components/leneda/__init__.py
+++ b/homeassistant/components/leneda/__init__.py
@@ -21,8 +21,6 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: LenedaConfigEntry) -> bool:
     """Set up Leneda from a config entry or subentry."""
-    _LOGGER.debug("Setting up entry %s", entry.entry_id)
-
     api_token, energy_id = entry.data[CONF_API_TOKEN], entry.data[CONF_ENERGY_ID]
     coordinator = LenedaCoordinator(hass, entry, api_token, energy_id)
     entry.runtime_data = coordinator
@@ -30,15 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LenedaConfigEntry) -> bo
     await coordinator.async_config_entry_first_refresh()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Set up a listener for subentry changes
-    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
-
     return True
-
-
-async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle update."""
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/leneda/__init__.py
+++ b/homeassistant/components/leneda/__init__.py
@@ -19,7 +19,7 @@ type LenedaConfigEntry = ConfigEntry[LenedaCoordinator]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: LenedaConfigEntry) -> bool:
     """Set up Leneda from a config entry or subentry."""
     _LOGGER.debug("Setting up entry %s", entry.entry_id)
 

--- a/homeassistant/components/leneda/__init__.py
+++ b/homeassistant/components/leneda/__init__.py
@@ -1,0 +1,53 @@
+"""The Leneda integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from .const import CONF_API_TOKEN, CONF_ENERGY_ID
+from .coordinator import LenedaCoordinator
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+type LenedaConfigEntry = ConfigEntry[LenedaCoordinator]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Leneda from a config entry or subentry."""
+    _LOGGER.debug("Setting up entry %s", entry.entry_id)
+
+    api_token, energy_id = entry.data[CONF_API_TOKEN], entry.data[CONF_ENERGY_ID]
+    coordinator = LenedaCoordinator(hass, entry, api_token, energy_id)
+    entry.runtime_data = coordinator
+
+    await coordinator.async_config_entry_first_refresh()
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Set up a listener for subentry changes
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
+    return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle update."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Remove a metering point device (only relevant for subentries)."""
+    return True

--- a/homeassistant/components/leneda/__init__.py
+++ b/homeassistant/components/leneda/__init__.py
@@ -9,7 +9,6 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import CONF_API_TOKEN, CONF_ENERGY_ID
 from .coordinator import LenedaCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -21,8 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: LenedaConfigEntry) -> bool:
     """Set up Leneda from a config entry or subentry."""
-    api_token, energy_id = entry.data[CONF_API_TOKEN], entry.data[CONF_ENERGY_ID]
-    coordinator = LenedaCoordinator(hass, entry, api_token, energy_id)
+    coordinator = LenedaCoordinator(hass, entry)
     entry.runtime_data = coordinator
 
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/leneda/config_flow.py
+++ b/homeassistant/components/leneda/config_flow.py
@@ -1,0 +1,155 @@
+"""Config flow for Leneda integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import logging
+from typing import Any, Final
+
+from leneda import LenedaClient
+from leneda.exceptions import ForbiddenException, UnauthorizedException
+from leneda.obis_codes import ObisCode
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.core import callback
+from homeassistant.helpers import selector
+
+from .const import CONF_API_TOKEN, CONF_ENERGY_ID, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+# Setup types
+SETUP_TYPE_PROBE: Final = "probe"
+SETUP_TYPE_MANUAL: Final = "manual"
+
+# Error messages
+ERROR_INVALID_METERING_POINT: Final = "invalid_metering_point"
+ERROR_SELECT_AT_LEAST_ONE: Final = "select_at_least_one"
+ERROR_DUPLICATE_METERING_POINT: Final = "duplicate_metering_point"
+ERROR_FORBIDDEN: Final = "forbidden"
+ERROR_UNAUTHORIZED: Final = "unauthorized"
+
+
+class LenedaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Leneda (main entry: authentication only)."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._api_token: str = ""
+        self._energy_id: str = ""
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication flow when API token becomes invalid."""
+        self._energy_id = entry_data[CONF_ENERGY_ID]
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauthentication confirmation step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._api_token = user_input[CONF_API_TOKEN]
+
+            # Validate new API token
+            try:
+                client = LenedaClient(
+                    api_key=self._api_token,
+                    energy_id=self._energy_id,
+                )
+                # Use a dummy metering point ID to test authentication
+                await client.probe_metering_point_obis_code(
+                    "dummy-metering-point", ObisCode.ELEC_CONSUMPTION_ACTIVE
+                )
+            except UnauthorizedException:
+                errors = {"base": ERROR_UNAUTHORIZED}
+            except ForbiddenException:
+                errors = {"base": ERROR_FORBIDDEN}
+            else:
+                # Update the config entry with new token
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_API_TOKEN: self._api_token},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_API_TOKEN): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD,
+                            autocomplete="leneda-api-token",
+                        )
+                    ),
+                }
+            ),
+            description_placeholders={"energy_id": self._energy_id},
+            errors=errors,
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step of the config flow."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_ENERGY_ID])
+            self._abort_if_unique_id_configured()
+            self._api_token = user_input[CONF_API_TOKEN]
+            self._energy_id = user_input[CONF_ENERGY_ID]
+
+            # Validate authentication by making a test API call
+            try:
+                client = LenedaClient(
+                    api_key=self._api_token,
+                    energy_id=self._energy_id,
+                )
+                # Use a dummy metering point ID to test authentication
+                await client.probe_metering_point_obis_code(
+                    "dummy-metering-point", ObisCode.ELEC_CONSUMPTION_ACTIVE
+                )
+            except UnauthorizedException:
+                errors = {"base": ERROR_UNAUTHORIZED}
+            except ForbiddenException:
+                errors = {"base": ERROR_FORBIDDEN}
+            else:
+                return self.async_create_entry(
+                    title=self._energy_id,
+                    data={
+                        CONF_API_TOKEN: self._api_token,
+                        CONF_ENERGY_ID: self._energy_id,
+                    },
+                )
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_API_TOKEN): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD,
+                            autocomplete="leneda-api-token",
+                        )
+                    ),
+                    vol.Required(CONF_ENERGY_ID): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.TEXT,
+                            autocomplete="leneda-energy-id",
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_config_entry_title(config_entry: config_entries.ConfigEntry) -> str:
+        """Get the title for the config entry."""
+        return config_entry.data.get(CONF_ENERGY_ID, "Leneda")

--- a/homeassistant/components/leneda/config_flow.py
+++ b/homeassistant/components/leneda/config_flow.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-import logging
 from typing import Any, Final
 
 from leneda import LenedaClient
@@ -11,14 +9,11 @@ from leneda.exceptions import ForbiddenException, UnauthorizedException
 from leneda.obis_codes import ObisCode
 import voluptuous as vol
 
-from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
 from homeassistant.core import callback
 from homeassistant.helpers import selector
 
 from .const import CONF_API_TOKEN, CONF_ENERGY_ID, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 # Setup types
 SETUP_TYPE_PROBE: Final = "probe"
@@ -32,7 +27,7 @@ ERROR_FORBIDDEN: Final = "forbidden"
 ERROR_UNAUTHORIZED: Final = "unauthorized"
 
 
-class LenedaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class LenedaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Leneda (main entry: authentication only)."""
 
     VERSION = 1
@@ -41,58 +36,6 @@ class LenedaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._api_token: str = ""
         self._energy_id: str = ""
-
-    async def async_step_reauth(
-        self, entry_data: Mapping[str, Any]
-    ) -> ConfigFlowResult:
-        """Handle reauthentication flow when API token becomes invalid."""
-        self._energy_id = entry_data[CONF_ENERGY_ID]
-        return await self.async_step_reauth_confirm()
-
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle reauthentication confirmation step."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            self._api_token = user_input[CONF_API_TOKEN]
-
-            # Validate new API token
-            try:
-                client = LenedaClient(
-                    api_key=self._api_token,
-                    energy_id=self._energy_id,
-                )
-                # Use a dummy metering point ID to test authentication
-                await client.probe_metering_point_obis_code(
-                    "dummy-metering-point", ObisCode.ELEC_CONSUMPTION_ACTIVE
-                )
-            except UnauthorizedException:
-                errors = {"base": ERROR_UNAUTHORIZED}
-            except ForbiddenException:
-                errors = {"base": ERROR_FORBIDDEN}
-            else:
-                # Update the config entry with new token
-                return self.async_update_reload_and_abort(
-                    self._get_reauth_entry(),
-                    data_updates={CONF_API_TOKEN: self._api_token},
-                )
-
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_API_TOKEN): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.PASSWORD,
-                            autocomplete="leneda-api-token",
-                        )
-                    ),
-                }
-            ),
-            description_placeholders={"energy_id": self._energy_id},
-            errors=errors,
-        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -106,11 +49,11 @@ class LenedaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._energy_id = user_input[CONF_ENERGY_ID]
 
             # Validate authentication by making a test API call
+            client = LenedaClient(
+                api_key=self._api_token,
+                energy_id=self._energy_id,
+            )
             try:
-                client = LenedaClient(
-                    api_key=self._api_token,
-                    energy_id=self._energy_id,
-                )
                 # Use a dummy metering point ID to test authentication
                 await client.probe_metering_point_obis_code(
                     "dummy-metering-point", ObisCode.ELEC_CONSUMPTION_ACTIVE
@@ -150,6 +93,6 @@ class LenedaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_config_entry_title(config_entry: config_entries.ConfigEntry) -> str:
+    def async_get_config_entry_title(config_entry: ConfigEntry) -> str:
         """Get the title for the config entry."""
         return config_entry.data.get(CONF_ENERGY_ID, "Leneda")

--- a/homeassistant/components/leneda/const.py
+++ b/homeassistant/components/leneda/const.py
@@ -1,0 +1,118 @@
+"""Constants for the Leneda integration."""
+
+from datetime import timedelta
+
+from leneda.obis_codes import ObisCode
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import (
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfReactiveEnergy,
+    UnitOfReactivePower,
+)
+
+DOMAIN = "leneda"
+
+CONF_API_TOKEN = "api_token"
+CONF_ENERGY_ID = "energy_id"
+CONF_METERING_POINT = "metering_point"
+
+SCAN_INTERVAL = timedelta(hours=1)
+
+# Sensor types and their corresponding OBIS codes
+SENSOR_TYPES = {
+    # Electricity Consumption
+    "electricity_consumption_active": {
+        "obis_code": ObisCode.ELEC_CONSUMPTION_ACTIVE,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_consumption_reactive": {
+        "obis_code": ObisCode.ELEC_CONSUMPTION_REACTIVE,
+        "device_class": SensorDeviceClass.REACTIVE_ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_consumption_covered_layer1": {
+        "obis_code": ObisCode.ELEC_CONSUMPTION_COVERED_LAYER1,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_consumption_covered_layer2": {
+        "obis_code": ObisCode.ELEC_CONSUMPTION_COVERED_LAYER2,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_consumption_covered_layer3": {
+        "obis_code": ObisCode.ELEC_CONSUMPTION_COVERED_LAYER3,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_consumption_covered_layer4": {
+        "obis_code": ObisCode.ELEC_CONSUMPTION_COVERED_LAYER4,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_consumption_remaining": {
+        "obis_code": ObisCode.ELEC_CONSUMPTION_REMAINING,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    # Electricity Production
+    "electricity_production_active": {
+        "obis_code": ObisCode.ELEC_PRODUCTION_ACTIVE,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_production_reactive": {
+        "obis_code": ObisCode.ELEC_PRODUCTION_REACTIVE,
+        "device_class": SensorDeviceClass.REACTIVE_ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_production_shared_layer1": {
+        "obis_code": ObisCode.ELEC_PRODUCTION_SHARED_LAYER1,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_production_shared_layer2": {
+        "obis_code": ObisCode.ELEC_PRODUCTION_SHARED_LAYER2,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_production_shared_layer3": {
+        "obis_code": ObisCode.ELEC_PRODUCTION_SHARED_LAYER3,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_production_shared_layer4": {
+        "obis_code": ObisCode.ELEC_PRODUCTION_SHARED_LAYER4,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "electricity_production_remaining": {
+        "obis_code": ObisCode.ELEC_PRODUCTION_REMAINING,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    # Gas Consumption
+    "gas_consumption_volume": {
+        "obis_code": ObisCode.GAS_CONSUMPTION_VOLUME,
+        "device_class": SensorDeviceClass.GAS,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "gas_consumption_standard_volume": {
+        "obis_code": ObisCode.GAS_CONSUMPTION_STANDARD_VOLUME,
+        "device_class": None,  # Ideally SensorDeviceClass.GAS, but Nm3 not supported by Hass
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "gas_consumption_energy": {
+        "obis_code": ObisCode.GAS_CONSUMPTION_ENERGY,
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+}
+
+UNIT_TO_AGGREGATED_UNIT = {
+    UnitOfPower.KILO_WATT.lower(): UnitOfEnergy.KILO_WATT_HOUR,
+    UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE.lower(): UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+}

--- a/homeassistant/components/leneda/coordinator.py
+++ b/homeassistant/components/leneda/coordinator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from typing import Any
 
 from leneda import LenedaClient
@@ -15,29 +14,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import DOMAIN, SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _create_statistic_id(metering_point: str, obis: str) -> str:
-    """Create a valid statistic ID from metering point and OBIS code.
-
-    Args:
-        metering_point: The metering point identifier
-        obis: The OBIS code
-
-    Returns:
-        A formatted statistic ID string
-
-    """
-    clean_mp = re.sub(r"[^a-z0-9]", "_", metering_point.lower())
-    clean_obis = re.sub(r"[^a-z0-9]", "_", obis.lower())
-    statistic_id = f"{DOMAIN}:{clean_mp}_{clean_obis}"
-    _LOGGER.debug(
-        "Created statistic ID: %s from metering_point: %s, obis: %s",
-        statistic_id,
-        metering_point,
-        obis,
-    )
-    return statistic_id
 
 
 class LenedaCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):

--- a/homeassistant/components/leneda/coordinator.py
+++ b/homeassistant/components/leneda/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, SCAN_INTERVAL
+from .const import CONF_API_TOKEN, CONF_ENERGY_ID, DOMAIN, SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,16 +25,12 @@ class LenedaCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self,
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        api_token: str,
-        energy_id: str,
     ) -> None:
         """Initialize the coordinator for all metering point subentries.
 
         Args:
             hass: Home Assistant instance
             config_entry: Configuration entry
-            api_token: API token for authentication
-            energy_id: Energy ID for the client
 
         """
         super().__init__(
@@ -44,7 +40,12 @@ class LenedaCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
         )
+        self.api_token, self.energy_id = (
+            config_entry.data[CONF_API_TOKEN],
+            config_entry.data[CONF_ENERGY_ID],
+        )
+
         self.client = LenedaClient(
-            api_key=api_token,
-            energy_id=energy_id,
+            api_key=self.api_token,
+            energy_id=self.energy_id,
         )

--- a/homeassistant/components/leneda/coordinator.py
+++ b/homeassistant/components/leneda/coordinator.py
@@ -1,0 +1,74 @@
+"""The Leneda coordinator for handling meter data and statistics."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from leneda import LenedaClient
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _create_statistic_id(metering_point: str, obis: str) -> str:
+    """Create a valid statistic ID from metering point and OBIS code.
+
+    Args:
+        metering_point: The metering point identifier
+        obis: The OBIS code
+
+    Returns:
+        A formatted statistic ID string
+
+    """
+    clean_mp = re.sub(r"[^a-z0-9]", "_", metering_point.lower())
+    clean_obis = re.sub(r"[^a-z0-9]", "_", obis.lower())
+    statistic_id = f"{DOMAIN}:{clean_mp}_{clean_obis}"
+    _LOGGER.debug(
+        "Created statistic ID: %s from metering_point: %s, obis: %s",
+        statistic_id,
+        metering_point,
+        obis,
+    )
+    return statistic_id
+
+
+class LenedaCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
+    """Handle fetching Leneda data, updating sensors and inserting statistics."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        api_token: str,
+        energy_id: str,
+    ) -> None:
+        """Initialize the coordinator for all metering point subentries.
+
+        Args:
+            hass: Home Assistant instance
+            config_entry: Configuration entry
+            api_token: API token for authentication
+            energy_id: Energy ID for the client
+
+        """
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+        self.client = LenedaClient(
+            api_key=api_token,
+            energy_id=energy_id,
+        )

--- a/homeassistant/components/leneda/icons.json
+++ b/homeassistant/components/leneda/icons.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "sensor": {
+      "electricity_consumption_active": {
+        "default": "mdi:lightning-bolt"
+      },
+      "electricity_consumption_reactive": {
+        "default": "mdi:lightning-bolt"
+      },
+      "electricity_consumption_covered_layer1": {
+        "default": "mdi:lightning-bolt"
+      },
+      "electricity_consumption_covered_layer2": {
+        "default": "mdi:lightning-bolt"
+      },
+      "electricity_consumption_covered_layer3": {
+        "default": "mdi:lightning-bolt"
+      },
+      "electricity_consumption_covered_layer4": {
+        "default": "mdi:lightning-bolt"
+      },
+      "electricity_consumption_remaining": {
+        "default": "mdi:lightning-bolt"
+      },
+      "electricity_production_active": {
+        "default": "mdi:solar-power"
+      },
+      "electricity_production_reactive": {
+        "default": "mdi:solar-power"
+      },
+      "electricity_production_shared_layer1": {
+        "default": "mdi:solar-power"
+      },
+      "electricity_production_shared_layer2": {
+        "default": "mdi:solar-power"
+      },
+      "electricity_production_shared_layer3": {
+        "default": "mdi:solar-power"
+      },
+      "electricity_production_shared_layer4": {
+        "default": "mdi:solar-power"
+      },
+      "electricity_production_remaining": {
+        "default": "mdi:solar-power"
+      },
+      "gas_consumption_volume": {
+        "default": "mdi:fire"
+      },
+      "gas_consumption_standard_volume": {
+        "default": "mdi:fire"
+      },
+      "gas_consumption_energy": {
+        "default": "mdi:fire"
+      }
+    }
+  }
+}

--- a/homeassistant/components/leneda/manifest.json
+++ b/homeassistant/components/leneda/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "leneda",
+  "name": "Leneda",
+  "codeowners": ["@fedus"],
+  "config_flow": true,
+  "dependencies": ["recorder"],
+  "documentation": "https://www.home-assistant.io/integrations/leneda",
+  "iot_class": "cloud_polling",
+  "loggers": ["leneda-client"],
+  "quality_scale": "bronze",
+  "requirements": ["leneda-client==0.5.0"]
+}

--- a/homeassistant/components/leneda/quality_scale.yaml
+++ b/homeassistant/components/leneda/quality_scale.yaml
@@ -1,0 +1,72 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  appropriate-polling: done
+  brands: done
+  common-modules:
+    status: done
+    comment: |
+      There are currently no common patterns.
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: todo
+  reauthentication-flow: done
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: todo
+  docs-data-update: done
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: done
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: done
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: done
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/leneda/sensor.py
+++ b/homeassistant/components/leneda/sensor.py
@@ -1,0 +1,96 @@
+"""Support for Leneda sensors."""
+
+from __future__ import annotations
+
+import logging
+from typing import Final
+
+from leneda.obis_codes import get_obis_info
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN, SENSOR_TYPES, UNIT_TO_AGGREGATED_UNIT
+
+_LOGGER = logging.getLogger(__name__)
+
+# Error messages
+ERROR_INVALID_SENSOR_TYPE: Final = "invalid_sensor_type"
+ERROR_SENSOR_CREATION_FAILED: Final = "sensor_creation_failed"
+
+
+class LenedaEnergySensor(CoordinatorEntity, SensorEntity):
+    """Representation of a Leneda sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, coordinator: DataUpdateCoordinator, metering_point: str, sensor_type: str
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._metering_point: str = metering_point
+        self._sensor_type: str = sensor_type
+
+        # Get sensor configuration
+        sensor_config = SENSOR_TYPES[sensor_type]
+        self._obis_code = sensor_config["obis_code"]
+
+        # Get OBIS code info
+        obis_info = get_obis_info(self._obis_code)
+
+        # Set sensor attributes
+        self._attr_name = f"{obis_info.description} {metering_point}"
+        self._attr_unique_id = f"{metering_point}_{sensor_type}"
+        self._attr_device_class = sensor_config["device_class"]
+        self._attr_state_class = sensor_config["state_class"]
+        self._attr_native_unit_of_measurement = UNIT_TO_AGGREGATED_UNIT.get(
+            obis_info.unit.lower(), obis_info.unit
+        )
+        self._attr_translation_key = sensor_type
+
+        # Set device info
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, metering_point)},
+            "name": metering_point,
+            "manufacturer": "Leneda",
+            "model": "Metering point",
+        }
+
+        # Set additional attributes
+        self._attr_extra_state_attributes = {
+            "metering_point": metering_point,
+            "sensor_type": sensor_type,
+            "obis_code": self._obis_code,
+            "obis_code_description": obis_info.description,
+            "service_type": obis_info.service_type,
+        }
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        if not self.coordinator.data:
+            return None
+
+        meter_data = self.coordinator.data.get(self._metering_point)
+        if not meter_data:
+            return None
+
+        return meter_data["values"].get(self._obis_code)
+
+    @property
+    def available(self) -> bool:
+        """Return if the sensor is available."""
+        if not self.coordinator.data:
+            return False
+
+        meter_data = self.coordinator.data.get(self._metering_point)
+        if not meter_data:
+            return False
+
+        # Check if the specific OBIS code has data
+        return meter_data["values"].get(self._obis_code) is not None

--- a/homeassistant/components/leneda/strings.json
+++ b/homeassistant/components/leneda/strings.json
@@ -1,0 +1,186 @@
+{
+  "common": {
+    "electricity_consumption_active": "Electricity consumption (active)",
+    "electricity_consumption_reactive": "Electricity consumption (reactive)",
+    "electricity_consumption_covered_layer1": "Electricity consumption (covered layer 1 - AIR)",
+    "electricity_consumption_covered_layer2": "Electricity consumption (covered layer 2 - ACR/ACF/AC1)",
+    "electricity_consumption_covered_layer3": "Electricity consumption (covered layer 3 - CEL)",
+    "electricity_consumption_covered_layer4": "Electricity consumption (covered layer 4 - APS/CER/CEN)",
+    "electricity_consumption_remaining": "Electricity consumption (remaining after sharing invoiced by supplier)",
+    "electricity_production_active": "Electricity production (active)",
+    "electricity_production_reactive": "Electricity production (reactive)",
+    "electricity_production_shared_layer1": "Electricity production (shared layer 1 - AIR)",
+    "electricity_production_shared_layer2": "Electricity production (shared layer 2 - ACR/ACF/AC1)",
+    "electricity_production_shared_layer3": "Electricity production (shared layer 3 - CEL)",
+    "electricity_production_shared_layer4": "Electricity production (shared layer 4 - APS/CER/CEN)",
+    "electricity_production_remaining": "Electricity production (remaining after sharing sold to market)",
+    "gas_consumption_volume": "Gas consumption (volume)",
+    "gas_consumption_standard_volume": "Gas consumption (standard volume)",
+    "gas_consumption_energy": "Gas consumption (energy)"
+  },
+  "config": {
+    "step": {
+      "user": {
+        "title": "Leneda Authentication",
+        "description": "Set up your Leneda integration by providing your Energy ID and API key.",
+        "data": {
+          "api_token": "API Key",
+          "energy_id": "Energy ID"
+        },
+        "data_description": {
+          "api_token": "Your Leneda API key",
+          "energy_id": "Your Leneda Energy ID"
+        }
+      },
+      "setup_type": {
+        "title": "Setup type",
+        "description": "Choose how you want to set up your metering point.",
+        "menu_options": {
+          "probe": "Automatic setup (probe for sensors)",
+          "manual": "Manual setup (select sensors)"
+        }
+      },
+      "probe_no_sensors": {
+        "title": "No sensors detected",
+        "description": "No sensors detected for metering point {metering_point}. The metering point might be invalid or not accessible. You can still continue to manual setup.",
+        "menu_options": {
+          "manual": "Continue to manual setup"
+        }
+      },
+      "manual": {
+        "title": "Manual setup",
+        "description": "Select the sensors to monitor for {metering_point}{probed_text}",
+        "data": {
+          "sensors": "Sensors"
+        },
+        "data_description": {
+          "sensors": "Select which sensors to enable"
+        }
+      },
+      "reauth_confirm": {
+        "description": "The Leneda integration needs to re-authenticate your account {energy_id}.",
+        "data": {
+          "api_token": "[%key:common::config_flow::data::api_key%]"
+        },
+        "data_description": {
+          "api_token": "Your new Leneda API token"
+        }
+      }
+    },
+    "error": {
+      "unknown": "Unknown error occurred",
+      "invalid_credentials": "Invalid credentials",
+      "connection_error": "Connection error",
+      "forbidden": "The access to the Leneda API is forbidden. This may be due to Leneda's geoblocking or other access restrictions",
+      "unauthorized": "The supplied API token and/or Energy ID were rejected",
+      "no_obis_codes": "No sensors detected. The metering point might be invalid or not accessible. You can continue to manual setup."
+    },
+    "abort": {
+      "already_configured": "This Energy ID is already configured",
+      "invalid_auth": "Invalid authentication",
+      "config_updated": "Configuration updated successfully",
+      "existing_config_not_found": "Existing configuration not found",
+      "reauth_successful": "Re-authentication successful",
+      "reauth_failed": "Re-authentication failed",
+      "unknown": "[%key:component::leneda::config::error::unknown%]",
+      "unauthorized": "[%key:component::leneda::config::error::unauthorized%]",
+      "forbidden": "[%key:component::leneda::config::error::forbidden%]"
+    }
+  },
+  "config_subentries": {
+    "metering_point": {
+      "initiate_flow": {
+        "user": "Add metering point",
+        "reconfigure": "Reconfigure metering point"
+      },
+      "entry_type": "Metering point",
+      "step": {
+        "init": {
+          "title": "Add Metering Point",
+          "description": "Enter the metering point ID to monitor.",
+          "data": {
+            "metering_point": "Metering point ID"
+          },
+          "data_description": {
+            "metering_point": "The ID of your metering point"
+          }
+        },
+        "setup_type": {
+          "title": "Setup type",
+          "description": "Choose how you want to set up your metering point.",
+          "menu_options": {
+            "probe": "Automatic setup (probe for sensors)",
+            "manual": "Manual setup (select sensors)"
+          }
+        },
+        "probe_no_sensors": {
+          "title": "No sensors detected",
+          "description": "No sensors detected for metering point {metering_point}. The metering point might be invalid or not accessible. You can still continue to manual setup.",
+          "menu_options": {
+            "manual": "Continue to manual setup"
+          }
+        },
+        "manual": {
+          "title": "Manual setup",
+          "description": "Select the sensors to monitor for {metering_point}{probed_text}",
+          "data": {
+            "sensors": "Sensors"
+          },
+          "data_description": {
+            "sensors": "Select which sensors to enable"
+          }
+        },
+        "finish": {
+          "title": "Finish",
+          "description": "Finish adding this metering point."
+        },
+        "configure_sensors": {
+          "title": "Manage sensors",
+          "description": "Select the sensors to monitor for {metering_point}",
+          "data": {
+            "sensors": "Sensors"
+          }
+        }
+      },
+      "progress": {
+        "fetch_obis": "Probing metering point for supported sensors"
+      },
+      "error": {
+        "invalid_metering_point": "The indicated metering point seems to be invalid",
+        "select_at_least_one": "Please select at least one sensor type"
+      },
+      "abort": {
+        "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+        "duplicate_metering_point": "This metering point is already configured"
+      }
+    }
+  },
+  "selector": {
+    "sensors": {
+      "options": {
+        "electricity_consumption_active": "[%key:component::leneda::common::electricity_consumption_active%]",
+        "electricity_consumption_reactive": "[%key:component::leneda::common::electricity_consumption_reactive%]",
+        "electricity_consumption_covered_layer1": "[%key:component::leneda::common::electricity_consumption_covered_layer1%]",
+        "electricity_consumption_covered_layer2": "[%key:component::leneda::common::electricity_consumption_covered_layer2%]",
+        "electricity_consumption_covered_layer3": "[%key:component::leneda::common::electricity_consumption_covered_layer3%]",
+        "electricity_consumption_covered_layer4": "[%key:component::leneda::common::electricity_consumption_covered_layer4%]",
+        "electricity_consumption_remaining": "[%key:component::leneda::common::electricity_consumption_remaining%]",
+        "electricity_production_active": "[%key:component::leneda::common::electricity_production_active%]",
+        "electricity_production_reactive": "[%key:component::leneda::common::electricity_production_reactive%]",
+        "electricity_production_shared_layer1": "[%key:component::leneda::common::electricity_production_shared_layer1%]",
+        "electricity_production_shared_layer2": "[%key:component::leneda::common::electricity_production_shared_layer2%]",
+        "electricity_production_shared_layer3": "[%key:component::leneda::common::electricity_production_shared_layer3%]",
+        "electricity_production_shared_layer4": "[%key:component::leneda::common::electricity_production_shared_layer4%]",
+        "electricity_production_remaining": "[%key:component::leneda::common::electricity_production_remaining%]",
+        "gas_consumption_volume": "[%key:component::leneda::common::gas_consumption_volume%]",
+        "gas_consumption_standard_volume": "[%key:component::leneda::common::gas_consumption_standard_volume%]",
+        "gas_consumption_energy": "[%key:component::leneda::common::gas_consumption_energy%]"
+      }
+    }
+  },
+  "device_automation": {
+    "action_type": {
+      "select_metering_point": "Select metering point"
+    }
+  }
+}

--- a/homeassistant/components/leneda/strings.json
+++ b/homeassistant/components/leneda/strings.json
@@ -24,7 +24,7 @@
         "title": "Leneda Authentication",
         "description": "Set up your Leneda integration by providing your Energy ID and API key.",
         "data": {
-          "api_token": "API Key",
+          "api_token": "[%key:common::config_flow::data::api_key%]",
           "energy_id": "Energy ID"
         },
         "data_description": {
@@ -96,7 +96,7 @@
       "entry_type": "Metering point",
       "step": {
         "init": {
-          "title": "Add Metering Point",
+          "title": "[%key:component::leneda::config_subentries::metering_point::initiate_flow::user%]",
           "description": "Enter the metering point ID to monitor.",
           "data": {
             "metering_point": "Metering point ID"

--- a/homeassistant/components/leneda/strings.json
+++ b/homeassistant/components/leneda/strings.json
@@ -21,7 +21,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Leneda Authentication",
+        "title": "Leneda authentication",
         "description": "Set up your Leneda integration by providing your Energy ID and API key.",
         "data": {
           "api_token": "[%key:common::config_flow::data::api_key%]",
@@ -114,20 +114,20 @@
           }
         },
         "probe_no_sensors": {
-          "title": "No sensors detected",
-          "description": "No sensors detected for metering point {metering_point}. The metering point might be invalid or not accessible. You can still continue to manual setup.",
+          "title": "[%key:component::leneda::config::step::probe_no_sensors::title%]",
+          "description": "[%key:component::leneda::config::step::probe_no_sensors::description%]",
           "menu_options": {
-            "manual": "Continue to manual setup"
+            "manual": "[%key:component::leneda::config::step::probe_no_sensors::menu_options::manual%]"
           }
         },
         "manual": {
-          "title": "Manual setup",
-          "description": "Select the sensors to monitor for {metering_point}{probed_text}",
+          "title": "[%key:component::leneda::config::step::manual::title%]",
+          "description": "[%key:component::leneda::config::step::manual::description%]",
           "data": {
-            "sensors": "Sensors"
+            "sensors": "[%key:component::leneda::config::step::manual::data::sensors%]"
           },
           "data_description": {
-            "sensors": "Select which sensors to enable"
+            "sensors": "[%key:component::leneda::config::step::manual::data_description::sensors%]"
           }
         },
         "finish": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -350,6 +350,7 @@ FLOWS = {
         "leaone",
         "led_ble",
         "lektrico",
+        "leneda",
         "letpot",
         "lg_netcast",
         "lg_soundbar",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3470,6 +3470,12 @@
       "config_flow": true,
       "iot_class": "local_polling"
     },
+    "leneda": {
+      "name": "Leneda",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "letpot": {
       "name": "LetPot",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1354,6 +1354,9 @@ led-ble==1.1.7
 # homeassistant.components.lektrico
 lektricowifi==0.1
 
+# homeassistant.components.leneda
+leneda-client==0.5.0
+
 # homeassistant.components.letpot
 letpot==0.6.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1173,6 +1173,9 @@ led-ble==1.1.7
 # homeassistant.components.lektrico
 lektricowifi==0.1
 
+# homeassistant.components.leneda
+leneda-client==0.5.0
+
 # homeassistant.components.letpot
 letpot==0.6.2
 

--- a/tests/components/leneda/__init__.py
+++ b/tests/components/leneda/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Leneda Energy integration."""

--- a/tests/components/leneda/test_config_flow.py
+++ b/tests/components/leneda/test_config_flow.py
@@ -1,0 +1,296 @@
+"""Test the Leneda config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from leneda.exceptions import ForbiddenException, UnauthorizedException
+from leneda.obis_codes import ObisCode
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.leneda.const import CONF_API_TOKEN, CONF_ENERGY_ID, DOMAIN
+from homeassistant.components.recorder.core import Recorder
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+# Mock values for testing
+MOCK_API_TOKEN = "test_api_token"
+MOCK_ENERGY_ID = "test_energy_id"
+MOCK_METERING_POINT = "MP001"
+MOCK_OBIS_CODES = [ObisCode.ELEC_CONSUMPTION_ACTIVE, ObisCode.GAS_CONSUMPTION_VOLUME]
+MOCK_NEW_API_TOKEN = "new_test_api_token"
+
+
+@pytest.fixture(autouse=True)
+async def recorder_mock(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+) -> None:
+    """Set up the recorder with a temporary SQLite database."""
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_TOKEN: MOCK_API_TOKEN,
+            CONF_ENERGY_ID: MOCK_ENERGY_ID,
+        },
+        options={},
+        unique_id=MOCK_ENERGY_ID,
+    )
+
+
+async def test_form_user_success(hass: HomeAssistant, recorder_mock: Recorder) -> None:
+    """Test successful user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.leneda.config_flow.LenedaClient.probe_metering_point_obis_code",
+        new_callable=AsyncMock,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_TOKEN: MOCK_API_TOKEN,
+                CONF_ENERGY_ID: MOCK_ENERGY_ID,
+            },
+        )
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == MOCK_ENERGY_ID
+    assert result2["data"] == {
+        CONF_API_TOKEN: MOCK_API_TOKEN,
+        CONF_ENERGY_ID: MOCK_ENERGY_ID,
+    }
+
+
+async def test_form_user_unauthorized(
+    hass: HomeAssistant, recorder_mock: Recorder
+) -> None:
+    """Test user flow with unauthorized error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.leneda.config_flow.LenedaClient.probe_metering_point_obis_code",
+        new_callable=AsyncMock,
+        side_effect=UnauthorizedException,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_TOKEN: MOCK_API_TOKEN,
+                CONF_ENERGY_ID: MOCK_ENERGY_ID,
+            },
+        )
+
+        assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "unauthorized"}
+
+
+async def test_form_user_forbidden(
+    hass: HomeAssistant, recorder_mock: Recorder
+) -> None:
+    """Test user flow with forbidden error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.leneda.config_flow.LenedaClient.probe_metering_point_obis_code",
+        new_callable=AsyncMock,
+        side_effect=ForbiddenException,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_TOKEN: MOCK_API_TOKEN,
+                CONF_ENERGY_ID: MOCK_ENERGY_ID,
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "forbidden"}
+
+
+async def test_form_user_duplicate(
+    hass: HomeAssistant, recorder_mock: Recorder, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test user flow with duplicate entry."""
+    # Add a mock existing entry
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.leneda.config_flow.LenedaClient.probe_metering_point_obis_code",
+        new_callable=AsyncMock,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_TOKEN: MOCK_API_TOKEN,
+                CONF_ENERGY_ID: MOCK_ENERGY_ID,
+            },
+        )
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_reauth_success(
+    hass: HomeAssistant, recorder_mock: Recorder, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test successful reauthentication flow."""
+    # Add a mock existing entry
+    mock_config_entry.add_to_hass(hass)
+
+    # Start reauth flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.leneda.config_flow.LenedaClient.probe_metering_point_obis_code",
+        new_callable=AsyncMock,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_TOKEN: MOCK_NEW_API_TOKEN,
+            },
+        )
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+
+    # Verify the config entry was updated with the new token
+    assert mock_config_entry.data[CONF_API_TOKEN] == MOCK_NEW_API_TOKEN
+
+
+async def test_reauth_unauthorized(
+    hass: HomeAssistant, recorder_mock: Recorder, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test reauthentication flow with unauthorized error."""
+    # Add a mock existing entry
+    mock_config_entry.add_to_hass(hass)
+
+    # Start reauth flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.leneda.config_flow.LenedaClient.probe_metering_point_obis_code",
+        new_callable=AsyncMock,
+        side_effect=UnauthorizedException,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_TOKEN: MOCK_NEW_API_TOKEN,
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "reauth_confirm"
+    assert result2["errors"] == {"base": "unauthorized"}
+
+    # Verify the config entry was not updated
+    assert mock_config_entry.data[CONF_API_TOKEN] == MOCK_API_TOKEN
+
+
+async def test_reauth_forbidden(
+    hass: HomeAssistant, recorder_mock: Recorder, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test reauthentication flow with forbidden error."""
+    # Add a mock existing entry
+    mock_config_entry.add_to_hass(hass)
+
+    # Start reauth flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.leneda.config_flow.LenedaClient.probe_metering_point_obis_code",
+        new_callable=AsyncMock,
+        side_effect=ForbiddenException,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_TOKEN: MOCK_NEW_API_TOKEN,
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "reauth_confirm"
+    assert result2["errors"] == {"base": "forbidden"}
+
+    # Verify the config entry was not updated
+    assert mock_config_entry.data[CONF_API_TOKEN] == MOCK_API_TOKEN
+
+
+async def test_reauth_flow_description(
+    hass: HomeAssistant, recorder_mock: Recorder, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test reauthentication flow description contains energy ID."""
+    # Add a mock existing entry
+    mock_config_entry.add_to_hass(hass)
+
+    # Start reauth flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert "energy_id" in result["description_placeholders"]
+    assert result["description_placeholders"]["energy_id"] == MOCK_ENERGY_ID


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change introduces a new integration for the Leneda Luxembourg Energy Platform. The platform allows users to read electricity and gas consumption and production data. This integration allows to connect Home Assistant to the platform.

The user configures an account (Energy-Id + API token), and can then add metering point(s) per account. A metering point is like an electrical or gas meters that can be read out.

Please note that this is a new iteration of an earlier attempt. The previous PR was closed by me: https://github.com/home-assistant/core/pull/144774

Major differences since the previous PR:

- Small iterations: I will not dump the whole integration into this PR, but add functionality step by step. As such, there might however be code in certain parts that will only become relevant later. I've tried to keep this at a minimum
- Instead of having just config entries for both account management and metering points configuration, I am now using config entries for authentication data only, and config subentries for individual metering points config (relevant code coming up in the next increments)

### What's in this PR?
This PR lays the groundwork for the Leneda integration and focuses on scaffolding and very basic core functionality:

- Basic init
- Basic coordinator (purely a shell right now)
- Config flow for the config entries excluding config subentries. In other words: config flow for authentication.
- Tests for the config flow


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39347
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Link to brands pull request: https://github.com/home-assistant/brands/pull/7151

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
