### PR TITLE
Purpleair polling frequency

### DIFF
--- a/homeassistant/components/purpleair/config_flow.py
+++ b/homeassistant/components/purpleair/config_flow.py
@@ -40,7 +40,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import CONF_SENSOR_INDICES, DOMAIN, LOGGER
+from .const import CONF_SENSOR_INDICES, CONF_UPDATE_INTERVAL, DOMAIN, LOGGER
 
 CONF_DISTANCE = "distance"
 CONF_NEARBY_SENSOR_OPTIONS = "nearby_sensor_options"
@@ -331,7 +331,15 @@ class PurpleAirOptionsFlowHandler(OptionsFlow):
                             CONF_SHOW_ON_MAP
                         )
                     },
-                ): bool
+                ): bool,
+                vol.Optional(
+                    CONF_UPDATE_INTERVAL,
+                    description={
+                        "suggested_value": self.config_entry.options.get(
+                            CONF_UPDATE_INTERVAL
+                        ),
+                    },
+                ): int,
             }
         )
 

--- a/homeassistant/components/purpleair/const.py
+++ b/homeassistant/components/purpleair/const.py
@@ -11,4 +11,4 @@ PLATFORMS: Final = [Platform.SENSOR]
 DOMAIN: Final[str] = "purpleair"
 
 CONF_SENSOR_INDICES: Final[str] = "sensor_indices"
-CONF_UPDATE_INTERVAL: str = "2"
+CONF_UPDATE_INTERVAL: Final[str] = "update_interval"

--- a/homeassistant/components/purpleair/const.py
+++ b/homeassistant/components/purpleair/const.py
@@ -11,3 +11,4 @@ PLATFORMS: Final = [Platform.SENSOR]
 DOMAIN: Final[str] = "purpleair"
 
 CONF_SENSOR_INDICES: Final[str] = "sensor_indices"
+CONF_UPDATE_INTERVAL: str = "2"

--- a/homeassistant/components/purpleair/coordinator.py
+++ b/homeassistant/components/purpleair/coordinator.py
@@ -68,7 +68,10 @@ class PurpleAirDataUpdateCoordinator(DataUpdateCoordinator[GetSensorsResponse]):
             name=entry.title,
             update_interval=timedelta(
                 minutes=DEFAULT_UPDATE_INTERVAL
-                if entry.options.get(CONF_UPDATE_INTERVAL) is None
+                if (
+                    entry.options.get(CONF_UPDATE_INTERVAL) is None
+                    or entry.options.get(CONF_UPDATE_INTERVAL) == "update_interval"
+                )
                 else float(str(entry.options.get(CONF_UPDATE_INTERVAL)))
             ),
         )

--- a/homeassistant/components/purpleair/coordinator.py
+++ b/homeassistant/components/purpleair/coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_SENSOR_INDICES, LOGGER
+from .const import CONF_SENSOR_INDICES, CONF_UPDATE_INTERVAL, LOGGER
 
 SENSOR_FIELDS_TO_RETRIEVE = [
     "0.3_um_count",
@@ -43,7 +43,7 @@ SENSOR_FIELDS_TO_RETRIEVE = [
     "voc",
 ]
 
-UPDATE_INTERVAL = timedelta(minutes=2)
+DEFAULT_UPDATE_INTERVAL = 2
 
 
 type PurpleAirConfigEntry = ConfigEntry[PurpleAirDataUpdateCoordinator]
@@ -66,7 +66,14 @@ class PurpleAirDataUpdateCoordinator(DataUpdateCoordinator[GetSensorsResponse]):
             LOGGER,
             config_entry=entry,
             name=entry.title,
-            update_interval=UPDATE_INTERVAL,
+            update_interval=timedelta(
+                minutes=DEFAULT_UPDATE_INTERVAL
+                if (
+                    entry.options.get(CONF_UPDATE_INTERVAL) is None
+                    or entry.options.get(CONF_UPDATE_INTERVAL) == "conf_update_interval"
+                )
+                else float(str(entry.options.get(CONF_UPDATE_INTERVAL)))
+            ),
         )
 
     async def _async_update_data(self) -> GetSensorsResponse:

--- a/homeassistant/components/purpleair/coordinator.py
+++ b/homeassistant/components/purpleair/coordinator.py
@@ -68,10 +68,7 @@ class PurpleAirDataUpdateCoordinator(DataUpdateCoordinator[GetSensorsResponse]):
             name=entry.title,
             update_interval=timedelta(
                 minutes=DEFAULT_UPDATE_INTERVAL
-                if (
-                    entry.options.get(CONF_UPDATE_INTERVAL) is None
-                    or entry.options.get(CONF_UPDATE_INTERVAL) == "conf_update_interval"
-                )
+                if entry.options.get(CONF_UPDATE_INTERVAL) is None
                 else float(str(entry.options.get(CONF_UPDATE_INTERVAL)))
             ),
         )

--- a/homeassistant/components/purpleair/strings.json
+++ b/homeassistant/components/purpleair/strings.json
@@ -95,7 +95,8 @@
       "settings": {
         "title": "[%key:component::purpleair::options::step::init::menu_options::settings%]",
         "data": {
-          "show_on_map": "Show configured sensor locations on the map"
+          "show_on_map": "Show configured sensor locations on the map",
+          "update_interval": "Interval to poll PurpleAir API"
         }
       }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  This pull request aims to improve the PurpleAir integration by allowing the user to change the polling frequency. The current default is 2 minutes, which consumes API credits (points) extremely fast.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [NA] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [NA] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [NA] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [NA] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
