### PR TITLE
Make connected stations coordinator a dict in devolo Home Network

### DIFF
--- a/homeassistant/components/devolo_home_network/coordinator.py
+++ b/homeassistant/components/devolo_home_network/coordinator.py
@@ -207,7 +207,7 @@ class DevoloUptimeGetCoordinator(DevoloDataUpdateCoordinator[int]):
 
 
 class DevoloWifiConnectedStationsGetCoordinator(
-    DevoloDataUpdateCoordinator[list[ConnectedStationInfo]]
+    DevoloDataUpdateCoordinator[dict[str, ConnectedStationInfo]]
 ):
     """Class to manage fetching data from the WifiGuestAccessGet endpoint."""
 
@@ -230,10 +230,11 @@ class DevoloWifiConnectedStationsGetCoordinator(
         )
         self.update_method = self.async_get_wifi_connected_station
 
-    async def async_get_wifi_connected_station(self) -> list[ConnectedStationInfo]:
+    async def async_get_wifi_connected_station(self) -> dict[str, ConnectedStationInfo]:
         """Fetch data from API endpoint."""
         assert self.device.device
-        return await self.device.device.async_get_wifi_connected_station()
+        clients = await self.device.device.async_get_wifi_connected_station()
+        return {client.mac_address: client for client in clients}
 
 
 class DevoloWifiGuestAccessGetCoordinator(

--- a/homeassistant/components/devolo_home_network/device_tracker.py
+++ b/homeassistant/components/devolo_home_network/device_tracker.py
@@ -28,9 +28,9 @@ async def async_setup_entry(
 ) -> None:
     """Get all devices and sensors and setup them via config entry."""
     device = entry.runtime_data.device
-    coordinators: dict[str, DevoloDataUpdateCoordinator[list[ConnectedStationInfo]]] = (
-        entry.runtime_data.coordinators
-    )
+    coordinators: dict[
+        str, DevoloDataUpdateCoordinator[dict[str, ConnectedStationInfo]]
+    ] = entry.runtime_data.coordinators
     registry = er.async_get(hass)
     tracked = set()
 
@@ -38,16 +38,16 @@ async def async_setup_entry(
     def new_device_callback() -> None:
         """Add new devices if needed."""
         new_entities = []
-        for station in coordinators[CONNECTED_WIFI_CLIENTS].data:
-            if station.mac_address in tracked:
+        for mac_address in coordinators[CONNECTED_WIFI_CLIENTS].data:
+            if mac_address in tracked:
                 continue
 
             new_entities.append(
                 DevoloScannerEntity(
-                    coordinators[CONNECTED_WIFI_CLIENTS], device, station.mac_address
+                    coordinators[CONNECTED_WIFI_CLIENTS], device, mac_address
                 )
             )
-            tracked.add(station.mac_address)
+            tracked.add(mac_address)
         async_add_entities(new_entities)
 
     @callback
@@ -82,7 +82,7 @@ async def async_setup_entry(
 
 # The pylint disable is needed because of https://github.com/pylint-dev/pylint/issues/9138
 class DevoloScannerEntity(  # pylint: disable=hass-enforce-class-module
-    CoordinatorEntity[DevoloDataUpdateCoordinator[list[ConnectedStationInfo]]],
+    CoordinatorEntity[DevoloDataUpdateCoordinator[dict[str, ConnectedStationInfo]]],
     ScannerEntity,
 ):
     """Representation of a devolo device tracker."""
@@ -91,7 +91,7 @@ class DevoloScannerEntity(  # pylint: disable=hass-enforce-class-module
 
     def __init__(
         self,
-        coordinator: DevoloDataUpdateCoordinator[list[ConnectedStationInfo]],
+        coordinator: DevoloDataUpdateCoordinator[dict[str, ConnectedStationInfo]],
         device: Device,
         mac: str,
     ) -> None:
@@ -107,14 +107,8 @@ class DevoloScannerEntity(  # pylint: disable=hass-enforce-class-module
         if not self.coordinator.data:
             return {}
 
-        station = next(
-            (
-                station
-                for station in self.coordinator.data
-                if station.mac_address == self.mac_address
-            ),
-            None,
-        )
+        assert self.mac_address
+        station = self.coordinator.data.get(self.mac_address)
         if station:
             attrs["wifi"] = WIFI_APTYPE.get(station.vap_type, STATE_UNKNOWN)
             attrs["band"] = (
@@ -127,11 +121,8 @@ class DevoloScannerEntity(  # pylint: disable=hass-enforce-class-module
     @property
     def is_connected(self) -> bool:
         """Return true if the device is connected to the network."""
-        return any(
-            station
-            for station in self.coordinator.data
-            if station.mac_address == self.mac_address
-        )
+        assert self.mac_address
+        return self.coordinator.data.get(self.mac_address) is not None
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/devolo_home_network/entity.py
+++ b/homeassistant/components/devolo_home_network/entity.py
@@ -21,7 +21,7 @@ from .coordinator import DevoloDataUpdateCoordinator, DevoloHomeNetworkConfigEnt
 type _DataType = (
     LogicalNetwork
     | DataRate
-    | list[ConnectedStationInfo]
+    | dict[str, ConnectedStationInfo]
     | list[NeighborAPInfo]
     | WifiGuestAccessGet
     | bool

--- a/homeassistant/components/devolo_home_network/sensor.py
+++ b/homeassistant/components/devolo_home_network/sensor.py
@@ -87,7 +87,7 @@ SENSOR_TYPES: dict[str, DevoloSensorEntityDescription[Any, Any]] = {
     ](
         key=CONNECTED_WIFI_CLIENTS,
         state_class=SensorStateClass.MEASUREMENT,
-        value_func=lambda data: len(data.keys()),
+        value_func=len,
     ),
     NEIGHBORING_WIFI_NETWORKS: DevoloSensorEntityDescription[list[NeighborAPInfo], int](
         key=NEIGHBORING_WIFI_NETWORKS,

--- a/homeassistant/components/devolo_home_network/sensor.py
+++ b/homeassistant/components/devolo_home_network/sensor.py
@@ -47,7 +47,11 @@ def _last_restart(runtime: int) -> datetime:
 
 
 type _CoordinatorDataType = (
-    LogicalNetwork | DataRate | list[ConnectedStationInfo] | list[NeighborAPInfo] | int
+    LogicalNetwork
+    | DataRate
+    | dict[str, ConnectedStationInfo]
+    | list[NeighborAPInfo]
+    | int
 )
 type _SensorDataType = int | float | datetime
 
@@ -79,11 +83,11 @@ SENSOR_TYPES: dict[str, DevoloSensorEntityDescription[Any, Any]] = {
         ),
     ),
     CONNECTED_WIFI_CLIENTS: DevoloSensorEntityDescription[
-        list[ConnectedStationInfo], int
+        dict[str, ConnectedStationInfo], int
     ](
         key=CONNECTED_WIFI_CLIENTS,
         state_class=SensorStateClass.MEASUREMENT,
-        value_func=len,
+        value_func=lambda data: len(data.keys()),
     ),
     NEIGHBORING_WIFI_NETWORKS: DevoloSensorEntityDescription[list[NeighborAPInfo], int](
         key=NEIGHBORING_WIFI_NETWORKS,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Having the DevoloWifiConnectedStationsGetCoordinator returning a dict instead of a list seems to make the usage easier because I can use a lookup instead of iterating over the list.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
