### PR TITLE
Quantum gateway data coordinator

### DIFF
--- a/homeassistant/components/quantum_gateway/__init__.py
+++ b/homeassistant/components/quantum_gateway/__init__.py
@@ -1,1 +1,56 @@
 """The quantum_gateway component."""
+
+from requests import RequestException
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PLATFORM
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DATA_COODINATOR, DOMAIN, LOGGER, PLATFORM_SCHEMA
+from .coordinator import QuantumGatewayCoordinator
+
+CONFIG_SCHEMA = vol.Schema(
+    {DEVICE_TRACKER_DOMAIN: [PLATFORM_SCHEMA]},
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Quantum Gateway component."""
+
+    options = next(
+        (
+            conf
+            for conf in config.get(DEVICE_TRACKER_DOMAIN, [])
+            if conf.get(CONF_PLATFORM) == DOMAIN
+        ),
+        None,
+    )
+    if not options:
+        return True
+
+    hass.data.setdefault(DOMAIN, {})
+    if options[CONF_HOST] not in hass.data[DOMAIN]:
+        hass.data[DOMAIN][options[CONF_HOST]] = {}
+
+    coordinator = QuantumGatewayCoordinator(hass, options)
+
+    try:
+        await coordinator._async_setup()  # noqa: SLF001
+        success_init = (
+            coordinator.scanner.success_init if coordinator.scanner else False
+        )
+    except RequestException:
+        success_init = False
+        LOGGER.error("Unable to connect to gateway. Check host")
+
+    if not success_init:
+        LOGGER.error("Unable to login to gateway. Check password and host")
+
+    hass.data[DOMAIN][options[CONF_HOST]][DATA_COODINATOR] = (
+        coordinator if success_init else None
+    )
+
+    return success_init

--- a/homeassistant/components/quantum_gateway/const.py
+++ b/homeassistant/components/quantum_gateway/const.py
@@ -2,6 +2,25 @@
 
 import logging
 
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
+)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_SSL
+from homeassistant.helpers import config_validation as cv
+
 LOGGER = logging.getLogger(__package__)
 
 DEFAULT_HOST = "myfiosgateway.com"
+
+DOMAIN = "quantum_gateway"
+PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_SSL, default=True): cv.boolean,
+        vol.Required(CONF_PASSWORD): cv.string,
+    },
+)
+
+DATA_COODINATOR = "coordinator"

--- a/homeassistant/components/quantum_gateway/coordinator.py
+++ b/homeassistant/components/quantum_gateway/coordinator.py
@@ -20,6 +20,8 @@ def get_scanner(host: str, password: str, use_https: bool) -> QuantumGatewayScan
 class QuantumGatewayCoordinator(DataUpdateCoordinator[dict[str, str]]):
     """Class to manage fetching data from the Quantum Gateway router."""
 
+    scanner: QuantumGatewayScanner | None
+
     def __init__(self, hass: HomeAssistant, options: ConfigType) -> None:
         """Initialize the data coordinator."""
         update_interval = options.get(CONF_SCAN_INTERVAL)
@@ -31,7 +33,6 @@ class QuantumGatewayCoordinator(DataUpdateCoordinator[dict[str, str]]):
             always_update=False,
         )
         self.options = options
-        self.scanner: QuantumGatewayScanner | None = None
 
     @override
     async def _async_setup(self):

--- a/homeassistant/components/quantum_gateway/coordinator.py
+++ b/homeassistant/components/quantum_gateway/coordinator.py
@@ -1,0 +1,55 @@
+"""Coordinator for the Quantum Gateway integration."""
+
+from typing import override
+
+from quantum_gateway import QuantumGatewayScanner
+
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_SSL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import LOGGER
+
+
+def get_scanner(host: str, password: str, use_https: bool) -> QuantumGatewayScanner:
+    """Return a Quantum Gateway scanner."""
+    return QuantumGatewayScanner(host, password, use_https)
+
+
+class QuantumGatewayCoordinator(DataUpdateCoordinator[dict[str, str]]):
+    """Class to manage fetching data from the Quantum Gateway router."""
+
+    def __init__(self, hass: HomeAssistant, options: ConfigType) -> None:
+        """Initialize the data coordinator."""
+        update_interval = options.get(CONF_SCAN_INTERVAL)
+        super().__init__(
+            hass,
+            LOGGER,
+            name="Quantum Gateway device scanner",
+            update_interval=update_interval,
+            always_update=False,
+        )
+        self.options = options
+        self._scanner: QuantumGatewayScanner | None = None
+
+    @override
+    async def _async_setup(self):
+        """Set up the Quantum Gateway device scanner."""
+        self._scanner = await self.hass.async_add_executor_job(
+            get_scanner,
+            self.options[CONF_HOST],
+            self.options[CONF_PASSWORD],
+            self.options[CONF_SSL],
+        )
+
+    @override
+    async def _async_update_data(self):
+        """Fetch the latest data from the Quantum Gateway."""
+        if self._scanner is None:
+            raise UpdateFailed("Scanner not initialized.")
+        try:
+            macs = await self.hass.async_add_executor_job(self._scanner.scan_devices)
+            return {mac: self._scanner.get_device_name(mac) for mac in macs}
+        except Exception as err:
+            raise UpdateFailed(f"Error scanning for devices: {err}") from err

--- a/homeassistant/components/quantum_gateway/coordinator.py
+++ b/homeassistant/components/quantum_gateway/coordinator.py
@@ -35,7 +35,7 @@ class QuantumGatewayCoordinator(DataUpdateCoordinator[dict[str, str]]):
         self.options = options
 
     @override
-    async def _async_setup(self):
+    async def _async_setup(self) -> None:
         """Set up the Quantum Gateway device scanner."""
         self.scanner = await self.hass.async_add_executor_job(
             get_scanner,
@@ -45,7 +45,7 @@ class QuantumGatewayCoordinator(DataUpdateCoordinator[dict[str, str]]):
         )
 
     @override
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, str]:
         """Fetch the latest data from the Quantum Gateway."""
         if self.scanner is None:
             raise UpdateFailed("Scanner not initialized.")

--- a/homeassistant/components/quantum_gateway/coordinator.py
+++ b/homeassistant/components/quantum_gateway/coordinator.py
@@ -31,12 +31,12 @@ class QuantumGatewayCoordinator(DataUpdateCoordinator[dict[str, str]]):
             always_update=False,
         )
         self.options = options
-        self._scanner: QuantumGatewayScanner | None = None
+        self.scanner: QuantumGatewayScanner | None = None
 
     @override
     async def _async_setup(self):
         """Set up the Quantum Gateway device scanner."""
-        self._scanner = await self.hass.async_add_executor_job(
+        self.scanner = await self.hass.async_add_executor_job(
             get_scanner,
             self.options[CONF_HOST],
             self.options[CONF_PASSWORD],
@@ -46,10 +46,10 @@ class QuantumGatewayCoordinator(DataUpdateCoordinator[dict[str, str]]):
     @override
     async def _async_update_data(self):
         """Fetch the latest data from the Quantum Gateway."""
-        if self._scanner is None:
+        if self.scanner is None:
             raise UpdateFailed("Scanner not initialized.")
         try:
-            macs = await self.hass.async_add_executor_job(self._scanner.scan_devices)
-            return {mac: self._scanner.get_device_name(mac) for mac in macs}
+            macs = await self.hass.async_add_executor_job(self.scanner.scan_devices)
+            return {mac: self.scanner.get_device_name(mac) for mac in macs}
         except Exception as err:
             raise UpdateFailed(f"Error scanning for devices: {err}") from err

--- a/homeassistant/components/quantum_gateway/device_tracker.py
+++ b/homeassistant/components/quantum_gateway/device_tracker.py
@@ -9,6 +9,7 @@ from homeassistant.components.device_tracker import (
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DATA_COODINATOR, DOMAIN, LOGGER, PLATFORM_SCHEMA  # noqa: F401
 from .coordinator import QuantumGatewayCoordinator
@@ -27,13 +28,17 @@ async def async_get_scanner(
     return QuantumGatewayDeviceScanner(hass, coordinator)
 
 
-class QuantumGatewayDeviceScanner(DeviceScanner):
+class QuantumGatewayDeviceScanner(  # type: ignore[misc]
+    CoordinatorEntity[QuantumGatewayCoordinator],
+    DeviceScanner,
+):  # pylint: disable=hass-enforce-class-module
     """Class which queries a Quantum Gateway."""
 
     def __init__(
         self, hass: HomeAssistant, coordinator: QuantumGatewayCoordinator
     ) -> None:
         """Initialize the scanner."""
+        super().__init__(coordinator)
 
         LOGGER.debug("Initializing")
 

--- a/homeassistant/components/quantum_gateway/device_tracker.py
+++ b/homeassistant/components/quantum_gateway/device_tracker.py
@@ -2,58 +2,42 @@
 
 from __future__ import annotations
 
-from requests.exceptions import RequestException
-import voluptuous as vol
-
 from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN,
-    PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
     DeviceScanner,
 )
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_SSL
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DEFAULT_HOST, LOGGER
+from .const import DATA_COODINATOR, DOMAIN, LOGGER, PLATFORM_SCHEMA  # noqa: F401
 from .coordinator import QuantumGatewayCoordinator
-
-PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-        vol.Optional(CONF_SSL, default=True): cv.boolean,
-        vol.Required(CONF_PASSWORD): cv.string,
-    }
-)
 
 
 async def async_get_scanner(
     hass: HomeAssistant, config: ConfigType
 ) -> QuantumGatewayDeviceScanner | None:
     """Validate the configuration and return a Quantum Gateway scanner."""
-    try:
-        scanner = QuantumGatewayDeviceScanner(hass, config[DEVICE_TRACKER_DOMAIN])
-        await scanner.coordinator._async_setup()  # noqa: SLF001
-        success_init = True
-    except RequestException:
-        success_init = False
-        LOGGER.error("Unable to connect to gateway. Check host")
+    coordinator = hass.data[DOMAIN][config[DEVICE_TRACKER_DOMAIN][CONF_HOST]][
+        DATA_COODINATOR
+    ]
+    if coordinator is None:
+        return None
 
-    if not success_init:
-        LOGGER.error("Unable to login to gateway. Check password and host")
-
-    return scanner if success_init else None
+    return QuantumGatewayDeviceScanner(hass, coordinator)
 
 
 class QuantumGatewayDeviceScanner(DeviceScanner):
     """Class which queries a Quantum Gateway."""
 
-    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+    def __init__(
+        self, hass: HomeAssistant, coordinator: QuantumGatewayCoordinator
+    ) -> None:
         """Initialize the scanner."""
 
         LOGGER.debug("Initializing")
 
-        self.coordinator = QuantumGatewayCoordinator(hass, config)
+        self.coordinator = coordinator
 
     async def async_scan_devices(self) -> list[str]:
         """Scan for new devices and return a list of found MACs."""

--- a/tests/components/quantum_gateway/__init__.py
+++ b/tests/components/quantum_gateway/__init__.py
@@ -1,13 +1,20 @@
 """Tests for the quantum_gateway component."""
 
+from typing import Any
+
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def setup_platform(hass: HomeAssistant) -> None:
+async def setup_platform(
+    hass: HomeAssistant, extra_options: dict[str, Any] | None = None
+) -> None:
     """Set up the quantum_gateway integration."""
+    if extra_options is None:
+        extra_options = {}
+
     result = await async_setup_component(
         hass,
         DEVICE_TRACKER_DOMAIN,
@@ -15,6 +22,7 @@ async def setup_platform(hass: HomeAssistant) -> None:
             DEVICE_TRACKER_DOMAIN: {
                 CONF_PLATFORM: "quantum_gateway",
                 CONF_PASSWORD: "fake_password",
+                **extra_options,
             }
         },
     )

--- a/tests/components/quantum_gateway/conftest.py
+++ b/tests/components/quantum_gateway/conftest.py
@@ -1,13 +1,13 @@
 """Fixtures for Quantum Gateway tests."""
 
-from collections.abc import Generator
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 
 @pytest.fixture
-async def mock_scanner() -> Generator[AsyncMock]:
+async def mock_scanner() -> AsyncGenerator[AsyncMock]:
     """Mock QuantumGatewayScanner instance."""
     with patch(
         "homeassistant.components.quantum_gateway.device_tracker.QuantumGatewayScanner",

--- a/tests/components/quantum_gateway/conftest.py
+++ b/tests/components/quantum_gateway/conftest.py
@@ -10,7 +10,7 @@ import pytest
 async def mock_scanner() -> AsyncGenerator[AsyncMock]:
     """Mock QuantumGatewayScanner instance."""
     with patch(
-        "homeassistant.components.quantum_gateway.device_tracker.QuantumGatewayScanner",
+        "homeassistant.components.quantum_gateway.coordinator.QuantumGatewayScanner",
         autospec=True,
     ) as mock_scanner:
         client = mock_scanner.return_value

--- a/tests/components/quantum_gateway/test_coordinator.py
+++ b/tests/components/quantum_gateway/test_coordinator.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from homeassistant.components.quantum_gateway.const import DATA_COODINATOR, DOMAIN
 from homeassistant.components.quantum_gateway.coordinator import (
     QuantumGatewayCoordinator,
 )
@@ -19,6 +20,26 @@ from tests.components.device_tracker.test_init import mock_yaml_devices  # noqa:
 
 
 @pytest.mark.usefixtures("yaml_devices")
+async def test_sets_update_interval_from_options(
+    hass: HomeAssistant, mock_scanner: AsyncMock
+) -> None:
+    """Test the update interval is set from the options."""
+    scan_interval = randint(1, 60)
+    host = "1.1.1.1"
+    extra_options = {
+        CONF_HOST: host,
+        CONF_SCAN_INTERVAL: scan_interval,
+    }
+
+    await setup_platform(hass, extra_options)
+
+    mock_scanner.assert_called_once()
+
+    coordinator = hass.data[DOMAIN][host][DATA_COODINATOR]
+
+    assert coordinator.update_interval == timedelta(seconds=scan_interval)
+
+
 async def test_update_fails_when_unitialized(
     hass: HomeAssistant, mock_scanner: AsyncMock
 ) -> None:

--- a/tests/components/quantum_gateway/test_coordinator.py
+++ b/tests/components/quantum_gateway/test_coordinator.py
@@ -1,0 +1,31 @@
+"""Test the Quantum Gateway coordinator."""
+
+from datetime import timedelta
+from random import randint
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant.components.quantum_gateway.coordinator import (
+    QuantumGatewayCoordinator,
+)
+from homeassistant.const import CONF_HOST, CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from . import setup_platform
+
+from tests.components.device_tracker.test_init import mock_yaml_devices  # noqa: F401
+
+
+@pytest.mark.usefixtures("yaml_devices")
+async def test_update_fails_when_unitialized(
+    hass: HomeAssistant, mock_scanner: AsyncMock
+) -> None:
+    """Test the update interval is set from the options."""
+    coordinator = QuantumGatewayCoordinator(hass, {})
+
+    mock_scanner.assert_not_called()
+
+    with pytest.raises(UpdateFailed, match="Scanner not initialized."):
+        await coordinator._async_update_data()

--- a/tests/components/quantum_gateway/test_device_tracker.py
+++ b/tests/components/quantum_gateway/test_device_tracker.py
@@ -36,6 +36,30 @@ async def test_get_scanner_error(hass: HomeAssistant, mock_scanner: AsyncMock) -
     assert "quantum_gateway.device_tracker" not in hass.config.components
 
 
+@pytest.mark.parametrize(
+    "scanner",
+    [
+        {"return_value": None},
+        {"return_value": AsyncMock(success_init=False)},
+    ],
+)
+@pytest.mark.usefixtures("yaml_devices")
+async def test_scan_devices_missing_init(
+    hass: HomeAssistant, mock_scanner: AsyncMock, scanner
+) -> None:
+    """Test failure when initializing scanner."""
+    mock_scanner.configure_mock(**scanner)
+    await setup_platform(hass)
+
+    assert "quantum_gateway.device_tracker" in hass.config.components
+
+    device_1 = hass.states.get("device_tracker.desktop")
+    assert device_1 is None
+
+    device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
+    assert device_2 is None
+
+
 @pytest.mark.usefixtures("yaml_devices")
 async def test_scan_devices_error(hass: HomeAssistant, mock_scanner: AsyncMock) -> None:
     """Test failure when scanning devices."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the Quantum Gateway device tracker to use a DataCorrdinator for handling its polling for data. This is another step in the path to updating the Quantum Gateway integration to be setup through the UI. 

The main change in the PR is that the Quantum Gateway scanner is now initialized at component setup instead of the device tracker platform setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
