### PR TITLE
Use async_load_fixture in skybell tests

### DIFF
--- a/tests/components/skybell/conftest.py
+++ b/tests/components/skybell/conftest.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, async_load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 USERNAME = "user"
@@ -53,39 +53,41 @@ def create_entry(hass: HomeAssistant) -> MockConfigEntry:
     return entry
 
 
-async def set_aioclient_responses(aioclient_mock: AiohttpClientMocker) -> None:
+async def set_aioclient_responses(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Set AioClient responses."""
     aioclient_mock.get(
         f"{BASE_URL}devices/{DEVICE_ID}/info/",
-        text=load_fixture("skybell/device_info.json"),
+        text=await async_load_fixture(hass, "device_info.json", DOMAIN),
     )
     aioclient_mock.get(
         f"{BASE_URL}devices/{DEVICE_ID}/settings/",
-        text=load_fixture("skybell/device_settings.json"),
+        text=await async_load_fixture(hass, "device_settings.json", DOMAIN),
     )
     aioclient_mock.get(
         f"{BASE_URL}devices/{DEVICE_ID}/activities/",
-        text=load_fixture("skybell/activities.json"),
+        text=await async_load_fixture(hass, "activities.json", DOMAIN),
     )
     aioclient_mock.get(
         f"{BASE_URL}devices/",
-        text=load_fixture("skybell/device.json"),
+        text=await async_load_fixture(hass, "device.json", DOMAIN),
     )
     aioclient_mock.get(
         USERS_ME_URL,
-        text=load_fixture("skybell/me.json"),
+        text=await async_load_fixture(hass, "me.json", DOMAIN),
     )
     aioclient_mock.post(
         f"{BASE_URL}login/",
-        text=load_fixture("skybell/login.json"),
+        text=await async_load_fixture(hass, "login.json", DOMAIN),
     )
     aioclient_mock.get(
         f"{BASE_URL}devices/{DEVICE_ID}/activities/1234567890ab1234567890ac/video/",
-        text=load_fixture("skybell/video.json"),
+        text=await async_load_fixture(hass, "video.json", DOMAIN),
     )
     aioclient_mock.get(
         f"{BASE_URL}devices/{DEVICE_ID}/avatar/",
-        text=load_fixture("skybell/avatar.json"),
+        text=await async_load_fixture(hass, "avatar.json", DOMAIN),
     )
     aioclient_mock.get(
         f"https://v3-production-devices-avatar.s3.us-west-2.amazonaws.com/{DEVICE_ID}.jpg",
@@ -96,12 +98,12 @@ async def set_aioclient_responses(aioclient_mock: AiohttpClientMocker) -> None:
 
 
 @pytest.fixture
-async def connection(aioclient_mock: AiohttpClientMocker) -> None:
+async def connection(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Fixture for good connection responses."""
-    await set_aioclient_responses(aioclient_mock)
+    await set_aioclient_responses(hass, aioclient_mock)
 
 
-def create_skybell(hass: HomeAssistant) -> Skybell:
+async def create_skybell(hass: HomeAssistant) -> Skybell:
     """Create Skybell object."""
     skybell = Skybell(
         username=USERNAME,
@@ -109,14 +111,15 @@ def create_skybell(hass: HomeAssistant) -> Skybell:
         get_devices=True,
         session=async_get_clientsession(hass),
     )
-    skybell._cache = orjson.loads(load_fixture("skybell/cache.json"))
+    skybell._cache = orjson.loads(await async_load_fixture(hass, "cache.json", DOMAIN))
     return skybell
 
 
-def mock_skybell(hass: HomeAssistant):
+async def mock_skybell(hass: HomeAssistant):
     """Mock Skybell object."""
     return patch(
-        "homeassistant.components.skybell.Skybell", return_value=create_skybell(hass)
+        "homeassistant.components.skybell.Skybell",
+        return_value=await create_skybell(hass),
     )
 
 
@@ -124,7 +127,7 @@ async def async_init_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Set up the Skybell integration in Home Assistant."""
     config_entry = create_entry(hass)
 
-    with mock_skybell(hass), patch("aioskybell.utils.async_save_cache"):
+    with await mock_skybell(hass), patch("aioskybell.utils.async_save_cache"):
         await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as follow-up to #144534 and needed for #145709

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
