### PR TITLE
Add new USB drives to Synology DSM without reloading integration

### DIFF
--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import cast
 
-from synology_dsm.api.core.external_usb import SynoCoreExternalUSB
+from synology_dsm.api.core.external_usb import (
+    SynoCoreExternalUSB,
+    SynoCoreExternalUSBDevice,
+)
 from synology_dsm.api.core.utilization import SynoCoreUtilization
 from synology_dsm.api.dsm.information import SynoDSMInformation
 from synology_dsm.api.storage.storage import SynoStorage
@@ -343,14 +346,42 @@ async def async_setup_entry(
     coordinator = data.coordinator_central
     storage = api.storage
     assert storage is not None
-    external_usb = api.external_usb
+    known_usb_devices: set[str] = set()
 
-    entities: list[
-        SynoDSMUtilSensor
-        | SynoDSMStorageSensor
-        | SynoDSMInfoSensor
-        | SynoDSMExternalUSBSensor
-    ] = [
+    def _check_usb_devices() -> None:
+        """Check for new USB devices during and after initial setup."""
+        if api.external_usb is not None and api.external_usb.get_devices:
+            current_usb_devices: set[str] = {
+                device.device_name for device in api.external_usb.get_devices.values()
+            }
+            new_usb_devices = current_usb_devices - known_usb_devices
+            if new_usb_devices:
+                known_usb_devices.update(new_usb_devices)
+                external_devices: list[SynoCoreExternalUSBDevice] = [
+                    device
+                    for device in api.external_usb.get_devices.values()
+                    if device.device_name in new_usb_devices
+                ]
+                new_usb_entities: list[SynoDSMExternalUSBSensor] = [
+                    SynoDSMExternalUSBSensor(
+                        api, coordinator, description, device.device_name
+                    )
+                    for device in entry.data.get(CONF_DEVICES, external_devices)
+                    for description in EXTERNAL_USB_DISK_SENSORS
+                ]
+                new_usb_entities.extend(
+                    [
+                        SynoDSMExternalUSBSensor(
+                            api, coordinator, description, partition.partition_title
+                        )
+                        for device in entry.data.get(CONF_DEVICES, external_devices)
+                        for partition in device.device_partitions.values()
+                        for description in EXTERNAL_USB_PARTITION_SENSORS
+                    ]
+                )
+                async_add_entities(new_usb_entities)
+
+    entities: list[SynoDSMUtilSensor | SynoDSMStorageSensor | SynoDSMInfoSensor] = [
         SynoDSMUtilSensor(api, coordinator, description)
         for description in UTILISATION_SENSORS
     ]
@@ -375,38 +406,15 @@ async def async_setup_entry(
             ]
         )
 
-    # Handle all external usb
-    if external_usb is not None and external_usb.get_devices:
-        entities.extend(
-            [
-                SynoDSMExternalUSBSensor(
-                    api, coordinator, description, device.device_name
-                )
-                for device in entry.data.get(
-                    CONF_DEVICES, external_usb.get_devices.values()
-                )
-                for description in EXTERNAL_USB_DISK_SENSORS
-            ]
-        )
-        entities.extend(
-            [
-                SynoDSMExternalUSBSensor(
-                    api, coordinator, description, partition.partition_title
-                )
-                for device in entry.data.get(
-                    CONF_DEVICES, external_usb.get_devices.values()
-                )
-                for partition in device.device_partitions.values()
-                for description in EXTERNAL_USB_PARTITION_SENSORS
-            ]
-        )
-
     entities.extend(
         [
             SynoDSMInfoSensor(api, coordinator, description)
             for description in INFORMATION_SENSORS
         ]
     )
+
+    _check_usb_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_check_usb_devices))
 
     async_add_entities(entities)
 

--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -515,6 +515,25 @@ class SynoDSMExternalUSBSensor(SynologyDSMDeviceEntity, SynoDSMSensor):
 
         return attr  # type: ignore[no-any-return]
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        found = False
+        external_usb = self._api.external_usb
+        assert external_usb is not None
+        if "device" in self.entity_description.key:
+            for device in external_usb.get_devices.values():
+                if device.device_name == self._device_id:
+                    found = True
+                    break
+        elif "partition" in self.entity_description.key:
+            for device in external_usb.get_devices.values():
+                for partition in device.device_partitions.values():
+                    if partition.partition_title == self._device_id:
+                        found = True
+                        break
+        return found and super().available
+
 
 class SynoDSMInfoSensor(SynoDSMSensor):
     """Representation a Synology information sensor."""

--- a/homeassistant/components/synology_dsm/sensor.py
+++ b/homeassistant/components/synology_dsm/sensor.py
@@ -523,25 +523,6 @@ class SynoDSMExternalUSBSensor(SynologyDSMDeviceEntity, SynoDSMSensor):
 
         return attr  # type: ignore[no-any-return]
 
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        found = False
-        external_usb = self._api.external_usb
-        assert external_usb is not None
-        if "device" in self.entity_description.key:
-            for device in external_usb.get_devices.values():
-                if device.device_name == self._device_id:
-                    found = True
-                    break
-        elif "partition" in self.entity_description.key:
-            for device in external_usb.get_devices.values():
-                for partition in device.device_partitions.values():
-                    if partition.partition_title == self._device_id:
-                        found = True
-                        break
-        return found and super().available
-
 
 class SynoDSMInfoSensor(SynoDSMSensor):
     """Representation a Synology information sensor."""

--- a/tests/components/synology_dsm/common.py
+++ b/tests/components/synology_dsm/common.py
@@ -144,8 +144,33 @@ def mock_dsm_external_usb_devices_usb1() -> dict[str, SynoCoreExternalUSBDevice]
 
 
 def mock_dsm_external_usb_devices_usb2() -> dict[str, SynoCoreExternalUSBDevice]:
-    """Mock SynologyDSM external USB device with USB Disk 2."""
+    """Mock SynologyDSM external USB device with USB Disk 1 and USB Disk 2."""
     return {
+        "usb1": SynoCoreExternalUSBDevice(
+            {
+                "dev_id": "usb1",
+                "dev_type": "usbDisk",
+                "dev_title": "USB Disk 1",
+                "producer": "Western Digital Technologies, Inc.",
+                "product": "easystore 264D",
+                "formatable": True,
+                "progress": "",
+                "status": "normal",
+                "total_size_mb": 15259648,
+                "partitions": [
+                    {
+                        "dev_fstype": "ntfs",
+                        "filesystem": "ntfs",
+                        "name_id": "usb1p1",
+                        "partition_title": "USB Disk 1 Partition 1",
+                        "share_name": "usbshare2",
+                        "status": "normal",
+                        "total_size_mb": 15259646,
+                        "used_size_mb": 5942441,
+                    }
+                ],
+            }
+        ),
         "usb2": SynoCoreExternalUSBDevice(
             {
                 "dev_id": "usb2",

--- a/tests/components/synology_dsm/common.py
+++ b/tests/components/synology_dsm/common.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock
 
 from awesomeversion import AwesomeVersion
+from synology_dsm.api.core.external_usb import SynoCoreExternalUSBDevice
+from synology_dsm.api.storage.storage import SynoStorageDisk, SynoStorageVolume
 
 from .consts import SERIAL
 
@@ -30,3 +32,143 @@ def mock_dsm_information(
         temperature=temperature,
         uptime=uptime,
     )
+
+
+def mock_dsm_storage_get_volume(volume_id: str) -> SynoStorageVolume:
+    """Mock SynologyDSM storage volume information for a specific volume."""
+    volumes = mock_dsm_storage_volumes()
+    for volume in volumes:
+        if volume.get("id") == volume_id:
+            return volume
+    raise ValueError(f"Volume with id {volume_id} not found in mock data.")
+
+
+def mock_dsm_storage_volumes() -> list[SynoStorageVolume]:
+    """Mock SynologyDSM storage volume information."""
+    volumes_data = {
+        "volume_1": {
+            "id": "volume_1",
+            "device_type": "btrfs",
+            "size": {
+                "free_inode": "1000000",
+                "total": "24000277250048",
+                "total_device": "24000277250048",
+                "total_inode": "2000000",
+                "used": "12000138625024",
+            },
+            "status": "normal",
+            "fs_type": "btrfs",
+        },
+    }
+    return [SynoStorageVolume(**volume_info) for volume_info in volumes_data.values()]
+
+
+def mock_dsm_storage_get_disk(disk_id: str) -> SynoStorageDisk:
+    """Mock SynologyDSM storage disk information for a specific disk."""
+    disks = mock_dsm_storage_disks()
+    for disk in disks:
+        if disk.get("id") == disk_id:
+            return disk
+    raise ValueError(f"Disk with id {disk_id} not found in mock data.")
+
+
+def mock_dsm_storage_disks() -> list[SynoStorageDisk]:
+    """Mock SynologyDSM storage disk information."""
+    disks_data = {
+        "sata1": {
+            "id": "sata1",
+            "name": "Drive 1",
+            "vendor": "Seagate",
+            "model": "ST24000NT002-3N1101",
+            "device": "/dev/sata1",
+            "temp": 32,
+            "size_total": "24000277250048",
+            "firm": "EN01",
+            "diskType": "SATA",
+        },
+        "sata2": {
+            "id": "sata2",
+            "name": "Drive 2",
+            "vendor": "Seagate",
+            "model": "ST24000NT002-3N1101",
+            "device": "/dev/sata2",
+            "temp": 32,
+            "size_total": "24000277250048",
+            "firm": "EN01",
+            "diskType": "SATA",
+        },
+        "sata3": {
+            "id": "sata3",
+            "name": "Drive 3",
+            "vendor": "Seagate",
+            "model": "ST24000NT002-3N1101",
+            "device": "/dev/sata3",
+            "temp": 32,
+            "size_total": "24000277250048",
+            "firm": "EN01",
+            "diskType": "SATA",
+        },
+    }
+    return [SynoStorageDisk(**disk_info) for disk_info in disks_data.values()]
+
+
+def mock_dsm_external_usb_devices_usb1() -> dict[str, SynoCoreExternalUSBDevice]:
+    """Mock SynologyDSM external USB device with USB Disk 1."""
+    return {
+        "usb1": SynoCoreExternalUSBDevice(
+            {
+                "dev_id": "usb1",
+                "dev_type": "usbDisk",
+                "dev_title": "USB Disk 1",
+                "producer": "Western Digital Technologies, Inc.",
+                "product": "easystore 264D",
+                "formatable": True,
+                "progress": "",
+                "status": "normal",
+                "total_size_mb": 15259648,
+                "partitions": [
+                    {
+                        "dev_fstype": "ntfs",
+                        "filesystem": "ntfs",
+                        "name_id": "usb1p1",
+                        "partition_title": "USB Disk 1 Partition 1",
+                        "share_name": "usbshare2",
+                        "status": "normal",
+                        "total_size_mb": 15259646,
+                        "used_size_mb": 5942441,
+                    }
+                ],
+            }
+        ),
+    }
+
+
+def mock_dsm_external_usb_devices_usb2() -> dict[str, SynoCoreExternalUSBDevice]:
+    """Mock SynologyDSM external USB device with USB Disk 2."""
+    return {
+        "usb2": SynoCoreExternalUSBDevice(
+            {
+                "dev_id": "usb2",
+                "dev_type": "usbDisk",
+                "dev_title": "USB Disk 2",
+                "producer": "Western Digital Technologies, Inc.",
+                "product": "easystore 264D",
+                "formatable": True,
+                "progress": "",
+                "status": "normal",
+                "total_size_mb": 15259648,
+                "partitions": [
+                    {
+                        "dev_fstype": "ntfs",
+                        "filesystem": "ntfs",
+                        "name_id": "usb2p1",
+                        "partition_title": "USB Disk 2 Partition 1",
+                        "share_name": "usbshare2",
+                        "status": "normal",
+                        "total_size_mb": 15259646,
+                        "used_size_mb": 5942441,
+                    }
+                ],
+            }
+        ),
+    }

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for Synology DSM USB."""
 
+from itertools import chain
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -210,86 +210,75 @@ async def test_external_usb_new_device(
 ) -> None:
     """Test Synology DSM USB adding new device."""
 
+    expected_sensors_disk_1 = {
+        "sensor.nas_meontheinternet_com_usb_disk_1_status": ("normal", {}),
+        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_size": (
+            "14901.998046875",
+            {},
+        ),
+        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_used_space": (
+            "5803.1650390625",
+            {},
+        ),
+        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_used": (
+            "38.9",
+            {},
+        ),
+    }
+    expected_sensors_disk_2 = {
+        "sensor.nas_meontheinternet_com_usb_disk_2_status": ("normal", {}),
+        "sensor.nas_meontheinternet_com_usb_disk_2_partition_1_partition_size": (
+            "14901.998046875",
+            {
+                "device_class": "data_size",
+                "state_class": "measurement",
+                "unit_of_measurement": "GiB",
+                "attribution": "Data provided by Synology",
+            },
+        ),
+        "sensor.nas_meontheinternet_com_usb_disk_2_partition_1_partition_used_space": (
+            "5803.1650390625",
+            {
+                "device_class": "data_size",
+                "state_class": "measurement",
+                "unit_of_measurement": "GiB",
+                "attribution": "Data provided by Synology",
+            },
+        ),
+        "sensor.nas_meontheinternet_com_usb_disk_2_partition_1_partition_used": (
+            "38.9",
+            {
+                "state_class": "measurement",
+                "unit_of_measurement": "%",
+                "attribution": "Data provided by Synology",
+            },
+        ),
+    }
+
+    # Initial check of existing sensors
+    for sensor_id, (expected_state, expected_attrs) in expected_sensors_disk_1.items():
+        sensor = hass.states.get(sensor_id)
+        assert sensor is not None
+        assert sensor.state == expected_state
+        for attr_key, attr_value in expected_attrs.items():
+            assert sensor.attributes[attr_key] == attr_value
+    for sensor_id in expected_sensors_disk_2:
+        assert hass.states.get(sensor_id) is None
+
     # Mock the get_devices method to simulate a USB disk being added
     setup_dsm_with_usb.external_usb.get_devices = mock_dsm_external_usb_devices_usb2()
     # Coordinator refresh
     await setup_dsm_with_usb.mock_entry.runtime_data.coordinator_central.async_request_refresh()
     await hass.async_block_till_done()
 
-    # Test USB Disk 1 status sensor
-    sensor = hass.states.get("sensor.nas_meontheinternet_com_usb_disk_1_status")
-    assert sensor is not None
-    assert sensor.state == "normal"
-
-    # Test USB Disk 1 Partition 1 size sensor
-    sensor = hass.states.get(
-        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_size"
-    )
-    assert sensor is not None
-    assert sensor.state == "14901.998046875"
-
-    # Test USB Disk 1 Partition 1 partition used space sensor
-    sensor = hass.states.get(
-        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_used_space"
-    )
-    assert sensor is not None
-    assert sensor.state == "5803.1650390625"
-
-    # Test USB Disk 1 Partition 1 partition used sensor
-    sensor = hass.states.get(
-        "sensor.nas_meontheinternet_com_usb_disk_1_partition_1_partition_used"
-    )
-    assert sensor is not None
-    assert sensor.state == "38.9"
-
-    # Test USB Disk 2 status sensor
-    sensor = hass.states.get("sensor.nas_meontheinternet_com_usb_disk_2_status")
-    assert sensor is not None
-    assert sensor.state == "normal"
-
-    # Test USB Disk 2 Partition 1 partition size sensor
-    sensor = hass.states.get(
-        "sensor.nas_meontheinternet_com_usb_disk_2_partition_1_partition_size"
-    )
-    assert sensor is not None
-    assert sensor.state == "14901.998046875"
-    assert (
-        sensor.attributes["friendly_name"]
-        == "nas.meontheinternet.com (USB Disk 2 Partition 1) Partition size"
-    )
-    assert sensor.attributes["device_class"] == "data_size"
-    assert sensor.attributes["state_class"] == "measurement"
-    assert sensor.attributes["unit_of_measurement"] == "GiB"
-    assert sensor.attributes["attribution"] == "Data provided by Synology"
-
-    # Test USB Disk 2 Partition 1 partition used space sensor
-    sensor = hass.states.get(
-        "sensor.nas_meontheinternet_com_usb_disk_2_partition_1_partition_used_space"
-    )
-    assert sensor is not None
-    assert sensor.state == "5803.1650390625"
-    assert (
-        sensor.attributes["friendly_name"]
-        == "nas.meontheinternet.com (USB Disk 2 Partition 1) Partition used space"
-    )
-    assert sensor.attributes["device_class"] == "data_size"
-    assert sensor.attributes["state_class"] == "measurement"
-    assert sensor.attributes["unit_of_measurement"] == "GiB"
-    assert sensor.attributes["attribution"] == "Data provided by Synology"
-
-    # Test USB Disk 2 Partition 1 partition used sensor
-    sensor = hass.states.get(
-        "sensor.nas_meontheinternet_com_usb_disk_2_partition_1_partition_used"
-    )
-    assert sensor is not None
-    assert sensor.state == "38.9"
-    assert (
-        sensor.attributes["friendly_name"]
-        == "nas.meontheinternet.com (USB Disk 2 Partition 1) Partition used"
-    )
-    assert sensor.attributes["state_class"] == "measurement"
-    assert sensor.attributes["unit_of_measurement"] == "%"
-    assert sensor.attributes["attribution"] == "Data provided by Synology"
+    for sensor_id, (expected_state, expected_attrs) in chain(
+        expected_sensors_disk_1.items(), expected_sensors_disk_2.items()
+    ):
+        sensor = hass.states.get(sensor_id)
+        assert sensor is not None
+        assert sensor.state == expected_state
+        for attr_key, attr_value in expected_attrs.items():
+            assert sensor.attributes[attr_key] == attr_value
 
 
 async def test_no_external_usb(

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -46,8 +46,10 @@ def mock_dsm_with_usb():
         dsm.information = mock_dsm_information()
         dsm.storage = Mock(
             get_disk=mock_dsm_storage_get_disk,
+            disk_temp=Mock(return_value=32),
             disks_ids=["sata1", "sata2", "sata3"],
             get_volume=mock_dsm_storage_get_volume,
+            volume_disk_temp_avg=Mock(return_value=32),
             volume_size_used=Mock(return_value=12000138625024),
             volumes_ids=["volume_1"],
             update=AsyncMock(return_value=True),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement the [devices added after integration setup](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/dynamic-devices/) rule to create entities when a new external USB drive is connected without requiring reloading the integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #144575
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
