### PR TITLE
Add option traffic_mode in here_travel_time

### DIFF
--- a/homeassistant/components/here_travel_time/const.py
+++ b/homeassistant/components/here_travel_time/const.py
@@ -19,6 +19,7 @@ CONF_ARRIVAL = "arrival"
 CONF_DEPARTURE = "departure"
 CONF_ARRIVAL_TIME = "arrival_time"
 CONF_DEPARTURE_TIME = "departure_time"
+CONF_TRAFFIC_MODE = "traffic_mode"
 
 DEFAULT_NAME = "HERE Travel Time"
 

--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -13,6 +13,7 @@ from here_routing import (
     Return,
     RoutingMode,
     Spans,
+    TrafficMode,
     TransportMode,
 )
 import here_transit
@@ -44,6 +45,7 @@ from .const import (
     CONF_ORIGIN_LATITUDE,
     CONF_ORIGIN_LONGITUDE,
     CONF_ROUTE_MODE,
+    CONF_TRAFFIC_MODE,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     ROUTE_MODE_FASTEST,
@@ -87,7 +89,7 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator[HERETravelTimeData]
         _LOGGER.debug(
             (
                 "Requesting route for origin: %s, destination: %s, route_mode: %s,"
-                " mode: %s, arrival: %s, departure: %s"
+                " mode: %s, arrival: %s, departure: %s, traffic_mode: %s"
             ),
             params.origin,
             params.destination,
@@ -95,6 +97,7 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator[HERETravelTimeData]
             TransportMode(params.travel_mode),
             params.arrival,
             params.departure,
+            params.traffic_mode,
         )
 
         try:
@@ -109,6 +112,7 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator[HERETravelTimeData]
                 routing_mode=params.route_mode,
                 arrival_time=params.arrival,
                 departure_time=params.departure,
+                traffic_mode=params.traffic_mode,
                 return_values=[Return.POLYINE, Return.SUMMARY],
                 spans=[Spans.NAMES],
             )
@@ -350,6 +354,11 @@ def prepare_parameters(
         if config_entry.options[CONF_ROUTE_MODE] == ROUTE_MODE_FASTEST
         else RoutingMode.SHORT
     )
+    traffic_mode = (
+        TrafficMode.DISABLED
+        if config_entry.options[CONF_TRAFFIC_MODE] is False
+        else TrafficMode.DEFAULT
+    )
 
     return HERETravelTimeAPIParams(
         destination=destination,
@@ -358,6 +367,7 @@ def prepare_parameters(
         route_mode=route_mode,
         arrival=arrival,
         departure=departure,
+        traffic_mode=traffic_mode,
     )
 
 

--- a/homeassistant/components/here_travel_time/model.py
+++ b/homeassistant/components/here_travel_time/model.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TypedDict
 
-from here_routing import RoutingMode
+from here_routing import RoutingMode, TrafficMode
 
 
 class HERETravelTimeData(TypedDict):
@@ -32,3 +32,4 @@ class HERETravelTimeAPIParams:
     route_mode: RoutingMode
     arrival: datetime | None
     departure: datetime | None
+    traffic_mode: TrafficMode

--- a/homeassistant/components/here_travel_time/strings.json
+++ b/homeassistant/components/here_travel_time/strings.json
@@ -60,8 +60,11 @@
     "step": {
       "init": {
         "data": {
-          "traffic_mode": "Use traffic and time-aware routing. (Needed for defining arrival/departure times)",
+          "traffic_mode": "Use traffic and time-aware routing",
           "route_mode": "Route mode"
+        },
+        "data_description": {
+          "traffic_mode": "Needed for defining arrival/departure times"
         }
       },
       "time_menu": {

--- a/homeassistant/components/here_travel_time/strings.json
+++ b/homeassistant/components/here_travel_time/strings.json
@@ -60,7 +60,7 @@
     "step": {
       "init": {
         "data": {
-          "traffic_mode": "Traffic mode",
+          "traffic_mode": "Use traffic and time-aware routing. (Needed for defining arrival/departure times)",
           "route_mode": "Route mode"
         }
       },

--- a/tests/components/here_travel_time/test_config_flow.py
+++ b/tests/components/here_travel_time/test_config_flow.py
@@ -6,7 +6,10 @@ from here_routing import HERERoutingError, HERERoutingUnauthorizedError
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.here_travel_time.config_flow import DEFAULT_OPTIONS
+from homeassistant.components.here_travel_time.config_flow import (
+    DEFAULT_OPTIONS,
+    HERETravelTimeConfigFlow,
+)
 from homeassistant.components.here_travel_time.const import (
     CONF_ARRIVAL_TIME,
     CONF_DEPARTURE_TIME,
@@ -87,6 +90,8 @@ async def option_init_result_fixture(
             CONF_MODE: TRAVEL_MODE_PUBLIC,
             CONF_NAME: "test",
         },
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -319,6 +324,8 @@ async def do_common_reconfiguration_steps(hass: HomeAssistant) -> None:
         unique_id="0123456789",
         data=DEFAULT_CONFIG,
         options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
 
@@ -400,6 +407,8 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         unique_id="0123456789",
         data=DEFAULT_CONFIG,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
 
@@ -416,10 +425,16 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         result["flow_id"],
         user_input={
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
+            CONF_TRAFFIC_MODE: False,
         },
     )
 
-    assert result["type"] is FlowResultType.MENU
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.options == {
+        CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
+        CONF_TRAFFIC_MODE: False,
+    }
 
 
 @pytest.mark.usefixtures("valid_response")

--- a/tests/components/here_travel_time/test_config_flow.py
+++ b/tests/components/here_travel_time/test_config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.components.here_travel_time.const import (
     CONF_ORIGIN_LATITUDE,
     CONF_ORIGIN_LONGITUDE,
     CONF_ROUTE_MODE,
+    CONF_TRAFFIC_MODE,
     DOMAIN,
     ROUTE_MODE_FASTEST,
     TRAVEL_MODE_BICYCLE,
@@ -249,6 +250,7 @@ async def test_step_destination_entity(
         CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
         CONF_ARRIVAL_TIME: None,
         CONF_DEPARTURE_TIME: None,
+        CONF_TRAFFIC_MODE: True,
     }
 
 
@@ -441,6 +443,7 @@ async def test_options_flow_arrival_time_step(
     assert entry.options == {
         CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
         CONF_ARRIVAL_TIME: "08:00:00",
+        CONF_TRAFFIC_MODE: True,
     }
 
 
@@ -465,6 +468,7 @@ async def test_options_flow_departure_time_step(
     assert entry.options == {
         CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
         CONF_DEPARTURE_TIME: "08:00:00",
+        CONF_TRAFFIC_MODE: True,
     }
 
 
@@ -481,4 +485,5 @@ async def test_options_flow_no_time_step(
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.options == {
         CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
+        CONF_TRAFFIC_MODE: True,
     }

--- a/tests/components/here_travel_time/test_init.py
+++ b/tests/components/here_travel_time/test_init.py
@@ -4,7 +4,10 @@ from datetime import datetime
 
 import pytest
 
-from homeassistant.components.here_travel_time.config_flow import DEFAULT_OPTIONS
+from homeassistant.components.here_travel_time.config_flow import (
+    DEFAULT_OPTIONS,
+    HERETravelTimeConfigFlow,
+)
 from homeassistant.components.here_travel_time.const import (
     CONF_ARRIVAL_TIME,
     CONF_DEPARTURE_TIME,
@@ -46,6 +49,8 @@ async def test_unload_entry(hass: HomeAssistant, options) -> None:
         unique_id="0123456789",
         data=DEFAULT_CONFIG,
         options=options,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
 
@@ -61,9 +66,10 @@ async def test_migrate_entry_v1_1_v1_2(
     """Test successful migration of entry data."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
-        version=1,
         data=DEFAULT_CONFIG,
         options=DEFAULT_OPTIONS,
+        version=1,
+        minor_version=1,
     )
     mock_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_entry.entry_id)

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -22,7 +22,10 @@ from here_transit import (
 )
 import pytest
 
-from homeassistant.components.here_travel_time.config_flow import DEFAULT_OPTIONS
+from homeassistant.components.here_travel_time.config_flow import (
+    DEFAULT_OPTIONS,
+    HERETravelTimeConfigFlow,
+)
 from homeassistant.components.here_travel_time.const import (
     CONF_ARRIVAL_TIME,
     CONF_DEPARTURE_TIME,
@@ -33,6 +36,7 @@ from homeassistant.components.here_travel_time.const import (
     CONF_ORIGIN_LATITUDE,
     CONF_ORIGIN_LONGITUDE,
     CONF_ROUTE_MODE,
+    CONF_TRAFFIC_MODE,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     ICON_BICYCLE,
@@ -86,29 +90,33 @@ from tests.common import (
 
 
 @pytest.mark.parametrize(
-    ("mode", "icon", "arrival_time", "departure_time"),
+    ("mode", "icon", "traffic_mode", "arrival_time", "departure_time"),
     [
         (
             TRAVEL_MODE_CAR,
             ICON_CAR,
+            False,
             None,
             None,
         ),
         (
             TRAVEL_MODE_BICYCLE,
             ICON_BICYCLE,
+            True,
             None,
             None,
         ),
         (
             TRAVEL_MODE_PEDESTRIAN,
             ICON_PEDESTRIAN,
+            True,
             None,
             "08:00:00",
         ),
         (
             TRAVEL_MODE_TRUCK,
             ICON_TRUCK,
+            True,
             None,
             "08:00:00",
         ),
@@ -119,6 +127,7 @@ async def test_sensor(
     hass: HomeAssistant,
     mode,
     icon,
+    traffic_mode,
     arrival_time,
     departure_time,
 ) -> None:
@@ -138,9 +147,12 @@ async def test_sensor(
         },
         options={
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
+            CONF_TRAFFIC_MODE: traffic_mode,
             CONF_ARRIVAL_TIME: arrival_time,
             CONF_DEPARTURE_TIME: departure_time,
         },
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -198,6 +210,8 @@ async def test_circular_ref(
             CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -229,7 +243,10 @@ async def test_public_transport(hass: HomeAssistant) -> None:
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
             CONF_ARRIVAL_TIME: "08:00:00",
             CONF_DEPARTURE_TIME: None,
+            CONF_TRAFFIC_MODE: True,
         },
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -261,6 +278,8 @@ async def test_no_attribution_response(hass: HomeAssistant) -> None:
             CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -308,6 +327,8 @@ async def test_entity_ids(hass: HomeAssistant, valid_response: MagicMock) -> Non
             CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -348,6 +369,8 @@ async def test_destination_entity_not_found(
             CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -376,6 +399,8 @@ async def test_origin_entity_not_found(
             CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -408,6 +433,8 @@ async def test_invalid_destination_entity_state(
             CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -442,6 +469,8 @@ async def test_invalid_origin_entity_state(
             CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -478,6 +507,8 @@ async def test_route_not_found(
                 CONF_NAME: "test",
             },
             options=DEFAULT_OPTIONS,
+            version=HERETravelTimeConfigFlow.VERSION,
+            minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
         )
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
@@ -589,7 +620,12 @@ async def test_restore_state(hass: HomeAssistant) -> None:
 
     # create and add entry
     mock_entry = MockConfigEntry(
-        domain=DOMAIN, unique_id=DOMAIN, data=DEFAULT_CONFIG, options=DEFAULT_OPTIONS
+        domain=DOMAIN,
+        unique_id=DOMAIN,
+        data=DEFAULT_CONFIG,
+        options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     mock_entry.add_to_hass(hass)
 
@@ -658,6 +694,8 @@ async def test_transit_errors(
                 CONF_NAME: "test",
             },
             options=DEFAULT_OPTIONS,
+            version=HERETravelTimeConfigFlow.VERSION,
+            minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
         )
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
@@ -684,6 +722,8 @@ async def test_routing_rate_limit(
             unique_id="0123456789",
             data=DEFAULT_CONFIG,
             options=DEFAULT_OPTIONS,
+            version=HERETravelTimeConfigFlow.VERSION,
+            minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
         )
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
@@ -741,6 +781,8 @@ async def test_transit_rate_limit(
                 CONF_NAME: "test",
             },
             options=DEFAULT_OPTIONS,
+            version=HERETravelTimeConfigFlow.VERSION,
+            minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
         )
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
@@ -793,6 +835,8 @@ async def test_multiple_sections(
             CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
+        version=HERETravelTimeConfigFlow.VERSION,
+        minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -11,6 +11,7 @@ from here_routing import (
     Return,
     RoutingMode,
     Spans,
+    TrafficMode,
     TransportMode,
 )
 from here_transit import (
@@ -324,6 +325,7 @@ async def test_entity_ids(hass: HomeAssistant, valid_response: MagicMock) -> Non
         routing_mode=RoutingMode.FAST,
         arrival_time=None,
         departure_time=None,
+        traffic_mode=TrafficMode.DEFAULT,
         return_values=[Return.POLYINE, Return.SUMMARY],
         spans=[Spans.NAMES],
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the option to disable the [traffic mode](https://www.here.com/docs/bundle/routing-api-developer-guide-v8/page/concepts/traffic.html).
The HERE API allows far more requests with traffic mode disabled in the free tier.

When the traffic mode is disabled departure/arrival time are ignored and current traffic conditions are not taken into account for route calculation.

This was requested [in the forum](https://community.home-assistant.io/t/custom-component-here-travel-time/125908/334)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
