### PR TITLE
Bump reolink-aio to 0.14.0

### DIFF
--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -82,7 +82,7 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinator[None]
             connections={(CONNECTION_NETWORK_MAC, self._host.api.mac_address)},
             name=self._host.api.nvr_name,
             model=self._host.api.model,
-            model_id=self._host.api.item_number,
+            model_id=self._host.api.item_number(),
             manufacturer=self._host.api.manufacturer,
             hw_version=self._host.api.hardware_version,
             sw_version=self._host.api.sw_version,

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.13.5"]
+  "requirements": ["reolink-aio==0.14.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2652,7 +2652,7 @@ renault-api==0.3.1
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.13.5
+reolink-aio==0.14.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2195,7 +2195,7 @@ renault-api==0.3.1
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.13.5
+reolink-aio==0.14.0
 
 # homeassistant.components.rflink
 rflink==0.0.66

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -99,7 +99,7 @@ def reolink_connect_class() -> Generator[MagicMock]:
         host_mock.sw_upload_progress.return_value = 100
         host_mock.manufacturer = "Reolink"
         host_mock.model = TEST_HOST_MODEL
-        host_mock.item_number = TEST_ITEM_NUMBER
+        host_mock.item_number.return_value = TEST_ITEM_NUMBER
         host_mock.camera_model.return_value = TEST_CAM_MODEL
         host_mock.camera_name.return_value = TEST_NVR_NAME
         host_mock.camera_hardware_version.return_value = "IPC_00001"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.14.0:
**Breaking changes:**
- [Make http_api a required argument of Baichuan](https://github.com/starkillerOG/reolink_aio/pull/124/commits/fc79dae981af1680b50d2a70a114e9a29370519a)
- [item_number changed from property to function with optional channel](https://github.com/starkillerOG/reolink_aio/pull/124/commits/451f42bb44ed0ef9fce7fb4d470248e2822939ee)

**Additions:**
- [Add Baichuan only device support: Reolink Floodlight WiFi/PoE](https://github.com/starkillerOG/reolink_aio/pull/124)
  - [GetDevInfo Baichuan fallback](https://github.com/starkillerOG/reolink_aio/pull/124/commits/ca573a0f6bb6293ed4f2a874a7a7813451794e0f)
  - [Add GetLocalLink Baichuan fallback](https://github.com/starkillerOG/reolink_aio/pull/124/commits/50d2aaba90d74a4c5336e9dc1702a34b0741bfde)
  - [GetP2p Baichuan fallback](https://github.com/starkillerOG/reolink_aio/pull/124/commits/f2e60c670592a743add26c09f14d7ceeab13b042)
  - [Add GetUser Baichuan fallback](https://github.com/starkillerOG/reolink_aio/pull/124/commits/c92f34c3d8722f10ea07a3f4a638d441dd2b105f)
  - [Check session_active for baichuan only](https://github.com/starkillerOG/reolink_aio/pull/124/commits/8c9965aaf2cbefa6734f350ce02cda5eefd7a267)
  - [Parse ChannelNum from Baichuan](https://github.com/starkillerOG/reolink_aio/pull/124/commits/ede1b4edde27b38aced9b344c1cd2791758626b1)
  - [Always process floodlight tcp push](https://github.com/starkillerOG/reolink_aio/pull/124/commits/2222f9b236dc1842eb450589b9586935f5d5515d)
  - [Add GetWhiteLed Baichuan fallback and brightness TCP pushes](https://github.com/starkillerOG/reolink_aio/pull/124/commits/e53cacb4910d100e22161754d5e9320d4d81e198)
  - [Implement floodlight mode status and brightness set](https://github.com/starkillerOG/reolink_aio/pull/124/commits/79f0a0c3b2bc04a7026083f976ab155aacbbd822)
  - [Add set floodlight mode baichuan fallback](https://github.com/starkillerOG/reolink_aio/pull/124/commits/ccafae558f79e8a9bed4549ddd06ead5d9413a17)
- [Add ir_brightness support](https://github.com/starkillerOG/reolink_aio/commit/b682a7aa3c5cceeea3dcba824da9d6727089485d)
- [Add cry_sensitivity support](https://github.com/starkillerOG/reolink_aio/commit/1ca0f82fcc98cbaf0df7e333eb745b4cb2c40e18)
- [Add baichuan floodlight capability](https://github.com/starkillerOG/reolink_aio/pull/124/commits/8f52a4b05c2ef143b8d8a6da24e914161a876499)
- [Add Baichuan fallback for GetPowerLed, GetIrLights and SetPowerLed](https://github.com/starkillerOG/reolink_aio/commit/015a1073fb7385c85737aaeb34d2ca69a5299659)
- [Implement SetIrLights Baichuan fallback](https://github.com/starkillerOG/reolink_aio/commit/56ea137d718f6a32e0cee9427f7345bedc6cdd08)

**Bug fixes:**
- [Improve spotlight mode ability detection](https://github.com/starkillerOG/reolink_aio/commit/1af96a1419a096da7a255651d50f0ee620a63275)
- [Do not skip baichuan get_host_data if no channels are connected](https://github.com/starkillerOG/reolink_aio/pull/124/commits/a3411108306237ffaaf86d1c4a299c6ffdab7780)
- [Improve detection of "audio" supported](https://github.com/starkillerOG/reolink_aio/pull/124/commits/c7a96c873aff4a306864f5bf5787f5c4f88c25be)

**Optimizations:**
- [Allow multiple @http_cmd funcs](https://github.com/starkillerOG/reolink_aio/pull/124/commits/395600de6b97069e1340066cfd78de5183be9f88)
- [restructure nvr_name/camera_name and nvr_serial->serial](https://github.com/starkillerOG/reolink_aio/pull/124/commits/461f28b2de75af412091ea01cc759804e4a4a9a7)
- [Combine model, hw_version, item_number, uid, sw_version and sw_version objects](https://github.com/starkillerOG/reolink_aio/pull/124/commits/451f42bb44ed0ef9fce7fb4d470248e2822939ee)
- [Stream and snapshot supported flags](https://github.com/starkillerOG/reolink_aio/pull/124/commits/e473838a1f8f41204a29daf92a1fa090d2c77bde)
- [Improve hardware_version, camera_model and camera_sw_version](https://github.com/starkillerOG/reolink_aio/pull/124/commits/528fc73a1265db18945c7cb895f37eae054ac792)
- [Only request GetMdState if motion_detection is supported](https://github.com/starkillerOG/reolink_aio/pull/124/commits/0fd067ab64773707e0034cfece4cf955b09cb903)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.13.5...0.14.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/135200
- This PR is related to issue: https://github.com/starkillerOG/reolink_aio/issues/20
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
