### PR TITLE
Move available property to entity.py for Squeezebox

### DIFF
--- a/homeassistant/components/squeezebox/button.py
+++ b/homeassistant/components/squeezebox/button.py
@@ -153,11 +153,6 @@ class SqueezeboxButtonEntity(SqueezeboxEntity, ButtonEntity):
             f"{format_mac(self._player.player_id)}_{entity_description.key}"
         )
 
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.available and super().available
-
     async def async_press(self) -> None:
         """Execute the button action."""
         await self._player.async_query("button", self.entity_description.press_action)

--- a/homeassistant/components/squeezebox/entity.py
+++ b/homeassistant/components/squeezebox/entity.py
@@ -33,6 +33,13 @@ class SqueezeboxEntity(CoordinatorEntity[SqueezeBoxPlayerUpdateCoordinator]):
             manufacturer=self._player.creator,
         )
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        # super().available refers to CoordinatorEntity.available (self.coordinator.last_update_success)
+        # self.coordinator.available is the custom availability flag from SqueezeBoxPlayerUpdateCoordinator
+        return self.coordinator.available and super().available
+
 
 class LMSStatusEntity(CoordinatorEntity[LMSStatusDataUpdateCoordinator]):
     """Defines a base status sensor entity."""

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -247,11 +247,6 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         )
 
     @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.available and super().available
-
-    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return device-specific attributes."""
         return {


### PR DESCRIPTION


## Proposed change
In the media_player and button platforms, we override the available property to include a custom flag on the coordinator

```python
    @property
    def available(self) -> bool:
        """Return True if entity is available."""
        return self.coordinator.available and super().available
```

This PR moves this override to the parent entity, SqueezeboxEntity, so that it will be covered by super().available when inherited and will also be used in any other platforms which inherit from SqueezeboxEntity, such as switch, which currently lacks the check on self.coordinator.available.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
