### PR TITLE
Use async_load_fixture in modern_forms tests

### DIFF
--- a/tests/components/modern_forms/__init__.py
+++ b/tests/components/modern_forms/__init__.py
@@ -1,7 +1,9 @@
 """Tests for the Modern Forms integration."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
+from functools import partial
 import json
+from typing import Any
 
 from aiomodernforms.const import COMMAND_QUERY_STATIC_DATA
 
@@ -9,40 +11,52 @@ from homeassistant.components.modern_forms.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_MAC, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, async_load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
 
 
-async def modern_forms_call_mock(method, url, data):
+async def modern_forms_call_mock(
+    hass: HomeAssistant, method: str, url: str, data: dict[str, Any]
+) -> AiohttpClientMockResponse:
     """Set up the basic returns based on info or status request."""
     if COMMAND_QUERY_STATIC_DATA in data:
-        fixture = "modern_forms/device_info.json"
+        fixture = "device_info.json"
     else:
-        fixture = "modern_forms/device_status.json"
+        fixture = "device_status.json"
     return AiohttpClientMockResponse(
-        method=method, url=url, json=json.loads(load_fixture(fixture))
+        method=method,
+        url=url,
+        json=json.loads(await async_load_fixture(hass, fixture, DOMAIN)),
     )
 
 
-async def modern_forms_no_light_call_mock(method, url, data):
+async def modern_forms_no_light_call_mock(
+    hass: HomeAssistant, method: str, url: str, data: dict[str, Any]
+) -> AiohttpClientMockResponse:
     """Set up the basic returns based on info or status request."""
     if COMMAND_QUERY_STATIC_DATA in data:
-        fixture = "modern_forms/device_info_no_light.json"
+        fixture = "device_info_no_light.json"
     else:
-        fixture = "modern_forms/device_status_no_light.json"
+        fixture = "device_status_no_light.json"
     return AiohttpClientMockResponse(
-        method=method, url=url, json=json.loads(load_fixture(fixture))
+        method=method,
+        url=url,
+        json=json.loads(await async_load_fixture(hass, fixture, DOMAIN)),
     )
 
 
-async def modern_forms_timers_set_mock(method, url, data):
+async def modern_forms_timers_set_mock(
+    hass: HomeAssistant, method: str, url: str, data: dict[str, Any]
+) -> AiohttpClientMockResponse:
     """Set up the basic returns based on info or status request."""
     if COMMAND_QUERY_STATIC_DATA in data:
-        fixture = "modern_forms/device_info.json"
+        fixture = "device_info.json"
     else:
-        fixture = "modern_forms/device_status_timers_active.json"
+        fixture = "device_status_timers_active.json"
     return AiohttpClientMockResponse(
-        method=method, url=url, json=json.loads(load_fixture(fixture))
+        method=method,
+        url=url,
+        json=json.loads(await async_load_fixture(hass, fixture, DOMAIN)),
     )
 
 
@@ -51,13 +65,15 @@ async def init_integration(
     aioclient_mock: AiohttpClientMocker,
     rgbw: bool = False,
     skip_setup: bool = False,
-    mock_type: Callable = modern_forms_call_mock,
+    mock_type: Callable[
+        [str, str, dict[str, Any]], Coroutine[Any, Any, AiohttpClientMockResponse]
+    ] = modern_forms_call_mock,
 ) -> MockConfigEntry:
     """Set up the Modern Forms integration in Home Assistant."""
 
     aioclient_mock.post(
         "http://192.168.1.123:80/mf",
-        side_effect=mock_type,
+        side_effect=partial(mock_type, hass),
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as follow-up to #144534 and needed for #145709

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
