### PR TITLE
Fix palette handling for LIFX Ceiling SKY effect

### DIFF
--- a/homeassistant/components/lifx/manager.py
+++ b/homeassistant/components/lifx/manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiolifx_effects
 from aiolifx_themes.painter import ThemePainter
@@ -31,8 +31,11 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_extract_referenced_entity_ids
 
 from .const import _ATTR_COLOR_TEMP, ATTR_THEME, DATA_LIFX_MANAGER, DOMAIN
-from .coordinator import LIFXUpdateCoordinator, Light
+from .coordinator import LIFXUpdateCoordinator
 from .util import convert_8_to_16, find_hsbk
+
+if TYPE_CHECKING:
+    from aiolifx.aiolifx import Light
 
 SCAN_INTERVAL = timedelta(seconds=10)
 
@@ -426,8 +429,8 @@ class LIFXManager:
     ) -> None:
         """Start the firmware-based Sky effect."""
         palette = kwargs.get(ATTR_PALETTE)
+        theme = Theme()
         if palette is not None:
-            theme = Theme()
             for hsbk in palette:
                 theme.add_hsbk(hsbk[0], hsbk[1], hsbk[2], hsbk[3])
 

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -843,7 +843,7 @@ async def test_sky_effect(hass: HomeAssistant) -> None:
         SERVICE_EFFECT_SKY,
         {
             ATTR_ENTITY_ID: entity_id,
-            ATTR_PALETTE: [],
+            ATTR_PALETTE: None,
             ATTR_SKY_TYPE: "Clouds",
             ATTR_CLOUD_SATURATION_MAX: 180,
             ATTR_CLOUD_SATURATION_MIN: 50,
@@ -854,7 +854,7 @@ async def test_sky_effect(hass: HomeAssistant) -> None:
     bulb.power_level = 65535
     bulb.effect = {
         "effect": "SKY",
-        "palette": [],
+        "palette": None,
         "sky_type": 2,
         "cloud_saturation_min": 50,
         "cloud_saturation_max": 180,


### PR DESCRIPTION
## Proposed change

Instantiate the `theme` variable in the correct context so it works regardless of whether a custom palette is provided or not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146567 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [-] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
