### PR TITLE
Create a deprecation/repair for `sensor.sun_solar_rising`

### DIFF
--- a/homeassistant/components/sun/sensor.py
+++ b/homeassistant/components/sun/sensor.py
@@ -18,6 +18,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 from homeassistant.helpers.typing import StateType
 
 from .const import DOMAIN, SIGNAL_EVENTS_CHANGED, SIGNAL_POSITION_CHANGED
@@ -149,6 +154,21 @@ class SunSensor(SensorEntity):
     async def async_added_to_hass(self) -> None:
         """Register signal listener when added to hass."""
         await super().async_added_to_hass()
+
+        if self.entity_description.key == "solar_rising":
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                "deprecated_sun_solar_rising",
+                breaks_in_ha_version="2026.1.0",
+                is_fixable=False,
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecated_sun_solar_rising",
+                translation_placeholders={
+                    "entity": self.entity_id,
+                },
+            )
+
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
@@ -156,3 +176,9 @@ class SunSensor(SensorEntity):
                 self.async_write_ha_state,
             )
         )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Call when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        if self.entity_description.key == "solar_rising":
+            async_delete_issue(self.hass, DOMAIN, "deprecated_sun_solar_rising")

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -40,8 +40,8 @@
   },
   "issues": {
     "deprecated_sun_solar_rising": {
-      "title": "Deprecated Sun solar rising sensor",
-      "description": "The sun 'solar rising' sensor is being deprecated; an equivalent 'solar rising' binary_sensor has been made available as a replacement. To resolve this issue, disable {entity}."
+      "title": "Deprecated 'Solar rising' sensor",
+      "description": "The 'Solar rising' sensor of the Sun integration is being deprecated; an equivalent 'Solar rising' binary sensor has been made available as a replacement. To resolve this issue, disable {entity}."
     }
   }
 }

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -37,5 +37,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "deprecated_sun_solar_rising": {
+      "title": "Deprecated Sun solar rising sensor",
+      "description": "The sun 'solar rising' sensor is being deprecated; an equivalent 'solar rising' binary_sensor has been made available as a replacement. To resolve this issue, disable {entity}."
+    }
   }
 }

--- a/tests/components/sun/test_sensor.py
+++ b/tests/components/sun/test_sensor.py
@@ -8,11 +8,14 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components import sun
+from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -179,3 +182,46 @@ async def test_setting_rising(
     assert entity
     assert entity.entity_category is EntityCategory.DIAGNOSTIC
     assert entity.unique_id == f"{entry_ids[0].entry_id}-solar_rising"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_deprecation(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test sensor.sun_solar_rising deprecation."""
+    utc_now = datetime(2016, 11, 1, 8, 0, 0, tzinfo=dt_util.UTC)
+    freezer.move_to(utc_now)
+    await async_setup_component(hass, sun.DOMAIN, {sun.DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(
+        domain="sun",
+        issue_id="deprecated_sun_solar_rising",
+    )
+    assert len(issue_registry.issues) == 1
+
+    entity_registry.async_update_entity(
+        "sensor.sun_solar_rising", disabled_by=er.RegistryEntryDisabler.USER
+    )
+    await hass.async_block_till_done()
+
+    assert not issue_registry.async_get_issue(
+        domain="sun",
+        issue_id="deprecated_sun_solar_rising",
+    )
+    assert len(issue_registry.issues) == 0
+
+    entity_registry.async_update_entity("sensor.sun_solar_rising", disabled_by=None)
+    await hass.async_block_till_done()
+    freezer.tick(delta=RELOAD_AFTER_UPDATE_DELAY)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(
+        domain="sun",
+        issue_id="deprecated_sun_solar_rising",
+    )
+    assert len(issue_registry.issues) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
In https://github.com/home-assistant/core/pull/140956 I added a binary_sensor to replace sensor.sun_solar_rising. 

Now the integration has a `sensor` and `binary_sensor` which represent the same thing.

This PR raises a repair if user has `sensor.sun_solar_rising` enabled in their instance, and requests them to disable it for eventual removal after the deprecation period. 

This sensor is diabled by default and I expect very few users will have ever enabled it. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
