### PR TITLE
Use async_load_fixture in moehlenhoff_alpha2 tests

### DIFF
--- a/tests/components/moehlenhoff_alpha2/__init__.py
+++ b/tests/components/moehlenhoff_alpha2/__init__.py
@@ -1,21 +1,23 @@
 """Tests for the moehlenhoff_alpha2 integration."""
 
+from functools import partialmethod
 from unittest.mock import patch
 
+from moehlenhoff_alpha2 import Alpha2Base
 import xmltodict
 
 from homeassistant.components.moehlenhoff_alpha2.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, async_load_fixture
 
 MOCK_BASE_HOST = "fake-base-host"
 
 
-async def mock_update_data(self):
+async def mock_update_data(self: Alpha2Base, hass: HomeAssistant) -> None:
     """Mock Alpha2Base.update_data."""
-    data = xmltodict.parse(load_fixture("static2.xml", DOMAIN))
+    data = xmltodict.parse(await async_load_fixture(hass, "static2.xml", DOMAIN))
     for _type in ("HEATAREA", "HEATCTRL", "IODEVICE"):
         if not isinstance(data["Devices"]["Device"][_type], list):
             data["Devices"]["Device"][_type] = [data["Devices"]["Device"][_type]]
@@ -26,7 +28,7 @@ async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Mock integration setup."""
     with patch(
         "homeassistant.components.moehlenhoff_alpha2.coordinator.Alpha2Base.update_data",
-        mock_update_data,
+        partialmethod(mock_update_data, hass),
     ):
         entry = MockConfigEntry(
             domain=DOMAIN,

--- a/tests/components/moehlenhoff_alpha2/test_config_flow.py
+++ b/tests/components/moehlenhoff_alpha2/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the moehlenhoff_alpha2 config flow."""
 
+from functools import partialmethod
 from unittest.mock import patch
 
 from homeassistant import config_entries
@@ -24,7 +25,7 @@ async def test_form(hass: HomeAssistant) -> None:
     with (
         patch(
             "homeassistant.components.moehlenhoff_alpha2.config_flow.Alpha2Base.update_data",
-            mock_update_data,
+            partialmethod(mock_update_data, hass),
         ),
         patch(
             "homeassistant.components.moehlenhoff_alpha2.async_setup_entry",
@@ -54,7 +55,10 @@ async def test_form_duplicate_error(hass: HomeAssistant) -> None:
 
     assert config_entry.data["host"] == MOCK_BASE_HOST
 
-    with patch("moehlenhoff_alpha2.Alpha2Base.update_data", mock_update_data):
+    with patch(
+        "moehlenhoff_alpha2.Alpha2Base.update_data",
+        partialmethod(mock_update_data, hass),
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             data={"host": MOCK_BASE_HOST},


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as follow-up to #144534 and needed for #145709

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
