### PR TITLE
Allow AWS S3 integration to use environmental auth

### DIFF
--- a/homeassistant/components/aws_s3/__init__.py
+++ b/homeassistant/components/aws_s3/__init__.py
@@ -33,13 +33,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: S3ConfigEntry) -> bool:
 
     data = cast(dict, entry.data)
     try:
+        access_key_id = data[CONF_ACCESS_KEY_ID] if data[CONF_ACCESS_KEY_ID] != 'env' else None
+        secret_access_key = data[CONF_SECRET_ACCESS_KEY] if data[CONF_ACCESS_KEY_ID] != 'env' else None
+
         session = AioSession()
         # pylint: disable-next=unnecessary-dunder-call
         client = await session.create_client(
             "s3",
             endpoint_url=data.get(CONF_ENDPOINT_URL),
-            aws_secret_access_key=data[CONF_SECRET_ACCESS_KEY],
-            aws_access_key_id=data[CONF_ACCESS_KEY_ID],
+            aws_secret_access_key=secret_access_key,
+            aws_access_key_id=access_key_id,
         ).__aenter__()
         await client.head_bucket(Bucket=data[CONF_BUCKET])
     except ClientError as err:

--- a/homeassistant/components/aws_s3/config_flow.py
+++ b/homeassistant/components/aws_s3/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     DEFAULT_ENDPOINT_URL,
     DESCRIPTION_AWS_S3_DOCS_URL,
     DESCRIPTION_BOTO3_DOCS_URL,
+    DESCRIPTION_BOTO3_CREDENTIALS_URL,
     DOMAIN,
 )
 
@@ -66,12 +67,15 @@ class S3ConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors[CONF_ENDPOINT_URL] = "invalid_endpoint_url"
             else:
                 try:
+                    access_key_id = user_input[CONF_ACCESS_KEY_ID] if user_input[CONF_ACCESS_KEY_ID] != 'env' else None
+                    secret_access_key = user_input[CONF_SECRET_ACCESS_KEY] if user_input[CONF_ACCESS_KEY_ID] != 'env' else None
+
                     session = AioSession()
                     async with session.create_client(
                         "s3",
                         endpoint_url=user_input.get(CONF_ENDPOINT_URL),
-                        aws_secret_access_key=user_input[CONF_SECRET_ACCESS_KEY],
-                        aws_access_key_id=user_input[CONF_ACCESS_KEY_ID],
+                        aws_secret_access_key=secret_access_key,
+                        aws_access_key_id=access_key_id,
                     ) as client:
                         await client.head_bucket(Bucket=user_input[CONF_BUCKET])
                 except ClientError:
@@ -97,5 +101,6 @@ class S3ConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={
                 "aws_s3_docs_url": DESCRIPTION_AWS_S3_DOCS_URL,
                 "boto3_docs_url": DESCRIPTION_BOTO3_DOCS_URL,
+                "boto3_credentials_url": DESCRIPTION_BOTO3_CREDENTIALS_URL,
             },
         )

--- a/homeassistant/components/aws_s3/const.py
+++ b/homeassistant/components/aws_s3/const.py
@@ -21,3 +21,4 @@ DATA_BACKUP_AGENT_LISTENERS: HassKey[list[Callable[[], None]]] = HassKey(
 
 DESCRIPTION_AWS_S3_DOCS_URL = "https://docs.aws.amazon.com/general/latest/gr/s3.html"
 DESCRIPTION_BOTO3_DOCS_URL = "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html"
+DESCRIPTION_BOTO3_CREDENTIALS_URL = "https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html"

--- a/homeassistant/components/aws_s3/strings.json
+++ b/homeassistant/components/aws_s3/strings.json
@@ -9,7 +9,7 @@
           "endpoint_url": "Endpoint URL"
         },
         "data_description": {
-          "access_key_id": "Access key ID to connect to AWS S3 API",
+          "access_key_id": "Access key ID to connect to AWS S3 API. Use `env` if you are providing credentials [via another method]({boto3_credentials_url}).",
           "secret_access_key": "Secret access key to connect to AWS S3 API",
           "bucket": "Bucket must already exist and be writable by the provided credentials.",
           "endpoint_url": "Endpoint URL provided to [Boto3 Session]({boto3_docs_url}). Region-specific [AWS S3 endpoints]({aws_s3_docs_url}) are available in their docs."


### PR DESCRIPTION
If "env" is passed as the access key ID, no explicit access key ID and secret access key will be passed to the AWS SDK, allowing the SDK to fall back to searching the environment for credentials to use.

This approach persists the easy-to-use but not-recommended-by-AWS approach of using an access key/secret key to authenticate, while allowing use of alternative approaches of authentication to be used by users if desired.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change allows users to skip providing an AWS Access Key ID and Secret Access Key as part of the configuration of the AWS S3 integration. When no access key/secret key are provided, the Boto3 SDK searches for credentials in other locations, including an `~/.aws/config` file and environment variables. Alternative configuration can be access keys/secret keys, or it can be something like a credentials provider for IAM Roles Anywhere or instance profiles.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #145862
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
