### PR TITLE
Add support for more cover devices in Fibaro

### DIFF
--- a/homeassistant/components/fibaro/cover.py
+++ b/homeassistant/components/fibaro/cover.py
@@ -28,44 +28,35 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Fibaro covers."""
     controller = entry.runtime_data
-    async_add_entities(
-        [FibaroCover(device) for device in controller.fibaro_devices[Platform.COVER]],
-        True,
-    )
+
+    entities: list[FibaroEntity] = []
+    for device in controller.fibaro_devices[Platform.COVER]:
+        # Positionable covers report the position over value
+        if device.value.has_value:
+            entities.append(PositionableFibaroCover(device))
+        else:
+            entities.append(FibaroCover(device))
+    async_add_entities(entities, True)
 
 
-class FibaroCover(FibaroEntity, CoverEntity):
-    """Representation a Fibaro Cover."""
+class PositionableFibaroCover(FibaroEntity, CoverEntity):
+    """Representation of a fibaro cover which supports positioning."""
 
     def __init__(self, fibaro_device: DeviceModel) -> None:
-        """Initialize the Vera device."""
+        """Initialize the device."""
         super().__init__(fibaro_device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
 
-        if self._is_open_close_only():
-            self._attr_supported_features = (
-                CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
-            )
-            if "stop" in self.fibaro_device.actions:
-                self._attr_supported_features |= CoverEntityFeature.STOP
-
     @staticmethod
-    def bound(position):
+    def bound(position: int | None) -> int | None:
         """Normalize the position."""
         if position is None:
             return None
-        position = int(position)
         if position <= 5:
             return 0
         if position >= 95:
             return 100
         return position
-
-    def _is_open_close_only(self) -> bool:
-        """Return if only open / close is supported."""
-        # Normally positionable devices report the position over value,
-        # so if it is missing we have a device which supports open / close only
-        return not self.fibaro_device.value.has_value
 
     def update(self) -> None:
         """Update the state."""
@@ -74,20 +65,15 @@ class FibaroCover(FibaroEntity, CoverEntity):
         self._attr_current_cover_position = self.bound(self.level)
         self._attr_current_cover_tilt_position = self.bound(self.level2)
 
-        device_state = self.fibaro_device.state
-
         # Be aware that opening and closing is only available for some modern
         # devices.
         # For example the Fibaro Roller Shutter 4 reports this correctly.
-        if device_state.has_value:
-            self._attr_is_opening = device_state.str_value().lower() == "opening"
-            self._attr_is_closing = device_state.str_value().lower() == "closing"
+        device_state = self.fibaro_device.state.str_value(default="").lower()
+        self._attr_is_opening = device_state == "opening"
+        self._attr_is_closing = device_state == "closing"
 
         closed: bool | None = None
-        if self._is_open_close_only():
-            if device_state.has_value and device_state.str_value().lower() != "unknown":
-                closed = device_state.str_value().lower() == "closed"
-        elif self.current_cover_position is not None:
+        if self.current_cover_position is not None:
             closed = self.current_cover_position == 0
         self._attr_is_closed = closed
 
@@ -96,7 +82,7 @@ class FibaroCover(FibaroEntity, CoverEntity):
         self.set_level(cast(int, kwargs.get(ATTR_POSITION)))
 
     def set_cover_tilt_position(self, **kwargs: Any) -> None:
-        """Move the cover to a specific position."""
+        """Move the slats to a specific position."""
         self.set_level2(cast(int, kwargs.get(ATTR_TILT_POSITION)))
 
     def open_cover(self, **kwargs: Any) -> None:
@@ -118,3 +104,62 @@ class FibaroCover(FibaroEntity, CoverEntity):
     def stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         self.action("stop")
+
+
+class FibaroCover(FibaroEntity, CoverEntity):
+    """Representation of a fibaro cover which supports only open / close commands."""
+
+    def __init__(self, fibaro_device: DeviceModel) -> None:
+        """Initialize the device."""
+        super().__init__(fibaro_device)
+        self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
+
+        self._attr_supported_features = (
+            CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+        )
+        if "stop" in self.fibaro_device.actions:
+            self._attr_supported_features |= CoverEntityFeature.STOP
+        if "rotateSlatsUp" in self.fibaro_device.actions:
+            self._attr_supported_features |= CoverEntityFeature.OPEN_TILT
+        if "rotateSlatsDown" in self.fibaro_device.actions:
+            self._attr_supported_features |= CoverEntityFeature.CLOSE_TILT
+        if "stopSlats" in self.fibaro_device.actions:
+            self._attr_supported_features |= CoverEntityFeature.STOP_TILT
+
+    def update(self) -> None:
+        """Update the state."""
+        super().update()
+
+        device_state = self.fibaro_device.state.str_value(default="").lower()
+
+        self._attr_is_opening = device_state == "opening"
+        self._attr_is_closing = device_state == "closing"
+
+        closed: bool | None = None
+        if device_state not in {"", "unknown"}:
+            closed = device_state == "closed"
+        self._attr_is_closed = closed
+
+    def open_cover(self, **kwargs: Any) -> None:
+        """Open the cover."""
+        self.action("open")
+
+    def close_cover(self, **kwargs: Any) -> None:
+        """Close the cover."""
+        self.action("close")
+
+    def stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover."""
+        self.action("stop")
+
+    def open_cover_tilt(self, **kwargs: Any) -> None:
+        """Open the cover slats."""
+        self.action("rotateSlatsUp")
+
+    def close_cover_tilt(self, **kwargs: Any) -> None:
+        """Close the cover slats."""
+        self.action("rotateSlatsDown")
+
+    def stop_cover_tilt(self, **kwargs: Any) -> None:
+        """Stop the cover slats turning."""
+        self.action("stopSlats")

--- a/tests/components/fibaro/conftest.py
+++ b/tests/components/fibaro/conftest.py
@@ -83,8 +83,8 @@ def mock_power_sensor() -> Mock:
 
 
 @pytest.fixture
-def mock_cover() -> Mock:
-    """Fixture for a cover."""
+def mock_positionable_cover() -> Mock:
+    """Fixture for a positionable cover."""
     cover = Mock()
     cover.fibaro_id = 3
     cover.parent_fibaro_id = 0
@@ -108,6 +108,42 @@ def mock_cover() -> Mock:
     state_mock = Mock()
     state_mock.has_value = True
     state_mock.str_value.return_value = "opening"
+    cover.state = state_mock
+    return cover
+
+
+@pytest.fixture
+def mock_cover() -> Mock:
+    """Fixture for a cover supporting slats but without positioning."""
+    cover = Mock()
+    cover.fibaro_id = 4
+    cover.parent_fibaro_id = 0
+    cover.name = "Test cover"
+    cover.room_id = 1
+    cover.dead = False
+    cover.visible = True
+    cover.enabled = True
+    cover.type = "com.fibaro.baseShutter"
+    cover.base_type = "com.fibaro.actor"
+    cover.properties = {"manufacturer": ""}
+    cover.actions = {
+        "open": 0,
+        "close": 0,
+        "stop": 0,
+        "rotateSlatsUp": 0,
+        "rotateSlatsDown": 0,
+        "stopSlats": 0,
+    }
+    cover.supported_features = {}
+    value_mock = Mock()
+    value_mock.has_value = False
+    cover.value = value_mock
+    value2_mock = Mock()
+    value2_mock.has_value = False
+    cover.value_2 = value2_mock
+    state_mock = Mock()
+    state_mock.has_value = True
+    state_mock.str_value.return_value = "closed"
     cover.state = state_mock
     return cover
 

--- a/tests/components/fibaro/test_cover.py
+++ b/tests/components/fibaro/test_cover.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock, patch
 
-from homeassistant.components.cover import CoverState
+from homeassistant.components.cover import CoverEntityFeature, CoverState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -10,6 +10,98 @@ from homeassistant.helpers import entity_registry as er
 from .conftest import init_integration
 
 from tests.common import MockConfigEntry
+
+
+async def test_positionable_cover_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_positionable_cover: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that the cover creates an entity."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [mock_positionable_cover]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        # Assert
+        entry = entity_registry.async_get("cover.room_1_test_cover_3")
+        assert entry
+        assert entry.supported_features == (
+            CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.STOP
+            | CoverEntityFeature.SET_POSITION
+        )
+        assert entry.unique_id == "hc2_111111.3"
+        assert entry.original_name == "Room 1 Test cover"
+
+
+async def test_cover_opening(
+    hass: HomeAssistant,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_positionable_cover: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that the cover opening state is reported."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [mock_positionable_cover]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        # Assert
+        assert hass.states.get("cover.room_1_test_cover_3").state == CoverState.OPENING
+
+
+async def test_cover_opening_closing_none(
+    hass: HomeAssistant,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_positionable_cover: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that the cover opening closing states return None if not available."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_positionable_cover.state.str_value.return_value = ""
+    mock_fibaro_client.read_devices.return_value = [mock_positionable_cover]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        # Assert
+        assert hass.states.get("cover.room_1_test_cover_3").state == CoverState.OPEN
+
+
+async def test_cover_closing(
+    hass: HomeAssistant,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_positionable_cover: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that the cover closing state is reported."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_positionable_cover.state.str_value.return_value = "closing"
+    mock_fibaro_client.read_devices.return_value = [mock_positionable_cover]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        # Assert
+        assert hass.states.get("cover.room_1_test_cover_3").state == CoverState.CLOSING
 
 
 async def test_cover_setup(
@@ -30,20 +122,28 @@ async def test_cover_setup(
         # Act
         await init_integration(hass, mock_config_entry)
         # Assert
-        entry = entity_registry.async_get("cover.room_1_test_cover_3")
+        entry = entity_registry.async_get("cover.room_1_test_cover_4")
         assert entry
-        assert entry.unique_id == "hc2_111111.3"
+        assert entry.supported_features == (
+            CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.STOP
+            | CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.STOP_TILT
+        )
+        assert entry.unique_id == "hc2_111111.4"
         assert entry.original_name == "Room 1 Test cover"
 
 
-async def test_cover_opening(
+async def test_cover_open_action(
     hass: HomeAssistant,
     mock_fibaro_client: Mock,
     mock_config_entry: MockConfigEntry,
     mock_cover: Mock,
     mock_room: Mock,
 ) -> None:
-    """Test that the cover opening state is reported."""
+    """Test that open_cover works."""
 
     # Arrange
     mock_fibaro_client.read_rooms.return_value = [mock_room]
@@ -52,47 +152,147 @@ async def test_cover_opening(
     with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
         # Act
         await init_integration(hass, mock_config_entry)
+        await hass.services.async_call(
+            "cover",
+            "open_cover",
+            {"entity_id": "cover.room_1_test_cover_4"},
+            blocking=True,
+        )
+
         # Assert
-        assert hass.states.get("cover.room_1_test_cover_3").state == CoverState.OPENING
+        mock_cover.execute_action.assert_called_once_with("open", ())
 
 
-async def test_cover_opening_closing_none(
+async def test_cover_close_action(
     hass: HomeAssistant,
     mock_fibaro_client: Mock,
     mock_config_entry: MockConfigEntry,
     mock_cover: Mock,
     mock_room: Mock,
 ) -> None:
-    """Test that the cover opening closing states return None if not available."""
+    """Test that close_cover works."""
 
     # Arrange
     mock_fibaro_client.read_rooms.return_value = [mock_room]
-    mock_cover.state.has_value = False
     mock_fibaro_client.read_devices.return_value = [mock_cover]
 
     with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
         # Act
         await init_integration(hass, mock_config_entry)
+        await hass.services.async_call(
+            "cover",
+            "close_cover",
+            {"entity_id": "cover.room_1_test_cover_4"},
+            blocking=True,
+        )
+
         # Assert
-        assert hass.states.get("cover.room_1_test_cover_3").state == CoverState.OPEN
+        mock_cover.execute_action.assert_called_once_with("close", ())
 
 
-async def test_cover_closing(
+async def test_cover_stop_action(
     hass: HomeAssistant,
     mock_fibaro_client: Mock,
     mock_config_entry: MockConfigEntry,
     mock_cover: Mock,
     mock_room: Mock,
 ) -> None:
-    """Test that the cover closing state is reported."""
+    """Test that stop_cover works."""
 
     # Arrange
     mock_fibaro_client.read_rooms.return_value = [mock_room]
-    mock_cover.state.str_value.return_value = "closing"
     mock_fibaro_client.read_devices.return_value = [mock_cover]
 
     with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
         # Act
         await init_integration(hass, mock_config_entry)
+        await hass.services.async_call(
+            "cover",
+            "stop_cover",
+            {"entity_id": "cover.room_1_test_cover_4"},
+            blocking=True,
+        )
+
         # Assert
-        assert hass.states.get("cover.room_1_test_cover_3").state == CoverState.CLOSING
+        mock_cover.execute_action.assert_called_once_with("stop", ())
+
+
+async def test_cover_open_slats_action(
+    hass: HomeAssistant,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_cover: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that open_cover_tilt works."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [mock_cover]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        await hass.services.async_call(
+            "cover",
+            "open_cover_tilt",
+            {"entity_id": "cover.room_1_test_cover_4"},
+            blocking=True,
+        )
+
+        # Assert
+        mock_cover.execute_action.assert_called_once_with("rotateSlatsUp", ())
+
+
+async def test_cover_close_tilt_action(
+    hass: HomeAssistant,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_cover: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that close_cover_tilt works."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [mock_cover]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        await hass.services.async_call(
+            "cover",
+            "close_cover_tilt",
+            {"entity_id": "cover.room_1_test_cover_4"},
+            blocking=True,
+        )
+
+        # Assert
+        mock_cover.execute_action.assert_called_once_with("rotateSlatsDown", ())
+
+
+async def test_cover_stop_slats_action(
+    hass: HomeAssistant,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_cover: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that stop_cover_tilt works."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [mock_cover]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.COVER]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        await hass.services.async_call(
+            "cover",
+            "stop_cover_tilt",
+            {"entity_id": "cover.room_1_test_cover_4"},
+            blocking=True,
+        )
+
+        # Assert
+        mock_cover.execute_action.assert_called_once_with("stopSlats", ())


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add detection for more types of covers in fibaro integration.
This brings better support for Elero JA Comfort-868 and maybe others.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #146336
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
