### PR TITLE
Make Meater cook state an enum

### DIFF
--- a/homeassistant/components/meater/sensor.py
+++ b/homeassistant/components/meater/sensor.py
@@ -25,6 +25,18 @@ from homeassistant.util import dt as dt_util
 from . import MeaterCoordinator
 from .const import DOMAIN
 
+COOK_STATES = {
+    "Not Started": "not_started",
+    "Configured": "configured",
+    "Started": "started",
+    "Ready For Resting": "ready_for_resting",
+    "Resting": "resting",
+    "Slightly Underdone": "slightly_underdone",
+    "Finished": "finished",
+    "Slightly Overdone": "slightly_overdone",
+    "OVERCOOK!": "overcooked",
+}
+
 
 @dataclass(frozen=True, kw_only=True)
 class MeaterSensorEntityDescription(SensorEntityDescription):
@@ -80,13 +92,13 @@ SENSOR_TYPES = (
         available=lambda probe: probe is not None and probe.cook is not None,
         value=lambda probe: probe.cook.name if probe.cook else None,
     ),
-    # One of Not Started, Configured, Started, Ready For Resting, Resting,
-    # Slightly Underdone, Finished, Slightly Overdone, OVERCOOK!. Not translated.
     MeaterSensorEntityDescription(
         key="cook_state",
         translation_key="cook_state",
         available=lambda probe: probe is not None and probe.cook is not None,
-        value=lambda probe: probe.cook.state if probe.cook else None,
+        device_class=SensorDeviceClass.ENUM,
+        options=list(COOK_STATES.values()),
+        value=lambda probe: COOK_STATES.get(probe.cook.state) if probe.cook else None,
     ),
     # Target temperature
     MeaterSensorEntityDescription(

--- a/homeassistant/components/meater/strings.json
+++ b/homeassistant/components/meater/strings.json
@@ -40,7 +40,18 @@
         "name": "Cooking"
       },
       "cook_state": {
-        "name": "Cook state"
+        "name": "Cook state",
+        "state": {
+          "not_started": "Not started",
+          "configured": "Configured",
+          "started": "Started",
+          "ready_for_resting": "Ready for resting",
+          "resting": "Resting",
+          "slightly_underdone": "Slightly underdone",
+          "finished": "Finished",
+          "slightly_overdone": "Slightly overdone",
+          "overcooked": "Overcooked"
+        }
       },
       "cook_target_temp": {
         "name": "Target temperature"

--- a/tests/components/meater/snapshots/test_sensor.ambr
+++ b/tests/components/meater/snapshots/test_sensor.ambr
@@ -161,7 +161,19 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'options': list([
+        'not_started',
+        'configured',
+        'started',
+        'ready_for_resting',
+        'resting',
+        'slightly_underdone',
+        'finished',
+        'slightly_overdone',
+        'overcooked',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -179,7 +191,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
     'original_name': None,
     'platform': 'meater',
@@ -194,13 +206,25 @@
 # name: test_entities[sensor.meater_40a72384fa80349314dfd97c84b73a5c1c9da57b59e26d67b573d618fe0d6e58_cook_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'options': list([
+        'not_started',
+        'configured',
+        'started',
+        'ready_for_resting',
+        'resting',
+        'slightly_underdone',
+        'finished',
+        'slightly_overdone',
+        'overcooked',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.meater_40a72384fa80349314dfd97c84b73a5c1c9da57b59e26d67b573d618fe0d6e58_cook_state',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'Started',
+    'state': 'started',
   })
 # ---
 # name: test_entities[sensor.meater_40a72384fa80349314dfd97c84b73a5c1c9da57b59e26d67b573d618fe0d6e58_cook_target_temp-entry]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The states of the meater probe cook state have been changed:

`Not Started` -> `not_started`
`Configured` -> `configured`
`Started` -> `started`
`Ready For Resting` -> `ready_for_resting`
`Resting` -> `resting`
`Slightly Underdone` -> `slightly_underdone`
`Finished` -> `finished`
`Slightly Overdone` -> `slightly_overdone`
`OVERCOOK!` -> `overcooked`


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make Meater cook state an enum

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
