### PR TITLE
[soundtouch] allow customized source setting

### DIFF
--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -277,6 +277,24 @@ class SoundTouchMediaPlayer(MediaPlayerEntity):
         elif source == Source.BLUETOOTH.value:
             _LOGGER.debug("Selecting source Bluetooth")
             self._device.select_source_bluetooth()
+
+        # Support a wider range of sources.
+        # See https://github.com/home-assistant/core/issues/141776 for more details.
+        elif "." in source:
+            parts = source.split(".")
+            sourceAccount = "" if len(parts) == 1 else parts[1]
+
+            # Use Python hackery to avoid necessary changes to upstream dependency.
+            class AdhocSource:
+                value = parts[0]
+
+            if sourceAccount:
+                _LOGGER.debug(f"Selecting source {parts[0]}.{sourceAccount}")
+            else:
+                _LOGGER.debug(f"Selecting source {parts[0]}")
+
+            self._device.select_content_item(AdhocSource, sourceAccount)
+
         else:
             _LOGGER.warning("Source %s is not supported", source)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allows more customized source setting for Bose Soundtouch devices.

### Issue

The current iteration only supports source setting of AUX or BLUETOOTH. However, there is [a lot more sources available](https://github.com/CharlesBlonde/libsoundtouch/blob/25163a7ae39de2724e2946e8b1b61484d2a590d6/libsoundtouch/utils.py#L43-L61), and the [entirety of the supported sources is device dependent](https://github.com/thlucas1/homeassistantcomponent_soundtouchplus/wiki/SoundTouch-WebServices-API#sources-list). As such, we need a method to proxy string values through the HomeAssistant interfaces to the upstream library so that proper sources can be set.

To further complicate matters, it looks like the `sourceAccount` field is used to distinguish between similar "sources". For example, when I queried my Soundtouch 300, I obtained the following (abridged) output:

```
<?xml version="1.0" encoding="UTF-8"?>
<sources deviceID="redacted">
  <sourceItem source="PRODUCT" sourceAccount="HDMI_1" status="UNAVAILABLE" isLocal="true" multiroomallowed="true">HDMI_1</sourceItem>
  <sourceItem source="PRODUCT" sourceAccount="TV" status="READY" isLocal="true" multiroomallowed="true">TV</sourceItem>
</sources>
```

From this output, it looks like the `TV` is supported, but the `HDMI_1` may not be. Furthermore, `PRODUCT` isn't even a valid source in the upstream `libsoundtouch` library (evidence that valid sources are device dependent).

### Fix

To support more granular source setting, I propose the following modification: instead of only supporting `AUX` and `BLUETOOTH`, this PR will allow values to be set as such:

```yaml
action: media_player.select_source
data:
  source: PRODUCT.TV
target:
  entity_id: media_player.bose_soundtouch
```

If no `sourceAccount` is necessary, a period with no source account can also be set (i.e. `PRODUCT.`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #141776

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
