### PR TITLE
Start deprecation of battery properties in vacuum

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -261,21 +261,19 @@ class StateVacuumEntity(
             method in cls.__dict__
             for method in ("_attr_battery_level", "battery_level")
         ):
-            # Integrations should use the 'activity' property instead of
-            # setting the state directly.
+            # Integrations should use a separate battery sensor.
             cls.__vacuum_legacy_battery_level = True
         if any(
             method in cls.__dict__ for method in ("_attr_battery_icon", "battery_icon")
         ):
-            # Integrations should use the 'activity' property instead of
-            # setting the state directly.
+            # Integrations should use a separate battery sensor.
             cls.__vacuum_legacy_battery_icon = True
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Set attribute.
 
-        Deprecation warning if setting '_attr_state' directly
-        unless already reported.
+        Deprecation warning if setting state, battery icon or battery level
+        attributes directly unless already reported.
         """
         if name == "_attr_state":
             self._report_deprecated_activity_handling()

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -443,7 +443,7 @@ async def test_vacuum_log_deprecated_battery_properties(
     config_flow_fixture: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test incorrectly using battery properties logs watning."""
+    """Test incorrectly using battery properties logs warning."""
 
     class MockLegacyVacuum(MockVacuum):
         """Mocked vacuum entity."""
@@ -492,6 +492,13 @@ async def test_vacuum_log_deprecated_battery_properties(
         " please report it to the author of the 'test' custom integration"
         in caplog.text
     )
+    assert (
+        "Detected that custom integration 'test' is setting the battery_level which has been deprecated."
+        " Integration test should implement a sensor instead with a correct device class and link it"
+        " to the same device. This will stop working in Home Assistant 2026.7,"
+        " please report it to the author of the 'test' custom integration"
+        in caplog.text
+    )
 
 
 @pytest.mark.usefixtures("mock_as_custom_component")
@@ -531,9 +538,17 @@ async def test_vacuum_log_deprecated_battery_properties_using_attr(
 
     state = hass.states.get(entity.entity_id)
     assert state is not None
+    entity.start()
 
     assert (
         "Detected that custom integration 'test' is setting the battery_level which has been deprecated."
+        " Integration test should implement a sensor instead with a correct device class and link it to"
+        " the same device. This will stop working in Home Assistant 2026.7,"
+        " please report it to the author of the 'test' custom integration"
+        in caplog.text
+    )
+    assert (
+        "Detected that custom integration 'test' is setting the battery_icon which has been deprecated."
         " Integration test should implement a sensor instead with a correct device class and link it to"
         " the same device. This will stop working in Home Assistant 2026.7,"
         " please report it to the author of the 'test' custom integration"
@@ -547,6 +562,13 @@ async def test_vacuum_log_deprecated_battery_properties_using_attr(
     # Test we only log once
     assert (
         "Detected that custom integration 'test' is setting the battery_level which has been deprecated."
+        " Integration test should implement a sensor instead with a correct device class and link it to"
+        " the same device. This will stop working in Home Assistant 2026.7,"
+        " please report it to the author of the 'test' custom integration"
+        not in caplog.text
+    )
+    assert (
+        "Detected that custom integration 'test' is setting the battery_icon which has been deprecated."
         " Integration test should implement a sensor instead with a correct device class and link it to"
         " the same device. This will stop working in Home Assistant 2026.7,"
         " please report it to the author of the 'test' custom integration"

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -435,3 +435,120 @@ async def test_vacuum_deprecated_state_does_not_break_state(
     state = hass.states.get(entity.entity_id)
     assert state is not None
     assert state.state == "cleaning"
+
+
+@pytest.mark.usefixtures("mock_as_custom_component")
+async def test_vacuum_log_deprecated_battery_properties(
+    hass: HomeAssistant,
+    config_flow_fixture: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test incorrectly using battery properties logs watning."""
+
+    class MockLegacyVacuum(MockVacuum):
+        """Mocked vacuum entity."""
+
+        @property
+        def activity(self) -> str:
+            """Return the state of the entity."""
+            return VacuumActivity.CLEANING
+
+        @property
+        def battery_level(self) -> int:
+            """Return the battery level of the vacuum."""
+            return 50
+
+        @property
+        def battery_icon(self) -> str:
+            """Return the battery icon of the vacuum."""
+            return "mdi:battery-50"
+
+    entity = MockLegacyVacuum(
+        name="Testing",
+        entity_id="vacuum.test",
+    )
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=help_async_setup_entry_init,
+            async_unload_entry=help_async_unload_entry,
+        ),
+        built_in=False,
+    )
+    setup_test_component_platform(hass, DOMAIN, [entity], from_config_entry=True)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+
+    assert (
+        "Detected that custom integration 'test' is setting the battery_icon which has been deprecated."
+        " Integration test should implement a sensor instead with a correct device class and link it"
+        " to the same device. This will stop working in Home Assistant 2026.7,"
+        " please report it to the author of the 'test' custom integration"
+        in caplog.text
+    )
+
+
+@pytest.mark.usefixtures("mock_as_custom_component")
+async def test_vacuum_log_deprecated_battery_properties_using_attr(
+    hass: HomeAssistant,
+    config_flow_fixture: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test incorrectly using _attr_battery_* attribute does log issue and raise repair."""
+
+    class MockLegacyVacuum(MockVacuum):
+        """Mocked vacuum entity."""
+
+        def start(self) -> None:
+            """Start cleaning."""
+            self._attr_battery_level = 50
+            self._attr_battery_icon = "mdi:battery-50"
+
+    entity = MockLegacyVacuum(
+        name="Testing",
+        entity_id="vacuum.test",
+    )
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=help_async_setup_entry_init,
+            async_unload_entry=help_async_unload_entry,
+        ),
+        built_in=False,
+    )
+    setup_test_component_platform(hass, DOMAIN, [entity], from_config_entry=True)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+
+    assert (
+        "Detected that custom integration 'test' is setting the battery_level which has been deprecated."
+        " Integration test should implement a sensor instead with a correct device class and link it to"
+        " the same device. This will stop working in Home Assistant 2026.7,"
+        " please report it to the author of the 'test' custom integration"
+        in caplog.text
+    )
+
+    await async_start(hass, entity.entity_id)
+
+    caplog.clear()
+    await async_start(hass, entity.entity_id)
+    # Test we only log once
+    assert (
+        "Detected that custom integration 'test' is setting the battery_level which has been deprecated."
+        " Integration test should implement a sensor instead with a correct device class and link it to"
+        " the same device. This will stop working in Home Assistant 2026.7,"
+        " please report it to the author of the 'test' custom integration"
+        not in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Starts deprecation of battery properties in `vacuum` in accordance with decision in https://github.com/home-assistant/architecture/discussions/938

TODO:
- [x] Dev docs: https://github.com/home-assistant/developers.home-assistant/pull/2695

Implementations seems to be in
- demo
- ecovacs
- lg_thinq
- matter
- miele
- mqtt
- neato
- roborock
- romy
- sharkiq
- switchbot
- switchbot_cloud
- template
- tplink
- tuya
- xiaomi_miio

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 