### PR TITLE
Use non-autospec mock for Reolink's button tests

### DIFF
--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -62,6 +62,100 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         yield mock_setup_entry
 
 
+def _init_host_mock(host_mock: MagicMock) -> None:
+    host_mock.get_host_data = AsyncMock(return_value=None)
+    host_mock.get_states = AsyncMock(return_value=None)
+    host_mock.check_new_firmware = AsyncMock(return_value=False)
+    host_mock.unsubscribe = AsyncMock(return_value=True)
+    host_mock.logout = AsyncMock(return_value=True)
+    host_mock.reboot = AsyncMock()
+    host_mock.set_ptz_command = AsyncMock()
+    host_mock.is_nvr = True
+    host_mock.is_hub = False
+    host_mock.mac_address = TEST_MAC
+    host_mock.uid = TEST_UID
+    host_mock.onvif_enabled = True
+    host_mock.rtmp_enabled = True
+    host_mock.rtsp_enabled = True
+    host_mock.nvr_name = TEST_NVR_NAME
+    host_mock.port = TEST_PORT
+    host_mock.use_https = TEST_USE_HTTPS
+    host_mock.is_admin = True
+    host_mock.user_level = "admin"
+    host_mock.protocol = "rtsp"
+    host_mock.channels = [0]
+    host_mock.stream_channels = [0]
+    host_mock.new_devices = False
+    host_mock.sw_version_update_required = False
+    host_mock.hardware_version = "IPC_00000"
+    host_mock.sw_version = "v1.0.0.0.0.0000"
+    host_mock.sw_upload_progress.return_value = 100
+    host_mock.manufacturer = "Reolink"
+    host_mock.model = TEST_HOST_MODEL
+    host_mock.supported.return_value = True
+    host_mock.item_number.return_value = TEST_ITEM_NUMBER
+    host_mock.camera_model.return_value = TEST_CAM_MODEL
+    host_mock.camera_name.return_value = TEST_NVR_NAME
+    host_mock.camera_hardware_version.return_value = "IPC_00001"
+    host_mock.camera_sw_version.return_value = "v1.1.0.0.0.0000"
+    host_mock.camera_sw_version_update_required.return_value = False
+    host_mock.camera_uid.return_value = TEST_UID_CAM
+    host_mock.camera_online.return_value = True
+    host_mock.channel_for_uid.return_value = 0
+    host_mock.get_encoding.return_value = "h264"
+    host_mock.firmware_update_available.return_value = False
+    host_mock.session_active = True
+    host_mock.timeout = 60
+    host_mock.renewtimer.return_value = 600
+    host_mock.wifi_connection = False
+    host_mock.wifi_signal = None
+    host_mock.whiteled_mode_list.return_value = []
+    host_mock.zoom_range.return_value = {
+        "zoom": {"pos": {"min": 0, "max": 100}},
+        "focus": {"pos": {"min": 0, "max": 100}},
+    }
+    host_mock.capabilities = {"Host": ["RTSP"], "0": ["motion_detection"]}
+    host_mock.checked_api_versions = {"GetEvents": 1}
+    host_mock.abilities = {"abilityChn": [{"aiTrack": {"permit": 0, "ver": 0}}]}
+    host_mock.get_raw_host_data.return_value = (
+        "{'host':'TEST_RESPONSE','channel':'TEST_RESPONSE'}"
+    )
+
+    # enums
+    host_mock.whiteled_mode.return_value = 1
+    host_mock.whiteled_mode_list.return_value = ["off", "auto"]
+    host_mock.doorbell_led.return_value = "Off"
+    host_mock.doorbell_led_list.return_value = ["stayoff", "auto"]
+    host_mock.auto_track_method.return_value = 3
+    host_mock.daynight_state.return_value = "Black&White"
+    host_mock.hub_alarm_tone_id.return_value = 1
+    host_mock.hub_visitor_tone_id.return_value = 1
+    host_mock.recording_packing_time_list = ["30 Minutes", "60 Minutes"]
+    host_mock.recording_packing_time = "60 Minutes"
+
+    # Baichuan
+    host_mock.baichuan_only = False
+    # Disable tcp push by default for tests
+    host_mock.baichuan.port = TEST_BC_PORT
+    host_mock.baichuan.events_active = False
+    host_mock.baichuan.unsubscribe_events = AsyncMock()
+    host_mock.baichuan.check_subscribe_events = AsyncMock()
+    host_mock.baichuan.mac_address.return_value = TEST_MAC_CAM
+    host_mock.baichuan.privacy_mode.return_value = False
+    host_mock.baichuan.day_night_state.return_value = "day"
+    host_mock.baichuan.subscribe_events.side_effect = ReolinkError("Test error")
+    host_mock.baichuan.active_scene = "off"
+    host_mock.baichuan.scene_names = ["off", "home"]
+    host_mock.baichuan.abilities = {
+        0: {"chnID": 0, "aitype": 34615},
+        "Host": {"pushAlarm": 7},
+    }
+    host_mock.baichuan.smart_location_list.return_value = [0]
+    host_mock.baichuan.smart_ai_type_list.return_value = ["people"]
+    host_mock.baichuan.smart_ai_index.return_value = 1
+    host_mock.baichuan.smart_ai_name.return_value = "zone1"
+
+
 @pytest.fixture(scope="module")
 def reolink_connect_class() -> Generator[MagicMock]:
     """Mock reolink connection and return both the host_mock and host_mock_class."""
@@ -71,97 +165,8 @@ def reolink_connect_class() -> Generator[MagicMock]:
         ) as host_mock_class,
     ):
         host_mock = host_mock_class.return_value
-        host_mock.get_host_data.return_value = None
-        host_mock.get_states.return_value = None
-        host_mock.supported.return_value = True
-        host_mock.check_new_firmware.return_value = False
-        host_mock.unsubscribe.return_value = True
-        host_mock.logout.return_value = True
-        host_mock.is_nvr = True
-        host_mock.is_hub = False
-        host_mock.mac_address = TEST_MAC
-        host_mock.uid = TEST_UID
-        host_mock.onvif_enabled = True
-        host_mock.rtmp_enabled = True
-        host_mock.rtsp_enabled = True
-        host_mock.nvr_name = TEST_NVR_NAME
-        host_mock.port = TEST_PORT
-        host_mock.use_https = TEST_USE_HTTPS
-        host_mock.is_admin = True
-        host_mock.user_level = "admin"
-        host_mock.protocol = "rtsp"
-        host_mock.channels = [0]
-        host_mock.stream_channels = [0]
-        host_mock.new_devices = False
-        host_mock.sw_version_update_required = False
-        host_mock.hardware_version = "IPC_00000"
-        host_mock.sw_version = "v1.0.0.0.0.0000"
-        host_mock.sw_upload_progress.return_value = 100
-        host_mock.manufacturer = "Reolink"
-        host_mock.model = TEST_HOST_MODEL
-        host_mock.item_number.return_value = TEST_ITEM_NUMBER
-        host_mock.camera_model.return_value = TEST_CAM_MODEL
-        host_mock.camera_name.return_value = TEST_NVR_NAME
-        host_mock.camera_hardware_version.return_value = "IPC_00001"
-        host_mock.camera_sw_version.return_value = "v1.1.0.0.0.0000"
-        host_mock.camera_sw_version_update_required.return_value = False
-        host_mock.camera_uid.return_value = TEST_UID_CAM
-        host_mock.camera_online.return_value = True
-        host_mock.channel_for_uid.return_value = 0
-        host_mock.get_encoding.return_value = "h264"
-        host_mock.firmware_update_available.return_value = False
-        host_mock.session_active = True
-        host_mock.timeout = 60
-        host_mock.renewtimer.return_value = 600
-        host_mock.wifi_connection = False
-        host_mock.wifi_signal = None
-        host_mock.whiteled_mode_list.return_value = []
-        host_mock.zoom_range.return_value = {
-            "zoom": {"pos": {"min": 0, "max": 100}},
-            "focus": {"pos": {"min": 0, "max": 100}},
-        }
-        host_mock.capabilities = {"Host": ["RTSP"], "0": ["motion_detection"]}
-        host_mock.checked_api_versions = {"GetEvents": 1}
-        host_mock.abilities = {"abilityChn": [{"aiTrack": {"permit": 0, "ver": 0}}]}
-        host_mock.get_raw_host_data.return_value = (
-            "{'host':'TEST_RESPONSE','channel':'TEST_RESPONSE'}"
-        )
-
-        reolink_connect.chime_list = []
-
-        # enums
-        host_mock.whiteled_mode.return_value = 1
-        host_mock.whiteled_mode_list.return_value = ["off", "auto"]
-        host_mock.doorbell_led.return_value = "Off"
-        host_mock.doorbell_led_list.return_value = ["stayoff", "auto"]
-        host_mock.auto_track_method.return_value = 3
-        host_mock.daynight_state.return_value = "Black&White"
-        host_mock.hub_alarm_tone_id.return_value = 1
-        host_mock.hub_visitor_tone_id.return_value = 1
-        host_mock.recording_packing_time_list = ["30 Minutes", "60 Minutes"]
-        host_mock.recording_packing_time = "60 Minutes"
-
-        # Baichuan
         host_mock.baichuan = create_autospec(Baichuan)
-        host_mock.baichuan_only = False
-        # Disable tcp push by default for tests
-        host_mock.baichuan.port = TEST_BC_PORT
-        host_mock.baichuan.events_active = False
-        host_mock.baichuan.mac_address.return_value = TEST_MAC_CAM
-        host_mock.baichuan.privacy_mode.return_value = False
-        host_mock.baichuan.day_night_state.return_value = "day"
-        host_mock.baichuan.subscribe_events.side_effect = ReolinkError("Test error")
-        host_mock.baichuan.active_scene = "off"
-        host_mock.baichuan.scene_names = ["off", "home"]
-        host_mock.baichuan.abilities = {
-            0: {"chnID": 0, "aitype": 34615},
-            "Host": {"pushAlarm": 7},
-        }
-        host_mock.baichuan.smart_location_list.return_value = [0]
-        host_mock.baichuan.smart_ai_type_list.return_value = ["people"]
-        host_mock.baichuan.smart_ai_index.return_value = 1
-        host_mock.baichuan.smart_ai_name.return_value = "zone1"
-
+        _init_host_mock(host_mock)
         yield host_mock_class
 
 
@@ -171,6 +176,18 @@ def reolink_connect(
 ) -> Generator[MagicMock]:
     """Mock reolink connection."""
     return reolink_connect_class.return_value
+
+
+@pytest.fixture
+def reolink_host() -> Generator[MagicMock]:
+    """Mock reolink Host class."""
+    with patch(
+        "homeassistant.components.reolink.host.Host", autospec=False
+    ) as host_mock_class:
+        host_mock = host_mock_class.return_value
+        host_mock.baichuan = MagicMock()
+        _init_host_mock(host_mock)
+        yield host_mock
 
 
 @pytest.fixture

--- a/tests/components/reolink/test_button.py
+++ b/tests/components/reolink/test_button.py
@@ -48,8 +48,6 @@ async def test_button(
             blocking=True,
         )
 
-    reolink_host.set_ptz_command.reset_mock(side_effect=True)
-
 
 async def test_ptz_move_service(
     hass: HomeAssistant,
@@ -80,8 +78,6 @@ async def test_ptz_move_service(
             {ATTR_ENTITY_ID: entity_id, ATTR_SPEED: 5},
             blocking=True,
         )
-
-    reolink_host.set_ptz_command.reset_mock(side_effect=True)
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -114,5 +110,3 @@ async def test_host_button(
             {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
-
-    reolink_host.reboot.reset_mock(side_effect=True)

--- a/tests/components/reolink/test_button.py
+++ b/tests/components/reolink/test_button.py
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry
 async def test_button(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test button entity with ptz up."""
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.BUTTON]):
@@ -37,9 +37,9 @@ async def test_button(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    reolink_connect.set_ptz_command.assert_called_once()
+    reolink_host.set_ptz_command.assert_called_once()
 
-    reolink_connect.set_ptz_command.side_effect = ReolinkError("Test error")
+    reolink_host.set_ptz_command.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             BUTTON_DOMAIN,
@@ -48,13 +48,13 @@ async def test_button(
             blocking=True,
         )
 
-    reolink_connect.set_ptz_command.reset_mock(side_effect=True)
+    reolink_host.set_ptz_command.reset_mock(side_effect=True)
 
 
 async def test_ptz_move_service(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test ptz_move entity service using PTZ button entity."""
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.BUTTON]):
@@ -70,9 +70,9 @@ async def test_ptz_move_service(
         {ATTR_ENTITY_ID: entity_id, ATTR_SPEED: 5},
         blocking=True,
     )
-    reolink_connect.set_ptz_command.assert_called_with(0, command="Up", speed=5)
+    reolink_host.set_ptz_command.assert_called_with(0, command="Up", speed=5)
 
-    reolink_connect.set_ptz_command.side_effect = ReolinkError("Test error")
+    reolink_host.set_ptz_command.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             DOMAIN,
@@ -81,14 +81,14 @@ async def test_ptz_move_service(
             blocking=True,
         )
 
-    reolink_connect.set_ptz_command.reset_mock(side_effect=True)
+    reolink_host.set_ptz_command.reset_mock(side_effect=True)
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_host_button(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test host button entity with reboot."""
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.BUTTON]):
@@ -104,9 +104,9 @@ async def test_host_button(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    reolink_connect.reboot.assert_called_once()
+    reolink_host.reboot.assert_called_once()
 
-    reolink_connect.reboot.side_effect = ReolinkError("Test error")
+    reolink_host.reboot.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             BUTTON_DOMAIN,
@@ -115,4 +115,4 @@ async def test_host_button(
             blocking=True,
         )
 
-    reolink_connect.reboot.reset_mock(side_effect=True)
+    reolink_host.reboot.reset_mock(side_effect=True)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is an initial PR to completely drop autospec'ed mocks from Reolink.

The reason is that autospec made the tests too slow, so the fixture scope was changed to 'module' in https://github.com/home-assistant/core/pull/125215
Having the fixture scope as 'module' makes the test methods spill over each other, which makes them fragile and more complex since they have to clean up the mock's state.

I will update the remaining platform tests in followup PRs.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
