### PR TITLE
Remove incorrect use of via_device in roon component

### DIFF
--- a/homeassistant/components/roon/event.py
+++ b/homeassistant/components/roon/event.py
@@ -69,7 +69,6 @@ class RoonEventEntity(EventEntity):
             name=cast(str | None, self.name),
             manufacturer="RoonLabs",
             model=dev_model,
-            via_device=(DOMAIN, self._server.roon_id),
         )
 
     def _roonapi_volume_callback(

--- a/homeassistant/components/roon/event.py
+++ b/homeassistant/components/roon/event.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
         if dev_id in event_entities:
             return
         # new player!
-        event_entity = RoonEventEntity(roon_server, player_data)
+        event_entity = RoonEventEntity(roon_server, player_data, config_entry.entry_id)
         event_entities.add(dev_id)
         async_add_entities([event_entity])
 
@@ -50,13 +50,14 @@ class RoonEventEntity(EventEntity):
     _attr_event_types = ["volume_up", "volume_down", "mute_toggle"]
     _attr_translation_key = "volume"
 
-    def __init__(self, server, player_data):
+    def __init__(self, server, player_data, core_id):
         """Initialize the entity."""
         self._server = server
         self._player_data = player_data
         player_name = player_data["display_name"]
         self._attr_name = f"{player_name} roon volume"
         self._attr_unique_id = self._player_data["dev_id"]
+        self._core_id = core_id
 
         if self._player_data.get("source_controls"):
             dev_model = self._player_data["source_controls"][0].get("display_name")
@@ -69,6 +70,7 @@ class RoonEventEntity(EventEntity):
             name=cast(str | None, self.name),
             manufacturer="RoonLabs",
             model=dev_model,
+            via_device=(DOMAIN, self._core_id),
         )
 
     def _roonapi_volume_callback(

--- a/homeassistant/components/roon/event.py
+++ b/homeassistant/components/roon/event.py
@@ -50,14 +50,14 @@ class RoonEventEntity(EventEntity):
     _attr_event_types = ["volume_up", "volume_down", "mute_toggle"]
     _attr_translation_key = "volume"
 
-    def __init__(self, server, player_data, core_id):
+    def __init__(self, server, player_data, entry_id):
         """Initialize the entity."""
         self._server = server
         self._player_data = player_data
         player_name = player_data["display_name"]
         self._attr_name = f"{player_name} roon volume"
         self._attr_unique_id = self._player_data["dev_id"]
-        self._core_id = core_id
+        self._entry_id = entry_id
 
         if self._player_data.get("source_controls"):
             dev_model = self._player_data["source_controls"][0].get("display_name")
@@ -70,7 +70,7 @@ class RoonEventEntity(EventEntity):
             name=cast(str | None, self.name),
             manufacturer="RoonLabs",
             model=dev_model,
-            via_device=(DOMAIN, self._core_id),
+            via_device=(DOMAIN, self._entry_id),
         )
 
     def _roonapi_volume_callback(

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -166,7 +166,6 @@ class RoonDevice(MediaPlayerEntity):
             name=cast(str | None, self.name),
             manufacturer="RoonLabs",
             model=dev_model,
-            via_device=(DOMAIN, self._server.roon_id),
         )
 
     def update_data(self, player_data=None):

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -72,7 +72,7 @@ async def async_setup_entry(
         dev_id = player_data["dev_id"]
         if dev_id not in media_players:
             # new player!
-            media_player = RoonDevice(roon_server, player_data)
+            media_player = RoonDevice(roon_server, player_data, config_entry.entry_id)
             media_players.add(dev_id)
             async_add_entities([media_player])
         else:
@@ -106,7 +106,7 @@ class RoonDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.PLAY_MEDIA
     )
 
-    def __init__(self, server, player_data):
+    def __init__(self, server, player_data, core_id):
         """Initialize Roon device object."""
         self._remove_signal_status = None
         self._server = server
@@ -125,6 +125,7 @@ class RoonDevice(MediaPlayerEntity):
         self._attr_volume_level = 0
         self._volume_fixed = True
         self._volume_incremental = False
+        self._core_id = core_id
         self.update_data(player_data)
 
     async def async_added_to_hass(self) -> None:
@@ -166,6 +167,7 @@ class RoonDevice(MediaPlayerEntity):
             name=cast(str | None, self.name),
             manufacturer="RoonLabs",
             model=dev_model,
+            via_device=(DOMAIN, self._core_id),
         )
 
     def update_data(self, player_data=None):

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -106,7 +106,7 @@ class RoonDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.PLAY_MEDIA
     )
 
-    def __init__(self, server, player_data, core_id):
+    def __init__(self, server, player_data, entry_id):
         """Initialize Roon device object."""
         self._remove_signal_status = None
         self._server = server
@@ -125,7 +125,7 @@ class RoonDevice(MediaPlayerEntity):
         self._attr_volume_level = 0
         self._volume_fixed = True
         self._volume_incremental = False
-        self._core_id = core_id
+        self._entry_id = entry_id
         self.update_data(player_data)
 
     async def async_added_to_hass(self) -> None:
@@ -167,7 +167,7 @@ class RoonDevice(MediaPlayerEntity):
             name=cast(str | None, self.name),
             manufacturer="RoonLabs",
             model=dev_model,
-            via_device=(DOMAIN, self._core_id),
+            via_device=(DOMAIN, self._entry_id),
         )
 
     def update_data(self, player_data=None):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Roon includes an incorrect use of `via_device` for historic reasons.

This PR removes the parameter, which as well as being incorrect, doesn't make sense for the component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/135485
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
