### PR TITLE
[APSystems] Fix: set measurements to type `increasing`

### DIFF
--- a/homeassistant/components/apsystems/sensor.py
+++ b/homeassistant/components/apsystems/sensor.py
@@ -60,7 +60,7 @@ SENSORS: tuple[ApsystemsLocalApiSensorDescription, ...] = (
         translation_key="lifetime_production",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.INCREASING,
         value_fn=lambda c: c.te1 + c.te2,
     ),
     ApsystemsLocalApiSensorDescription(
@@ -68,7 +68,7 @@ SENSORS: tuple[ApsystemsLocalApiSensorDescription, ...] = (
         translation_key="lifetime_production_p1",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.INCREASING,
         value_fn=lambda c: c.te1,
     ),
     ApsystemsLocalApiSensorDescription(
@@ -76,7 +76,7 @@ SENSORS: tuple[ApsystemsLocalApiSensorDescription, ...] = (
         translation_key="lifetime_production_p2",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.INCREASING,
         value_fn=lambda c: c.te2,
     ),
     ApsystemsLocalApiSensorDescription(
@@ -84,7 +84,7 @@ SENSORS: tuple[ApsystemsLocalApiSensorDescription, ...] = (
         translation_key="today_production",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.INCREASING,
         value_fn=lambda c: c.e1 + c.e2,
     ),
     ApsystemsLocalApiSensorDescription(
@@ -92,7 +92,7 @@ SENSORS: tuple[ApsystemsLocalApiSensorDescription, ...] = (
         translation_key="today_production_p1",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.INCREASING,
         value_fn=lambda c: c.e1,
     ),
     ApsystemsLocalApiSensorDescription(
@@ -100,7 +100,7 @@ SENSORS: tuple[ApsystemsLocalApiSensorDescription, ...] = (
         translation_key="today_production_p2",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.INCREASING,
         value_fn=lambda c: c.e2,
     ),
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Fixes `2025-06-05 20:20:10.381 WARNING (Recorder) [homeassistant.components.sensor.recorder] Entity sensor.balkonkraftwerk_erzeugung_von_p2_uber_lebensdauer from integration apsystems has state class total_increasing, but its state is not strictly increasing. Triggered by state 0.93135 (0.93138) with last_updated set to 2025-06-05T18:18:50.233882+00:00.`

## Type of change
This changes the type of the measurements from `TOTAL_INCREASING` to `INCREASING`. 
This should not be necessary as this values _should_ only increase, however as you can see in the log above, they don't (ever so slighly). I assume this is a rounding error in the device somewhere itself.
 

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Another way to solved this would be to round the values in the integration before saving them. This would be sensible (in my opinion) as determining `kWh`s to the `0.00001` is somewhat unsensible.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
