### PR TITLE
Ensure mqtt sensor has a valid native unit of measurement

### DIFF
--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -35,7 +35,6 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.service_info.mqtt import ReceivePayloadType
 from homeassistant.helpers.typing import ConfigType, VolSchemaType
 from homeassistant.util import dt as dt_util
@@ -48,7 +47,6 @@ from .const import (
     CONF_OPTIONS,
     CONF_STATE_TOPIC,
     CONF_SUGGESTED_DISPLAY_PRECISION,
-    DOMAIN,
     PAYLOAD_NONE,
 )
 from .entity import MqttAvailabilityMixin, MqttEntity, async_setup_entity_entry_helper
@@ -138,12 +136,9 @@ def validate_sensor_state_and_device_class_config(config: ConfigType) -> ConfigT
         device_class in DEVICE_CLASS_UNITS
         and unit_of_measurement not in DEVICE_CLASS_UNITS[device_class]
     ):
-        _LOGGER.warning(
-            "The unit of measurement `%s` is not valid "
-            "together with device class `%s`. "
-            "this will stop working in HA Core 2025.7.0",
-            unit_of_measurement,
-            device_class,
+        raise vol.Invalid(
+            f"The unit of measurement `{unit_of_measurement}` is not valid "
+            f"together with device class `{device_class}`",
         )
 
     return config
@@ -194,40 +189,8 @@ class MqttSensor(MqttEntity, RestoreSensor):
         None
     )
 
-    @callback
-    def async_check_uom(self) -> None:
-        """Check if the unit of measurement is valid with the device class."""
-        if (
-            self._discovery_data is not None
-            or self.device_class is None
-            or self.native_unit_of_measurement is None
-        ):
-            return
-        if (
-            self.device_class in DEVICE_CLASS_UNITS
-            and self.native_unit_of_measurement
-            not in DEVICE_CLASS_UNITS[self.device_class]
-        ):
-            async_create_issue(
-                self.hass,
-                DOMAIN,
-                self.entity_id,
-                issue_domain=sensor.DOMAIN,
-                is_fixable=False,
-                severity=IssueSeverity.WARNING,
-                learn_more_url=URL_DOCS_SUPPORTED_SENSOR_UOM,
-                translation_placeholders={
-                    "uom": self.native_unit_of_measurement,
-                    "device_class": self.device_class.value,
-                    "entity_id": self.entity_id,
-                },
-                translation_key="invalid_unit_of_measurement",
-                breaks_in_ha_version="2025.7.0",
-            )
-
     async def mqtt_async_added_to_hass(self) -> None:
         """Restore state for entities with expire_after set."""
-        self.async_check_uom()
         last_state: State | None
         last_sensor_data: SensorExtraStoredData | None
         if (

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -3,10 +3,6 @@
     "invalid_platform_config": {
       "title": "Invalid config found for MQTT {domain} item",
       "description": "Home Assistant detected an invalid config for a manually configured item.\n\nPlatform domain: **{domain}**\nConfiguration file: **{config_file}**\nNear line: **{line}**\nConfiguration found:\n```yaml\n{config}\n```\nError: **{error}**.\n\nMake sure the configuration is valid and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."
-    },
-    "invalid_unit_of_measurement": {
-      "title": "Sensor with invalid unit of measurement",
-      "description": "Manual configured Sensor entity **{entity_id}** has a configured unit of measurement **{uom}** which is not valid with configured device class **{device_class}**. Make sure a valid unit of measurement is configured or remove the device class, and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."
     }
   },
   "config": {

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -898,42 +898,12 @@ async def test_invalid_unit_of_measurement(
         "The unit of measurement `ppm` is not valid together with device class `energy`"
         in caplog.text
     )
-    # A repair issue was logged
+    # A repair issue was logged for the failing YAML config
     assert len(events) == 1
-    assert events[0].data["issue_id"] == "sensor.test"
-    # Assert the sensor works
-    async_fire_mqtt_message(hass, "test-topic", "100")
-    await hass.async_block_till_done()
+    assert events[0].data["domain"] == mqtt.DOMAIN
+    # Assert the sensor is not created
     state = hass.states.get("sensor.test")
-    assert state is not None
-    assert state.state == "100"
-
-    caplog.clear()
-
-    discovery_payload = {
-        "name": "bla",
-        "state_topic": "test-topic2",
-        "device_class": "temperature",
-        "unit_of_measurement": "C",
-    }
-    # Now discover an other invalid sensor
-    async_fire_mqtt_message(
-        hass, "homeassistant/sensor/bla/config", json.dumps(discovery_payload)
-    )
-    await hass.async_block_till_done()
-    assert (
-        "The unit of measurement `C` is not valid together with device class `temperature`"
-        in caplog.text
-    )
-    # Assert the sensor works
-    async_fire_mqtt_message(hass, "test-topic2", "21")
-    await hass.async_block_till_done()
-    state = hass.states.get("sensor.bla")
-    assert state is not None
-    assert state.state == "21"
-
-    # No new issue was registered for the discovered entity
-    assert len(events) == 1
+    assert state is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
MQTT sensors so no longer support a unit of measurment configuration that is not supported by the device or state class after 6 months of deprecation. Users were instructed to to update their configs with warning logs and repair issues.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure mqtt sensor has a valid native unit of measurement

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
