### PR TITLE
Add extended class for OptionsFlow that automatically reloads

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -369,14 +369,14 @@ class ConfigSubentry:
         }
 
 
-class ConfigEntry[DataT = Any]:
+class ConfigEntry[_DataT = Any]:
     """Hold a configuration entry."""
 
     entry_id: str
     domain: str
     title: str
     data: MappingProxyType[str, Any]
-    runtime_data: DataT
+    runtime_data: _DataT
     options: MappingProxyType[str, Any]
     subentries: MappingProxyType[str, ConfigSubentry]
     unique_id: str | None
@@ -1272,13 +1272,13 @@ class ConfigEntry[DataT = Any]:
         )
 
     @callback
-    def async_create_task[R](
+    def async_create_task[_R](
         self,
         hass: HomeAssistant,
-        target: Coroutine[Any, Any, R],
+        target: Coroutine[Any, Any, _R],
         name: str | None = None,
         eager_start: bool = True,
-    ) -> asyncio.Task[R]:
+    ) -> asyncio.Task[_R]:
         """Create a task from within the event loop.
 
         This method must be run in the event loop.
@@ -1296,13 +1296,13 @@ class ConfigEntry[DataT = Any]:
         return task
 
     @callback
-    def async_create_background_task[R](
+    def async_create_background_task[_R](
         self,
         hass: HomeAssistant,
-        target: Coroutine[Any, Any, R],
+        target: Coroutine[Any, Any, _R],
         name: str,
         eager_start: bool = True,
-    ) -> asyncio.Task[R]:
+    ) -> asyncio.Task[_R]:
         """Create a background task tied to the config entry lifecycle.
 
         Background tasks are automatically canceled when config entry is unloaded.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3612,7 +3612,7 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
 class OptionsFlowWithReload(OptionsFlow):
     """Automatic reloading class for config options flows.
 
-    Triggers an automatic reload of the config entry when the low ends with
+    Triggers an automatic reload of the config entry when the flow ends with
     calling `async_create_entry` with changed options.
     It's not allowed to use this class if the integration uses config entry
     update listeners.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3613,10 +3613,11 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
 
 
 class OptionsFlowWithReload(OptionsFlow):
-    """Extended class for config options flows.
+    """Automatic reloading class for config options flows.
 
     Triggers an automatic reload of the config entry when the options are changed.
-    Integrations does not need to use a config entry update listener when using this class.
+    Integrations can not use this automatic reloading Options flow class
+    together with config entry update listeners.
     """
 
     automatic_reload: bool = True

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3180,15 +3180,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
 
         :param reload_even_if_entry_is_unchanged: set this to `False` if the entry
         should not be reloaded if it is unchanged
-
-        Using this method in combination with `update_listeners` is not supported.
-        If the entry has `update_listeners`, this method will raise a ValueError.
         """
-        if entry.update_listeners:
-            raise ValueError(
-                "Using async_update_reload_and_abort in combination with "
-                "update_listeners is not supported"
-            )
         if data_updates is not UNDEFINED:
             if data is not UNDEFINED:
                 raise ValueError("Cannot set both data and data_updates")

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3485,13 +3485,14 @@ class OptionsFlowManager(
         entry = self.hass.config_entries.async_get_known_entry(flow.handler)
 
         if result["data"] is not None:
+            entry_updated = self.hass.config_entries.async_update_entry(
+                entry, options=result["data"]
+            )
             if (
-                self.hass.config_entries.async_update_entry(
-                    entry, options=result["data"]
-                )
+                entry_updated is True
+                and hasattr(flow, "automatic_reload") is True
+                and flow.automatic_reload is True  # type: ignore[attr-defined]
                 and not entry.update_listeners
-                and hasattr(flow, "automatic_reload")
-                and flow.automatic_reload
             ):
                 self.hass.config_entries.async_schedule_reload(entry.entry_id)
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -8685,7 +8685,7 @@ async def test_options_flow_automatic_reload(
 
     await hass.config_entries.async_setup(original_entry.entry_id)
     assert original_entry.state is config_entries.ConfigEntryState.LOADED
-    assert "loaded entry First" in caplog.text
+    assert "loaded entry Test with options {'test': 'first'}" in caplog.text
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -8715,7 +8715,75 @@ async def test_options_flow_automatic_reload(
         )
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert "loaded entry Updated" in caplog.text
+    assert "loaded entry Test with options {'test': 'updated'}" in caplog.text
+
+
+async def test_options_flow_with_automatic_reload_no_support_update_listener(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test options flow with automatic reload does not support using update listeners."""
+    original_entry = MockConfigEntry(
+        domain="test", title="Test", data={}, options={"test": "first"}
+    )
+    original_entry.add_to_hass(hass)
+
+    async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+        """Mock setup entry."""
+        config_entries._LOGGER.info(
+            "loaded entry %s with options %s", entry.title, entry.options
+        )
+        entry.update_listeners = AsyncMock(return_value=True)
+        return True
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry,
+            async_unload_entry=AsyncMock(return_value=True),
+        ),
+    )
+    mock_platform(hass, "test.config_flow", None)
+
+    await hass.config_entries.async_setup(original_entry.entry_id)
+    assert original_entry.state is config_entries.ConfigEntryState.LOADED
+    assert "loaded entry Test with options {'test': 'first'}" in caplog.text
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        @staticmethod
+        @callback
+        def async_get_options_flow(config_entry):
+            """Test options flow."""
+
+            class _OptionsFlow(config_entries.OptionsFlowWithReload):
+                """Test flow."""
+
+                async def async_step_init(self, user_input=None):
+                    """Test user step."""
+                    if user_input is not None:
+                        return self.async_create_entry(data=user_input)
+                    return self.async_show_form(
+                        step_id="init", data_schema=vol.Schema({"test": str})
+                    )
+
+            return _OptionsFlow()
+
+    with mock_config_flow("test", TestFlow):
+        result = await hass.config_entries.options.async_init(original_entry.entry_id)
+        with pytest.raises(
+            ValueError,
+            match="Config entry update listeners should not be used with OptionsFlowWithReload",
+        ):
+            result = await hass.config_entries.options.async_configure(
+                result["flow_id"], {"test": "updated"}
+            )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert "loaded entry Test with options {'test': 'updated'}" not in caplog.text
 
 
 @pytest.mark.parametrize("integration_frame_path", ["custom_components/my_integration"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds new extended class for options flow to allow automatic reload of the integration when config options change.

First step in a series of PR's
1. Create this extended class for options flow
2. Change all integrations that only uses update listeners for reloading to use the new extended class
3. Create PR to disallow use of `async_update_reload_and_abort`/`_abort_if_unique_id_configured` together with update listeners (avoid possible double reloading)

This PR derives from suggestion in this PR https://github.com/home-assistant/core/pull/133450#issuecomment-2737073674

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2730

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 