### PR TITLE
Use async_load_fixture in remaining tests

### DIFF
--- a/tests/components/hassio/test_backup.py
+++ b/tests/components/hassio/test_backup.py
@@ -54,7 +54,7 @@ from homeassistant.setup import async_setup_component
 
 from .test_init import MOCK_ENVIRON
 
-from tests.common import load_json_object_fixture, mock_platform
+from tests.common import async_load_json_object_fixture, mock_platform
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 TEST_BACKUP = supervisor_backups.Backup(
@@ -1018,8 +1018,10 @@ async def test_reader_writer_create_addon_folder_error(
     supervisor_client.jobs.get_job.side_effect = [
         TEST_JOB_NOT_DONE,
         supervisor_jobs.Job.from_dict(
-            load_json_object_fixture(
-                "backup_done_with_addon_folder_errors.json", DOMAIN
+            (
+                await async_load_json_object_fixture(
+                    hass, "backup_done_with_addon_folder_errors.json", DOMAIN
+                )
             )["data"]
         ),
     ]

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DHCP_DATA, DISCOVERY_DATA, HOMEKIT_DATA, MOCK_SERIAL
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 @pytest.mark.usefixtures("mock_hunterdouglas_hub")
@@ -330,7 +330,9 @@ async def test_form_unsupported_device(
     # Simulate a gen 3 secondary hub
     with patch(
         "homeassistant.components.hunterdouglas_powerview.util.Hub.request_raw_data",
-        return_value=load_json_object_fixture("gen3/gateway/secondary.json", DOMAIN),
+        return_value=await async_load_json_object_fixture(
+            hass, "gen3/gateway/secondary.json", DOMAIN
+        ),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/nexia/test_switch.py
+++ b/tests/components/nexia/test_switch.py
@@ -29,7 +29,7 @@ async def test_nexia_sensor_switch(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test NexiaRoomIQSensorSwitch."""
-    await async_init_integration(hass, house_fixture="nexia/sensors_xl1050_house.json")
+    await async_init_integration(hass, house_fixture="sensors_xl1050_house.json")
     sw1_id = f"{Platform.SWITCH}.center_nativezone_include_center"
     sw1 = {ATTR_ENTITY_ID: sw1_id}
     sw2_id = f"{Platform.SWITCH}.center_nativezone_include_upstairs"

--- a/tests/components/nexia/util.py
+++ b/tests/components/nexia/util.py
@@ -18,7 +18,7 @@ async def async_init_integration(
     skip_setup: bool = False,
     exception: Exception | None = None,
     *,
-    house_fixture="nexia/mobile_houses_123456.json",
+    house_fixture="mobile_houses_123456.json",
 ) -> MockConfigEntry:
     """Set up the nexia integration in Home Assistant."""
 

--- a/tests/components/nexia/util.py
+++ b/tests/components/nexia/util.py
@@ -9,7 +9,7 @@ from homeassistant.components.nexia.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, async_load_fixture
 from tests.test_util.aiohttp import mock_aiohttp_client
 
 
@@ -22,9 +22,9 @@ async def async_init_integration(
 ) -> MockConfigEntry:
     """Set up the nexia integration in Home Assistant."""
 
-    session_fixture = "nexia/session_123456.json"
-    sign_in_fixture = "nexia/sign_in.json"
-    set_fan_speed_fixture = "nexia/set_fan_speed_2293892.json"
+    session_fixture = "session_123456.json"
+    sign_in_fixture = "sign_in.json"
+    set_fan_speed_fixture = "set_fan_speed_2293892.json"
     with (
         mock_aiohttp_client() as mock_session,
         patch("nexia.home.load_or_create_uuid", return_value=uuid.uuid4()),
@@ -40,19 +40,20 @@ async def async_init_integration(
             )
         else:
             mock_session.post(
-                nexia.API_MOBILE_SESSION_URL, text=load_fixture(session_fixture)
+                nexia.API_MOBILE_SESSION_URL,
+                text=await async_load_fixture(hass, session_fixture, DOMAIN),
             )
         mock_session.get(
             nexia.API_MOBILE_HOUSES_URL.format(house_id=123456),
-            text=load_fixture(house_fixture),
+            text=await async_load_fixture(hass, house_fixture, DOMAIN),
         )
         mock_session.post(
             nexia.API_MOBILE_ACCOUNTS_SIGN_IN_URL,
-            text=load_fixture(sign_in_fixture),
+            text=await async_load_fixture(hass, sign_in_fixture, DOMAIN),
         )
         mock_session.post(
             "https://www.mynexia.com/mobile/xxl_thermostats/2293892/fan_speed",
-            text=load_fixture(set_fan_speed_fixture),
+            text=await async_load_fixture(hass, set_fan_speed_fixture, DOMAIN),
         )
         entry = MockConfigEntry(
             domain=DOMAIN,

--- a/tests/components/nuki/__init__.py
+++ b/tests/components/nuki/__init__.py
@@ -9,8 +9,8 @@ from .mock import MOCK_INFO, setup_nuki_integration
 
 from tests.common import (
     MockConfigEntry,
-    load_json_array_fixture,
-    load_json_object_fixture,
+    async_load_json_array_fixture,
+    async_load_json_object_fixture,
 )
 
 
@@ -21,15 +21,19 @@ async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
         mock.get("http://1.1.1.1:8080/info", json=MOCK_INFO)
         mock.get(
             "http://1.1.1.1:8080/list",
-            json=load_json_array_fixture("list.json", DOMAIN),
+            json=await async_load_json_array_fixture(hass, "list.json", DOMAIN),
         )
         mock.get(
             "http://1.1.1.1:8080/callback/list",
-            json=load_json_object_fixture("callback_list.json", DOMAIN),
+            json=await async_load_json_object_fixture(
+                hass, "callback_list.json", DOMAIN
+            ),
         )
         mock.get(
             "http://1.1.1.1:8080/callback/add",
-            json=load_json_object_fixture("callback_add.json", DOMAIN),
+            json=await async_load_json_object_fixture(
+                hass, "callback_add.json", DOMAIN
+            ),
         )
         entry = await setup_nuki_integration(hass)
         await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/overkiz/test_diagnostics.py
+++ b/tests/components/overkiz/test_diagnostics.py
@@ -8,7 +8,7 @@ from homeassistant.components.overkiz.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
     get_diagnostics_for_device,
@@ -23,7 +23,9 @@ async def test_diagnostics(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics."""
-    diagnostic_data = load_json_object_fixture("overkiz/setup_tahoma_switch.json")
+    diagnostic_data = await async_load_json_object_fixture(
+        hass, "setup_tahoma_switch.json", DOMAIN
+    )
 
     with patch.multiple(
         "pyoverkiz.client.OverkizClient",
@@ -44,7 +46,9 @@ async def test_device_diagnostics(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device diagnostics."""
-    diagnostic_data = load_json_object_fixture("overkiz/setup_tahoma_switch.json")
+    diagnostic_data = await async_load_json_object_fixture(
+        hass, "setup_tahoma_switch.json", DOMAIN
+    )
 
     device = device_registry.async_get_device(
         identifiers={(DOMAIN, "rts://****-****-6867/16756006")}

--- a/tests/components/switchbot_cloud/test_sensor.py
+++ b/tests/components/switchbot_cloud/test_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 
 from . import configure_integration
 
-from tests.common import load_json_object_fixture, snapshot_platform
+from tests.common import async_load_json_object_fixture, snapshot_platform
 
 
 async def test_meter(
@@ -33,7 +33,9 @@ async def test_meter(
             hubDeviceId="test-hub-id",
         ),
     ]
-    mock_get_status.return_value = load_json_object_fixture("meter_status.json", DOMAIN)
+    mock_get_status.return_value = await async_load_json_object_fixture(
+        hass, "meter_status.json", DOMAIN
+    )
 
     with patch("homeassistant.components.switchbot_cloud.PLATFORMS", [Platform.SENSOR]):
         entry = await configure_integration(hass)

--- a/tests/components/youless/__init__.py
+++ b/tests/components/youless/__init__.py
@@ -8,8 +8,8 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import (
     MockConfigEntry,
-    load_json_array_fixture,
-    load_json_object_fixture,
+    async_load_json_array_fixture,
+    async_load_json_object_fixture,
 )
 
 
@@ -18,16 +18,22 @@ async def init_component(hass: HomeAssistant) -> MockConfigEntry:
     with requests_mock.Mocker() as mock:
         mock.get(
             "http://1.1.1.1/d",
-            json=load_json_object_fixture("device.json", youless.DOMAIN),
+            json=await async_load_json_object_fixture(
+                hass, "device.json", youless.DOMAIN
+            ),
         )
         mock.get(
             "http://1.1.1.1/e",
-            json=load_json_array_fixture("enologic.json", youless.DOMAIN),
+            json=await async_load_json_array_fixture(
+                hass, "enologic.json", youless.DOMAIN
+            ),
             headers={"Content-Type": "application/json"},
         )
         mock.get(
             "http://1.1.1.1/f",
-            json=load_json_object_fixture("phase.json", youless.DOMAIN),
+            json=await async_load_json_object_fixture(
+                hass, "phase.json", youless.DOMAIN
+            ),
             headers={"Content-Type": "application/json"},
         )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as follow-up to #144534 and needed for #145709

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
