### PR TITLE
Update availability for switch entities for Squeezebox

### DIFF
--- a/homeassistant/components/squeezebox/entity.py
+++ b/homeassistant/components/squeezebox/entity.py
@@ -55,3 +55,12 @@ class LMSStatusEntity(CoordinatorEntity[LMSStatusDataUpdateCoordinator]):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.data[STATUS_QUERY_UUID])},
         )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        # Check basic coordinator availability (i.e., last_update_success) and  coordinator.data is populated
+        if not super().available or not self.coordinator.data:
+            return False
+        # Check if the specific key this entity relies on is present in the data
+        return self.entity_description.key in self.coordinator.data

--- a/homeassistant/components/squeezebox/entity.py
+++ b/homeassistant/components/squeezebox/entity.py
@@ -59,8 +59,8 @@ class LMSStatusEntity(CoordinatorEntity[LMSStatusDataUpdateCoordinator]):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        # Check basic coordinator availability (i.e., last_update_success) and  coordinator.data is populated
-        if not super().available or not self.coordinator.data:
+        # Check basic coordinator availability (i.e., last_update_success)
+        if not super().available:
             return False
         # Check if the specific key this entity relies on is present in the data
         return self.entity_description.key in self.coordinator.data

--- a/homeassistant/components/squeezebox/switch.py
+++ b/homeassistant/components/squeezebox/switch.py
@@ -133,7 +133,11 @@ class SqueezeBoxAlarmEntity(SqueezeboxEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return whether the alarm is available."""
-        return super().available and self._alarm_id in self.coordinator.data["alarms"]
+        return (
+            super().available
+            and self.coordinator.available
+            and self._alarm_id in self.coordinator.data["alarms"]
+        )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -183,3 +187,9 @@ class SqueezeBoxAlarmsEnabledEntity(SqueezeboxEntity, SwitchEntity):
         """Turn on the switch."""
         await self.coordinator.player.async_set_alarms_enabled(True)
         await self.coordinator.async_request_refresh()
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        # Add this property to correctly check player and coordinator availability
+        return self.coordinator.available and super().available


### PR DESCRIPTION

## Proposed change
This PR ensures that the switch platform, used for alarms in Squeezebox integration, are marked unavailable for the specific condition where the response data is provided by the server, but doesn't contain the expected data.

This issue was identified by the entity-unavailable rule checker.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
