### PR TITLE
Remove deprecated service in plex

### DIFF
--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -56,7 +56,6 @@ AUTOMATIC_SETUP_STRING = "Obtain a new token from plex.tv"
 MANUAL_SETUP_STRING = "Configure Plex server manually"
 
 SERVICE_REFRESH_LIBRARY = "refresh_library"
-SERVICE_SCAN_CLIENTS = "scan_for_clients"
 
 PLEX_URI_SCHEME = "plex://"
 

--- a/homeassistant/components/plex/icons.json
+++ b/homeassistant/components/plex/icons.json
@@ -9,9 +9,6 @@
   "services": {
     "refresh_library": {
       "service": "mdi:refresh"
-    },
-    "scan_for_clients": {
-      "service": "mdi:database-refresh"
     }
   }
 }

--- a/homeassistant/components/plex/services.py
+++ b/homeassistant/components/plex/services.py
@@ -9,16 +9,8 @@ from yarl import URL
 
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import (
-    DOMAIN,
-    PLEX_UPDATE_PLATFORMS_SIGNAL,
-    PLEX_URI_SCHEME,
-    SERVERS,
-    SERVICE_REFRESH_LIBRARY,
-    SERVICE_SCAN_CLIENTS,
-)
+from .const import DOMAIN, PLEX_URI_SCHEME, SERVERS, SERVICE_REFRESH_LIBRARY
 from .errors import MediaNotFound
 from .helpers import get_plex_data
 from .models import PlexMediaSearchResult
@@ -37,23 +29,11 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     async def async_refresh_library_service(service_call: ServiceCall) -> None:
         await hass.async_add_executor_job(refresh_library, hass, service_call)
 
-    async def async_scan_clients_service(_: ServiceCall) -> None:
-        _LOGGER.warning(
-            "This service is deprecated in favor of the scan_clients button entity."
-            " Service calls will still work for now but the service will be removed in"
-            " a future release"
-        )
-        for server_id in get_plex_data(hass)[SERVERS]:
-            async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
-
     hass.services.async_register(
         DOMAIN,
         SERVICE_REFRESH_LIBRARY,
         async_refresh_library_service,
         schema=REFRESH_LIBRARY_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_SCAN_CLIENTS, async_scan_clients_service
     )
 
 

--- a/homeassistant/components/plex/services.yaml
+++ b/homeassistant/components/plex/services.yaml
@@ -9,5 +9,3 @@ refresh_library:
       example: "TV Shows"
       selector:
         text:
-
-scan_for_clients:

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -83,10 +83,6 @@
           "description": "Name of the Plex library to refresh."
         }
       }
-    },
-    "scan_for_clients": {
-      "name": "Scan for clients",
-      "description": "Scans for available clients from the Plex server(s), local network, and plex.tv."
     }
   }
 }

--- a/tests/components/plex/test_services.py
+++ b/tests/components/plex/test_services.py
@@ -17,7 +17,6 @@ from homeassistant.components.plex.const import (
     PLEX_SERVER_CONFIG,
     PLEX_URI_SCHEME,
     SERVICE_REFRESH_LIBRARY,
-    SERVICE_SCAN_CLIENTS,
 )
 from homeassistant.components.plex.services import process_plex_payload
 from homeassistant.const import CONF_URL
@@ -105,15 +104,6 @@ async def test_refresh_library(
         )
     assert "Multiple Plex servers configured" in str(excinfo.value)
     assert refresh.call_count == 1
-
-
-async def test_scan_clients(hass: HomeAssistant, mock_plex_server) -> None:
-    """Test scan_for_clients service call."""
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SCAN_CLIENTS,
-        blocking=True,
-    )
 
 
 async def test_lookup_media_for_other_integrations(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated `plex.scan_for_clients` service has been removed in favor of the "Scan Clients" `button` entity.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #67055

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
