### PR TITLE
Adjust core create_task tests with event_loop patch

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -255,45 +255,51 @@ async def test_async_add_hass_job_schedule_partial_callback() -> None:
     partial = functools.partial(ha.callback(job))
 
     ha.HomeAssistant._async_add_hass_job(hass, ha.HassJob(partial))
-    assert len(hass.loop.call_soon.mock_calls) == 1
-    assert len(hass.loop.create_task.mock_calls) == 0
-    assert len(hass.add_job.mock_calls) == 0
+    assert hass.loop.call_soon.call_count == 1
+    assert hass.loop.create_task.call_count == 0
+    assert hass.add_job.call_count == 0
 
 
 async def test_async_add_hass_job_schedule_corofunction_eager_start() -> None:
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
+    hass = MagicMock(loop=(loop := asyncio.get_running_loop()))
 
     async def job():
         pass
 
-    with patch(
-        "homeassistant.core.create_eager_task", wraps=create_eager_task
-    ) as mock_create_eager_task:
+    with (
+        patch(
+            "homeassistant.core.create_eager_task", wraps=create_eager_task
+        ) as mock_create_eager_task,
+        patch.object(loop, "call_soon") as mock_loop_call_soon,
+    ):
         hass_job = ha.HassJob(job)
         task = ha.HomeAssistant._async_add_hass_job(hass, hass_job)
-        assert len(hass.loop.call_soon.mock_calls) == 0
-        assert len(hass.add_job.mock_calls) == 0
+        assert mock_loop_call_soon.call_count == 0
+        assert hass.add_job.call_count == 0
         assert mock_create_eager_task.mock_calls
         await task
 
 
 async def test_async_add_hass_job_schedule_partial_corofunction_eager_start() -> None:
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
+    hass = MagicMock(loop=(loop := asyncio.get_running_loop()))
 
     async def job():
         pass
 
     partial = functools.partial(job)
 
-    with patch(
-        "homeassistant.core.create_eager_task", wraps=create_eager_task
-    ) as mock_create_eager_task:
+    with (
+        patch(
+            "homeassistant.core.create_eager_task", wraps=create_eager_task
+        ) as mock_create_eager_task,
+        patch.object(loop, "call_soon") as mock_loop_call_soon,
+    ):
         hass_job = ha.HassJob(partial)
         task = ha.HomeAssistant._async_add_hass_job(hass, hass_job)
-        assert len(hass.loop.call_soon.mock_calls) == 0
-        assert len(hass.add_job.mock_calls) == 0
+        assert mock_loop_call_soon.call_count == 0
+        assert hass.add_job.call_count == 0
         assert mock_create_eager_task.mock_calls
         await task
 
@@ -306,35 +312,40 @@ async def test_async_add_job_add_hass_threaded_job_to_pool() -> None:
         pass
 
     ha.HomeAssistant._async_add_hass_job(hass, ha.HassJob(job))
-    assert len(hass.loop.call_soon.mock_calls) == 0
-    assert len(hass.loop.create_task.mock_calls) == 0
-    assert len(hass.loop.run_in_executor.mock_calls) == 2
+    assert hass.loop.call_soon.call_count == 0
+    assert hass.loop.create_task.call_count == 0
+    assert hass.loop.run_in_executor.call_count == 2
 
 
 async def test_async_create_task_schedule_coroutine() -> None:
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
+    hass = MagicMock(loop=(loop := asyncio.get_running_loop()))
 
     async def job():
         pass
 
-    ha.HomeAssistant.async_create_task_internal(hass, job(), eager_start=False)
-    assert len(hass.loop.call_soon.mock_calls) == 0
-    assert len(hass.loop.create_task.mock_calls) == 1
-    assert len(hass.add_job.mock_calls) == 0
+    with (
+        patch.object(loop, "call_soon") as mock_loop_call_soon,
+        patch.object(loop, "create_task") as mock_loop_create_task,
+    ):
+        ha.HomeAssistant.async_create_task_internal(hass, job(), eager_start=False)
+        assert mock_loop_call_soon.call_count == 0
+        assert mock_loop_create_task.call_count == 1
+        assert hass.add_job.call_count == 0
 
 
 async def test_async_create_task_eager_start_schedule_coroutine() -> None:
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
+    hass = MagicMock(loop=(loop := asyncio.get_running_loop()))
 
     async def job():
         pass
 
-    ha.HomeAssistant.async_create_task_internal(hass, job(), eager_start=True)
-    # Should create the task directly since 3.12 supports eager_start
-    assert len(hass.loop.create_task.mock_calls) == 0
-    assert len(hass.add_job.mock_calls) == 0
+    with patch.object(loop, "create_task") as mock_loop_create_task:
+        ha.HomeAssistant.async_create_task_internal(hass, job(), eager_start=True)
+        # Should create the task directly since 3.12 supports eager_start
+        assert mock_loop_create_task.call_count == 0
+        assert hass.add_job.call_count == 0
 
 
 async def test_async_create_task_schedule_coroutine_with_name() -> None:
@@ -347,9 +358,9 @@ async def test_async_create_task_schedule_coroutine_with_name() -> None:
     task = ha.HomeAssistant.async_create_task_internal(
         hass, job(), "named task", eager_start=False
     )
-    assert len(hass.loop.call_soon.mock_calls) == 0
-    assert len(hass.loop.create_task.mock_calls) == 1
-    assert len(hass.add_job.mock_calls) == 0
+    assert hass.loop.call_soon.call_count == 0
+    assert hass.loop.create_task.call_count == 1
+    assert hass.add_job.call_count == 0
     assert "named task" in str(task)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -314,7 +314,7 @@ async def test_async_add_job_add_hass_threaded_job_to_pool() -> None:
     ha.HomeAssistant._async_add_hass_job(hass, ha.HassJob(job))
     assert hass.loop.call_soon.call_count == 0
     assert hass.loop.create_task.call_count == 0
-    assert hass.loop.run_in_executor.call_count == 2
+    assert hass.loop.run_in_executor.call_count == 1
 
 
 async def test_async_create_task_schedule_coroutine() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -328,10 +328,12 @@ async def test_async_create_task_schedule_coroutine() -> None:
         patch.object(loop, "call_soon") as mock_loop_call_soon,
         patch.object(loop, "create_task") as mock_loop_create_task,
     ):
-        ha.HomeAssistant.async_create_task_internal(hass, job(), eager_start=False)
+        coro = job()
+        ha.HomeAssistant.async_create_task_internal(hass, coro, eager_start=False)
         assert mock_loop_call_soon.call_count == 0
         assert mock_loop_create_task.call_count == 1
         assert hass.add_job.call_count == 0
+        await coro
 
 
 async def test_async_create_task_eager_start_schedule_coroutine() -> None:
@@ -355,13 +357,15 @@ async def test_async_create_task_schedule_coroutine_with_name() -> None:
     async def job():
         pass
 
+    coro = job()
     task = ha.HomeAssistant.async_create_task_internal(
-        hass, job(), "named task", eager_start=False
+        hass, coro, "named task", eager_start=False
     )
     assert hass.loop.call_soon.call_count == 0
     assert hass.loop.create_task.call_count == 1
     assert hass.add_job.call_count == 0
     assert "named task" in str(task)
+    await coro
 
 
 async def test_async_run_eager_hass_job_calls_callback() -> None:


### PR DESCRIPTION
## Proposed change
Python 3.14 will check during task creating if the provided loop is the running loop. Just replacing the loop with a mock won't work anymore.
```
RuntimeError: loop <MagicMock name='mock.loop' id='...'> is not the running loop
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
