### PR TITLE
Fix telegram_bot RuntimeWarning in tests

### DIFF
--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -1,6 +1,6 @@
 """Config flow tests for the Telegram Bot integration."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from telegram import ChatFullInfo, User
 from telegram.constants import AccentColor
@@ -305,10 +305,19 @@ async def test_reauth_flow(
 
     # test: valid
 
-    with patch(
-        "homeassistant.components.telegram_bot.config_flow.Bot.get_me",
-        return_value=User(123456, "Testbot", True),
+    with (
+        patch(
+            "homeassistant.components.telegram_bot.config_flow.Bot.get_me",
+            return_value=User(123456, "Testbot", True),
+        ),
+        patch(
+            "homeassistant.components.telegram_bot.webhooks.PushBot",
+        ) as mock_pushbot,
     ):
+        mock_pushbot.return_value.start_application = AsyncMock()
+        mock_pushbot.return_value.register_webhook = AsyncMock()
+        mock_pushbot.return_value.shutdown = AsyncMock()
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_API_KEY: "new mock api key"},


### PR DESCRIPTION
## Proposed change
```py
tests/components/telegram_bot/test_config_flow.py::test_reauth_flow
  /home/runner/work/ha-core/ha-core/venv/lib/python3.13/site-packages/telegram/ext/_application.py:645:
      RuntimeWarning: coroutine 'Application._update_fetcher' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/telegram_bot/__init__.py", line 436, in async_setup_entry
      receiver_service = await MODULES[p_type].async_setup_platform(hass, bot, entry)
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/telegram_bot/webhooks.py", line 40, in async_setup_platform
      await pushbot.start_application()
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/telegram_bot/webhooks.py", line 109, in start_application
      await self.application.start()
    File "/home/runner/work/ha-core/ha-core/venv/lib/python3.13/site-packages/telegram/ext/_application.py", line 645, in start
      self._update_fetcher(), name=f"Application:{self.bot.id}:update_fetcher"
    self._update_fetcher(), name=f"Application:{self.bot.id}:update_fetcher"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
