### PR TITLE
Move vesync services to separate module

### DIFF
--- a/homeassistant/components/vesync/services.py
+++ b/homeassistant/components/vesync/services.py
@@ -1,0 +1,32 @@
+"""VeSync integration."""
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .common import async_generate_device_list
+from .const import DOMAIN, SERVICE_UPDATE_DEVS, VS_DEVICES, VS_DISCOVERY, VS_MANAGER
+
+
+async def _async_new_device_discovery(service: ServiceCall) -> None:
+    """Discover if new devices should be added."""
+    hass = service.hass
+    manager = hass.data[DOMAIN][VS_MANAGER]
+    devices = hass.data[DOMAIN][VS_DEVICES]
+
+    new_devices = await async_generate_device_list(hass, manager)
+
+    device_set = set(new_devices)
+    new_devices = list(device_set.difference(devices))
+    if new_devices and devices:
+        devices.extend(new_devices)
+        async_dispatcher_send(hass, VS_DISCOVERY.format(VS_DEVICES), new_devices)
+        return
+    if new_devices and not devices:
+        devices.extend(new_devices)
+
+
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register integration services."""
+    hass.services.async_register(
+        DOMAIN, SERVICE_UPDATE_DEVS, _async_new_device_discovery
+    )

--- a/tests/components/vesync/test_init.py
+++ b/tests/components/vesync/test_init.py
@@ -4,8 +4,12 @@ from unittest.mock import Mock, patch
 
 from pyvesync import VeSync
 
-from homeassistant.components.vesync import SERVICE_UPDATE_DEVS, async_setup_entry
-from homeassistant.components.vesync.const import DOMAIN, VS_DEVICES, VS_MANAGER
+from homeassistant.components.vesync.const import (
+    DOMAIN,
+    SERVICE_UPDATE_DEVS,
+    VS_DEVICES,
+    VS_MANAGER,
+)
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -36,7 +40,7 @@ async def test_async_setup_entry__no_devices(
 ) -> None:
     """Test setup connects to vesync and creates empty config when no devices."""
     with patch.object(hass.config_entries, "async_forward_entry_setups") as setups_mock:
-        assert await async_setup_entry(hass, config_entry)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         # Assert platforms loaded
         await hass.async_block_till_done()
         assert setups_mock.call_count == 1
@@ -68,7 +72,7 @@ async def test_async_setup_entry__loads_fans(
     }
 
     with patch.object(hass.config_entries, "async_forward_entry_setups") as setups_mock:
-        assert await async_setup_entry(hass, config_entry)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         # Assert platforms loaded
         await hass.async_block_till_done()
         assert setups_mock.call_count == 1

--- a/tests/components/vesync/test_init.py
+++ b/tests/components/vesync/test_init.py
@@ -105,7 +105,7 @@ async def test_async_new_device_discovery(
 
     # Mock discovery of new fan which would get added to VS_DEVICES.
     with patch(
-        "homeassistant.components.vesync.async_generate_device_list",
+        "homeassistant.components.vesync.services.async_generate_device_list",
         return_value=[fan],
     ):
         await hass.services.async_call(DOMAIN, SERVICE_UPDATE_DEVS, {}, blocking=True)
@@ -117,7 +117,7 @@ async def test_async_new_device_discovery(
     # Mock discovery of new humidifier which would invoke discovery in all platforms.
     # The mocked humidifier needs to have all properties populated for correct processing.
     with patch(
-        "homeassistant.components.vesync.async_generate_device_list",
+        "homeassistant.components.vesync.services.async_generate_device_list",
         return_value=[humidifier],
     ):
         await hass.services.async_call(DOMAIN, SERVICE_UPDATE_DEVS, {}, blocking=True)

--- a/tests/components/vesync/test_init.py
+++ b/tests/components/vesync/test_init.py
@@ -40,7 +40,7 @@ async def test_async_setup_entry__no_devices(
 ) -> None:
     """Test setup connects to vesync and creates empty config when no devices."""
     with patch.object(hass.config_entries, "async_forward_entry_setups") as setups_mock:
-        await hass.config_entries.async_setup(config_entry.entry_id)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         # Assert platforms loaded
         await hass.async_block_till_done()
         assert setups_mock.call_count == 1
@@ -72,7 +72,7 @@ async def test_async_setup_entry__loads_fans(
     }
 
     with patch.object(hass.config_entries, "async_forward_entry_setups") as setups_mock:
-        await hass.config_entries.async_setup(config_entry.entry_id)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         # Assert platforms loaded
         await hass.async_block_till_done()
         assert setups_mock.call_count == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
