### PR TITLE
Add support for Reolink Floodlight PoE/WiFi

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -32,6 +32,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import (
     BATTERY_PASSIVE_WAKE_UPDATE_INTERVAL,
+    CONF_BC_ONLY,
     CONF_BC_PORT,
     CONF_SUPPORTS_PRIVACY_MODE,
     CONF_USE_HTTPS,
@@ -107,6 +108,7 @@ async def async_setup_entry(
         or host.api.supported(None, "privacy_mode")
         != config_entry.data.get(CONF_SUPPORTS_PRIVACY_MODE)
         or host.api.baichuan.port != config_entry.data.get(CONF_BC_PORT)
+        or host.api.baichuan_only != config_entry.data.get(CONF_BC_ONLY)
     ):
         if host.api.port != config_entry.data[CONF_PORT]:
             _LOGGER.warning(
@@ -130,6 +132,7 @@ async def async_setup_entry(
             CONF_PORT: host.api.port,
             CONF_USE_HTTPS: host.api.use_https,
             CONF_BC_PORT: host.api.baichuan.port,
+            CONF_BC_ONLY: host.api.baichuan_only,
             CONF_SUPPORTS_PRIVACY_MODE: host.api.supported(None, "privacy_mode"),
         }
         hass.config_entries.async_update_entry(config_entry, data=data)

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -38,7 +38,13 @@ from homeassistant.helpers import config_validation as cv, selector
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import CONF_BC_PORT, CONF_SUPPORTS_PRIVACY_MODE, CONF_USE_HTTPS, DOMAIN
+from .const import (
+    CONF_BC_ONLY,
+    CONF_BC_PORT,
+    CONF_SUPPORTS_PRIVACY_MODE,
+    CONF_USE_HTTPS,
+    DOMAIN,
+)
 from .exceptions import (
     PasswordIncompatible,
     ReolinkException,
@@ -296,6 +302,7 @@ class ReolinkFlowHandler(ConfigFlow, domain=DOMAIN):
                 user_input[CONF_PORT] = host.api.port
                 user_input[CONF_USE_HTTPS] = host.api.use_https
                 user_input[CONF_BC_PORT] = host.api.baichuan.port
+                user_input[CONF_BC_ONLY] = host.api.baichuan_only
                 user_input[CONF_SUPPORTS_PRIVACY_MODE] = host.api.supported(
                     None, "privacy_mode"
                 )

--- a/homeassistant/components/reolink/const.py
+++ b/homeassistant/components/reolink/const.py
@@ -4,6 +4,7 @@ DOMAIN = "reolink"
 
 CONF_USE_HTTPS = "use_https"
 CONF_BC_PORT = "baichuan_port"
+CONF_BC_ONLY = "baichuan_only"
 CONF_SUPPORTS_PRIVACY_MODE = "privacy_mode_supported"
 
 # Conserve battery by not waking the battery cameras each minute during normal update

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -38,6 +38,7 @@ from .const import (
     BATTERY_ALL_WAKE_UPDATE_INTERVAL,
     BATTERY_PASSIVE_WAKE_UPDATE_INTERVAL,
     BATTERY_WAKE_UPDATE_INTERVAL,
+    CONF_BC_ONLY,
     CONF_BC_PORT,
     CONF_SUPPORTS_PRIVACY_MODE,
     CONF_USE_HTTPS,
@@ -97,6 +98,7 @@ class ReolinkHost:
             timeout=DEFAULT_TIMEOUT,
             aiohttp_get_session_callback=get_aiohttp_session,
             bc_port=config.get(CONF_BC_PORT, DEFAULT_BC_PORT),
+            bc_only=config.get(CONF_BC_ONLY, False),
         )
 
         self.last_wake: defaultdict[int, float] = defaultdict(float)
@@ -220,19 +222,27 @@ class ReolinkHost:
         enable_onvif = None
         enable_rtmp = None
 
-        if not self._api.rtsp_enabled:
+        if not self._api.rtsp_enabled and not self._api.baichuan_only:
             _LOGGER.debug(
                 "RTSP is disabled on %s, trying to enable it", self._api.nvr_name
             )
             enable_rtsp = True
 
-        if not self._api.onvif_enabled and onvif_supported:
+        if (
+            not self._api.onvif_enabled
+            and onvif_supported
+            and not self._api.baichuan_only
+        ):
             _LOGGER.debug(
                 "ONVIF is disabled on %s, trying to enable it", self._api.nvr_name
             )
             enable_onvif = True
 
-        if not self._api.rtmp_enabled and self._api.protocol == "rtmp":
+        if (
+            not self._api.rtmp_enabled
+            and self._api.protocol == "rtmp"
+            and not self._api.baichuan_only
+        ):
             _LOGGER.debug(
                 "RTMP is disabled on %s, trying to enable it", self._api.nvr_name
             )

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -10,6 +10,7 @@ from reolink_aio.exceptions import ReolinkError
 
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
 from homeassistant.components.reolink.const import (
+    CONF_BC_ONLY,
     CONF_BC_PORT,
     CONF_SUPPORTS_PRIVACY_MODE,
     CONF_USE_HTTPS,
@@ -194,6 +195,7 @@ def config_entry(hass: HomeAssistant) -> MockConfigEntry:
             CONF_USE_HTTPS: TEST_USE_HTTPS,
             CONF_SUPPORTS_PRIVACY_MODE: TEST_PRIVACY,
             CONF_BC_PORT: TEST_BC_PORT,
+            CONF_BC_ONLY: False,
         },
         options={
             CONF_PROTOCOL: DEFAULT_PROTOCOL,

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -156,6 +156,49 @@ async def test_config_flow_privacy_success(
     reolink_connect.baichuan.privacy_mode.return_value = False
 
 
+async def test_config_flow_baichuan_only(
+    hass: HomeAssistant, reolink_connect: MagicMock, mock_setup_entry: MagicMock
+) -> None:
+    """Successful flow manually initialized by the user for baichuan only device."""
+    reolink_connect.baichuan_only = True
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_HOST: TEST_HOST,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == TEST_NVR_NAME
+    assert result["data"] == {
+        CONF_HOST: TEST_HOST,
+        CONF_USERNAME: TEST_USERNAME,
+        CONF_PASSWORD: TEST_PASSWORD,
+        CONF_PORT: TEST_PORT,
+        CONF_USE_HTTPS: TEST_USE_HTTPS,
+        CONF_SUPPORTS_PRIVACY_MODE: TEST_PRIVACY,
+        CONF_BC_PORT: TEST_BC_PORT,
+        CONF_BC_ONLY: True,
+    }
+    assert result["options"] == {
+        CONF_PROTOCOL: DEFAULT_PROTOCOL,
+    }
+    assert result["result"].unique_id == TEST_MAC
+
+    reolink_connect.baichuan_only = False
+
+
 async def test_config_flow_errors(
     hass: HomeAssistant, reolink_connect: MagicMock, mock_setup_entry: MagicMock
 ) -> None:

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -19,6 +19,7 @@ from homeassistant import config_entries
 from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
 from homeassistant.components.reolink.const import (
+    CONF_BC_ONLY,
     CONF_BC_PORT,
     CONF_SUPPORTS_PRIVACY_MODE,
     CONF_USE_HTTPS,
@@ -91,6 +92,7 @@ async def test_config_flow_manual_success(
         CONF_USE_HTTPS: TEST_USE_HTTPS,
         CONF_SUPPORTS_PRIVACY_MODE: TEST_PRIVACY,
         CONF_BC_PORT: TEST_BC_PORT,
+        CONF_BC_ONLY: False,
     }
     assert result["options"] == {
         CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -144,6 +146,7 @@ async def test_config_flow_privacy_success(
         CONF_USE_HTTPS: TEST_USE_HTTPS,
         CONF_SUPPORTS_PRIVACY_MODE: TEST_PRIVACY,
         CONF_BC_PORT: TEST_BC_PORT,
+        CONF_BC_ONLY: False,
     }
     assert result["options"] == {
         CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -308,6 +311,7 @@ async def test_config_flow_errors(
         CONF_USE_HTTPS: TEST_USE_HTTPS,
         CONF_SUPPORTS_PRIVACY_MODE: TEST_PRIVACY,
         CONF_BC_PORT: TEST_BC_PORT,
+        CONF_BC_ONLY: False,
     }
     assert result["options"] == {
         CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -329,6 +333,7 @@ async def test_options_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) ->
             CONF_PORT: TEST_PORT,
             CONF_USE_HTTPS: TEST_USE_HTTPS,
             CONF_BC_PORT: TEST_BC_PORT,
+            CONF_BC_ONLY: False,
         },
         options={
             CONF_PROTOCOL: "rtsp",
@@ -368,6 +373,7 @@ async def test_reauth(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
             CONF_PORT: TEST_PORT,
             CONF_USE_HTTPS: TEST_USE_HTTPS,
             CONF_BC_PORT: TEST_BC_PORT,
+            CONF_BC_ONLY: False,
         },
         options={
             CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -414,6 +420,7 @@ async def test_reauth_abort_unique_id_mismatch(
             CONF_PORT: TEST_PORT,
             CONF_USE_HTTPS: TEST_USE_HTTPS,
             CONF_BC_PORT: TEST_BC_PORT,
+            CONF_BC_ONLY: False,
         },
         options={
             CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -484,6 +491,7 @@ async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
         CONF_USE_HTTPS: TEST_USE_HTTPS,
         CONF_SUPPORTS_PRIVACY_MODE: TEST_PRIVACY,
         CONF_BC_PORT: TEST_BC_PORT,
+        CONF_BC_ONLY: False,
     }
     assert result["options"] == {
         CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -507,6 +515,7 @@ async def test_dhcp_ip_update_aborted_if_wrong_mac(
             CONF_PORT: TEST_PORT,
             CONF_USE_HTTPS: TEST_USE_HTTPS,
             CONF_BC_PORT: TEST_BC_PORT,
+            CONF_BC_ONLY: False,
         },
         options={
             CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -548,6 +557,7 @@ async def test_dhcp_ip_update_aborted_if_wrong_mac(
             timeout=DEFAULT_TIMEOUT,
             aiohttp_get_session_callback=ANY,
             bc_port=TEST_BC_PORT,
+            bc_only=False,
         )
         assert expected_call in reolink_connect_class.call_args_list
 
@@ -606,6 +616,7 @@ async def test_dhcp_ip_update(
             CONF_PORT: TEST_PORT,
             CONF_USE_HTTPS: TEST_USE_HTTPS,
             CONF_BC_PORT: TEST_BC_PORT,
+            CONF_BC_ONLY: False,
         },
         options={
             CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -649,6 +660,7 @@ async def test_dhcp_ip_update(
             timeout=DEFAULT_TIMEOUT,
             aiohttp_get_session_callback=ANY,
             bc_port=TEST_BC_PORT,
+            bc_only=False,
         )
         assert expected_call in reolink_connect_class.call_args_list
 
@@ -686,6 +698,7 @@ async def test_dhcp_ip_update_ingnored_if_still_connected(
             CONF_PORT: TEST_PORT,
             CONF_USE_HTTPS: TEST_USE_HTTPS,
             CONF_BC_PORT: TEST_BC_PORT,
+            CONF_BC_ONLY: False,
         },
         options={
             CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -718,6 +731,7 @@ async def test_dhcp_ip_update_ingnored_if_still_connected(
         timeout=DEFAULT_TIMEOUT,
         aiohttp_get_session_callback=ANY,
         bc_port=TEST_BC_PORT,
+        bc_only=False,
     )
     assert expected_call in reolink_connect_class.call_args_list
 
@@ -748,6 +762,7 @@ async def test_reconfig(hass: HomeAssistant, mock_setup_entry: MagicMock) -> Non
             CONF_PORT: TEST_PORT,
             CONF_USE_HTTPS: TEST_USE_HTTPS,
             CONF_BC_PORT: TEST_BC_PORT,
+            CONF_BC_ONLY: False,
         },
         options={
             CONF_PROTOCOL: DEFAULT_PROTOCOL,
@@ -795,6 +810,7 @@ async def test_reconfig_abort_unique_id_mismatch(
             CONF_PORT: TEST_PORT,
             CONF_USE_HTTPS: TEST_USE_HTTPS,
             CONF_BC_PORT: TEST_BC_PORT,
+            CONF_BC_ONLY: False,
         },
         options={
             CONF_PROTOCOL: DEFAULT_PROTOCOL,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for Reolink Floodlight PoE/WiFi

The baichuan_only config parameter will make sure that no attempt is made to login to the HTTP API, greatly reducing startup time.
Withouth this it still works, but first both the HTTP and HTTPS port login is attempted 3 times before continuing on to Baichuan which will suceed after which it will figure out that the Floodlight does not support HTTP(s). This makes sure the whole HTTP(s) attempts are skipped.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/starkillerOG/reolink_aio/issues/20
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39540
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
