### PR TITLE
Add sorting to entity creation in APCUPSD to fix flaky snapshot tests

### DIFF
--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -421,7 +421,10 @@ async def async_setup_entry(
     # periodical (or manual) self test since last daemon restart. It might not be available
     # when we set up the integration, and we do not know if it would ever be available. Here we
     # add it anyway and mark it as unknown initially.
-    for resource in available_resources | {LAST_S_TEST}:
+    #
+    # We sort the resources to ensure deterministic entity creation order, which generally helps
+    # in tests and entity registry consistency.
+    for resource in sorted(available_resources | {LAST_S_TEST}):
         if resource not in SENSORS:
             _LOGGER.warning("Invalid resource from APCUPSd: %s", resource.upper())
             continue

--- a/tests/components/apcupsd/snapshots/test_sensor.ambr
+++ b/tests/components/apcupsd/snapshots/test_sensor.ambr
@@ -404,102 +404,6 @@
     'state': 'USB Cable',
   })
 # ---
-# name: test_sensor[sensor.myups_daemon_version-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.myups_daemon_version',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Daemon version',
-    'platform': 'apcupsd',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'version',
-    'unique_id': 'XXXXXXXXXXXX_version',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[sensor.myups_daemon_version-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'MyUPS Daemon version',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.myups_daemon_version',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '3.14.14 (31 May 2016) unknown',
-  })
-# ---
-# name: test_sensor[sensor.myups_date_and_time-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.myups_date_and_time',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Date and time',
-    'platform': 'apcupsd',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'date_and_time',
-    'unique_id': 'XXXXXXXXXXXX_end apc',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[sensor.myups_date_and_time-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'MyUPS Date and time',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.myups_date_and_time',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1970-01-01 00:00:00 0000',
-  })
-# ---
 # name: test_sensor[sensor.myups_driver-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -546,54 +450,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'USB UPS Driver',
-  })
-# ---
-# name: test_sensor[sensor.myups_firmware_version-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.myups_firmware_version',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Firmware version',
-    'platform': 'apcupsd',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'firmware_version',
-    'unique_id': 'XXXXXXXXXXXX_firmware',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[sensor.myups_firmware_version-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'MyUPS Firmware version',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.myups_firmware_version',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '928.a8 .D USB FW:a8',
   })
 # ---
 # name: test_sensor[sensor.myups_input_voltage-entry]
@@ -904,102 +760,6 @@
     'state': 'Stand Alone',
   })
 # ---
-# name: test_sensor[sensor.myups_model-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.myups_model',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Model',
-    'platform': 'apcupsd',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'model',
-    'unique_id': 'XXXXXXXXXXXX_model',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[sensor.myups_model-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'MyUPS Model',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.myups_model',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'Back-UPS ES 600',
-  })
-# ---
-# name: test_sensor[sensor.myups_name-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.myups_name',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Name',
-    'platform': 'apcupsd',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'ups_name',
-    'unique_id': 'XXXXXXXXXXXX_upsname',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[sensor.myups_name-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'MyUPS Name',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.myups_name',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'MyUPS',
-  })
-# ---
 # name: test_sensor[sensor.myups_nominal_apparent_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -1157,6 +917,342 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '330',
+  })
+# ---
+# name: test_sensor[sensor.myups_none-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.myups_none',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'apcupsd',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'apc_status',
+    'unique_id': 'XXXXXXXXXXXX_apc',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[sensor.myups_none-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'MyUPS None',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myups_none',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '001,038,0985',
+  })
+# ---
+# name: test_sensor[sensor.myups_none_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.myups_none_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'apcupsd',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'date',
+    'unique_id': 'XXXXXXXXXXXX_date',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[sensor.myups_none_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'MyUPS None',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myups_none_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1970-01-01 00:00:00 0000',
+  })
+# ---
+# name: test_sensor[sensor.myups_none_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.myups_none_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'apcupsd',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'date_and_time',
+    'unique_id': 'XXXXXXXXXXXX_end apc',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[sensor.myups_none_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'MyUPS None',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myups_none_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1970-01-01 00:00:00 0000',
+  })
+# ---
+# name: test_sensor[sensor.myups_none_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.myups_none_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'apcupsd',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'firmware_version',
+    'unique_id': 'XXXXXXXXXXXX_firmware',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[sensor.myups_none_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'MyUPS None',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myups_none_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '928.a8 .D USB FW:a8',
+  })
+# ---
+# name: test_sensor[sensor.myups_none_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.myups_none_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'apcupsd',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'model',
+    'unique_id': 'XXXXXXXXXXXX_model',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[sensor.myups_none_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'MyUPS None',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myups_none_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Back-UPS ES 600',
+  })
+# ---
+# name: test_sensor[sensor.myups_none_6-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.myups_none_6',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'apcupsd',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ups_name',
+    'unique_id': 'XXXXXXXXXXXX_upsname',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[sensor.myups_none_6-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'MyUPS None',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myups_none_6',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'MyUPS',
+  })
+# ---
+# name: test_sensor[sensor.myups_none_7-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.myups_none_7',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'apcupsd',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'version',
+    'unique_id': 'XXXXXXXXXXXX_version',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[sensor.myups_none_7-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'MyUPS None',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myups_none_7',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.14.14 (31 May 2016) unknown',
   })
 # ---
 # name: test_sensor[sensor.myups_output_current-entry]
@@ -1503,102 +1599,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'ONLINE',
-  })
-# ---
-# name: test_sensor[sensor.myups_status_data-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.myups_status_data',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Status data',
-    'platform': 'apcupsd',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'apc_status',
-    'unique_id': 'XXXXXXXXXXXX_apc',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[sensor.myups_status_data-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'MyUPS Status data',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.myups_status_data',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '001,038,0985',
-  })
-# ---
-# name: test_sensor[sensor.myups_status_date-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.myups_status_date',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Status date',
-    'platform': 'apcupsd',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'date',
-    'unique_id': 'XXXXXXXXXXXX_date',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[sensor.myups_status_date-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'MyUPS Status date',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.myups_status_date',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1970-01-01 00:00:00 0000',
   })
 # ---
 # name: test_sensor[sensor.myups_status_flag-entry]

--- a/tests/components/apcupsd/test_binary_sensor.py
+++ b/tests/components/apcupsd/test_binary_sensor.py
@@ -23,6 +23,7 @@ async def test_binary_sensor(
     """Test states of binary sensors."""
     with patch("homeassistant.components.apcupsd.PLATFORMS", [Platform.BINARY_SENSOR]):
         config_entry = await async_init_integration(hass, status=MOCK_STATUS)
+
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 

--- a/tests/components/apcupsd/test_sensor.py
+++ b/tests/components/apcupsd/test_sensor.py
@@ -33,6 +33,7 @@ async def test_sensor(
     """Test states of sensor."""
     with patch("homeassistant.components.apcupsd.PLATFORMS", [Platform.SENSOR]):
         config_entry = await async_init_integration(hass, status=MOCK_STATUS)
+
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Our snapshot tests for APCUPSD are flaky. It seems to stem from the fact that `snapshot_platform` does not sort entities (anymore?) and our entity creation logic is not deterministic (we are iterating over an unordered set of available resources to add entities).

This PR fixes this by adding sorting to the available resource names when adding entities for deterministic ordering.

Perhaps adding sorting to `snapshot_platform` is better or do we actually want to enforce deterministic entity creation ordering (I do not remember seeing such requirement in dev docs)?

After this PR running `for i in {1..10}; do pytest ./tests/components/apcupsd/test_sensor.py::test_sensor || break; done` succeeds (on `dev` it fails).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
