### PR TITLE
Update pytest to 8.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -492,6 +492,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
   "error::sqlalchemy.exc.SAWarning",
+  "error:usefixtures\\(\\) in .* without arguments has no effect:UserWarning",  # pytest
 
   # -- HomeAssistant - aiohttp
   # Overwrite web.Application to pass a custom default argument to _make_request

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -30,7 +30,7 @@ pytest-timeout==2.4.0
 pytest-unordered==0.6.1
 pytest-picked==0.5.1
 pytest-xdist==3.7.0
-pytest==8.3.5
+pytest==8.4.0
 requests-mock==1.12.1
 respx==0.22.0
 syrupy==4.9.1

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -1866,7 +1866,7 @@ async def test_exception_platform_pre(hass: HomeAssistant) -> None:
             BackupManagerExceptionGroup,
             (
                 "Multiple errors when creating backup: Error during pre-backup: Boom, "
-                "Error during post-backup: Test exception (2 sub-exceptions)"
+                "Error during post-backup: Test exception"
             ),
         ),
         (
@@ -1874,7 +1874,7 @@ async def test_exception_platform_pre(hass: HomeAssistant) -> None:
             BackupManagerExceptionGroup,
             (
                 "Multiple errors when creating backup: Error during pre-backup: Boom, "
-                "Error during post-backup: Test exception (2 sub-exceptions)"
+                "Error during post-backup: Test exception"
             ),
         ),
     ],

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -28,9 +28,8 @@ from homeassistant.util.dt import UTC
 
 from . import init_integration
 
-pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
-
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the forms."""
 
@@ -74,6 +73,7 @@ async def test_form(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_form_province_no_alias(hass: HomeAssistant) -> None:
     """Test we get the forms."""
 
@@ -115,6 +115,7 @@ async def test_form_province_no_alias(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_form_no_country(hass: HomeAssistant) -> None:
     """Test we get the forms correctly without a country."""
 
@@ -154,6 +155,7 @@ async def test_form_no_country(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_form_no_subdivision(hass: HomeAssistant) -> None:
     """Test we get the forms correctly without subdivision."""
 
@@ -196,6 +198,7 @@ async def test_form_no_subdivision(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_options_form(hass: HomeAssistant) -> None:
     """Test we get the form in options."""
 
@@ -242,6 +245,7 @@ async def test_options_form(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
     """Test errors in setup entry."""
 
@@ -314,6 +318,7 @@ async def test_form_incorrect_dates(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_options_form_incorrect_dates(hass: HomeAssistant) -> None:
     """Test errors in options."""
 
@@ -390,6 +395,7 @@ async def test_options_form_incorrect_dates(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_options_form_abort_duplicate(hass: HomeAssistant) -> None:
     """Test errors in options for duplicates."""
 
@@ -443,6 +449,7 @@ async def test_options_form_abort_duplicate(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "already_configured"}
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
     """Test errors in setup entry."""
 
@@ -515,6 +522,7 @@ async def test_form_incorrect_date_range(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_options_form_incorrect_date_ranges(hass: HomeAssistant) -> None:
     """Test errors in options."""
 
@@ -589,9 +597,6 @@ async def test_options_form_incorrect_date_ranges(hass: HomeAssistant) -> None:
         "province": "BW",
         "language": "de",
     }
-
-
-pytestmark = pytest.mark.usefixtures()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 import pathlib
 import socket
 
+from _pytest.compat import get_real_func
 from aiohttp import web
 import pytest
 import pytest_socket
@@ -100,7 +101,7 @@ async def test_evict_faked_translations(hass: HomeAssistant, translations_once) 
 
     # The evict_faked_translations fixture has module scope, so we set it up and
     # tear it down manually
-    real_func = evict_faked_translations.__pytest_wrapped__.obj
+    real_func = get_real_func(evict_faked_translations)
     gen: Generator = real_func(translations_once)
 
     # Set up the evict_faked_translations fixture


### PR DESCRIPTION
## Proposed change
https://docs.pytest.org/en/stable/changelog.html

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
