### PR TITLE
Migrate Enphase envoy from httpx to aiohttp

### DIFF
--- a/homeassistant/components/enphase_envoy/__init__.py
+++ b/homeassistant/components/enphase_envoy/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import httpx
 from pyenphase import Envoy
 
 from homeassistant.config_entries import ConfigEntry
@@ -10,7 +9,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
     DOMAIN,
@@ -26,18 +25,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
 
     host = entry.data[CONF_HOST]
     options = entry.options
-    envoy = (
-        Envoy(
-            host,
-            httpx.AsyncClient(
-                verify=False, limits=httpx.Limits(max_keepalive_connections=0)
-            ),
-        )
-        if options.get(
-            OPTION_DISABLE_KEEP_ALIVE, OPTION_DISABLE_KEEP_ALIVE_DEFAULT_VALUE
-        )
-        else Envoy(host, get_async_client(hass, verify_ssl=False))
-    )
+    session = async_create_clientsession(hass, verify_ssl=False)
+    if options.get(OPTION_DISABLE_KEEP_ALIVE, OPTION_DISABLE_KEEP_ALIVE_DEFAULT_VALUE):
+        # User set option to disable keep-alive
+        pass
+
+    envoy = Envoy(host, session)
     coordinator = EnphaseUpdateCoordinator(hass, envoy, entry)
 
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/enphase_envoy/__init__.py
+++ b/homeassistant/components/enphase_envoy/__init__.py
@@ -11,12 +11,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import (
-    DOMAIN,
-    OPTION_DISABLE_KEEP_ALIVE,
-    OPTION_DISABLE_KEEP_ALIVE_DEFAULT_VALUE,
-    PLATFORMS,
-)
+from .const import DOMAIN, PLATFORMS
 from .coordinator import EnphaseConfigEntry, EnphaseUpdateCoordinator
 
 
@@ -24,12 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     """Set up Enphase Envoy from a config entry."""
 
     host = entry.data[CONF_HOST]
-    options = entry.options
     session = async_create_clientsession(hass, verify_ssl=False)
-    if options.get(OPTION_DISABLE_KEEP_ALIVE, OPTION_DISABLE_KEEP_ALIVE_DEFAULT_VALUE):
-        # User set option to disable keep-alive
-        pass
-
     envoy = Envoy(host, session)
     coordinator = EnphaseUpdateCoordinator(hass, envoy, entry)
 

--- a/homeassistant/components/enphase_envoy/config_flow.py
+++ b/homeassistant/components/enphase_envoy/config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.helpers.typing import VolDictType
 
@@ -63,7 +63,7 @@ async def validate_input(
     description_placeholders: dict[str, str],
 ) -> Envoy:
     """Validate the user input allows us to connect."""
-    envoy = Envoy(host, get_async_client(hass, verify_ssl=False))
+    envoy = Envoy(host, async_get_clientsession(hass, verify_ssl=False))
     try:
         await envoy.setup()
         await envoy.authenticate(username=username, password=password)

--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -6,6 +6,7 @@ import copy
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from aiohttp import ClientResponse
 from attr import asdict
 from pyenphase.envoy import Envoy
 from pyenphase.exceptions import EnvoyError
@@ -69,14 +70,14 @@ async def _get_fixture_collection(envoy: Envoy, serial: str) -> dict[str, Any]:
 
     for end_point in end_points:
         try:
-            response = await envoy.request(end_point)
-            fixture_data[end_point] = response.text.replace("\n", "").replace(
-                serial, CLEAN_TEXT
+            response: ClientResponse = await envoy.request(end_point)
+            fixture_data[end_point] = (
+                (await response.text()).replace("\n", "").replace(serial, CLEAN_TEXT)
             )
             fixture_data[f"{end_point}_log"] = json_dumps(
                 {
                     "headers": dict(response.headers.items()),
-                    "code": response.status_code,
+                    "code": response.status,
                 }
             )
         except EnvoyError as err:

--- a/homeassistant/components/enphase_envoy/entity.py
+++ b/homeassistant/components/enphase_envoy/entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 from typing import Any, Concatenate
 
-from httpx import HTTPError
+from aiohttp import ClientError
 from pyenphase import EnvoyData
 from pyenphase.exceptions import EnvoyError
 
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import EnphaseUpdateCoordinator
 
-ACTIONERRORS = (EnvoyError, HTTPError)
+ACTIONERRORS = (EnvoyError, ClientError)
 
 
 class EnvoyBaseEntity(CoordinatorEntity[EnphaseUpdateCoordinator]):

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
   "quality_scale": "platinum",
-  "requirements": ["pyenphase==2.0.0"],
+  "requirements": ["pyenphase==2.0.1"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
   "quality_scale": "platinum",
-  "requirements": ["pyenphase==1.26.1"],
+  "requirements": ["pyenphase==2.0.0"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1958,7 +1958,7 @@ pyeiscp==0.0.7
 pyemoncms==0.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.26.1
+pyenphase==2.0.0
 
 # homeassistant.components.envisalink
 pyenvisalink==4.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1958,7 +1958,7 @@ pyeiscp==0.0.7
 pyemoncms==0.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==2.0.0
+pyenphase==2.0.1
 
 # homeassistant.components.envisalink
 pyenvisalink==4.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1630,7 +1630,7 @@ pyeiscp==0.0.7
 pyemoncms==0.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==2.0.0
+pyenphase==2.0.1
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1630,7 +1630,7 @@ pyeiscp==0.0.7
 pyemoncms==0.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.26.1
+pyenphase==2.0.0
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0

--- a/tests/components/enphase_envoy/conftest.py
+++ b/tests/components/enphase_envoy/conftest.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import jwt
+import multidict
 from pyenphase import (
     EnvoyACBPower,
     EnvoyBatteryAggregate,
@@ -101,9 +102,11 @@ async def mock_envoy(
         mock_envoy.auth = EnvoyTokenAuth("127.0.0.1", token=token, envoy_serial="1234")
         mock_envoy.serial_number = "1234"
         mock = Mock()
-        mock.status_code = 200
-        mock.text = "Testing request \nreplies."
-        mock.headers = {"Hello": "World"}
+        mock.status = 200
+        aiohttp_text = AsyncMock()
+        aiohttp_text.return_value = "Testing request \nreplies."
+        mock.text = aiohttp_text
+        mock.headers = multidict.MultiDict([("Hello", "World")])
         mock_envoy.request.return_value = mock
 
         # determine fixture file name, default envoy if no request passed


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR replaces enphase_envoy integration's  use of httpx by aiohttp. This improves integration startup time and some issues with digestauth for older version.

The change is implemented by [bumping pyenphase to 2.0.1](https://github.com/pyenphase/pyenphase/compare/v1.26.1...v2.0.1)  ([release log](https://pyenphase.readthedocs.io/en/stable/changelog.html#v2-0-0-2025-06-06)) and adapting clients, errors, responses and tests from httpx to aiohttp versions

This PR replaces and closes #145940 which is based on early changes in the underlying pyenphase library.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: replaces #145940 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
