### PR TITLE
Fix missing key for ecosmart in older Wallbox models

### DIFF
--- a/homeassistant/components/wallbox/const.py
+++ b/homeassistant/components/wallbox/const.py
@@ -74,3 +74,4 @@ class EcoSmartMode(StrEnum):
     OFF = "off"
     ECO_MODE = "eco_mode"
     FULL_SOLAR = "full_solar"
+    DISABLED = "disabled"

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -175,10 +175,11 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         eco_smart_mode = (
             data[CHARGER_DATA_KEY]
             .get(CHARGER_ECO_SMART_KEY, {})
-            .get(CHARGER_ECO_SMART_MODE_KEY)
+            .get(CHARGER_ECO_SMART_MODE_KEY,-1)
         )
-
-        if eco_smart_enabled is False:
+        if eco_smart_mode == -1:
+            data[CHARGER_ECO_SMART_KEY] = EcoSmartMode.DISABLED
+        elif eco_smart_enabled is False:
             data[CHARGER_ECO_SMART_KEY] = EcoSmartMode.OFF
         elif eco_smart_mode == 0:
             data[CHARGER_ECO_SMART_KEY] = EcoSmartMode.ECO_MODE

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -175,7 +175,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         eco_smart_mode = (
             data[CHARGER_DATA_KEY]
             .get(CHARGER_ECO_SMART_KEY, {})
-            .get(CHARGER_ECO_SMART_MODE_KEY,-1)
+            .get(CHARGER_ECO_SMART_MODE_KEY, -1)
         )
         if eco_smart_mode == -1:
             data[CHARGER_ECO_SMART_KEY] = EcoSmartMode.DISABLED

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -175,9 +175,9 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         eco_smart_mode = (
             data[CHARGER_DATA_KEY]
             .get(CHARGER_ECO_SMART_KEY, {})
-            .get(CHARGER_ECO_SMART_MODE_KEY, -1)
+            .get(CHARGER_ECO_SMART_MODE_KEY)
         )
-        if eco_smart_mode == -1:
+        if eco_smart_mode is None:
             data[CHARGER_ECO_SMART_KEY] = EcoSmartMode.DISABLED
         elif eco_smart_enabled is False:
             data[CHARGER_ECO_SMART_KEY] = EcoSmartMode.OFF

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -166,12 +166,18 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
         # Set current solar charging mode
-        eco_smart_enabled = data[CHARGER_DATA_KEY][CHARGER_ECO_SMART_KEY][
-            CHARGER_ECO_SMART_STATUS_KEY
-        ]
-        eco_smart_mode = data[CHARGER_DATA_KEY][CHARGER_ECO_SMART_KEY][
-            CHARGER_ECO_SMART_MODE_KEY
-        ]
+        eco_smart_enabled = (
+            data[CHARGER_DATA_KEY]
+            .get(CHARGER_ECO_SMART_KEY, {})
+            .get(CHARGER_ECO_SMART_STATUS_KEY)
+        )
+
+        eco_smart_mode = (
+            data[CHARGER_DATA_KEY]
+            .get(CHARGER_ECO_SMART_KEY, {})
+            .get(CHARGER_ECO_SMART_MODE_KEY)
+        )
+
         if eco_smart_enabled is False:
             data[CHARGER_ECO_SMART_KEY] = EcoSmartMode.OFF
         elif eco_smart_mode == 0:

--- a/homeassistant/components/wallbox/select.py
+++ b/homeassistant/components/wallbox/select.py
@@ -63,15 +63,15 @@ async def async_setup_entry(
 ) -> None:
     """Create wallbox select entities in HASS."""
     coordinator: WallboxCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    async_add_entities(
-        WallboxSelect(coordinator, description)
-        for ent in coordinator.data
-        if (
-            (description := SELECT_TYPES.get(ent))
-            and description.supported_fn(coordinator)
-        )
-    )
+    if  coordinator.data[CHARGER_ECO_SMART_KEY] != EcoSmartMode.DISABLED:
+        async_add_entities(
+            WallboxSelect(coordinator, description)
+            for ent in coordinator.data
+            if (
+                (description := SELECT_TYPES.get(ent))
+                and description.supported_fn(coordinator)
+                )
+            )
 
 
 class WallboxSelect(WallboxEntity, SelectEntity):

--- a/homeassistant/components/wallbox/select.py
+++ b/homeassistant/components/wallbox/select.py
@@ -63,15 +63,15 @@ async def async_setup_entry(
 ) -> None:
     """Create wallbox select entities in HASS."""
     coordinator: WallboxCoordinator = hass.data[DOMAIN][entry.entry_id]
-    if  coordinator.data[CHARGER_ECO_SMART_KEY] != EcoSmartMode.DISABLED:
+    if coordinator.data[CHARGER_ECO_SMART_KEY] != EcoSmartMode.DISABLED:
         async_add_entities(
             WallboxSelect(coordinator, description)
             for ent in coordinator.data
             if (
                 (description := SELECT_TYPES.get(ent))
                 and description.supported_fn(coordinator)
-                )
             )
+        )
 
 
 class WallboxSelect(WallboxEntity, SelectEntity):

--- a/tests/components/wallbox/__init__.py
+++ b/tests/components/wallbox/__init__.py
@@ -215,7 +215,10 @@ async def setup_integration(hass: HomeAssistant, entry: MockConfigEntry) -> None
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-async def setup_integration_no_eco_mode(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+
+async def setup_integration_no_eco_mode(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
     """Test wallbox sensor class setup."""
     with requests_mock.Mocker() as mock_request:
         mock_request.get(
@@ -236,6 +239,7 @@ async def setup_integration_no_eco_mode(hass: HomeAssistant, entry: MockConfigEn
 
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+
 
 async def setup_integration_select(
     hass: HomeAssistant, entry: MockConfigEntry, response

--- a/tests/components/wallbox/__init__.py
+++ b/tests/components/wallbox/__init__.py
@@ -215,6 +215,27 @@ async def setup_integration(hass: HomeAssistant, entry: MockConfigEntry) -> None
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
+async def setup_integration_no_eco_mode(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Test wallbox sensor class setup."""
+    with requests_mock.Mocker() as mock_request:
+        mock_request.get(
+            "https://user-api.wall-box.com/users/signin",
+            json=authorisation_response,
+            status_code=HTTPStatus.OK,
+        )
+        mock_request.get(
+            "https://api.wall-box.com/chargers/status/12345",
+            json=test_response_no_power_boost,
+            status_code=HTTPStatus.OK,
+        )
+        mock_request.put(
+            "https://api.wall-box.com/v2/charger/12345",
+            json={CHARGER_MAX_CHARGING_CURRENT_KEY: 20},
+            status_code=HTTPStatus.OK,
+        )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
 async def setup_integration_select(
     hass: HomeAssistant, entry: MockConfigEntry, response

--- a/tests/components/wallbox/test_init.py
+++ b/tests/components/wallbox/test_init.py
@@ -13,8 +13,8 @@ from . import (
     authorisation_response,
     setup_integration,
     setup_integration_connection_error,
-    setup_integration_read_only,
     setup_integration_no_eco_mode,
+    setup_integration_read_only,
     test_response,
 )
 

--- a/tests/components/wallbox/test_init.py
+++ b/tests/components/wallbox/test_init.py
@@ -14,6 +14,7 @@ from . import (
     setup_integration,
     setup_integration_connection_error,
     setup_integration_read_only,
+    setup_integration_no_eco_mode,
     test_response,
 )
 
@@ -138,3 +139,16 @@ async def test_wallbox_refresh_failed_read_only(
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+async def test_wallbox_setup_load_entry_no_eco_mode(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    """Test Wallbox Unload."""
+
+    await setup_integration_no_eco_mode(hass, entry)
+    assert entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    assert entry.state is ConfigEntryState.NOT_LOADED
+
+

--- a/tests/components/wallbox/test_init.py
+++ b/tests/components/wallbox/test_init.py
@@ -140,6 +140,7 @@ async def test_wallbox_refresh_failed_read_only(
     assert await hass.config_entries.async_unload(entry.entry_id)
     assert entry.state is ConfigEntryState.NOT_LOADED
 
+
 async def test_wallbox_setup_load_entry_no_eco_mode(
     hass: HomeAssistant, entry: MockConfigEntry
 ) -> None:
@@ -150,5 +151,3 @@ async def test_wallbox_setup_load_entry_no_eco_mode(
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     assert entry.state is ConfigEntryState.NOT_LOADED
-
-


### PR DESCRIPTION
## Proposed change
This is a fix for an issue which is caused by older models not returning the necessary key for ecosmart in the API output. We change from a key index to a get function. Please include in a minor / bugfix release.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146839
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
