### PR TITLE
Add support for Opower near-realtime reads endpoint

### DIFF
--- a/tests/components/opower/test_coordinator.py
+++ b/tests/components/opower/test_coordinator.py
@@ -1,0 +1,283 @@
+"""Tests for the Opower coordinator, particularly testing merging realtime and cost usage reads."""
+
+from collections.abc import Awaitable, Callable, Generator
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from opower import Account, CostRead, MeterType, Opower, UsageRead
+from opower.utilities.coned import ConEd
+from opower.utilities.enmax import Enmax
+import pytest
+
+from homeassistant.components.opower.const import CONF_UTILITY, DOMAIN
+from homeassistant.components.opower.coordinator import (
+    CONF_PASSWORD,
+    CONF_TOTP_SECRET,
+    CONF_USERNAME,
+    OpowerCoordinator,
+)
+from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder.statistics import get_last_statistics
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def account() -> Account:
+    """Fixture to create a test account."""
+    return Account(
+        customer="",
+        uuid="",
+        utility_account_id="test_utility_account_id",
+        id="",
+        meter_type=MeterType.ELEC,
+        read_resolution="",
+    )
+
+
+@pytest.fixture
+def opower(account: Account) -> Generator[Opower]:
+    """Fixture to create a mock Opower instance that lets us mock out API call methods."""
+    with patch("homeassistant.components.opower.coordinator.Opower") as opower_mock:
+        opower = opower_mock.return_value
+
+        # Mock opower calls used in initial insert statistics run
+        opower.async_login = AsyncMock()
+        opower.async_get_forecast = AsyncMock()
+        opower.utility = ConEd  # ConEd supports realtime usage reads
+        opower.async_get_accounts = AsyncMock(return_value=[account])
+        opower.async_get_cost_reads = AsyncMock(return_value=[])
+        opower.async_get_realtime_usage_reads = AsyncMock(return_value=[])
+        yield opower
+
+
+@pytest.fixture
+async def coordinator_factory(
+    opower: Opower, recorder_mock: Recorder, hass: HomeAssistant
+) -> Callable[[], Awaitable[OpowerCoordinator]]:
+    """Fixture that sets up the Opower coordinator and returns it. Returns as a factory function so that we can edit the Opower mock before the coordinator is created."""
+
+    async def factory():
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_UTILITY: "coned",
+                CONF_USERNAME: "fake_username",
+                CONF_PASSWORD: "fake_password",
+                CONF_TOTP_SECRET: "fake_totp_secret",
+            },
+        )
+        entry.add_to_hass(hass)
+        assert await async_setup_component(hass, DOMAIN, {})
+        return entry.runtime_data
+
+    return factory
+
+
+async def test_no_realtime_if_not_supported(
+    coordinator_factory: Callable[[], Awaitable[OpowerCoordinator]],
+    account: Account,
+    opower: Opower,
+    hass: HomeAssistant,
+) -> None:
+    """Test that we only fetch cost reads if the utility does not support realtime reads."""
+    opower.utility = Enmax  # Enmax does not support realtime usage reads
+    del opower.async_get_realtime_usage_reads  # Should throw error if called
+    opower.async_get_cost_reads = AsyncMock(
+        return_value=[
+            CostRead(
+                start_time=datetime.fromisoformat("2020-01-01T00:00Z"),
+                end_time=datetime.fromisoformat("2020-01-01T01:00Z"),
+                consumption=2,
+                provided_cost=0,
+            )
+        ]
+    )
+    coordinator = await coordinator_factory()
+    statistics_id = coordinator._consumption_statistic_id(account)
+    statistics = get_last_statistics(
+        hass,
+        100,
+        statistics_id,
+        False,
+        {"sum"},
+    )[statistics_id]
+    assert statistics == [
+        {
+            "start": datetime.fromisoformat("2020-01-01T00:00Z").timestamp(),
+            "end": datetime.fromisoformat("2020-01-01T01:00Z").timestamp(),
+            "sum": 2.0,
+        }
+    ]
+
+
+async def test_only_realtime(
+    coordinator_factory: Callable[[], Awaitable[OpowerCoordinator]],
+    account: Account,
+    opower: Opower,
+    hass: HomeAssistant,
+) -> None:
+    """Test that 15 minute realtime intervals get aggregated into hourly stats."""
+    opower.async_get_realtime_usage_reads = AsyncMock(
+        return_value=[
+            # Add four distinct values for 15 minute intervals of first hour.
+            UsageRead(
+                start_time=datetime.fromisoformat("2020-01-01T00:00Z"),
+                end_time=datetime.fromisoformat("2020-01-01T00:15Z"),
+                consumption=1,
+            ),
+            UsageRead(
+                start_time=datetime.fromisoformat("2020-01-01T00:15Z"),
+                end_time=datetime.fromisoformat("2020-01-01T00:30Z"),
+                consumption=10,
+            ),
+            UsageRead(
+                start_time=datetime.fromisoformat("2020-01-01T00:30Z"),
+                end_time=datetime.fromisoformat("2020-01-01T00:45Z"),
+                consumption=100,
+            ),
+            UsageRead(
+                start_time=datetime.fromisoformat("2020-01-01T00:45Z"),
+                end_time=datetime.fromisoformat("2020-01-01T01:00Z"),
+                consumption=1000,
+            ),
+            # Add another value in the next hour.
+            UsageRead(
+                start_time=datetime.fromisoformat("2020-01-01T01:00Z"),
+                end_time=datetime.fromisoformat("2020-01-01T01:15Z"),
+                consumption=2,
+            ),
+        ]
+    )
+    coordinator = await coordinator_factory()
+    statistics_id = coordinator._consumption_statistic_id(account)
+    statistics = get_last_statistics(
+        hass,
+        100,
+        statistics_id,
+        False,
+        {"sum"},
+    )[statistics_id]
+    assert statistics == [
+        {
+            "start": datetime.fromisoformat("2020-01-01T01:00Z").timestamp(),
+            "end": datetime.fromisoformat("2020-01-01T02:00Z").timestamp(),
+            "sum": 1113.0,
+        },
+        {
+            "start": datetime.fromisoformat("2020-01-01T00:00Z").timestamp(),
+            "end": datetime.fromisoformat("2020-01-01T01:00Z").timestamp(),
+            "sum": 1111.0,
+        },
+    ]
+
+
+async def test_merged_reads_interleaved(
+    coordinator_factory: Callable[[], Awaitable[OpowerCoordinator]],
+    account: Account,
+    opower: Opower,
+    hass: HomeAssistant,
+) -> None:
+    """We can have cost data interleaved with realtime data. In this test, we have hour 0 cost, hour 1 realtime, hour 2 cost."""
+    opower.async_get_realtime_usage_reads = AsyncMock(
+        return_value=[
+            UsageRead(
+                start_time=datetime.fromisoformat("2020-01-01T01:00Z"),
+                end_time=datetime.fromisoformat("2020-01-01T01:15Z"),
+                consumption=1,
+            ),
+            UsageRead(
+                start_time=datetime.fromisoformat("2020-01-01T01:15Z"),
+                end_time=datetime.fromisoformat("2020-01-01T01:30Z"),
+                consumption=10,
+            ),
+        ]
+    )
+    opower.async_get_cost_reads = AsyncMock(
+        return_value=[
+            CostRead(
+                start_time=datetime.fromisoformat("2020-01-01T00:00Z"),
+                end_time=datetime.fromisoformat("2020-01-01T01:00Z"),
+                consumption=2,
+                provided_cost=0,
+            ),
+            CostRead(
+                start_time=datetime.fromisoformat("2020-01-01T02:00Z"),
+                end_time=datetime.fromisoformat("2020-01-01T03:00Z"),
+                consumption=20,
+                provided_cost=0,
+            ),
+        ]
+    )
+    coordinator = await coordinator_factory()
+    statistics_id = coordinator._consumption_statistic_id(account)
+    statistics = get_last_statistics(
+        hass,
+        100,
+        statistics_id,
+        False,
+        {"sum"},
+    )[statistics_id]
+    assert statistics == [
+        {
+            "start": datetime.fromisoformat("2020-01-01T02:00Z").timestamp(),
+            "end": datetime.fromisoformat("2020-01-01T03:00Z").timestamp(),
+            "sum": 33.0,
+        },
+        {
+            "start": datetime.fromisoformat("2020-01-01T01:00Z").timestamp(),
+            "end": datetime.fromisoformat("2020-01-01T02:00Z").timestamp(),
+            "sum": 13.0,
+        },
+        {
+            "start": datetime.fromisoformat("2020-01-01T00:00Z").timestamp(),
+            "end": datetime.fromisoformat("2020-01-01T01:00Z").timestamp(),
+            "sum": 2.0,
+        },
+    ]
+
+
+async def test_merged_reads_prioritizes_cost_reads(
+    coordinator_factory: Callable[[], Awaitable[OpowerCoordinator]],
+    account: Account,
+    opower: Opower,
+    hass: HomeAssistant,
+) -> None:
+    """Test that cost reads are prioritized over realtime reads."""
+    opower.async_get_realtime_usage_reads = AsyncMock(
+        return_value=[
+            UsageRead(
+                start_time=datetime.fromisoformat("2020-01-01T00:00Z"),
+                end_time=datetime.fromisoformat("2020-01-01T00:15Z"),
+                consumption=1,
+            )
+        ]
+    )
+    opower.async_get_cost_reads = AsyncMock(
+        return_value=[
+            CostRead(
+                start_time=datetime.fromisoformat("2020-01-01T00:00Z"),
+                end_time=datetime.fromisoformat("2020-01-01T01:00Z"),
+                consumption=2,
+                provided_cost=0,
+            )
+        ]
+    )
+    coordinator = await coordinator_factory()
+    statistics_id = coordinator._consumption_statistic_id(account)
+    statistics = get_last_statistics(
+        hass,
+        100,
+        statistics_id,
+        False,
+        {"sum"},
+    )[statistics_id]
+    assert statistics == [
+        {
+            "start": datetime.fromisoformat("2020-01-01T00:00Z").timestamp(),
+            "end": datetime.fromisoformat("2020-01-01T01:00Z").timestamp(),
+            "sum": 2.0,
+        }
+    ]


### PR DESCRIPTION
## Proposed change
Support near-realtime energy reads from the Opower near-realtime endpoint. 

This change builds on https://github.com/tronikos/opower/pull/104 to add support for querying the near-realtime endpoint from Opower. For ConEd at least, the near-realtime endpoint returns the last (I think) 24 hours of data in 15 minute intervals, and is updated more frequently than the cost-reads endpoint. In my testing, the endpoint seems to have data as new as one hour old. I also found documentation from ConEd that matches this:

> For real time data, Meter Readings are available for last 24 hours. For
Electricity data, data latency will be 45 minutes from the request processing
time.

(https://cdne-dcxprod-sitecore.azureedge.net/-/media/files/coned/documents/accountandbilling/share-my-data/onboarding-doc.pdf, page 25)

Since the near-realtime endpoint only returns the last day of data, this change merges the near-realtime data with the existing cost-reads data, and prioritizes the cost-read data if both are available. Prioritizing cost-read data matches the message that shows up on the ConEd website when viewing the "Real Time Usage" section:

> Please note: Your real-time usage may not match billing. Billed usage is validated and may have a multiplier applied, which will be shown on your bill statement.

I left the update interval to 12 hours for now. Ideally it should be much more frequent, maybe every 15 minutes, but when I was testing this locally, at some point ConEd started blocking my IP address, and I had to request a new dynamic IP from my ISP to regain access. I suspect my IP address got flagged as abusive, but I'm not sure what the threshold is. 

I added tests to validate that the merged cost-read and near-realtime data is correctly written to statistics. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/tronikos/opower/issues/24
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure