### PR TITLE
Add Zeroconf support for bsblan integration

### DIFF
--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -55,15 +55,8 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
         self.host = str(discovery_info.ip_address)
         self.port = discovery_info.port or DEFAULT_PORT
 
-        # Try to get MAC from properties first (for new firmware)
+        # Get MAC from properties
         self.mac = discovery_info.properties.get("mac")
-
-        # If MAC not found in properties, try to parse from raw TXT records
-        if not self.mac and hasattr(discovery_info, "properties_raw"):
-            for key in discovery_info.properties_raw:
-                if key.startswith(b"mac="):
-                    self.mac = key[4:].decode("utf-8")
-                    break
 
         # If MAC was found in zeroconf, use it immediately
         if self.mac:

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -205,12 +205,6 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(
                 format_mac(self.mac), raise_on_progress=raise_on_progress
             )
-        elif self.mac != retrieved_mac:
-            # MAC from zeroconf doesn't match retrieved MAC - update it
-            self.mac = retrieved_mac
-            await self.async_set_unique_id(
-                format_mac(self.mac), raise_on_progress=raise_on_progress
-            )
 
         # Always allow updating host/port for both user and discovery flows
         # This ensures connectivity is maintained when devices change IP addresses

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -99,10 +99,23 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
                         CONF_PORT: self.port,
                     }
                 )
+                # No auth needed, go to a simple confirmation step
+                return await self.async_step_discovery_no_auth_confirm()
 
         # Proceed to get credentials
         self.context["title_placeholders"] = {"name": f"BSBLAN {self.host}"}
         return await self.async_step_discovery_confirm()
+
+    async def async_step_discovery_no_auth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle confirmation for a discovered device that needs no authentication."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="discovery_no_auth_confirm",
+                description_placeholders={"host": str(self.host)},
+            )
+        return self._async_create_entry()
 
     async def async_step_discovery_confirm(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNA
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import CONF_PASSKEY, DEFAULT_PORT, DOMAIN
 
@@ -21,12 +22,14 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    host: str
-    port: int
-    mac: str
-    passkey: str | None = None
-    username: str | None = None
-    password: str | None = None
+    def __init__(self) -> None:
+        """Initialize BSBLan flow."""
+        self.host: str | None = None
+        self.port: int = DEFAULT_PORT
+        self.mac: str | None = None
+        self.passkey: str | None = None
+        self.username: str | None = None
+        self.password: str | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -41,6 +44,68 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
         self.username = user_input.get(CONF_USERNAME)
         self.password = user_input.get(CONF_PASSWORD)
 
+        return await self._validate_and_create()
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle Zeroconf discovery."""
+
+        self.host = str(discovery_info.ip_address)
+        self.port = discovery_info.port or DEFAULT_PORT
+
+        # Try to get MAC from properties first (for future compatibility)
+        self.mac = discovery_info.properties.get("mac")
+
+        # If MAC not found in properties, try to parse from raw TXT records
+        if not self.mac and hasattr(discovery_info, "properties_raw"):
+            for key in discovery_info.properties_raw:
+                if key.startswith(b"mac="):
+                    self.mac = key[4:].decode("utf-8")
+                    break
+
+        # If still no MAC found, abort the discovery flow
+        if not self.mac:
+            return self.async_abort(reason="no_mac_address")
+
+        # Check if the device is already configured using MAC
+        await self.async_set_unique_id(format_mac(self.mac))
+        self._abort_if_unique_id_configured(
+            updates={
+                CONF_HOST: self.host,
+                CONF_PORT: self.port,
+            }
+        )
+
+        # Proceed to get credentials
+        self.context["title_placeholders"] = {"name": f"BSBLAN {self.host}"}
+        return await self.async_step_discovery_confirm()
+
+    async def async_step_discovery_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle getting credentials for discovered device."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="discovery_confirm",
+                data_schema=vol.Schema(
+                    {
+                        vol.Optional(CONF_PASSKEY): str,
+                        vol.Optional(CONF_USERNAME): str,
+                        vol.Optional(CONF_PASSWORD): str,
+                    }
+                ),
+                description_placeholders={"host": str(self.host)},
+            )
+
+        self.passkey = user_input.get(CONF_PASSKEY)
+        self.username = user_input.get(CONF_USERNAME)
+        self.password = user_input.get(CONF_PASSWORD)
+
+        return await self._validate_and_create()
+
+    async def _validate_and_create(self) -> ConfigFlowResult:
+        """Validate device connection and create entry."""
         try:
             await self._get_bsblan_info()
         except BSBLANError:
@@ -67,6 +132,7 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @callback
     def _async_create_entry(self) -> ConfigFlowResult:
+        """Create the config entry."""
         return self.async_create_entry(
             title=format_mac(self.mac),
             data={
@@ -79,7 +145,7 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
         )
 
     async def _get_bsblan_info(self, raise_on_progress: bool = True) -> None:
-        """Get device information from an BSBLAN device."""
+        """Get device information from a BSBLAN device."""
         config = BSBLANConfig(
             host=self.host,
             passkey=self.passkey,

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -67,7 +67,12 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
         # If MAC was found in zeroconf, use it immediately
         if self.mac:
             await self.async_set_unique_id(format_mac(self.mac))
-            self._abort_if_unique_id_configured()
+            self._abort_if_unique_id_configured(
+                updates={
+                    CONF_HOST: self.host,
+                    CONF_PORT: self.port,
+                }
+            )
         else:
             # For older firmware without MAC in zeroconf:
             # Use discovery without unique ID pattern - will get MAC via API later
@@ -185,13 +190,11 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
                 format_mac(self.mac), raise_on_progress=raise_on_progress
             )
 
-        # For discovered devices, don't allow updating host/port
-        if is_discovery:
-            self._abort_if_unique_id_configured()
-        else:
-            self._abort_if_unique_id_configured(
-                updates={
-                    CONF_HOST: self.host,
-                    CONF_PORT: self.port,
-                }
-            )
+        # Always allow updating host/port for both user and discovery flows
+        # This ensures connectivity is maintained when devices change IP addresses
+        self._abort_if_unique_id_configured(
+            updates={
+                CONF_HOST: self.host,
+                CONF_PORT: self.port,
+            }
+        )

--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -7,5 +7,11 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["bsblan"],
-  "requirements": ["python-bsblan==2.1.0"]
+  "requirements": ["python-bsblan==2.1.0"],
+  "zeroconf": [
+    {
+      "type": "_http._tcp.local.",
+      "name": "bsb-lan*"
+    }
+  ]
 }

--- a/homeassistant/components/bsblan/sensor.py
+++ b/homeassistant/components/bsblan/sensor.py
@@ -20,6 +20,8 @@ from . import BSBLanConfigEntry, BSBLanData
 from .coordinator import BSBLanCoordinatorData
 from .entity import BSBLanEntity
 
+PARALLEL_UPDATES = 1
+
 
 @dataclass(frozen=True, kw_only=True)
 class BSBLanSensorEntityDescription(SensorEntityDescription):

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -24,14 +24,14 @@
         "title": "BSB-Lan device discovered",
         "description": "A BSB-Lan device was discovered at {host}. Please provide credentials if required.",
         "data": {
-          "passkey": "Passkey string",
+          "passkey": "[%key:component::bsblan::config::step::user::data::passkey%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "passkey": "The passkey for your BSB-Lan device.",
-          "username": "The username for your BSB-Lan device.",
-          "password": "The password for your BSB-Lan device."
+          "passkey": "[%key:component::bsblan::config::step::user::data_description::passkey%]",
+          "username": "[%key:component::bsblan::config::step::user::data_description::username%]",
+          "password": "[%key:component::bsblan::config::step::user::data_description::password%]"
         }
       }
     },

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -13,7 +13,25 @@
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of your BSB-Lan device."
+          "host": "The hostname or IP address of your BSB-Lan device.",
+          "port": "The port number of your BSB-Lan device.",
+          "passkey": "The passkey for your BSB-Lan device.",
+          "username": "The username for your BSB-Lan device.",
+          "password": "The password for your BSB-Lan device."
+        }
+      },
+      "discovery_confirm": {
+        "title": "BSB-Lan device discovered",
+        "description": "A BSB-Lan device was discovered at {host}. Please provide credentials if required.",
+        "data": {
+          "passkey": "Passkey string",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "passkey": "The passkey for your BSB-Lan device.",
+          "username": "The username for your BSB-Lan device.",
+          "password": "The password for your BSB-Lan device."
         }
       }
     },
@@ -22,7 +40,8 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "no_mac_address": "No MAC address found in device announcement"
     }
   },
   "exceptions": {

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -40,8 +40,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "no_mac_address": "No MAC address found in device announcement"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
   },
   "exceptions": {

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -564,12 +564,12 @@ ZEROCONF = {
             "name": "bosch shc*",
         },
         {
-            "domain": "eheimdigital",
-            "name": "eheimdigital._http._tcp.local.",
-        },
-        {
             "domain": "bsblan",
             "name": "bsb-lan*",
+        },
+        {
+            "domain": "eheimdigital",
+            "name": "eheimdigital._http._tcp.local.",
         },
         {
             "domain": "lektrico",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -568,6 +568,10 @@ ZEROCONF = {
             "name": "eheimdigital._http._tcp.local.",
         },
         {
+            "domain": "bsblan",
+            "name": "bsb-lan*",
+        },
+        {
             "domain": "lektrico",
             "name": "lektrico*",
         },

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -1,7 +1,8 @@
 """Fixtures for BSBLAN integration tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
+from ipaddress import ip_address
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from bsblan import Device, HotWaterState, Info, Sensor, State, StaticState
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from homeassistant.components.bsblan.const import CONF_PASSKEY, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -78,3 +80,66 @@ async def init_integration(
     await hass.async_block_till_done()
 
     return mock_config_entry
+
+
+# ZeroconfServiceInfo fixtures for different discovery scenarios
+
+
+@pytest.fixture
+def zeroconf_discovery_info() -> ZeroconfServiceInfo:
+    """Return zeroconf discovery info for a BSBLAN device with MAC address."""
+    return ZeroconfServiceInfo(
+        ip_address=ip_address("10.0.2.60"),
+        ip_addresses=[ip_address("10.0.2.60")],
+        name="BSB-LAN web service._http._tcp.local.",
+        type="_http._tcp.local.",
+        properties={"mac": "00:80:41:19:69:90"},
+        port=80,
+        hostname="BSB-LAN.local.",
+    )
+
+
+@pytest.fixture
+def zeroconf_discovery_info_no_mac() -> Mock:
+    """Return zeroconf discovery info for a BSBLAN device without MAC address."""
+    discovery_info = Mock()
+    discovery_info.ip_address = ip_address("10.0.2.60")
+    discovery_info.ip_addresses = [ip_address("10.0.2.60")]
+    discovery_info.name = "BSB-LAN web service._http._tcp.local."
+    discovery_info.type = "_http._tcp.local."
+    discovery_info.properties = {}  # No MAC in properties
+    discovery_info.properties_raw = {}  # No MAC in properties_raw either
+    discovery_info.port = 80
+    discovery_info.hostname = "BSB-LAN.local."
+    return discovery_info
+
+
+@pytest.fixture
+def zeroconf_discovery_info_different_ip() -> ZeroconfServiceInfo:
+    """Return zeroconf discovery info for a BSBLAN device with different IP."""
+    return ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.1.100"),
+        ip_addresses=[ip_address("192.168.1.100")],
+        name="BSB-LAN web service._http._tcp.local.",
+        type="_http._tcp.local.",
+        properties={"mac": "00:80:41:19:69:90"},
+        port=8080,
+        hostname="BSB-LAN.local.",
+    )
+
+
+@pytest.fixture
+def zeroconf_discovery_info_properties_raw() -> Mock:
+    """Return zeroconf discovery info with MAC in properties_raw."""
+    discovery_info = Mock()
+    discovery_info.ip_address = ip_address("10.0.2.60")
+    discovery_info.ip_addresses = [ip_address("10.0.2.60")]
+    discovery_info.name = "BSB-LAN web service._http._tcp.local."
+    discovery_info.type = "_http._tcp.local."
+    discovery_info.properties = {}  # No MAC in properties
+    discovery_info.properties_raw = {
+        b"mac=00:80:41:19:69:90": b""
+    }  # MAC in properties_raw
+    discovery_info.port = 80
+    discovery_info.hostname = "BSB-LAN.local."
+    return discovery_info

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -143,3 +143,17 @@ def zeroconf_discovery_info_properties_raw() -> Mock:
     discovery_info.port = 80
     discovery_info.hostname = "BSB-LAN.local."
     return discovery_info
+
+
+@pytest.fixture
+def zeroconf_discovery_info_different_mac() -> ZeroconfServiceInfo:
+    """Return zeroconf discovery info with a different MAC than the device API returns."""
+    return ZeroconfServiceInfo(
+        ip_address=ip_address("10.0.2.60"),
+        ip_addresses=[ip_address("10.0.2.60")],
+        name="BSB-LAN web service._http._tcp.local.",
+        type="_http._tcp.local.",
+        properties={"mac": "aa:bb:cc:dd:ee:ff"},  # Different MAC than in device.json
+        port=80,
+        hostname="BSB-LAN.local.",
+    )

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -1,8 +1,7 @@
 """Fixtures for BSBLAN integration tests."""
 
 from collections.abc import Generator
-from ipaddress import ip_address
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from bsblan import Device, HotWaterState, Info, Sensor, State, StaticState
 import pytest
@@ -10,7 +9,6 @@ import pytest
 from homeassistant.components.bsblan.const import CONF_PASSKEY, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -80,80 +78,3 @@ async def init_integration(
     await hass.async_block_till_done()
 
     return mock_config_entry
-
-
-# ZeroconfServiceInfo fixtures for different discovery scenarios
-
-
-@pytest.fixture
-def zeroconf_discovery_info() -> ZeroconfServiceInfo:
-    """Return zeroconf discovery info for a BSBLAN device with MAC address."""
-    return ZeroconfServiceInfo(
-        ip_address=ip_address("10.0.2.60"),
-        ip_addresses=[ip_address("10.0.2.60")],
-        name="BSB-LAN web service._http._tcp.local.",
-        type="_http._tcp.local.",
-        properties={"mac": "00:80:41:19:69:90"},
-        port=80,
-        hostname="BSB-LAN.local.",
-    )
-
-
-@pytest.fixture
-def zeroconf_discovery_info_no_mac() -> Mock:
-    """Return zeroconf discovery info for a BSBLAN device without MAC address."""
-    discovery_info = Mock()
-    discovery_info.ip_address = ip_address("10.0.2.60")
-    discovery_info.ip_addresses = [ip_address("10.0.2.60")]
-    discovery_info.name = "BSB-LAN web service._http._tcp.local."
-    discovery_info.type = "_http._tcp.local."
-    discovery_info.properties = {}  # No MAC in properties
-    discovery_info.properties_raw = {}  # No MAC in properties_raw either
-    discovery_info.port = 80
-    discovery_info.hostname = "BSB-LAN.local."
-    return discovery_info
-
-
-@pytest.fixture
-def zeroconf_discovery_info_different_ip() -> ZeroconfServiceInfo:
-    """Return zeroconf discovery info for a BSBLAN device with different IP."""
-    return ZeroconfServiceInfo(
-        ip_address=ip_address("192.168.1.100"),
-        ip_addresses=[ip_address("192.168.1.100")],
-        name="BSB-LAN web service._http._tcp.local.",
-        type="_http._tcp.local.",
-        properties={"mac": "00:80:41:19:69:90"},
-        port=8080,
-        hostname="BSB-LAN.local.",
-    )
-
-
-@pytest.fixture
-def zeroconf_discovery_info_properties_raw() -> Mock:
-    """Return zeroconf discovery info with MAC in properties_raw."""
-    discovery_info = Mock()
-    discovery_info.ip_address = ip_address("10.0.2.60")
-    discovery_info.ip_addresses = [ip_address("10.0.2.60")]
-    discovery_info.name = "BSB-LAN web service._http._tcp.local."
-    discovery_info.type = "_http._tcp.local."
-    discovery_info.properties = {}  # No MAC in properties
-    discovery_info.properties_raw = {
-        b"mac=00:80:41:19:69:90": b""
-    }  # MAC in properties_raw
-    discovery_info.port = 80
-    discovery_info.hostname = "BSB-LAN.local."
-    return discovery_info
-
-
-@pytest.fixture
-def zeroconf_discovery_info_different_mac() -> ZeroconfServiceInfo:
-    """Return zeroconf discovery info with a different MAC than the device API returns."""
-    return ZeroconfServiceInfo(
-        ip_address=ip_address("10.0.2.60"),
-        ip_addresses=[ip_address("10.0.2.60")],
-        name="BSB-LAN web service._http._tcp.local.",
-        type="_http._tcp.local.",
-        properties={"mac": "aa:bb:cc:dd:ee:ff"},  # Different MAC than in device.json
-        port=80,
-        hostname="BSB-LAN.local.",
-    )

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -376,7 +376,7 @@ async def test_zeroconf_discovery_no_mac_no_auth_required(
     result = await _init_zeroconf_flow(hass, zeroconf_discovery_info_no_mac)
 
     # Should now show the discovery_confirm form to the user
-    _assert_form_result(result, "discovery_no_auth_confirm")
+    _assert_form_result(result, "discovery_confirm")
 
     # User confirms the discovery
     result2 = await _configure_flow(hass, result["flow_id"], {})

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -1,10 +1,11 @@
 """Tests for the BSBLan device config flow."""
 
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 from bsblan import BSBLANConnectionError
+import pytest
 
-from homeassistant.components.bsblan import config_flow
 from homeassistant.components.bsblan.const import CONF_PASSKEY, DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
@@ -15,6 +16,124 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
+# ZeroconfServiceInfo fixtures for different discovery scenarios
+
+
+@pytest.fixture
+def zeroconf_discovery_info() -> ZeroconfServiceInfo:
+    """Return zeroconf discovery info for a BSBLAN device with MAC address."""
+    return ZeroconfServiceInfo(
+        ip_address=ip_address("10.0.2.60"),
+        ip_addresses=[ip_address("10.0.2.60")],
+        name="BSB-LAN web service._http._tcp.local.",
+        type="_http._tcp.local.",
+        properties={"mac": "00:80:41:19:69:90"},
+        port=80,
+        hostname="BSB-LAN.local.",
+    )
+
+
+@pytest.fixture
+def zeroconf_discovery_info_no_mac() -> Mock:
+    """Return zeroconf discovery info for a BSBLAN device without MAC address."""
+    discovery_info = Mock()
+    discovery_info.ip_address = ip_address("10.0.2.60")
+    discovery_info.ip_addresses = [ip_address("10.0.2.60")]
+    discovery_info.name = "BSB-LAN web service._http._tcp.local."
+    discovery_info.type = "_http._tcp.local."
+    discovery_info.properties = {}  # No MAC in properties
+    discovery_info.properties_raw = {}  # No MAC in properties_raw either
+    discovery_info.port = 80
+    discovery_info.hostname = "BSB-LAN.local."
+    return discovery_info
+
+
+@pytest.fixture
+def zeroconf_discovery_info_properties_raw() -> Mock:
+    """Return zeroconf discovery info with MAC in properties_raw."""
+    discovery_info = Mock()
+    discovery_info.ip_address = ip_address("10.0.2.60")
+    discovery_info.ip_addresses = [ip_address("10.0.2.60")]
+    discovery_info.name = "BSB-LAN web service._http._tcp.local."
+    discovery_info.type = "_http._tcp.local."
+    discovery_info.properties = {}  # No MAC in properties
+    discovery_info.properties_raw = {
+        b"mac=00:80:41:19:69:90": b""
+    }  # MAC in properties_raw
+    discovery_info.port = 80
+    discovery_info.hostname = "BSB-LAN.local."
+    return discovery_info
+
+
+@pytest.fixture
+def zeroconf_discovery_info_different_mac() -> ZeroconfServiceInfo:
+    """Return zeroconf discovery info with a different MAC than the device API returns."""
+    return ZeroconfServiceInfo(
+        ip_address=ip_address("10.0.2.60"),
+        ip_addresses=[ip_address("10.0.2.60")],
+        name="BSB-LAN web service._http._tcp.local.",
+        type="_http._tcp.local.",
+        properties={"mac": "aa:bb:cc:dd:ee:ff"},  # Different MAC than in device.json
+        port=80,
+        hostname="BSB-LAN.local.",
+    )
+
+
+# Helper functions to reduce repetition
+
+
+async def _init_user_flow(hass: HomeAssistant, user_input: dict | None = None):
+    """Initialize a user config flow."""
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data=user_input,
+    )
+
+
+async def _init_zeroconf_flow(hass: HomeAssistant, discovery_info):
+    """Initialize a zeroconf config flow."""
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+
+async def _configure_flow(hass: HomeAssistant, flow_id: str, user_input: dict):
+    """Configure a flow with user input."""
+    return await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input=user_input,
+    )
+
+
+def _assert_create_entry_result(
+    result, expected_title: str, expected_data: dict, expected_unique_id: str
+):
+    """Assert that result is a successful CREATE_ENTRY."""
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert result.get("title") == expected_title
+    assert result.get("data") == expected_data
+    assert "result" in result
+    assert result["result"].unique_id == expected_unique_id
+
+
+def _assert_form_result(
+    result, expected_step_id: str, expected_errors: dict | None = None
+):
+    """Assert that result is a FORM with correct step and optional errors."""
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == expected_step_id
+    if expected_errors:
+        assert result.get("errors") == expected_errors
+
+
+def _assert_abort_result(result, expected_reason: str):
+    """Assert that result is an ABORT with correct reason."""
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == expected_reason
+
 
 async def test_full_user_flow_implementation(
     hass: HomeAssistant,
@@ -22,17 +141,13 @@ async def test_full_user_flow_implementation(
     mock_setup_entry: AsyncMock,
 ) -> None:
     """Test the full manual user flow from start to finish."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
 
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "user"
-
-    result2 = await hass.config_entries.flow.async_configure(
+    result2 = await _configure_flow(
+        hass,
         result["flow_id"],
-        user_input={
+        {
             CONF_HOST: "127.0.0.1",
             CONF_PORT: 80,
             CONF_PASSKEY: "1234",
@@ -41,17 +156,18 @@ async def test_full_user_flow_implementation(
         },
     )
 
-    assert result2.get("type") is FlowResultType.CREATE_ENTRY
-    assert result2.get("title") == format_mac("00:80:41:19:69:90")
-    assert result2.get("data") == {
-        CONF_HOST: "127.0.0.1",
-        CONF_PORT: 80,
-        CONF_PASSKEY: "1234",
-        CONF_USERNAME: "admin",
-        CONF_PASSWORD: "admin1234",
-    }
-    assert "result" in result2
-    assert result2["result"].unique_id == format_mac("00:80:41:19:69:90")
+    _assert_create_entry_result(
+        result2,
+        format_mac("00:80:41:19:69:90"),
+        {
+            CONF_HOST: "127.0.0.1",
+            CONF_PORT: 80,
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+        format_mac("00:80:41:19:69:90"),
+    )
 
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_bsblan.device.mock_calls) == 1
@@ -59,13 +175,8 @@ async def test_full_user_flow_implementation(
 
 async def test_show_user_form(hass: HomeAssistant) -> None:
     """Test that the user set up form is served."""
-    result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    assert result["step_id"] == "user"
-    assert result["type"] is FlowResultType.FORM
+    result = await _init_user_flow(hass)
+    _assert_form_result(result, "user")
 
 
 async def test_connection_error(
@@ -75,10 +186,9 @@ async def test_connection_error(
     """Test we show user form on BSBLan connection error."""
     mock_bsblan.device.side_effect = BSBLANConnectionError
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={
+    result = await _init_user_flow(
+        hass,
+        {
             CONF_HOST: "127.0.0.1",
             CONF_PORT: 80,
             CONF_PASSKEY: "1234",
@@ -87,9 +197,7 @@ async def test_connection_error(
         },
     )
 
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("errors") == {"base": "cannot_connect"}
-    assert result.get("step_id") == "user"
+    _assert_form_result(result, "user", {"base": "cannot_connect"})
 
 
 async def test_user_device_exists_abort(
@@ -99,10 +207,10 @@ async def test_user_device_exists_abort(
 ) -> None:
     """Test we abort flow if BSBLAN device already configured."""
     mock_config_entry.add_to_hass(hass)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={
+
+    result = await _init_user_flow(
+        hass,
+        {
             CONF_HOST: "127.0.0.1",
             CONF_PORT: 80,
             CONF_PASSKEY: "1234",
@@ -111,8 +219,7 @@ async def test_user_device_exists_abort(
         },
     )
 
-    assert result.get("type") is FlowResultType.ABORT
-    assert result.get("reason") == "already_configured"
+    _assert_abort_result(result, "already_configured")
 
 
 async def test_zeroconf_discovery(
@@ -122,37 +229,31 @@ async def test_zeroconf_discovery(
     zeroconf_discovery_info: ZeroconfServiceInfo,
 ) -> None:
     """Test the Zeroconf discovery flow."""
-    discovery_info = zeroconf_discovery_info
+    result = await _init_zeroconf_flow(hass, zeroconf_discovery_info)
+    _assert_form_result(result, "discovery_confirm")
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
-
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "discovery_confirm"
-
-    result2 = await hass.config_entries.flow.async_configure(
+    result2 = await _configure_flow(
+        hass,
         result["flow_id"],
-        user_input={
+        {
             CONF_PASSKEY: "1234",
             CONF_USERNAME: "admin",
             CONF_PASSWORD: "admin1234",
         },
     )
 
-    assert result2.get("type") is FlowResultType.CREATE_ENTRY
-    assert result2.get("title") == format_mac("00:80:41:19:69:90")
-    assert result2.get("data") == {
-        CONF_HOST: "10.0.2.60",
-        CONF_PORT: 80,
-        CONF_PASSKEY: "1234",
-        CONF_USERNAME: "admin",
-        CONF_PASSWORD: "admin1234",
-    }
-    assert "result" in result2
-    assert result2["result"].unique_id == format_mac("00:80:41:19:69:90")
+    _assert_create_entry_result(
+        result2,
+        format_mac("00:80:41:19:69:90"),
+        {
+            CONF_HOST: "10.0.2.60",
+            CONF_PORT: 80,
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+        format_mac("00:80:41:19:69:90"),
+    )
 
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_bsblan.device.mock_calls) == 1
@@ -177,17 +278,8 @@ async def test_abort_if_existing_entry_for_zeroconf(
     )
     entry.add_to_hass(hass)
 
-    # Mock zeroconf discovery of the same device
-    discovery_info = zeroconf_discovery_info
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
-
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    result = await _init_zeroconf_flow(hass, zeroconf_discovery_info)
+    _assert_abort_result(result, "already_configured")
 
 
 async def test_zeroconf_discovery_mac_from_properties_raw(
@@ -197,38 +289,31 @@ async def test_zeroconf_discovery_mac_from_properties_raw(
     zeroconf_discovery_info_properties_raw: Mock,
 ) -> None:
     """Test Zeroconf discovery when MAC is found in properties_raw instead of properties."""
-    # Create a mock object that mimics ZeroconfServiceInfo but allows properties_raw
-    discovery_info = zeroconf_discovery_info_properties_raw
+    result = await _init_zeroconf_flow(hass, zeroconf_discovery_info_properties_raw)
+    _assert_form_result(result, "discovery_confirm")
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
-
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "discovery_confirm"
-
-    result2 = await hass.config_entries.flow.async_configure(
+    result2 = await _configure_flow(
+        hass,
         result["flow_id"],
-        user_input={
+        {
             CONF_PASSKEY: "1234",
             CONF_USERNAME: "admin",
             CONF_PASSWORD: "admin1234",
         },
     )
 
-    assert result2.get("type") is FlowResultType.CREATE_ENTRY
-    assert result2.get("title") == format_mac("00:80:41:19:69:90")
-    assert result2.get("data") == {
-        CONF_HOST: "10.0.2.60",
-        CONF_PORT: 80,
-        CONF_PASSKEY: "1234",
-        CONF_USERNAME: "admin",
-        CONF_PASSWORD: "admin1234",
-    }
-    assert "result" in result2
-    assert result2["result"].unique_id == format_mac("00:80:41:19:69:90")
+    _assert_create_entry_result(
+        result2,
+        format_mac("00:80:41:19:69:90"),
+        {
+            CONF_HOST: "10.0.2.60",
+            CONF_PORT: 80,
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+        format_mac("00:80:41:19:69:90"),
+    )
 
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_bsblan.device.mock_calls) == 1
@@ -240,20 +325,11 @@ async def test_zeroconf_discovery_no_mac_in_announcement(
     zeroconf_discovery_info_no_mac: Mock,
 ) -> None:
     """Test Zeroconf discovery works when no MAC address is in the announcement."""
-    # Create a mock object that mimics ZeroconfServiceInfo but allows properties_raw
-    discovery_info = zeroconf_discovery_info_no_mac
+    result = await _init_zeroconf_flow(hass, zeroconf_discovery_info_no_mac)
+    _assert_form_result(result, "discovery_confirm")
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "discovery_confirm"
-
-    # Now complete the discovery by providing credentials and connecting
-    result2 = await hass.config_entries.flow.async_configure(
+    result2 = await _configure_flow(
+        hass,
         result["flow_id"],
         {
             CONF_USERNAME: "admin",
@@ -261,17 +337,18 @@ async def test_zeroconf_discovery_no_mac_in_announcement(
         },
     )
 
-    await hass.async_block_till_done()
-
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "00:80:41:19:69:90"  # MAC from fixture file
-    assert result2["data"] == {
-        CONF_HOST: "10.0.2.60",
-        CONF_PORT: 80,
-        CONF_PASSKEY: None,
-        CONF_USERNAME: "admin",
-        CONF_PASSWORD: "secret",
-    }
+    _assert_create_entry_result(
+        result2,
+        "00:80:41:19:69:90",  # MAC from fixture file
+        {
+            CONF_HOST: "10.0.2.60",
+            CONF_PORT: 80,
+            CONF_PASSKEY: None,
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "secret",
+        },
+        "00:80:41:19:69:90",
+    )
 
 
 async def test_zeroconf_discovery_connection_error(
@@ -282,37 +359,28 @@ async def test_zeroconf_discovery_connection_error(
     """Test connection error during zeroconf discovery shows the correct form."""
     mock_bsblan.device.side_effect = BSBLANConnectionError
 
-    discovery_info = zeroconf_discovery_info
+    result = await _init_zeroconf_flow(hass, zeroconf_discovery_info)
+    _assert_form_result(result, "discovery_confirm")
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
-
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "discovery_confirm"
-
-    result2 = await hass.config_entries.flow.async_configure(
+    result2 = await _configure_flow(
+        hass,
         result["flow_id"],
-        user_input={
+        {
             CONF_PASSKEY: "1234",
             CONF_USERNAME: "admin",
             CONF_PASSWORD: "admin1234",
         },
     )
 
-    assert result2.get("type") is FlowResultType.FORM
-    assert result2.get("step_id") == "discovery_confirm"
-    assert result2.get("errors") == {"base": "cannot_connect"}
+    _assert_form_result(result2, "discovery_confirm", {"base": "cannot_connect"})
 
 
-async def test_zeroconf_discovery_doesnt_update_host_port_on_existing_entry(
+async def test_zeroconf_discovery_updates_host_port_on_existing_entry(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
     zeroconf_discovery_info: ZeroconfServiceInfo,
 ) -> None:
-    """Test that discovered devices don't update host/port of existing entries."""
+    """Test that discovered devices update host/port of existing entries."""
     # Create an existing entry with different host/port
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -326,22 +394,12 @@ async def test_zeroconf_discovery_doesnt_update_host_port_on_existing_entry(
     )
     entry.add_to_hass(hass)
 
-    # Mock zeroconf discovery of the same device but with different IP/port
-    discovery_info = zeroconf_discovery_info
+    result = await _init_zeroconf_flow(hass, zeroconf_discovery_info)
+    _assert_abort_result(result, "already_configured")
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
-
-    # Should abort because device is already configured
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-    # Verify the existing entry was NOT updated with new host/port
-    assert entry.data[CONF_HOST] == "192.168.1.100"  # Original host preserved
-    assert entry.data[CONF_PORT] == 8080  # Original port preserved
+    # Verify the existing entry WAS updated with new host/port from discovery
+    assert entry.data[CONF_HOST] == "10.0.2.60"  # Updated host from discovery
+    assert entry.data[CONF_PORT] == 80  # Updated port from discovery
 
 
 async def test_user_flow_can_update_existing_host_port(
@@ -363,10 +421,9 @@ async def test_user_flow_can_update_existing_host_port(
     entry.add_to_hass(hass)
 
     # Try to configure the same device with different host/port via user flow
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={
+    result = await _init_user_flow(
+        hass,
+        {
             CONF_HOST: "10.0.2.60",  # Different IP
             CONF_PORT: 80,  # Different port
             CONF_PASSKEY: "1234",
@@ -375,9 +432,7 @@ async def test_user_flow_can_update_existing_host_port(
         },
     )
 
-    # Should abort because device is already configured, but should update host/port
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    _assert_abort_result(result, "already_configured")
 
     # Verify the existing entry WAS updated with new host/port (user flow behavior)
     assert entry.data[CONF_HOST] == "10.0.2.60"  # Updated host
@@ -393,39 +448,31 @@ async def test_zeroconf_discovery_mac_mismatch_updates_unique_id(
     """Test Zeroconf discovery when MAC from discovery differs from device API."""
     # The fixture provides MAC "aa:bb:cc:dd:ee:ff" in Zeroconf discovery
     # But the mock device API returns "00:80:41:19:69:90" (from device.json)
-    discovery_info = zeroconf_discovery_info_different_mac
+    result = await _init_zeroconf_flow(hass, zeroconf_discovery_info_different_mac)
+    _assert_form_result(result, "discovery_confirm")
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
-
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "discovery_confirm"
-
-    result2 = await hass.config_entries.flow.async_configure(
+    result2 = await _configure_flow(
+        hass,
         result["flow_id"],
-        user_input={
+        {
             CONF_PASSKEY: "1234",
             CONF_USERNAME: "admin",
             CONF_PASSWORD: "admin1234",
         },
     )
 
-    assert result2.get("type") is FlowResultType.CREATE_ENTRY
-    # Title should use the MAC from the device API, not from Zeroconf
-    assert result2.get("title") == format_mac("00:80:41:19:69:90")
-    assert result2.get("data") == {
-        CONF_HOST: "10.0.2.60",
-        CONF_PORT: 80,
-        CONF_PASSKEY: "1234",
-        CONF_USERNAME: "admin",
-        CONF_PASSWORD: "admin1234",
-    }
-    assert "result" in result2
-    # Unique ID should be updated to the MAC from device API
-    assert result2["result"].unique_id == format_mac("00:80:41:19:69:90")
+    _assert_create_entry_result(
+        result2,
+        format_mac("00:80:41:19:69:90"),  # Title should use MAC from device API
+        {
+            CONF_HOST: "10.0.2.60",
+            CONF_PORT: 80,
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+        format_mac("00:80:41:19:69:90"),  # Unique ID updated to MAC from device API
+    )
 
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_bsblan.device.mock_calls) == 1

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -1,16 +1,18 @@
 """Tests for the BSBLan device config flow."""
 
-from unittest.mock import AsyncMock, MagicMock
+from ipaddress import ip_address
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 from bsblan import BSBLANConnectionError
 
 from homeassistant.components.bsblan import config_flow
 from homeassistant.components.bsblan.const import CONF_PASSKEY, DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -112,3 +114,170 @@ async def test_user_device_exists_abort(
 
     assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "already_configured"
+
+
+async def test_zeroconf_discovery(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test the Zeroconf discovery flow."""
+    discovery_info = ZeroconfServiceInfo(
+        ip_address=ip_address("10.0.2.60"),
+        ip_addresses=[ip_address("10.0.2.60")],
+        name="BSB-LAN web service._http._tcp.local.",
+        type="_http._tcp.local.",
+        properties={"mac": "00:80:41:19:69:90"},  # Include MAC address
+        port=80,
+        hostname="BSB-LAN.local.",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "discovery_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+    )
+
+    assert result2.get("type") is FlowResultType.CREATE_ENTRY
+    assert result2.get("title") == format_mac("00:80:41:19:69:90")
+    assert result2.get("data") == {
+        CONF_HOST: "10.0.2.60",
+        CONF_PORT: 80,
+        CONF_PASSKEY: "1234",
+        CONF_USERNAME: "admin",
+        CONF_PASSWORD: "admin1234",
+    }
+    assert "result" in result2
+    assert result2["result"].unique_id == format_mac("00:80:41:19:69:90")
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_bsblan.device.mock_calls) == 1
+
+
+async def test_abort_if_existing_entry_for_zeroconf(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test we abort if the same host/port already exists during zeroconf discovery."""
+    # Create an existing entry
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "127.0.0.1",
+            CONF_PORT: 80,
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+        unique_id="00:80:41:19:69:90",
+    )
+    entry.add_to_hass(hass)
+
+    # Mock zeroconf discovery of the same device
+    discovery_info = ZeroconfServiceInfo(
+        ip_address=ip_address("10.0.2.60"),
+        ip_addresses=[ip_address("10.0.2.60")],
+        name="BSB-LAN web service._http._tcp.local.",
+        type="_http._tcp.local.",
+        properties={"mac": "00:80:41:19:69:90"},  # Include MAC address
+        port=80,
+        hostname="BSB-LAN.local.",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_discovery_mac_from_properties_raw(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test Zeroconf discovery when MAC is found in properties_raw instead of properties."""
+    # Create a mock object that mimics ZeroconfServiceInfo but allows properties_raw
+    discovery_info = Mock()
+    discovery_info.ip_address = ip_address("10.0.2.60")
+    discovery_info.ip_addresses = [ip_address("10.0.2.60")]
+    discovery_info.name = "BSB-LAN web service._http._tcp.local."
+    discovery_info.type = "_http._tcp.local."
+    discovery_info.properties = {}  # No MAC in properties
+    discovery_info.properties_raw = {
+        b"mac=00:80:41:19:69:90": b""
+    }  # MAC in properties_raw
+    discovery_info.port = 80
+    discovery_info.hostname = "BSB-LAN.local."
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "discovery_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+    )
+
+    assert result2.get("type") is FlowResultType.CREATE_ENTRY
+    assert result2.get("title") == format_mac("00:80:41:19:69:90")
+    assert result2.get("data") == {
+        CONF_HOST: "10.0.2.60",
+        CONF_PORT: 80,
+        CONF_PASSKEY: "1234",
+        CONF_USERNAME: "admin",
+        CONF_PASSWORD: "admin1234",
+    }
+    assert "result" in result2
+    assert result2["result"].unique_id == format_mac("00:80:41:19:69:90")
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_bsblan.device.mock_calls) == 1
+
+
+async def test_zeroconf_discovery_no_mac_abort(
+    hass: HomeAssistant,
+) -> None:
+    """Test Zeroconf discovery aborts when no MAC address is found."""
+    # Create a mock object that mimics ZeroconfServiceInfo but allows properties_raw
+    discovery_info = Mock()
+    discovery_info.ip_address = ip_address("10.0.2.60")
+    discovery_info.ip_addresses = [ip_address("10.0.2.60")]
+    discovery_info.name = "BSB-LAN web service._http._tcp.local."
+    discovery_info.type = "_http._tcp.local."
+    discovery_info.properties = {}  # No MAC in properties
+    discovery_info.properties_raw = {}  # No MAC in properties_raw either
+    discovery_info.port = 80
+    discovery_info.hostname = "BSB-LAN.local."
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "no_mac_address"

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -487,45 +487,6 @@ async def test_user_flow_can_update_existing_host_port(
     assert entry.data[CONF_PORT] == 80  # Updated port
 
 
-async def test_zeroconf_discovery_mac_mismatch_updates_unique_id(
-    hass: HomeAssistant,
-    mock_bsblan: MagicMock,
-    mock_setup_entry: AsyncMock,
-    zeroconf_discovery_info_different_mac: ZeroconfServiceInfo,
-) -> None:
-    """Test Zeroconf discovery when MAC from discovery differs from device API."""
-    # The fixture provides MAC "aa:bb:cc:dd:ee:ff" in Zeroconf discovery
-    # But the mock device API returns "00:80:41:19:69:90" (from device.json)
-    result = await _init_zeroconf_flow(hass, zeroconf_discovery_info_different_mac)
-    _assert_form_result(result, "discovery_confirm")
-
-    result2 = await _configure_flow(
-        hass,
-        result["flow_id"],
-        {
-            CONF_PASSKEY: "1234",
-            CONF_USERNAME: "admin",
-            CONF_PASSWORD: "admin1234",
-        },
-    )
-
-    _assert_create_entry_result(
-        result2,
-        format_mac("00:80:41:19:69:90"),  # Title should use MAC from device API
-        {
-            CONF_HOST: "10.0.2.60",
-            CONF_PORT: 80,
-            CONF_PASSKEY: "1234",
-            CONF_USERNAME: "admin",
-            CONF_PASSWORD: "admin1234",
-        },
-        format_mac("00:80:41:19:69:90"),  # Unique ID updated to MAC from device API
-    )
-
-    assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_bsblan.device.mock_calls) == 1
-
-
 async def test_zeroconf_discovery_connection_error_recovery(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -376,7 +376,7 @@ async def test_zeroconf_discovery_no_mac_no_auth_required(
     result = await _init_zeroconf_flow(hass, zeroconf_discovery_info_no_mac)
 
     # Should now show the discovery_confirm form to the user
-    _assert_form_result(result, "discovery_confirm")
+    _assert_form_result(result, "discovery_no_auth_confirm")
 
     # User confirms the discovery
     result2 = await _configure_flow(hass, result["flow_id"], {})
@@ -395,8 +395,8 @@ async def test_zeroconf_discovery_no_mac_no_auth_required(
     )
 
     assert len(mock_setup_entry.mock_calls) == 1
-    # Should be called twice: once in zeroconf step, once in _validate_and_create
-    assert len(mock_bsblan.device.mock_calls) == 2
+    # Should be called once in zeroconf step, as _validate_and_create is skipped
+    assert len(mock_bsblan.device.mock_calls) == 1
 
 
 async def test_zeroconf_discovery_connection_error(

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -126,6 +126,7 @@ def _assert_form_result(
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == expected_step_id
     if expected_errors is None:
+        # Handle both None and {} as valid "no errors" states (like other integrations)
         assert result.get("errors") in ({}, None)
     else:
         assert result.get("errors") == expected_errors

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -125,8 +125,7 @@ def _assert_form_result(
     """Assert that result is a FORM with correct step and optional errors."""
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == expected_step_id
-    if expected_errors:
-        assert result.get("errors") == expected_errors
+    assert result.get("errors") == expected_errors
 
 
 def _assert_abort_result(result, expected_reason: str):

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -375,9 +375,14 @@ async def test_zeroconf_discovery_no_mac_no_auth_required(
     """Test Zeroconf discovery when no MAC in announcement but device accessible without auth."""
     result = await _init_zeroconf_flow(hass, zeroconf_discovery_info_no_mac)
 
-    # Should create entry directly without showing discovery_confirm form
+    # Should now show the discovery_confirm form to the user
+    _assert_form_result(result, "discovery_confirm")
+
+    # User confirms the discovery
+    result2 = await _configure_flow(hass, result["flow_id"], {})
+
     _assert_create_entry_result(
-        result,
+        result2,
         "00:80:41:19:69:90",  # MAC from fixture file
         {
             CONF_HOST: "10.0.2.60",

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -125,7 +125,10 @@ def _assert_form_result(
     """Assert that result is a FORM with correct step and optional errors."""
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == expected_step_id
-    assert result.get("errors") == expected_errors
+    if expected_errors is None:
+        assert result.get("errors") in ({}, None)
+    else:
+        assert result.get("errors") == expected_errors
 
 
 def _assert_abort_result(result, expected_reason: str):

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for the BSBLan device config flow."""
 
 from ipaddress import ip_address
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock
 
 from bsblan import BSBLANConnectionError
 import pytest
@@ -34,17 +34,17 @@ def zeroconf_discovery_info() -> ZeroconfServiceInfo:
 
 
 @pytest.fixture
-def zeroconf_discovery_info_no_mac() -> Mock:
+def zeroconf_discovery_info_no_mac() -> ZeroconfServiceInfo:
     """Return zeroconf discovery info for a BSBLAN device without MAC address."""
-    discovery_info = Mock()
-    discovery_info.ip_address = ip_address("10.0.2.60")
-    discovery_info.ip_addresses = [ip_address("10.0.2.60")]
-    discovery_info.name = "BSB-LAN web service._http._tcp.local."
-    discovery_info.type = "_http._tcp.local."
-    discovery_info.properties = {}  # No MAC in properties
-    discovery_info.port = 80
-    discovery_info.hostname = "BSB-LAN.local."
-    return discovery_info
+    return ZeroconfServiceInfo(
+        ip_address=ip_address("10.0.2.60"),
+        ip_addresses=[ip_address("10.0.2.60")],
+        name="BSB-LAN web service._http._tcp.local.",
+        type="_http._tcp.local.",
+        properties={},  # No MAC in properties
+        port=80,
+        hostname="BSB-LAN.local.",
+    )
 
 
 @pytest.fixture
@@ -270,7 +270,7 @@ async def test_abort_if_existing_entry_for_zeroconf(
 async def test_zeroconf_discovery_no_mac_requires_auth(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    zeroconf_discovery_info_no_mac: Mock,
+    zeroconf_discovery_info_no_mac: ZeroconfServiceInfo,
 ) -> None:
     """Test Zeroconf discovery when no MAC in announcement and device requires auth."""
     # Make the first API call (without auth) fail, second call (with auth) succeed
@@ -315,7 +315,7 @@ async def test_zeroconf_discovery_no_mac_no_auth_required(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
     mock_setup_entry: AsyncMock,
-    zeroconf_discovery_info_no_mac: Mock,
+    zeroconf_discovery_info_no_mac: ZeroconfServiceInfo,
 ) -> None:
     """Test Zeroconf discovery when no MAC in announcement but device accessible without auth."""
     result = await _init_zeroconf_flow(hass, zeroconf_discovery_info_no_mac)
@@ -546,7 +546,7 @@ async def test_connection_error_recovery(
 async def test_zeroconf_discovery_no_mac_duplicate_host_port(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    zeroconf_discovery_info_no_mac: Mock,
+    zeroconf_discovery_info_no_mac: ZeroconfServiceInfo,
 ) -> None:
     """Test Zeroconf discovery aborts when no MAC and same host/port already configured."""
     # Create an existing entry with same host/port but no unique_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add zeroconfig to bsblan integration


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39389
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr