### PR TITLE
Make switch_as_x tests represent real life

### DIFF
--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -77,9 +77,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # If the tracked switch is no longer in the device, remove our config entry
             # from the device
             if (
-                not (s_entity_entry := entity_registry.async_get(data[CONF_ENTITY_ID]))
+                not (
+                    updated_entity_entry := entity_registry.async_get(
+                        data[CONF_ENTITY_ID]
+                    )
+                )
                 or not device_registry.async_get(device_id)
-                or s_entity_entry.device_id == device_id
+                or updated_entity_entry.device_id == device_id
             ):
                 # No need to do any cleanup
                 return

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -26,12 +26,12 @@ def async_add_to_device(
     hass: HomeAssistant, entry: ConfigEntry, entity_id: str
 ) -> str | None:
     """Add our config entry to the tracked entity's device."""
-    registry = er.async_get(hass)
+    entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
     device_id = None
 
     if (
-        not (wrapped_switch := registry.async_get(entity_id))
+        not (wrapped_switch := entity_registry.async_get(entity_id))
         or not (device_id := wrapped_switch.device_id)
         or not (device_registry.async_get(device_id))
     ):
@@ -44,10 +44,12 @@ def async_add_to_device(
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
-    registry = er.async_get(hass)
+    entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
     try:
-        entity_id = er.async_validate_entity_id(registry, entry.options[CONF_ENTITY_ID])
+        entity_id = er.async_validate_entity_id(
+            entity_registry, entry.options[CONF_ENTITY_ID]
+        )
     except vol.Invalid:
         # The entity is identified by an unknown entity registry ID
         _LOGGER.error(
@@ -75,7 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # If the tracked switch is no longer in the device, remove our config entry
             # from the device
             if (
-                not (entity_entry := registry.async_get(data[CONF_ENTITY_ID]))
+                not (entity_entry := entity_registry.async_get(data[CONF_ENTITY_ID]))
                 or not device_registry.async_get(device_id)
                 or entity_entry.device_id == device_id
             ):

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return
 
         if "entity_id" in data["changes"]:
-            # Entity_id changed, reload the config entry
+            # Entity_id changed, update the config entry
             hass.config_entries.async_update_entry(
                 entry,
                 options={**entry.options, CONF_ENTITY_ID: data["entity_id"]},

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -130,15 +130,20 @@ async def test_config_flow_registered_entity(
 async def test_options(
     hass: HomeAssistant,
     target_domain: Platform,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test reconfiguring."""
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="ABC"
+    )
+    switch_entity_id = switch_entity_entry.entity_id
     switch_state = STATE_ON
-    hass.states.async_set("switch.ceiling", switch_state)
+    hass.states.async_set(switch_entity_id, switch_state)
     switch_as_x_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.ceiling",
+            CONF_ENTITY_ID: switch_entity_id,
             CONF_INVERT: True,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -170,13 +175,13 @@ async def test_options(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
-        CONF_ENTITY_ID: "switch.ceiling",
+        CONF_ENTITY_ID: switch_entity_id,
         CONF_INVERT: False,
         CONF_TARGET_DOMAIN: target_domain,
     }
     assert config_entry.data == {}
     assert config_entry.options == {
-        CONF_ENTITY_ID: "switch.ceiling",
+        CONF_ENTITY_ID: switch_entity_id,
         CONF_INVERT: False,
         CONF_TARGET_DOMAIN: target_domain,
     }

--- a/tests/components/switch_as_x/test_cover.py
+++ b/tests/components/switch_as_x/test_cover.py
@@ -20,18 +20,25 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test cover switch default state."""
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="Garage Door"
+    )
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.test",
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.COVER,
         },

--- a/tests/components/switch_as_x/test_fan.py
+++ b/tests/components/switch_as_x/test_fan.py
@@ -18,18 +18,25 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test fan switch default state."""
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="Wind Machine"
+    )
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.test",
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.FAN,
         },
@@ -42,7 +49,6 @@ async def test_default_state(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     state = hass.states.get("fan.wind_machine")
-    assert state is not None
     assert state.state == "unavailable"
     assert state.attributes["supported_features"] == 48
 

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -44,13 +44,13 @@ async def test_config_entry_unregistered_uuid(
     hass: HomeAssistant, target_domain: str
 ) -> None:
     """Test light switch setup from config entry with unknown entity registry id."""
-    fake_uuid = "a266a680b608c32770e6c45bfe6b8411"
+    fake_entity_id = "switch.something"
 
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: fake_uuid,
+            CONF_ENTITY_ID: fake_entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -96,7 +96,7 @@ async def test_entity_registry_events(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: registry_entry.id,
+            CONF_ENTITY_ID: switch_entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -180,7 +180,7 @@ async def test_device_registry_config_entry_1(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -238,7 +238,7 @@ async def test_device_registry_config_entry_2(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -316,7 +316,7 @@ async def test_config_entry_uuid(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: registry_entry.id,
+            CONF_ENTITY_ID: registry_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -356,7 +356,7 @@ async def test_device(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -440,7 +440,7 @@ async def test_reset_hidden_by(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -478,7 +478,7 @@ async def test_entity_category_inheritance(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -516,7 +516,7 @@ async def test_entity_options(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -571,7 +571,7 @@ async def test_entity_name(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -697,7 +697,7 @@ async def test_custom_name_2(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -763,7 +763,7 @@ async def test_import_expose_settings_1(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -824,7 +824,7 @@ async def test_import_expose_settings_2(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -889,7 +889,7 @@ async def test_restore_expose_settings(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -271,11 +271,15 @@ async def test_config_entry_entity_id(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, target_domain: Platform
 ) -> None:
     """Test light switch setup from config entry with entity id."""
+    registry_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="ABC"
+    )
+    switch_entity_id = registry_entry.entity_id
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.abc",
+            CONF_ENTITY_ID: switch_entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -382,12 +386,16 @@ async def test_setup_and_remove_config_entry(
     target_domain: Platform,
 ) -> None:
     """Test removing a config entry."""
+    registry_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="ABC"
+    )
+    switch_entity_id = registry_entry.entity_id
     # Setup the config entry
     switch_as_x_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.test",
+            CONF_ENTITY_ID: switch_entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: target_domain,
         },
@@ -931,12 +939,16 @@ async def test_migrate(
     target_domain: Platform,
 ) -> None:
     """Test migration."""
+    registry_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="ABC"
+    )
+    switch_entity_id = registry_entry.entity_id
     # Setup the config entry
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.test",
+            CONF_ENTITY_ID: switch_entity_id,
             CONF_TARGET_DOMAIN: target_domain,
         },
         title="ABC",
@@ -950,7 +962,7 @@ async def test_migrate(
     # Check migration was successful and added invert option
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.options == {
-        CONF_ENTITY_ID: "switch.test",
+        CONF_ENTITY_ID: switch_entity_id,
         CONF_INVERT: False,
         CONF_TARGET_DOMAIN: target_domain,
     }

--- a/tests/components/switch_as_x/test_light.py
+++ b/tests/components/switch_as_x/test_light.py
@@ -28,18 +28,25 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test light switch default state."""
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="Christmas Tree Lights"
+    )
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.test",
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.LIGHT,
         },
@@ -52,7 +59,6 @@ async def test_default_state(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     state = hass.states.get("light.christmas_tree_lights")
-    assert state is not None
     assert state.state == "unavailable"
     assert state.attributes["supported_features"] == 0
     assert state.attributes.get(ATTR_BRIGHTNESS) is None

--- a/tests/components/switch_as_x/test_lock.py
+++ b/tests/components/switch_as_x/test_lock.py
@@ -20,18 +20,25 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test lock switch default state."""
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="candy_jar"
+    )
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.test",
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.LOCK,
         },

--- a/tests/components/switch_as_x/test_siren.py
+++ b/tests/components/switch_as_x/test_siren.py
@@ -18,18 +18,25 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test siren switch default state."""
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="Noise Maker"
+    )
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.test",
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.SIREN,
         },

--- a/tests/components/switch_as_x/test_valve.py
+++ b/tests/components/switch_as_x/test_valve.py
@@ -20,22 +20,29 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def test_default_state(hass: HomeAssistant) -> None:
+async def test_default_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test valve switch default state."""
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", original_name="Valve"
+    )
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
         options={
-            CONF_ENTITY_ID: "switch.test",
+            CONF_ENTITY_ID: switch_entity_entry.entity_id,
             CONF_INVERT: False,
             CONF_TARGET_DOMAIN: Platform.VALVE,
         },
-        title="Garage Door",
+        title="Valve",
         version=SwitchAsXConfigFlowHandler.VERSION,
         minor_version=SwitchAsXConfigFlowHandler.MINOR_VERSION,
     )
@@ -43,7 +50,7 @@ async def test_default_state(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("valve.garage_door")
+    state = hass.states.get("valve.valve")
     assert state is not None
     assert state.state == "unavailable"
     assert state.attributes["supported_features"] == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make switch_as_x tests represent real life, as the `entry.options[CONF_ENTITY_ID]` is set by the EntitySelector, and that returns an entity_id, rather than an UUID. Hence the tests don't represent real life and apparently seem to break if we use an entity_id, so that is something we should change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
