### PR TITLE
Deprecated hass.http.register_static_path now raises error

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -511,12 +511,14 @@ class HomeAssistantHTTP:
     ) -> None:
         """Register a folder or file to serve as a static path."""
         frame.report_usage(
-            "calls hass.http.register_static_path which is deprecated because "
-            "it does blocking I/O in the event loop, instead "
+            "calls hass.http.register_static_path which "
+            "does blocking I/O in the event loop, instead "
             "call `await hass.http.async_register_static_paths("
             f'[StaticPathConfig("{url_path}", "{path}", {cache_headers})])`',
             exclude_integrations={"http"},
-            core_behavior=frame.ReportBehavior.LOG,
+            core_behavior=frame.ReportBehavior.ERROR,
+            core_integration_behavior=frame.ReportBehavior.ERROR,
+            custom_integration_behavior=frame.ReportBehavior.ERROR,
             breaks_in_ha_version="2025.7",
         )
         configs = [StaticPathConfig(url_path, path, cache_headers)]

--- a/tests/components/http/test_cors.py
+++ b/tests/components/http/test_cors.py
@@ -16,6 +16,7 @@ from aiohttp.hdrs import (
 from aiohttp.test_utils import TestClient
 import pytest
 
+from homeassistant.components.http import StaticPathConfig
 from homeassistant.components.http.cors import setup_cors
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.http import KEY_ALLOW_CONFIGURED_CORS, HomeAssistantView
@@ -157,7 +158,9 @@ async def test_cors_on_static_files(
     assert await async_setup_component(
         hass, "frontend", {"http": {"cors_allowed_origins": ["http://www.example.com"]}}
     )
-    hass.http.register_static_path("/something", str(Path(__file__).parent))
+    await hass.http.async_register_static_paths(
+        [StaticPathConfig("/something", str(Path(__file__).parent))]
+    )
 
     client = await hass_client()
     resp = await client.options(

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -530,17 +530,14 @@ async def test_register_static_paths(
     """Test registering a static path with old api."""
     assert await async_setup_component(hass, "frontend", {})
     path = str(Path(__file__).parent)
-    hass.http.register_static_path("/something", path)
-    client = await hass_client()
-    resp = await client.get("/something/__init__.py")
-    assert resp.status == HTTPStatus.OK
 
-    assert (
+    match_error = (
         "Detected code that calls hass.http.register_static_path "
-        "which is deprecated because it does blocking I/O in the "
-        "event loop, instead call "
+        "which does blocking I/O in the event loop, instead call "
         "`await hass.http.async_register_static_paths"
-    ) in caplog.text
+    )
+    with pytest.raises(RuntimeError, match=match_error):
+        hass.http.register_static_path("/something", path)
 
 
 async def test_ssl_issue_if_no_urls_configured(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously deprecated use of `hass.http.register_static_path` will now raise an error. Use `await hass.http.async_register_static_path` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 