### PR TITLE
Fix Meteo france Ciel clair condition mapping

### DIFF
--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -40,7 +40,7 @@ ATTR_NEXT_RAIN_DT_REF = "forecast_time_ref"
 
 
 CONDITION_CLASSES: dict[str, list[str]] = {
-    ATTR_CONDITION_CLEAR_NIGHT: ["Nuit Claire", "Nuit claire"],
+    ATTR_CONDITION_CLEAR_NIGHT: ["Nuit Claire", "Nuit claire", "Ciel clair"],
     ATTR_CONDITION_CLOUDY: ["Très nuageux", "Couvert"],
     ATTR_CONDITION_FOG: [
         "Brume ou bancs de brouillard",
@@ -89,7 +89,7 @@ CONDITION_CLASSES: dict[str, list[str]] = {
         "Quelques flocons",
     ],
     ATTR_CONDITION_SNOWY_RAINY: ["Pluie et neige", "Pluie verglaçante"],
-    ATTR_CONDITION_SUNNY: ["Ensoleillé", "Ciel clair"],
+    ATTR_CONDITION_SUNNY: ["Ensoleillé"],
     ATTR_CONDITION_WINDY: [],
     ATTR_CONDITION_WINDY_VARIANT: [],
     ATTR_CONDITION_EXCEPTIONAL: [],

--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -40,7 +40,7 @@ ATTR_NEXT_RAIN_DT_REF = "forecast_time_ref"
 
 
 CONDITION_CLASSES: dict[str, list[str]] = {
-    ATTR_CONDITION_CLEAR_NIGHT: ["Nuit Claire", "Nuit claire", "Ciel clair"],
+    ATTR_CONDITION_CLEAR_NIGHT: ["Nuit Claire", "Nuit claire"],
     ATTR_CONDITION_CLOUDY: ["Très nuageux", "Couvert"],
     ATTR_CONDITION_FOG: [
         "Brume ou bancs de brouillard",
@@ -89,7 +89,7 @@ CONDITION_CLASSES: dict[str, list[str]] = {
         "Quelques flocons",
     ],
     ATTR_CONDITION_SNOWY_RAINY: ["Pluie et neige", "Pluie verglaçante"],
-    ATTR_CONDITION_SUNNY: ["Ensoleillé"],
+    ATTR_CONDITION_SUNNY: ["Ensoleillé", "Ciel clair"],
     ATTR_CONDITION_WINDY: [],
     ATTR_CONDITION_WINDY_VARIANT: [],
     ATTR_CONDITION_EXCEPTIONAL: [],

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -55,7 +55,7 @@ def format_condition(condition: str, force_day: bool = False) -> str:
     """Return condition from dict CONDITION_MAP."""
     mapped_condition = CONDITION_MAP.get(condition, condition)
     if force_day and mapped_condition == ATTR_CONDITION_CLEAR_NIGHT:
-        # Meteo-France can return clear condition instead of sunny for daily weather, so we map it to sunny
+        # Meteo-France can return clear night condition instead of sunny for daily weather, so we map it to sunny
         return ATTR_CONDITION_SUNNY
     return mapped_condition
 

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -6,6 +6,8 @@ import time
 from meteofrance_api.model.forecast import Forecast as MeteoFranceForecast
 
 from homeassistant.components.weather import (
+    ATTR_CONDITION_CLEAR_NIGHT,
+    ATTR_CONDITION_SUNNY,
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_HUMIDITY,
     ATTR_FORECAST_NATIVE_PRECIPITATION,
@@ -49,9 +51,12 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def format_condition(condition: str):
+def format_condition(condition: str, force_day: bool = False) -> str:
     """Return condition from dict CONDITION_MAP."""
-    return CONDITION_MAP.get(condition, condition)
+    mapped_condition = CONDITION_MAP.get(condition, condition)
+    if force_day and mapped_condition == ATTR_CONDITION_CLEAR_NIGHT:
+        return ATTR_CONDITION_SUNNY
+    return mapped_condition
 
 
 async def async_setup_entry(
@@ -212,7 +217,7 @@ class MeteoFranceWeather(
                             forecast["dt"]
                         ).isoformat(),
                         ATTR_FORECAST_CONDITION: format_condition(
-                            forecast["weather12H"]["desc"]
+                            forecast["weather12H"]["desc"], force_day=True
                         ),
                         ATTR_FORECAST_HUMIDITY: forecast["humidity"]["max"],
                         ATTR_FORECAST_NATIVE_TEMP: forecast["T"]["max"],

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -55,6 +55,7 @@ def format_condition(condition: str, force_day: bool = False) -> str:
     """Return condition from dict CONDITION_MAP."""
     mapped_condition = CONDITION_MAP.get(condition, condition)
     if force_day and mapped_condition == ATTR_CONDITION_CLEAR_NIGHT:
+        # Meteo-France can return clear condition instead of sunny for daily weather, so we map it to sunny
         return ATTR_CONDITION_SUNNY
     return mapped_condition
 


### PR DESCRIPTION
## Proposed change

"Ciel clair" was incorrectly mapped to "clear-night".

The change about "Ciel clair" was introduced in https://github.com/home-assistant/core/pull/143198. Feel free to comment about concerns. I introduced a boolean to force `sunny` instead of `clear-night` when requesting daily forecast.

### Before

![CleanShot 2025-06-16 at 18 49 37](https://github.com/user-attachments/assets/bb13ce3b-f113-444c-981e-c823552320b7)

### After

![CleanShot 2025-06-16 at 18 49 06](https://github.com/user-attachments/assets/63d53c19-46aa-44ec-b5eb-8ed513c3fca9)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
