### PR TITLE
Record current IQS for NextDNS

### DIFF
--- a/homeassistant/components/nextdns/manifest.json
+++ b/homeassistant/components/nextdns/manifest.json
@@ -7,5 +7,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["nextdns"],
+  "quality_scale": "bronze",
   "requirements": ["nextdns==4.1.0"]
 }

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -11,7 +11,9 @@ rules:
   config-flow-test-coverage:
     status: todo
     comment: Tests should end with the creation of a config entry or an abort.
-  config-flow: done
+  config-flow:
+    status: todo
+    comment: Data description is missing.
   dependency-transparency: done
   docs-actions:
     status: exempt
@@ -78,7 +80,7 @@ rules:
   icon-translations: done
   reconfiguration-flow:
     status: exempt
-    comment: There is no parameter that can be changed.
+    comment: Only parameter that could be changed profile_id would force a new config entry.
   repair-issues:
     status: exempt
     comment: This integration doesn't have any cases where raising an issue is needed.

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -11,9 +11,7 @@ rules:
   config-flow-test-coverage:
     status: todo
     comment: Tests should end with the creation of a config entry or an abort.
-  config-flow:
-    status: todo
-    comment: Data description is missing.
+  config-flow: done
   dependency-transparency: done
   docs-actions:
     status: exempt
@@ -41,9 +39,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates:
-    status: todo
-    comment: Set PARALLEL_UPDATES=0 for read only plarforms.
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: done
 

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -33,7 +33,7 @@ rules:
   docs-configuration-parameters:
     status: exempt
     comment: No options to configure.
-  docs-installation-parameters: todo
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -16,7 +16,7 @@ rules:
     comment: The integration does not register services.
   docs-high-level-description: done
   docs-installation-instructions: done
-  docs-removal-instructions: todo
+  docs-removal-instructions: done
   entity-event-setup: done
   entity-unique-id: done
   has-entity-name: done

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -74,7 +74,7 @@ rules:
     comment: This integration has a fixed single service.
   entity-category: done
   entity-device-class: done
-  entity-disabled-by-default: todo
+  entity-disabled-by-default: done
   entity-translations: done
   exception-translations: done
   icon-translations: done

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -54,7 +54,7 @@ rules:
   docs-examples: todo
   docs-known-limitations:
     status: todo
-    comment: Add info that there is no known limitations.
+    comment: Add info that there are no known limitations.
   docs-supported-devices:
     status: exempt
     comment: This is a service, which doesn't integrate with any devices.

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -73,8 +73,8 @@ rules:
   exception-translations: done
   icon-translations: done
   reconfiguration-flow:
-    status: exempt
-    comment: Only parameter that could be changed profile_id would force a new config entry.
+    status: todo
+    comment: Allow API key to be changed in the re-configure flow.
   repair-issues:
     status: exempt
     comment: This integration doesn't have any cases where raising an issue is needed.

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -1,0 +1,92 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: The integration does not register services.
+  appropriate-polling: done
+  brands: done
+  common-modules:
+    status: todo
+    comment: Base entity should be stored in the entity.py file.
+  config-flow-test-coverage:
+    status: todo
+    comment: Tests should end with the creation of a config entry or an abort.
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: The integration does not register services.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: todo
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: The integration does not register services.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: No options to configure.
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates:
+    status: todo
+    comment: Set PARALLEL_UPDATES=0 for read only plarforms.
+  reauthentication-flow: done
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info:
+    status: exempt
+    comment: The integration is a cloud service and thus does not support discovery.
+  discovery:
+    status: exempt
+    comment: The integration is a cloud service and thus does not support discovery.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations:
+    status: done
+    comment: No known limitations.
+  docs-supported-devices:
+    status: exempt
+    comment: This is a service, which doesn't integrate with any devices.
+  docs-supported-functions: todo
+  docs-troubleshooting:
+    status: exempt
+    comment: No known issues that could be resolved by the user.
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: This integration has a fixed single service.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow:
+    status: exempt
+    comment: There is no parameter that can be changed.
+  repair-issues:
+    status: exempt
+    comment: This integration doesn't have any cases where raising an issue is needed.
+  stale-devices:
+    status: exempt
+    comment: This integration has a fixed single service.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -5,9 +5,7 @@ rules:
     comment: The integration does not register services.
   appropriate-polling: done
   brands: done
-  common-modules:
-    status: todo
-    comment: Base entity should be stored in the entity.py file.
+  common-modules: done
   config-flow-test-coverage:
     status: todo
     comment: Tests should end with the creation of a config entry or an abort.

--- a/homeassistant/components/nextdns/quality_scale.yaml
+++ b/homeassistant/components/nextdns/quality_scale.yaml
@@ -6,9 +6,7 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow-test-coverage:
-    status: todo
-    comment: Tests should end with the creation of a config entry or an abort.
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
   docs-actions:
@@ -39,7 +37,9 @@ rules:
   log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
-  test-coverage: done
+  test-coverage:
+    status: todo
+    comment: Patch NextDns object instead of functions.
 
   # Gold
   devices: done
@@ -53,8 +53,8 @@ rules:
   docs-data-update: todo
   docs-examples: todo
   docs-known-limitations:
-    status: done
-    comment: No known limitations.
+    status: todo
+    comment: Add info that there is no known limitations.
   docs-supported-devices:
     status: exempt
     comment: This is a service, which doesn't integrate with any devices.

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1732,7 +1732,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "nexia",
     "nextbus",
     "nextcloud",
-    "nextdns",
     "nyt_games",
     "nfandroidtv",
     "nibe_heatpump",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -691,7 +691,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "nexia",
     "nextbus",
     "nextcloud",
-    "nextdns",
     "nfandroidtv",
     "nibe_heatpump",
     "nice_go",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
## Bronze
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [x] `brands` - Has branding assets available for the integration
- [x] `common-modules` - Place common patterns in common modules
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `dependency-transparency` - Dependency transparency
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice

## Silver
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `integration-owner` - Has an integration owner
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [x] `parallel-updates` - Number of parallel updates is specified
- [ ] `reauthentication-flow` - Reauthentication needs to be available via the UI
- [ ] `test-coverage` - Above 95% test coverage for all integration modules

## Gold
- [x] `devices` - The integration creates devices
- [x] `diagnostics` - Implements diagnostics
- [x] `discovery-update-info` - Integration uses discovery info to update network information
- [x] `discovery` - Devices can be discovered
- [ ] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-examples` - The documentation provides automation examples the user can use.
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `dynamic-devices` - Devices added after integration setup
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [x] `entity-device-class` - Entities use device classes where possible
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [x] `entity-translations` - Entities have translated names
- [x] `exception-translations` - Exception messages are translatable
- [x] `icon-translations` - Entities implement icon translations
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [x] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [x] `stale-devices` - Stale devices are removed

## Platinum
- [x] `async-dependency` - Dependency is async
- [x] `inject-websession` - The integration dependency supports passing in a websession
- [x] `strict-typing` - Strict typing



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
