### PR TITLE
Bump pysmarlaapi version to 0.9.0

### DIFF
--- a/homeassistant/components/smarla/__init__.py
+++ b/homeassistant/components/smarla/__init__.py
@@ -22,11 +22,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: FederwiegeConfigEntry) -
 
     federwiege = Federwiege(hass.loop, connection)
     federwiege.register()
-    federwiege.connect()
 
     entry.runtime_data = federwiege
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    federwiege.connect()
 
     return True
 

--- a/homeassistant/components/smarla/manifest.json
+++ b/homeassistant/components/smarla/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "loggers": ["pysmarlaapi", "pysignalr"],
   "quality_scale": "bronze",
-  "requirements": ["pysmarlaapi==0.8.2"]
+  "requirements": ["pysmarlaapi==0.9.0"]
 }

--- a/homeassistant/components/smarla/number.py
+++ b/homeassistant/components/smarla/number.py
@@ -53,9 +53,10 @@ class SmarlaNumber(SmarlaBaseEntity, NumberEntity):
     _property: Property[int]
 
     @property
-    def native_value(self) -> float:
+    def native_value(self) -> float | None:
         """Return the entity value to represent the entity state."""
-        return self._property.get()
+        v = self._property.get()
+        return float(v) if v is not None else None
 
     def set_native_value(self, value: float) -> None:
         """Update to the smarla device."""

--- a/homeassistant/components/smarla/switch.py
+++ b/homeassistant/components/smarla/switch.py
@@ -52,7 +52,7 @@ class SmarlaSwitch(SmarlaBaseEntity, SwitchEntity):
     _property: Property[bool]
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return the entity value to represent the entity state."""
         return self._property.get()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2338,7 +2338,7 @@ pysma==0.7.5
 pysmappee==0.2.29
 
 # homeassistant.components.smarla
-pysmarlaapi==0.8.2
+pysmarlaapi==0.9.0
 
 # homeassistant.components.smartthings
 pysmartthings==3.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1938,7 +1938,7 @@ pysma==0.7.5
 pysmappee==0.2.29
 
 # homeassistant.components.smarla
-pysmarlaapi==0.8.2
+pysmarlaapi==0.9.0
 
 # homeassistant.components.smartthings
 pysmartthings==3.2.3

--- a/tests/components/smarla/snapshots/test_number.ambr
+++ b/tests/components/smarla/snapshots/test_number.ambr
@@ -53,6 +53,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1',
+    'state': '1.0',
   })
 # ---

--- a/tests/components/smarla/test_number.py
+++ b/tests/components/smarla/test_number.py
@@ -93,11 +93,11 @@ async def test_number_state_update(
 
     entity_id = entity_info["entity_id"]
 
-    assert hass.states.get(entity_id).state == "1"
+    assert hass.states.get(entity_id).state == "1.0"
 
     mock_number_property.get.return_value = 100
 
     await update_property_listeners(mock_number_property)
     await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == "100"
+    assert hass.states.get(entity_id).state == "100.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Changed default values of all properties to `None` in the pysmarlaapi library. This further fixes the statistics for the entities in Home Assistant.

Link to library diff: https://github.com/Explicatis-GmbH/pysmarlaapi/compare/0.8.2...0.9.0?diff=unified&w


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
