### PR TITLE
Add delay_on and delay_off options to template binary sensors

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -325,7 +325,7 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity, RestoreEntity):
         def _set_state(_):
             """Set state of template binary sensor."""
             self._attr_is_on = state
-            self.async_write_ha_state()
+            self._write_state()
 
         delay = (self._delay_on if state else self._delay_off).total_seconds()
         # state with delay. Cancelled if template result changes.

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -325,7 +325,7 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity, RestoreEntity):
         def _set_state(_):
             """Set state of template binary sensor."""
             self._attr_is_on = state
-            self._write_state()
+            self._write_state_and_update_preview()
 
         delay = (self._delay_on if state else self._delay_off).total_seconds()
         # state with delay. Cancelled if template result changes.

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -317,6 +317,8 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity, RestoreEntity):
             state is None
             or (state and not self._delay_on)
             or (not state and not self._delay_off)
+            # We should directly reflect the state for previews (even if delay is set) for the best UX.
+            or self._preview_callback
         ):
             self._attr_is_on = state
             return
@@ -325,7 +327,7 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity, RestoreEntity):
         def _set_state(_):
             """Set state of template binary sensor."""
             self._attr_is_on = state
-            self._write_state_and_update_preview()
+            self.async_write_ha_state()
 
         delay = (self._delay_on if state else self._delay_off).total_seconds()
         # state with delay. Cancelled if template result changes.

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -51,7 +51,11 @@ from .alarm_control_panel import (
     CONF_TRIGGER_ACTION,
     TemplateCodeFormat,
 )
-from .binary_sensor import async_create_preview_binary_sensor
+from .binary_sensor import (
+    CONF_DELAY_OFF,
+    CONF_DELAY_ON,
+    async_create_preview_binary_sensor,
+)
 from .const import CONF_PRESS, CONF_TURN_OFF, CONF_TURN_ON, DOMAIN
 from .number import (
     CONF_MAX,
@@ -117,6 +121,10 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
                     ),
                 ),
             }
+        schema |= {
+            vol.Optional(CONF_DELAY_ON): selector.DurationSelector(),
+            vol.Optional(CONF_DELAY_OFF): selector.DurationSelector(),
+        }
 
     if domain == Platform.BUTTON:
         schema |= {

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -26,10 +26,14 @@
           "device_id": "[%key:common::config_flow::data::device%]",
           "device_class": "[%key:component::template::config::step::sensor::data::device_class%]",
           "name": "[%key:common::config_flow::data::name%]",
-          "state": "[%key:component::template::config::step::sensor::data::state%]"
+          "state": "[%key:component::template::config::step::sensor::data::state%]",
+          "delay_on": "Delay turning on",
+          "delay_off": "Delay turning off"
         },
         "data_description": {
-          "device_id": "[%key:component::template::config::step::sensor::data_description::device_id%]"
+          "device_id": "[%key:component::template::config::step::sensor::data_description::device_id%]",
+          "delay_on": "Time to wait before this binary sensor turns on.",
+          "delay_off": "Time to wait before this binary sensor turns off."
         },
         "title": "Template binary sensor"
       },
@@ -154,10 +158,14 @@
       "binary_sensor": {
         "data": {
           "device_id": "[%key:common::config_flow::data::device%]",
-          "state": "[%key:component::template::config::step::sensor::data::state%]"
+          "state": "[%key:component::template::config::step::sensor::data::state%]",
+          "delay_on": "[%key:component::template::config::step::binary_sensor::data::delay_on%]",
+          "delay_off": "[%key:component::template::config::step::binary_sensor::data::delay_off%]"
         },
         "data_description": {
-          "device_id": "[%key:component::template::config::step::sensor::data_description::device_id%]"
+          "device_id": "[%key:component::template::config::step::sensor::data_description::device_id%]",
+          "delay_on": "[%key:component::template::config::step::binary_sensor::data_description::delay_on%]",
+          "delay_off": "[%key:component::template::config::step::binary_sensor::data_description::delay_off%]"
         },
         "title": "[%key:component::template::config::step::binary_sensor::title%]"
       },

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -481,10 +481,10 @@ class TemplateEntity(AbstractTemplateEntity):
                     event, update.template, update.last_result, update.result
                 )
 
-        self._write_state()
+        self._write_state_and_update_preview()
 
     @callback
-    def _write_state(self):
+    def _write_state_and_update_preview(self):
         if not self._preview_callback:
             self.async_write_ha_state()
             return

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -481,10 +481,6 @@ class TemplateEntity(AbstractTemplateEntity):
                     event, update.template, update.last_result, update.result
                 )
 
-        self._write_state_and_update_preview()
-
-    @callback
-    def _write_state_and_update_preview(self):
         if not self._preview_callback:
             self.async_write_ha_state()
             return

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -481,6 +481,10 @@ class TemplateEntity(AbstractTemplateEntity):
                     event, update.template, update.last_result, update.result
                 )
 
+        self._write_state()
+
+    @callback
+    def _write_state(self):
         if not self._preview_callback:
             self.async_write_ha_state()
             return

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -82,6 +82,18 @@ BINARY_SENSOR_OPTIONS = {
             {},
         ),
         (
+            "binary_sensor",
+            {
+                "state": "{{ states('binary_sensor.one') == 'on' or states('binary_sensor.two') == 'on' }}"
+            },
+            "unknown",  # With delay_on, binary sensor starts as unknown until delay expires
+            {"one": "on", "two": "off"},
+            {},
+            {"delay_on": {"seconds": 5}, "delay_off": {"seconds": 3}},
+            {"delay_on": {"seconds": 5}, "delay_off": {"seconds": 3}},
+            {},
+        ),
+        (
             "sensor",
             {
                 "state": "{{ float(states('sensor.one')) + float(states('sensor.two')) }}"
@@ -277,6 +289,12 @@ async def test_config_flow(
             {},
         ),
         (
+            "binary_sensor",
+            {"state": "{{ false }}"},
+            {"delay_on": {"seconds": 2}, "delay_off": {"seconds": 1}},
+            {"delay_on": {"seconds": 2}, "delay_off": {"seconds": 1}},
+        ),
+        (
             "switch",
             {"value_template": "{{ false }}"},
             {},
@@ -431,6 +449,21 @@ async def test_config_flow_device(
             {"one": "on", "two": "off"},
             {},
             {},
+            "state",
+        ),
+        (
+            "binary_sensor",
+            {
+                "state": "{{ states('binary_sensor.one') == 'on' or states('binary_sensor.two') == 'on' }}"
+            },
+            {
+                "state": "{{ states('binary_sensor.one') == 'on' and states('binary_sensor.two') == 'on' }}",
+            },
+            # Because of delay_on, the binary sensor statuses will both be "unknown" before and after the option updates.
+            ["unknown", "unknown"],
+            {"one": "on", "two": "off"},
+            {"delay_on": {"seconds": 10}, "delay_off": {"seconds": 5}},
+            {"delay_on": {"seconds": 10}, "delay_off": {"seconds": 5}},
             "state",
         ),
         (
@@ -1322,6 +1355,12 @@ async def test_option_flow_sensor_preview_config_entry_removed(
             {"state": "{{ states('select.one') }}"},
             {"options": "{{ ['off', 'on', 'auto'] }}"},
             {"options": "{{ ['off', 'on', 'auto'] }}"},
+        ),
+        (
+            "binary_sensor",
+            {"state": "{{ false }}"},
+            {"delay_on": {"seconds": 4}, "delay_off": {"seconds": 2}},
+            {"delay_on": {"seconds": 4}, "delay_off": {"seconds": 2}},
         ),
         (
             "switch",

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -712,6 +712,15 @@ async def test_options(
             [{}, {}],
             [["one", "two"], ["one", "two"]],
         ),
+        (
+            "binary_sensor",
+            "{{ states.binary_sensor.one.state == 'on' or states.binary_sensor.two.state == 'on' }}",
+            {"delay_on": {"seconds": 2}, "delay_off": {"seconds": 1}},
+            {"one": "on", "two": "off"},
+            ["off", "on"],  # Delays are not evaluated for previews.
+            [{}, {}],
+            [["one", "two"], ["one"]],
+        ),
     ],
 )
 async def test_config_flow_preview(
@@ -1169,6 +1178,17 @@ async def test_config_flow_preview_bad_state(
             {},
             {"one": "30.0", "two": "20.0"},
             "10.0",
+            {},
+            ["one", "two"],
+        ),
+        (
+            "binary_sensor",
+            "{{ states('binary_sensor.one') == 'on' or states('binary_sensor.two') == 'on' }}",
+            "{{ states('binary_sensor.one') == 'on' and states('binary_sensor.two') == 'on' }}",
+            {"delay_on": {"seconds": 3}, "delay_off": {"seconds": 2}},
+            {"delay_on": {"seconds": 3}, "delay_off": {"seconds": 2}},
+            {"one": "on", "two": "off"},
+            "off",  # Delays are not evaluated for previews.
             {},
             ["one", "two"],
         ),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR introduces the YAML-configurable `delay_on` and `delay_off` to the config flow UI as duration selector. 

YAML allows these configurations to also be a template. However, for config flow UI it feels more user-friendly to expose as a simple duration selector. We can consider making this a template in the future (without a breaking change) if there are enough demands.

<img width="425" alt="Screenshot 2025-06-29 at 10 28 14 PM" src="https://github.com/user-attachments/assets/b8fcac15-2ff8-476c-82de-c17b79e155e0" />



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
