### PR TITLE
Add config option for controlling Ollama think parameter

### DIFF
--- a/homeassistant/components/ollama/__init__.py
+++ b/homeassistant/components/ollama/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_MODEL,
     CONF_NUM_CTX,
     CONF_PROMPT,
+    CONF_THINK,
     DEFAULT_TIMEOUT,
     DOMAIN,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "CONF_MODEL",
     "CONF_NUM_CTX",
     "CONF_PROMPT",
+    "CONF_THINK",
     "CONF_URL",
     "DOMAIN",
 ]

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -22,6 +22,7 @@ from homeassistant.const import CONF_LLM_HASS_API, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
@@ -41,10 +42,12 @@ from .const import (
     CONF_MODEL,
     CONF_NUM_CTX,
     CONF_PROMPT,
+    CONF_THINK,
     DEFAULT_KEEP_ALIVE,
     DEFAULT_MAX_HISTORY,
     DEFAULT_MODEL,
     DEFAULT_NUM_CTX,
+    DEFAULT_THINK,
     DEFAULT_TIMEOUT,
     DOMAIN,
     MAX_NUM_CTX,
@@ -280,6 +283,12 @@ def ollama_config_option_schema(
                 min=-1, max=sys.maxsize, step=1, mode=NumberSelectorMode.BOX
             )
         ),
+        vol.Optional(
+            CONF_THINK,
+            description={
+                "suggested_value": options.get("think", DEFAULT_THINK),
+            },
+        ): BooleanSelector(),
     }
 
 

--- a/homeassistant/components/ollama/const.py
+++ b/homeassistant/components/ollama/const.py
@@ -4,6 +4,7 @@ DOMAIN = "ollama"
 
 CONF_MODEL = "model"
 CONF_PROMPT = "prompt"
+CONF_THINK = "think"
 
 CONF_KEEP_ALIVE = "keep_alive"
 DEFAULT_KEEP_ALIVE = -1  # seconds. -1 = indefinite, 0 = never
@@ -15,6 +16,7 @@ CONF_NUM_CTX = "num_ctx"
 DEFAULT_NUM_CTX = 8192
 MIN_NUM_CTX = 2048
 MAX_NUM_CTX = 131072
+DEFAULT_THINK = False
 
 CONF_MAX_HISTORY = "max_history"
 DEFAULT_MAX_HISTORY = 20

--- a/homeassistant/components/ollama/conversation.py
+++ b/homeassistant/components/ollama/conversation.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_MODEL,
     CONF_NUM_CTX,
     CONF_PROMPT,
+    CONF_THINK,
     DEFAULT_KEEP_ALIVE,
     DEFAULT_MAX_HISTORY,
     DEFAULT_NUM_CTX,
@@ -256,6 +257,7 @@ class OllamaConversationEntity(
                     # keep_alive requires specifying unit. In this case, seconds
                     keep_alive=f"{settings.get(CONF_KEEP_ALIVE, DEFAULT_KEEP_ALIVE)}s",
                     options={CONF_NUM_CTX: settings.get(CONF_NUM_CTX, DEFAULT_NUM_CTX)},
+                    think=settings.get(CONF_THINK),
                 )
             except (ollama.RequestError, ollama.ResponseError) as err:
                 _LOGGER.error("Unexpected error talking to Ollama server: %s", err)

--- a/homeassistant/components/ollama/strings.json
+++ b/homeassistant/components/ollama/strings.json
@@ -30,12 +30,14 @@
           "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
           "max_history": "Max history messages",
           "num_ctx": "Context window size",
-          "keep_alive": "Keep alive"
+          "keep_alive": "Keep alive",
+          "think": "Think before responding"
         },
         "data_description": {
           "prompt": "Instruct how the LLM should respond. This can be a template.",
           "keep_alive": "Duration in seconds for Ollama to keep model in memory. -1 = indefinite, 0 = never.",
-          "num_ctx": "Maximum number of text tokens the model can process. Lower to reduce Ollama RAM, or increase for a large number of exposed entities."
+          "num_ctx": "Maximum number of text tokens the model can process. Lower to reduce Ollama RAM, or increase for a large number of exposed entities.",
+          "think": "If enabled, the LLM will think before responding. This can improve response quality but may increase latency."
         }
       }
     }

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -168,6 +168,7 @@ async def test_options(
             ollama.CONF_PROMPT: "test prompt",
             ollama.CONF_MAX_HISTORY: 100,
             ollama.CONF_NUM_CTX: 32768,
+            ollama.CONF_THINK: True,
         },
     )
     await hass.async_block_till_done()
@@ -176,6 +177,7 @@ async def test_options(
         ollama.CONF_PROMPT: "test prompt",
         ollama.CONF_MAX_HISTORY: 100,
         ollama.CONF_NUM_CTX: 32768,
+        ollama.CONF_THINK: True,
     }
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allows enabling or disable thinking for supported models. Neither option will display thinking content in the chat. Future support for displaying think content will require frontend changes for formatting.

I verified that with an old version of Ollama, the request still succeeds, however the think tags are not filtered.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140003
- This PR is related to issue: #145079
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39375
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
