### PR TITLE
Homee add button_state to event entities

### DIFF
--- a/homeassistant/components/homee/strings.json
+++ b/homeassistant/components/homee/strings.json
@@ -160,6 +160,30 @@
       }
     },
     "event": {
+      "button_state": {
+        "name": "Button",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "upper": "Upper button",
+              "lower": "Lower button",
+              "released": "Released"
+            }
+          }
+        }
+      },
+      "button_state_instance": {
+        "name": "Button {instance}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "upper": "Upper button",
+              "lower": "Lower button",
+              "released": "Released"
+            }
+          }
+        }
+      },
       "up_down_remote": {
         "name": "Up/down remote",
         "state_attributes": {

--- a/homeassistant/components/homee/strings.json
+++ b/homeassistant/components/homee/strings.json
@@ -177,9 +177,9 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "upper": "Upper button",
-              "lower": "Lower button",
-              "released": "Released"
+              "upper": "[%key;component::homee::entity::event::button_state::state_attributes::event_type::state::upper%]",
+              "lower": "[%key;component::homee::entity::event::button_state::state_attributes::event_type::state::lower%]",
+              "released": "[%key;component::homee::entity::event::button_state::state_attributes::event_type::state::released%]"
             }
           }
         }
@@ -189,7 +189,7 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "release": "Released",
+              "release": "[%key;component::homee::entity::event::button_state::state_attributes::event_type::state::released%]",
               "up": "Up",
               "down": "Down",
               "stop": "Stop",

--- a/homeassistant/components/homee/strings.json
+++ b/homeassistant/components/homee/strings.json
@@ -161,7 +161,7 @@
     },
     "event": {
       "button_state": {
-        "name": "Button",
+        "name": "Switch",
         "state_attributes": {
           "event_type": {
             "state": {
@@ -173,7 +173,7 @@
         }
       },
       "button_state_instance": {
-        "name": "Button {instance}",
+        "name": "Switch {instance}",
         "state_attributes": {
           "event_type": {
             "state": {

--- a/tests/components/homee/fixtures/events.json
+++ b/tests/components/homee/fixtures/events.json
@@ -41,6 +41,48 @@
       "options": {
         "observed_by": [145]
       }
+    },
+    {
+      "id": 2,
+      "node_id": 1,
+      "instance": 1,
+      "minimum": 0,
+      "maximum": 3,
+      "current_value": 2.0,
+      "target_value": 2.0,
+      "last_value": 0.0,
+      "unit": "n/a",
+      "step_value": 1.0,
+      "editable": 0,
+      "type": 40,
+      "state": 1,
+      "last_changed": 1749885830,
+      "changed_by": 1,
+      "changed_by_id": 0,
+      "based_on": 1,
+      "data": "",
+      "name": ""
+    },
+    {
+      "id": 3,
+      "node_id": 1,
+      "instance": 2,
+      "minimum": 0,
+      "maximum": 3,
+      "current_value": 2.0,
+      "target_value": 2.0,
+      "last_value": 2.0,
+      "unit": "n/a",
+      "step_value": 1.0,
+      "editable": 0,
+      "type": 40,
+      "state": 1,
+      "last_changed": 1749885830,
+      "changed_by": 1,
+      "changed_by_id": 0,
+      "based_on": 1,
+      "data": "",
+      "name": ""
     }
   ]
 }

--- a/tests/components/homee/snapshots/test_event.ambr
+++ b/tests/components/homee/snapshots/test_event.ambr
@@ -1,4 +1,126 @@
 # serializer version: 1
+# name: test_event_snapshot[event.remote_control_button_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'upper',
+        'lower',
+        'released',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.remote_control_button_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'Button 1',
+    'platform': 'homee',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button_state_instance',
+    'unique_id': '00055511EECC-1-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_event_snapshot[event.remote_control_button_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'button',
+      'event_type': None,
+      'event_types': list([
+        'upper',
+        'lower',
+        'released',
+      ]),
+      'friendly_name': 'Remote Control Button 1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.remote_control_button_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_event_snapshot[event.remote_control_button_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'event_types': list([
+        'upper',
+        'lower',
+        'released',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.remote_control_button_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'Button 2',
+    'platform': 'homee',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button_state_instance',
+    'unique_id': '00055511EECC-1-3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_event_snapshot[event.remote_control_button_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'button',
+      'event_type': None,
+      'event_types': list([
+        'upper',
+        'lower',
+        'released',
+      ]),
+      'friendly_name': 'Remote Control Button 2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.remote_control_button_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_event_snapshot[event.remote_control_up_down_remote-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/homee/snapshots/test_event.ambr
+++ b/tests/components/homee/snapshots/test_event.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_event_snapshot[event.remote_control_button_1-entry]
+# name: test_event_snapshot[event.remote_control_switch_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -18,7 +18,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.remote_control_button_1',
+    'entity_id': 'event.remote_control_switch_1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -30,7 +30,7 @@
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button 1',
+    'original_name': 'Switch 1',
     'platform': 'homee',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -40,7 +40,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_event_snapshot[event.remote_control_button_1-state]
+# name: test_event_snapshot[event.remote_control_switch_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
@@ -50,17 +50,17 @@
         'lower',
         'released',
       ]),
-      'friendly_name': 'Remote Control Button 1',
+      'friendly_name': 'Remote Control Switch 1',
     }),
     'context': <ANY>,
-    'entity_id': 'event.remote_control_button_1',
+    'entity_id': 'event.remote_control_switch_1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_event_snapshot[event.remote_control_button_2-entry]
+# name: test_event_snapshot[event.remote_control_switch_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -79,7 +79,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.remote_control_button_2',
+    'entity_id': 'event.remote_control_switch_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -91,7 +91,7 @@
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button 2',
+    'original_name': 'Switch 2',
     'platform': 'homee',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -101,7 +101,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_event_snapshot[event.remote_control_button_2-state]
+# name: test_event_snapshot[event.remote_control_switch_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
@@ -111,10 +111,10 @@
         'lower',
         'released',
       ]),
-      'friendly_name': 'Remote Control Button 2',
+      'friendly_name': 'Remote Control Switch 2',
     }),
     'context': <ANY>,
-    'entity_id': 'event.remote_control_button_2',
+    'entity_id': 'event.remote_control_switch_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/homee/test_event.py
+++ b/tests/components/homee/test_event.py
@@ -35,7 +35,7 @@ from tests.common import MockConfigEntry, snapshot_platform
             ],
         ),
         (
-            "event.remote_control_button_2",
+            "event.remote_control_switch_2",
             3,
             ["upper", "lower", "released"],
         ),

--- a/tests/components/homee/test_event.py
+++ b/tests/components/homee/test_event.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.event import ATTR_EVENT_TYPE
@@ -14,38 +15,54 @@ from . import build_mock_node, setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
-async def test_event_fires(
+@pytest.mark.parametrize(
+    ("entity_id", "attribute_id", "expected_event_types"),
+    [
+        (
+            "event.remote_control_up_down_remote",
+            1,
+            [
+                "released",
+                "up",
+                "down",
+                "stop",
+                "up_long",
+                "down_long",
+                "stop_long",
+                "c_button",
+                "b_button",
+                "a_button",
+            ],
+        ),
+        (
+            "event.remote_control_button_2",
+            3,
+            ["upper", "lower", "released"],
+        ),
+    ],
+)
+async def test_event_triggers(
     hass: HomeAssistant,
     mock_homee: MagicMock,
     mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    attribute_id: int,
+    expected_event_types: list[str],
 ) -> None:
     """Test that the correct event fires when the attribute changes."""
-
-    EVENT_TYPES = [
-        "released",
-        "up",
-        "down",
-        "stop",
-        "up_long",
-        "down_long",
-        "stop_long",
-        "c_button",
-        "b_button",
-        "a_button",
-    ]
     mock_homee.nodes = [build_mock_node("events.json")]
     mock_homee.get_node_by_id.return_value = mock_homee.nodes[0]
     await setup_integration(hass, mock_config_entry)
 
     # Simulate the event triggers.
-    attribute = mock_homee.nodes[0].attributes[0]
-    for i, event_type in enumerate(EVENT_TYPES):
+    attribute = mock_homee.nodes[0].attributes[attribute_id - 1]
+    for i, event_type in enumerate(expected_event_types):
         attribute.current_value = i
         attribute.add_on_changed_listener.call_args_list[1][0][0](attribute)
         await hass.async_block_till_done()
 
         # Check if the event was fired
-        state = hass.states.get("event.remote_control_up_down_remote")
+        state = hass.states.get(entity_id)
         assert state.attributes[ATTR_EVENT_TYPE] == event_type
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the BUTTON_STATE attribute as an event entity, if it is part of a remote control node.
Additional info on the device can be found in the corresponding issue (see below).

The check if the parent node is a remote control is needed, since there is at least one known device where this attribute-type is used for a toggle switch - this will be added as a binary sensor later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146720
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
