### PR TITLE
Fix incorrect categories handling in holiday

### DIFF
--- a/homeassistant/components/holiday/calendar.py
+++ b/homeassistant/components/holiday/calendar.py
@@ -25,17 +25,12 @@ def _get_obj_holidays_and_language(
     selected_categories: list[str] | None,
 ) -> tuple[HolidayBase, str]:
     """Get the object for the requested country and year."""
-    if selected_categories is None:
-        categories = [PUBLIC]
-    else:
-        categories = [PUBLIC, *selected_categories]
-
     obj_holidays = country_holidays(
         country,
         subdiv=province,
         years={dt_util.now().year, dt_util.now().year + 1},
         language=language,
-        categories=categories,
+        categories=selected_categories,
     )
     if language == "en":
         for lang in obj_holidays.supported_languages:
@@ -45,7 +40,7 @@ def _get_obj_holidays_and_language(
                     subdiv=province,
                     years={dt_util.now().year, dt_util.now().year + 1},
                     language=lang,
-                    categories=categories,
+                    categories=selected_categories,
                 )
                 language = lang
                 break
@@ -59,7 +54,7 @@ def _get_obj_holidays_and_language(
             subdiv=province,
             years={dt_util.now().year, dt_util.now().year + 1},
             language=default_language,
-            categories=categories,
+            categories=selected_categories,
         )
         language = default_language
 
@@ -76,6 +71,11 @@ async def async_setup_entry(
     province: str | None = config_entry.data.get(CONF_PROVINCE)
     categories: list[str] | None = config_entry.options.get(CONF_CATEGORIES)
     language = hass.config.language
+
+    if categories is None:
+        categories = [PUBLIC]
+    else:
+        categories = [PUBLIC, *categories]
 
     obj_holidays, language = await hass.async_add_executor_job(
         _get_obj_holidays_and_language, country, province, language, categories


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Categories was only correctly handled for state, not for `get_events`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146414
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 