### PR TITLE
Cleanup devolo Home Control tests

### DIFF
--- a/tests/components/devolo_home_control/test_binary_sensor.py
+++ b/tests/components/devolo_home_control/test_binary_sensor.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import patch
 
-import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -19,7 +18,6 @@ from .mocks import (
 )
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_binary_sensor(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
 ) -> None:
@@ -58,7 +56,6 @@ async def test_binary_sensor(
     )
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_remote_control(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
 ) -> None:
@@ -99,7 +96,6 @@ async def test_remote_control(
     )
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_disabled(hass: HomeAssistant) -> None:
     """Test setup of a disabled device."""
     entry = configure_integration(hass)
@@ -113,7 +109,6 @@ async def test_disabled(hass: HomeAssistant) -> None:
     assert hass.states.get(f"{BINARY_SENSOR_DOMAIN}.test_door") is None
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_remove_from_hass(hass: HomeAssistant) -> None:
     """Test removing entity."""
     entry = configure_integration(hass)

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -66,44 +66,6 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
         assert result["reason"] == "already_configured"
 
 
-async def test_form_advanced_options(hass: HomeAssistant) -> None:
-    """Test if we get the advanced options if user has enabled it."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {}
-
-    with (
-        patch(
-            "homeassistant.components.devolo_home_control.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
-        patch(
-            "homeassistant.components.devolo_home_control.Mydevolo.uuid",
-            return_value="123456",
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "devolo Home Control"
-    assert result2["data"] == {
-        "username": "test-username",
-        "password": "test-password",
-    }
-
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
 async def test_form_zeroconf(hass: HomeAssistant) -> None:
     """Test that the zeroconf confirmation form is served."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/devolo_home_control/test_diagnostics.py
+++ b/tests/components/devolo_home_control/test_diagnostics.py
@@ -1,7 +1,5 @@
 """Tests for the devolo Home Control diagnostics."""
 
-from __future__ import annotations
-
 from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion

--- a/tests/components/devolo_home_control/test_init.py
+++ b/tests/components/devolo_home_control/test_init.py
@@ -19,7 +19,6 @@ from .mocks import HomeControlMock, HomeControlMockBinarySensor
 from tests.typing import WebSocketGenerator
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test setup entry."""
     entry = configure_integration(hass)
@@ -44,7 +43,6 @@ async def test_setup_entry_maintenance(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_setup_gateway_offline(hass: HomeAssistant) -> None:
     """Test setup entry fails on gateway offline."""
     entry = configure_integration(hass)

--- a/tests/components/devolo_home_control/test_siren.py
+++ b/tests/components/devolo_home_control/test_siren.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import patch
 
-import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.siren import DOMAIN as SIREN_DOMAIN
@@ -14,7 +13,6 @@ from . import configure_integration
 from .mocks import HomeControlMock, HomeControlMockSiren
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_siren(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
 ) -> None:
@@ -45,7 +43,6 @@ async def test_siren(
     assert hass.states.get(f"{SIREN_DOMAIN}.test").state == STATE_UNAVAILABLE
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_siren_switching(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
 ) -> None:
@@ -98,7 +95,6 @@ async def test_siren_switching(
         property_set.assert_called_once_with(0)
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_siren_change_default_tone(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
 ) -> None:
@@ -130,7 +126,6 @@ async def test_siren_change_default_tone(
         property_set.assert_called_once_with(2)
 
 
-@pytest.mark.usefixtures("mock_zeroconf")
 async def test_remove_from_hass(hass: HomeAssistant) -> None:
     """Test removing entity."""
     entry = configure_integration(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Three small cleanup in the devolo Home Control tests:

1. Remove a test that was actually obsolete since https://github.com/home-assistant/core/pull/132821
2. Remove explicit use of the mock_zeroconf fixture as there is an auto-used devolo_home_control_mock_async_zeroconf fixure
3. Remove unused imports

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
