### PR TITLE
Remove Z-Wave useless reconfigure options

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -46,7 +46,6 @@ from .addon import get_addon_manager
 from .const import (
     ADDON_SLUG,
     CONF_ADDON_DEVICE,
-    CONF_ADDON_LOG_LEVEL,
     CONF_ADDON_LR_S2_ACCESS_CONTROL_KEY,
     CONF_ADDON_LR_S2_AUTHENTICATED_KEY,
     CONF_ADDON_NETWORK_KEY,
@@ -77,16 +76,7 @@ TITLE = "Z-Wave JS"
 
 ADDON_SETUP_TIMEOUT = 5
 ADDON_SETUP_TIMEOUT_ROUNDS = 40
-CONF_LOG_LEVEL = "log_level"
 
-ADDON_LOG_LEVELS = {
-    "error": "Error",
-    "warn": "Warn",
-    "info": "Info",
-    "verbose": "Verbose",
-    "debug": "Debug",
-    "silly": "Silly",
-}
 ADDON_USER_INPUT_MAP = {
     CONF_ADDON_DEVICE: CONF_USB_PATH,
     CONF_ADDON_S0_LEGACY_KEY: CONF_S0_LEGACY_KEY,
@@ -95,7 +85,6 @@ ADDON_USER_INPUT_MAP = {
     CONF_ADDON_S2_UNAUTHENTICATED_KEY: CONF_S2_UNAUTHENTICATED_KEY,
     CONF_ADDON_LR_S2_ACCESS_CONTROL_KEY: CONF_LR_S2_ACCESS_CONTROL_KEY,
     CONF_ADDON_LR_S2_AUTHENTICATED_KEY: CONF_LR_S2_AUTHENTICATED_KEY,
-    CONF_ADDON_LOG_LEVEL: CONF_LOG_LEVEL,
 }
 
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
@@ -1094,7 +1083,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_ADDON_S2_UNAUTHENTICATED_KEY: self.s2_unauthenticated_key,
                 CONF_ADDON_LR_S2_ACCESS_CONTROL_KEY: self.lr_s2_access_control_key,
                 CONF_ADDON_LR_S2_AUTHENTICATED_KEY: self.lr_s2_authenticated_key,
-                CONF_ADDON_LOG_LEVEL: user_input[CONF_LOG_LEVEL],
             }
 
             await self._async_set_addon_config(addon_config_updates)
@@ -1129,7 +1117,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
         lr_s2_authenticated_key = addon_config.get(
             CONF_ADDON_LR_S2_AUTHENTICATED_KEY, self.lr_s2_authenticated_key or ""
         )
-        log_level = addon_config.get(CONF_ADDON_LOG_LEVEL, "info")
 
         try:
             ports = await async_get_usb_ports(self.hass)
@@ -1156,9 +1143,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_LR_S2_AUTHENTICATED_KEY, default=lr_s2_authenticated_key
                 ): str,
-                vol.Optional(CONF_LOG_LEVEL, default=log_level): vol.In(
-                    ADDON_LOG_LEVELS
-                ),
             }
         )
 

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -46,7 +46,6 @@ from .addon import get_addon_manager
 from .const import (
     ADDON_SLUG,
     CONF_ADDON_DEVICE,
-    CONF_ADDON_EMULATE_HARDWARE,
     CONF_ADDON_LOG_LEVEL,
     CONF_ADDON_LR_S2_ACCESS_CONTROL_KEY,
     CONF_ADDON_LR_S2_AUTHENTICATED_KEY,
@@ -78,7 +77,6 @@ TITLE = "Z-Wave JS"
 
 ADDON_SETUP_TIMEOUT = 5
 ADDON_SETUP_TIMEOUT_ROUNDS = 40
-CONF_EMULATE_HARDWARE = "emulate_hardware"
 CONF_LOG_LEVEL = "log_level"
 
 ADDON_LOG_LEVELS = {
@@ -98,7 +96,6 @@ ADDON_USER_INPUT_MAP = {
     CONF_ADDON_LR_S2_ACCESS_CONTROL_KEY: CONF_LR_S2_ACCESS_CONTROL_KEY,
     CONF_ADDON_LR_S2_AUTHENTICATED_KEY: CONF_LR_S2_AUTHENTICATED_KEY,
     CONF_ADDON_LOG_LEVEL: CONF_LOG_LEVEL,
-    CONF_ADDON_EMULATE_HARDWARE: CONF_EMULATE_HARDWARE,
 }
 
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
@@ -1098,9 +1095,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_ADDON_LR_S2_ACCESS_CONTROL_KEY: self.lr_s2_access_control_key,
                 CONF_ADDON_LR_S2_AUTHENTICATED_KEY: self.lr_s2_authenticated_key,
                 CONF_ADDON_LOG_LEVEL: user_input[CONF_LOG_LEVEL],
-                CONF_ADDON_EMULATE_HARDWARE: user_input.get(
-                    CONF_EMULATE_HARDWARE, False
-                ),
             }
 
             await self._async_set_addon_config(addon_config_updates)
@@ -1136,7 +1130,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_ADDON_LR_S2_AUTHENTICATED_KEY, self.lr_s2_authenticated_key or ""
         )
         log_level = addon_config.get(CONF_ADDON_LOG_LEVEL, "info")
-        emulate_hardware = addon_config.get(CONF_ADDON_EMULATE_HARDWARE, False)
 
         try:
             ports = await async_get_usb_ports(self.hass)
@@ -1166,7 +1159,6 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_LOG_LEVEL, default=log_level): vol.In(
                     ADDON_LOG_LEVELS
                 ),
-                vol.Optional(CONF_EMULATE_HARDWARE, default=emulate_hardware): bool,
             }
         )
 

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -16,7 +16,6 @@ LR_ADDON_VERSION = AwesomeVersion("0.5.0")
 USER_AGENT = {APPLICATION_NAME: HA_VERSION}
 
 CONF_ADDON_DEVICE = "device"
-CONF_ADDON_EMULATE_HARDWARE = "emulate_hardware"
 CONF_ADDON_LOG_LEVEL = "log_level"
 CONF_ADDON_NETWORK_KEY = "network_key"
 CONF_ADDON_S0_LEGACY_KEY = "s0_legacy_key"

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -16,7 +16,6 @@ LR_ADDON_VERSION = AwesomeVersion("0.5.0")
 USER_AGENT = {APPLICATION_NAME: HA_VERSION}
 
 CONF_ADDON_DEVICE = "device"
-CONF_ADDON_LOG_LEVEL = "log_level"
 CONF_ADDON_NETWORK_KEY = "network_key"
 CONF_ADDON_S0_LEGACY_KEY = "s0_legacy_key"
 CONF_ADDON_S2_ACCESS_CONTROL_KEY = "s2_access_control_key"

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -52,7 +52,6 @@
       },
       "configure_addon_reconfigure": {
         "data": {
-          "emulate_hardware": "Emulate Hardware",
           "log_level": "Log level",
           "lr_s2_access_control_key": "[%key:component::zwave_js::config::step::configure_addon_user::data::lr_s2_access_control_key%]",
           "lr_s2_authenticated_key": "[%key:component::zwave_js::config::step::configure_addon_user::data::lr_s2_authenticated_key%]",

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -52,7 +52,6 @@
       },
       "configure_addon_reconfigure": {
         "data": {
-          "log_level": "Log level",
           "lr_s2_access_control_key": "[%key:component::zwave_js::config::step::configure_addon_user::data::lr_s2_access_control_key%]",
           "lr_s2_authenticated_key": "[%key:component::zwave_js::config::step::configure_addon_user::data::lr_s2_authenticated_key%]",
           "s0_legacy_key": "[%key:component::zwave_js::config::step::configure_addon_user::data::s0_legacy_key%]",

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -2567,7 +2567,6 @@ async def test_reconfigure_not_addon_with_addon_stop_fail(
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             0,
         ),
@@ -2592,7 +2591,6 @@ async def test_reconfigure_not_addon_with_addon_stop_fail(
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             1,
         ),
@@ -2707,7 +2705,6 @@ async def test_reconfigure_addon_running(
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             {
                 "usb_path": "/test",
@@ -2718,7 +2715,6 @@ async def test_reconfigure_addon_running(
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
         ),
     ],
@@ -2837,7 +2833,6 @@ async def different_device_server_version(*args):
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             {
                 "usb_path": "/new",
@@ -2848,34 +2843,6 @@ async def different_device_server_version(*args):
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
                 "log_level": "info",
-                "emulate_hardware": False,
-            },
-            0,
-            different_device_server_version,
-        ),
-        (
-            {},
-            {
-                "device": "/test",
-                "network_key": "old123",
-                "s0_legacy_key": "old123",
-                "s2_access_control_key": "old456",
-                "s2_authenticated_key": "old789",
-                "s2_unauthenticated_key": "old987",
-                "lr_s2_access_control_key": "old654",
-                "lr_s2_authenticated_key": "old321",
-                "log_level": "info",
-            },
-            {
-                "usb_path": "/new",
-                "s0_legacy_key": "new123",
-                "s2_access_control_key": "new456",
-                "s2_authenticated_key": "new789",
-                "s2_unauthenticated_key": "new987",
-                "lr_s2_access_control_key": "new654",
-                "lr_s2_authenticated_key": "new321",
-                "log_level": "info",
-                "emulate_hardware": False,
             },
             0,
             different_device_server_version,
@@ -2946,8 +2913,7 @@ async def test_reconfigure_different_device(
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
     await hass.async_block_till_done()
 
-    # Default emulate_hardware is False.
-    addon_options = {"emulate_hardware": False} | old_addon_options
+    addon_options = {} | old_addon_options
     # Legacy network key is not reset.
     addon_options.pop("network_key")
 
@@ -2995,7 +2961,6 @@ async def test_reconfigure_different_device(
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             {
                 "usb_path": "/new",
@@ -3006,7 +2971,6 @@ async def test_reconfigure_different_device(
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             0,
             [SupervisorError(), None],
@@ -3023,7 +2987,6 @@ async def test_reconfigure_different_device(
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             {
                 "usb_path": "/new",
@@ -3034,7 +2997,6 @@ async def test_reconfigure_different_device(
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             0,
             [
@@ -3152,7 +3114,6 @@ async def test_reconfigure_addon_running_server_info_failure(
         "lr_s2_access_control_key": "old654",
         "lr_s2_authenticated_key": "old321",
         "log_level": "info",
-        "emulate_hardware": False,
     }
     new_addon_options = {
         "usb_path": "/test",
@@ -3163,7 +3124,6 @@ async def test_reconfigure_addon_running_server_info_failure(
         "lr_s2_access_control_key": "old654",
         "lr_s2_authenticated_key": "old321",
         "log_level": "info",
-        "emulate_hardware": False,
     }
     addon_options.update(old_addon_options)
     entry = integration
@@ -3237,7 +3197,6 @@ async def test_reconfigure_addon_running_server_info_failure(
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             0,
         ),
@@ -3262,7 +3221,6 @@ async def test_reconfigure_addon_running_server_info_failure(
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
                 "log_level": "info",
-                "emulate_hardware": False,
             },
             1,
         ),

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -2566,7 +2566,6 @@ async def test_reconfigure_not_addon_with_addon_stop_fail(
                 "s2_unauthenticated_key": "new987",
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
-                "log_level": "info",
             },
             0,
         ),
@@ -2590,7 +2589,6 @@ async def test_reconfigure_not_addon_with_addon_stop_fail(
                 "s2_unauthenticated_key": "new987",
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
-                "log_level": "info",
             },
             1,
         ),
@@ -2704,7 +2702,6 @@ async def test_reconfigure_addon_running(
                 "s2_unauthenticated_key": "old987",
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
-                "log_level": "info",
             },
             {
                 "usb_path": "/test",
@@ -2714,7 +2711,6 @@ async def test_reconfigure_addon_running(
                 "s2_unauthenticated_key": "old987",
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
-                "log_level": "info",
             },
         ),
     ],
@@ -2832,7 +2828,6 @@ async def different_device_server_version(*args):
                 "s2_unauthenticated_key": "old987",
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
-                "log_level": "info",
             },
             {
                 "usb_path": "/new",
@@ -2842,7 +2837,6 @@ async def different_device_server_version(*args):
                 "s2_unauthenticated_key": "new987",
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
-                "log_level": "info",
             },
             0,
             different_device_server_version,
@@ -2960,7 +2954,6 @@ async def test_reconfigure_different_device(
                 "s2_unauthenticated_key": "old987",
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
-                "log_level": "info",
             },
             {
                 "usb_path": "/new",
@@ -2970,7 +2963,6 @@ async def test_reconfigure_different_device(
                 "s2_unauthenticated_key": "new987",
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
-                "log_level": "info",
             },
             0,
             [SupervisorError(), None],
@@ -2986,7 +2978,6 @@ async def test_reconfigure_different_device(
                 "s2_unauthenticated_key": "old987",
                 "lr_s2_access_control_key": "old654",
                 "lr_s2_authenticated_key": "old321",
-                "log_level": "info",
             },
             {
                 "usb_path": "/new",
@@ -2996,7 +2987,6 @@ async def test_reconfigure_different_device(
                 "s2_unauthenticated_key": "new987",
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
-                "log_level": "info",
             },
             0,
             [
@@ -3113,7 +3103,6 @@ async def test_reconfigure_addon_running_server_info_failure(
         "s2_unauthenticated_key": "old987",
         "lr_s2_access_control_key": "old654",
         "lr_s2_authenticated_key": "old321",
-        "log_level": "info",
     }
     new_addon_options = {
         "usb_path": "/test",
@@ -3123,7 +3112,6 @@ async def test_reconfigure_addon_running_server_info_failure(
         "s2_unauthenticated_key": "old987",
         "lr_s2_access_control_key": "old654",
         "lr_s2_authenticated_key": "old321",
-        "log_level": "info",
     }
     addon_options.update(old_addon_options)
     entry = integration
@@ -3196,7 +3184,6 @@ async def test_reconfigure_addon_running_server_info_failure(
                 "s2_unauthenticated_key": "new987",
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
-                "log_level": "info",
             },
             0,
         ),
@@ -3220,7 +3207,6 @@ async def test_reconfigure_addon_running_server_info_failure(
                 "s2_unauthenticated_key": "new987",
                 "lr_s2_access_control_key": "new654",
                 "lr_s2_authenticated_key": "new321",
-                "log_level": "info",
             },
             1,
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The emulate hardware and log level options of the add-on are currently also exposed in the reconfigure flow in the integration. The emulate hardware option is not an option that users should use, and the log level option isn't needed as we have a log panel in the Z-Wave config panel and we also sync the driver debug log level with the integration debug log level.
- Remove both options from the reconfigure flow as they are just confusing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/83
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
