### PR TITLE
Use async_load_fixture in youtube tests

### DIFF
--- a/tests/components/youtube/__init__.py
+++ b/tests/components/youtube/__init__.py
@@ -6,7 +6,10 @@ import json
 from youtubeaio.models import YouTubeChannel, YouTubePlaylistItem, YouTubeSubscription
 from youtubeaio.types import AuthScope
 
-from tests.common import load_fixture
+from homeassistant.components.youtube import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import async_load_fixture
 
 
 class MockYouTube:
@@ -16,11 +19,13 @@ class MockYouTube:
 
     def __init__(
         self,
-        channel_fixture: str = "youtube/get_channel.json",
-        playlist_items_fixture: str = "youtube/get_playlist_items.json",
-        subscriptions_fixture: str = "youtube/get_subscriptions.json",
+        hass: HomeAssistant,
+        channel_fixture: str = "get_channel.json",
+        playlist_items_fixture: str = "get_playlist_items.json",
+        subscriptions_fixture: str = "get_subscriptions.json",
     ) -> None:
         """Initialize mock service."""
+        self.hass = hass
         self._channel_fixture = channel_fixture
         self._playlist_items_fixture = playlist_items_fixture
         self._subscriptions_fixture = subscriptions_fixture
@@ -32,7 +37,9 @@ class MockYouTube:
 
     async def get_user_channels(self) -> AsyncGenerator[YouTubeChannel]:
         """Get channels for authenticated user."""
-        channels = json.loads(load_fixture(self._channel_fixture))
+        channels = json.loads(
+            await async_load_fixture(self.hass, self._channel_fixture, DOMAIN)
+        )
         for item in channels["items"]:
             yield YouTubeChannel(**item)
 
@@ -42,7 +49,9 @@ class MockYouTube:
         """Get channels."""
         if self._thrown_error is not None:
             raise self._thrown_error
-        channels = json.loads(load_fixture(self._channel_fixture))
+        channels = json.loads(
+            await async_load_fixture(self.hass, self._channel_fixture, DOMAIN)
+        )
         for item in channels["items"]:
             yield YouTubeChannel(**item)
 
@@ -50,13 +59,17 @@ class MockYouTube:
         self, playlist_id: str, amount: int
     ) -> AsyncGenerator[YouTubePlaylistItem]:
         """Get channels."""
-        channels = json.loads(load_fixture(self._playlist_items_fixture))
+        channels = json.loads(
+            await async_load_fixture(self.hass, self._playlist_items_fixture, DOMAIN)
+        )
         for item in channels["items"]:
             yield YouTubePlaylistItem(**item)
 
     async def get_user_subscriptions(self) -> AsyncGenerator[YouTubeSubscription]:
         """Get channels for authenticated user."""
-        channels = json.loads(load_fixture(self._subscriptions_fixture))
+        channels = json.loads(
+            await async_load_fixture(self.hass, self._subscriptions_fixture, DOMAIN)
+        )
         for item in channels["items"]:
             yield YouTubeSubscription(**item)
 

--- a/tests/components/youtube/conftest.py
+++ b/tests/components/youtube/conftest.py
@@ -107,7 +107,7 @@ async def mock_setup_integration(
     )
 
     async def func() -> MockYouTube:
-        mock = MockYouTube()
+        mock = MockYouTube(hass)
         with patch("homeassistant.components.youtube.api.YouTube", return_value=mock):
             assert await async_setup_component(hass, DOMAIN, {})
             await hass.async_block_till_done()

--- a/tests/components/youtube/test_config_flow.py
+++ b/tests/components/youtube/test_config_flow.py
@@ -61,7 +61,7 @@ async def test_full_flow(
         ) as mock_setup,
         patch(
             "homeassistant.components.youtube.config_flow.YouTube",
-            return_value=MockYouTube(),
+            return_value=MockYouTube(hass),
         ),
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -114,7 +114,7 @@ async def test_flow_abort_without_channel(
     assert resp.status == 200
     assert resp.headers["content-type"] == "text/html; charset=utf-8"
 
-    service = MockYouTube(channel_fixture="youtube/get_no_channel.json")
+    service = MockYouTube(hass, channel_fixture="get_no_channel.json")
     with (
         patch("homeassistant.components.youtube.async_setup_entry", return_value=True),
         patch(
@@ -156,8 +156,9 @@ async def test_flow_abort_without_subscriptions(
     assert resp.headers["content-type"] == "text/html; charset=utf-8"
 
     service = MockYouTube(
-        channel_fixture="youtube/get_no_channel.json",
-        subscriptions_fixture="youtube/get_no_subscriptions.json",
+        hass,
+        channel_fixture="get_no_channel.json",
+        subscriptions_fixture="get_no_subscriptions.json",
     )
     with (
         patch("homeassistant.components.youtube.async_setup_entry", return_value=True),
@@ -199,7 +200,7 @@ async def test_flow_without_subscriptions(
     assert resp.status == 200
     assert resp.headers["content-type"] == "text/html; charset=utf-8"
 
-    service = MockYouTube(subscriptions_fixture="youtube/get_no_subscriptions.json")
+    service = MockYouTube(hass, subscriptions_fixture="get_no_subscriptions.json")
     with (
         patch("homeassistant.components.youtube.async_setup_entry", return_value=True),
         patch(
@@ -352,7 +353,7 @@ async def test_reauth(
         },
     )
 
-    youtube = MockYouTube(channel_fixture=f"youtube/{fixture}.json")
+    youtube = MockYouTube(hass, channel_fixture=f"{fixture}.json")
     with (
         patch(
             "homeassistant.components.youtube.async_setup_entry", return_value=True
@@ -422,7 +423,7 @@ async def test_options_flow(
     await setup_integration()
     with patch(
         "homeassistant.components.youtube.config_flow.YouTube",
-        return_value=MockYouTube(),
+        return_value=MockYouTube(hass),
     ):
         entry = hass.config_entries.async_entries(DOMAIN)[0]
         result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -476,7 +477,7 @@ async def test_own_channel_included(
         ) as mock_setup,
         patch(
             "homeassistant.components.youtube.config_flow.YouTube",
-            return_value=MockYouTube(),
+            return_value=MockYouTube(hass),
         ),
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -522,7 +523,7 @@ async def test_options_flow_own_channel(
     await setup_integration()
     with patch(
         "homeassistant.components.youtube.config_flow.YouTube",
-        return_value=MockYouTube(),
+        return_value=MockYouTube(hass),
     ):
         entry = hass.config_entries.async_entries(DOMAIN)[0]
         result = await hass.config_entries.options.async_init(entry.entry_id)

--- a/tests/components/youtube/test_sensor.py
+++ b/tests/components/youtube/test_sensor.py
@@ -1,5 +1,6 @@
 """Sensor tests for the YouTube integration."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -48,6 +49,7 @@ async def test_sensor_without_uploaded_video(
         future = dt_util.utcnow() + timedelta(minutes=15)
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
+        await asyncio.sleep(0.1)
 
     state = hass.states.get("sensor.google_for_developers_latest_upload")
     assert state == snapshot
@@ -78,6 +80,7 @@ async def test_sensor_updating(
         future = dt_util.utcnow() + timedelta(minutes=15)
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
+        await asyncio.sleep(0.1)
     state = hass.states.get("sensor.google_for_developers_latest_upload")
     assert state
     assert state.name == "Google for Developers Latest upload"

--- a/tests/components/youtube/test_sensor.py
+++ b/tests/components/youtube/test_sensor.py
@@ -42,7 +42,7 @@ async def test_sensor_without_uploaded_video(
     with patch(
         "homeassistant.components.youtube.api.AsyncConfigEntryAuth.get_resource",
         return_value=MockYouTube(
-            playlist_items_fixture="youtube/get_no_playlist_items.json"
+            hass, playlist_items_fixture="get_no_playlist_items.json"
         ),
     ):
         future = dt_util.utcnow() + timedelta(minutes=15)
@@ -72,7 +72,7 @@ async def test_sensor_updating(
     with patch(
         "homeassistant.components.youtube.api.AsyncConfigEntryAuth.get_resource",
         return_value=MockYouTube(
-            playlist_items_fixture="youtube/get_playlist_items_2.json"
+            hass, playlist_items_fixture="get_playlist_items_2.json"
         ),
     ):
         future = dt_util.utcnow() + timedelta(minutes=15)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as follow-up to #144534 and needed for #145709

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
