### PR TITLE
Add tests for sonos switch alarms on and off

### DIFF
--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -91,8 +91,7 @@ class SonosMockAlarmClock(SonosMockService):
     def __init__(self, return_value: dict[str, str], ip_address="192.168.42.2") -> None:
         """Initialize the instance."""
         super().__init__("AlarmClock", ip_address)
-        self.ListAlarms = Mock()
-        self.ListAlarms.return_value = return_value
+        self.ListAlarms = Mock(return_value=return_value)
         self.UpdateAlarm = Mock()
 
 

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -88,19 +88,11 @@ class SonosMockService:
 class SonosMockAlarmClock(SonosMockService):
     """Mock a Sonos AlarmClock Service used in callbacks."""
 
-    def __init__(self, ip_address="192.168.42.2") -> None:
+    def __init__(self, return_value: dict[str, str], ip_address="192.168.42.2") -> None:
         """Initialize the instance."""
         super().__init__("AlarmClock", ip_address)
         self.ListAlarms = Mock()
-        self.ListAlarms.return_value = {
-            "CurrentAlarmListVersion": "RINCON_test:14",
-            "CurrentAlarmList": "<Alarms>"
-            '<Alarm ID="14" StartTime="07:00:00" Duration="02:00:00" Recurrence="DAILY" '
-            'Enabled="1" RoomUUID="RINCON_test" ProgramURI="x-rincon-buzzer:0" '
-            'ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" Volume="25" '
-            'IncludeLinkedZones="0"/>'
-            "</Alarms>",
-        }
+        self.ListAlarms.return_value = return_value
         self.UpdateAlarm = Mock()
 
 
@@ -614,37 +606,37 @@ def music_library_fixture(
 @pytest.fixture(name="alarm_clock")
 def alarm_clock_fixture() -> SonosMockAlarmClock:
     """Create alarmClock fixture."""
-    alarm_clock = SonosMockAlarmClock()
-    alarm_clock.ListAlarms.return_value = {
-        "CurrentAlarmListVersion": "RINCON_test:14",
-        "CurrentAlarmList": "<Alarms>"
-        '<Alarm ID="14" StartTime="07:00:00" Duration="02:00:00" Recurrence="DAILY" '
-        'Enabled="1" RoomUUID="RINCON_test" ProgramURI="x-rincon-buzzer:0" '
-        'ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" Volume="25" '
-        'IncludeLinkedZones="0"/>'
-        "</Alarms>",
-    }
-    return alarm_clock
+    return SonosMockAlarmClock(
+        {
+            "CurrentAlarmListVersion": "RINCON_test:14",
+            "CurrentAlarmList": "<Alarms>"
+            '<Alarm ID="14" StartTime="07:00:00" Duration="02:00:00" Recurrence="DAILY" '
+            'Enabled="1" RoomUUID="RINCON_test" ProgramURI="x-rincon-buzzer:0" '
+            'ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" Volume="25" '
+            'IncludeLinkedZones="0"/>'
+            "</Alarms>",
+        }
+    )
 
 
 @pytest.fixture(name="alarm_clock_extended")
 def alarm_clock_fixture_extended() -> SonosMockAlarmClock:
     """Create alarmClock fixture."""
-    alarm_clock = SonosMockAlarmClock()
-    alarm_clock.ListAlarms.return_value = {
-        "CurrentAlarmListVersion": "RINCON_test:15",
-        "CurrentAlarmList": "<Alarms>"
-        '<Alarm ID="14" StartTime="07:00:00" Duration="02:00:00" Recurrence="DAILY" '
-        'Enabled="1" RoomUUID="RINCON_test" ProgramURI="x-rincon-buzzer:0" '
-        'ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" Volume="25" '
-        'IncludeLinkedZones="0"/>'
-        '<Alarm ID="15" StartTime="07:00:00" Duration="02:00:00" '
-        'Recurrence="DAILY" Enabled="1" RoomUUID="RINCON_test" '
-        'ProgramURI="x-rincon-buzzer:0" ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" '
-        'Volume="25" IncludeLinkedZones="0"/>'
-        "</Alarms>",
-    }
-    return alarm_clock
+    return SonosMockAlarmClock(
+        {
+            "CurrentAlarmListVersion": "RINCON_test:15",
+            "CurrentAlarmList": "<Alarms>"
+            '<Alarm ID="14" StartTime="07:00:00" Duration="02:00:00" Recurrence="DAILY" '
+            'Enabled="1" RoomUUID="RINCON_test" ProgramURI="x-rincon-buzzer:0" '
+            'ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" Volume="25" '
+            'IncludeLinkedZones="0"/>'
+            '<Alarm ID="15" StartTime="07:00:00" Duration="02:00:00" '
+            'Recurrence="DAILY" Enabled="1" RoomUUID="RINCON_test" '
+            'ProgramURI="x-rincon-buzzer:0" ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" '
+            'Volume="25" IncludeLinkedZones="0"/>'
+            "</Alarms>",
+        }
+    )
 
 
 @pytest.fixture(name="speaker_model")

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -85,6 +85,25 @@ class SonosMockService:
         self.subscribe = AsyncMock(return_value=SonosMockSubscribe(ip_address))
 
 
+class SonosMockAlarmClock(SonosMockService):
+    """Mock a Sonos AlarmClock Service used in callbacks."""
+
+    def __init__(self, ip_address="192.168.42.2") -> None:
+        """Initialize the instance."""
+        super().__init__("AlarmClock", ip_address)
+        self.ListAlarms = Mock()
+        self.ListAlarms.return_value = {
+            "CurrentAlarmListVersion": "RINCON_test:14",
+            "CurrentAlarmList": "<Alarms>"
+            '<Alarm ID="14" StartTime="07:00:00" Duration="02:00:00" Recurrence="DAILY" '
+            'Enabled="1" RoomUUID="RINCON_test" ProgramURI="x-rincon-buzzer:0" '
+            'ProgramMetaData="" PlayMode="SHUFFLE_NOREPEAT" Volume="25" '
+            'IncludeLinkedZones="0"/>'
+            "</Alarms>",
+        }
+        self.UpdateAlarm = Mock()
+
+
 class SonosMockEvent:
     """Mock a sonos Event used in callbacks."""
 
@@ -593,11 +612,9 @@ def music_library_fixture(
 
 
 @pytest.fixture(name="alarm_clock")
-def alarm_clock_fixture():
+def alarm_clock_fixture() -> SonosMockAlarmClock:
     """Create alarmClock fixture."""
-    alarm_clock = SonosMockService("AlarmClock")
-    # pylint: disable-next=attribute-defined-outside-init
-    alarm_clock.ListAlarms = Mock()
+    alarm_clock = SonosMockAlarmClock()
     alarm_clock.ListAlarms.return_value = {
         "CurrentAlarmListVersion": "RINCON_test:14",
         "CurrentAlarmList": "<Alarms>"
@@ -611,11 +628,9 @@ def alarm_clock_fixture():
 
 
 @pytest.fixture(name="alarm_clock_extended")
-def alarm_clock_fixture_extended():
+def alarm_clock_fixture_extended() -> SonosMockAlarmClock:
     """Create alarmClock fixture."""
-    alarm_clock = SonosMockService("AlarmClock")
-    # pylint: disable-next=attribute-defined-outside-init
-    alarm_clock.ListAlarms = Mock()
+    alarm_clock = SonosMockAlarmClock()
     alarm_clock.ListAlarms.return_value = {
         "CurrentAlarmListVersion": "RINCON_test:15",
         "CurrentAlarmList": "<Alarms>"

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -178,7 +178,7 @@ async def test_alarm_create_delete(
     alarm_event,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test for correct creation and deletion of alarms during runtime."""
+    """Test enabling and disabling of alarm."""
     one_alarm = copy(alarm_clock.ListAlarms.return_value)
     two_alarms = copy(alarm_clock_extended.ListAlarms.return_value)
 

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -156,7 +156,7 @@ async def test_switch_alarm_turn_on(
     service: str,
     expected_result: str,
 ) -> None:
-    """Test for correct creation and deletion of alarms during runtime."""
+    """Test enabling and disabling of alarm."""
     await async_setup_sonos()
 
     await hass.services.async_call(
@@ -178,7 +178,7 @@ async def test_alarm_create_delete(
     alarm_event,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test enabling and disabling of alarm."""
+    """Test for correct creation and deletion of alarms during runtime."""
     one_alarm = copy(alarm_clock.ListAlarms.return_value)
     two_alarms = copy(alarm_clock_extended.ListAlarms.return_value)
 

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -4,6 +4,8 @@ from copy import copy
 from datetime import timedelta
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.sonos.const import DATA_SONOS_DISCOVERY_MANAGER
 from homeassistant.components.sonos.switch import (
     ATTR_DURATION,
@@ -13,13 +15,21 @@ from homeassistant.components.sonos.switch import (
     ATTR_RECURRENCE,
     ATTR_VOLUME,
 )
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
-from homeassistant.const import ATTR_TIME, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_TIME,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from .conftest import SonosMockEvent
+from .conftest import MockSoCo, SonosMockEvent
 
 from tests.common import async_fire_time_changed
 
@@ -130,6 +140,33 @@ async def test_switch_attributes(
     touch_controls = entity_registry.entities["switch.zone_a_touch_controls"]
     touch_controls_state = hass.states.get(touch_controls.entity_id)
     assert touch_controls_state.state == STATE_ON
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_result"),
+    [
+        (SERVICE_TURN_OFF, "0"),
+        (SERVICE_TURN_ON, "1"),
+    ],
+)
+async def test_switch_alarm_turn_on(
+    hass: HomeAssistant,
+    async_setup_sonos,
+    soco: MockSoCo,
+    service: str,
+    expected_result: str,
+) -> None:
+    """Test for correct creation and deletion of alarms during runtime."""
+    await async_setup_sonos()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, service, {ATTR_ENTITY_ID: "switch.sonos_alarm_14"}, blocking=True
+    )
+
+    assert soco.alarmClock.UpdateAlarm.call_count == 1
+    call_args = soco.alarmClock.UpdateAlarm.call_args[0]
+    assert call_args[0][0] == ("ID", "14")
+    assert call_args[0][4] == ("Enabled", expected_result)
 
 
 async def test_alarm_create_delete(


### PR DESCRIPTION
## Proposed change

Add tests for turning a sonos alarm on or off via the created switch entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
