### PR TITLE
Remove internals from Sonos test_init.py

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -400,17 +400,72 @@ class SonosDiscoveryManager:
     ) -> None:
         """Add and maintain Sonos devices from a manual configuration."""
 
-        try:
-            # Loop through each configured host and verify that Soco attributes are available for it.
-            for host in self.hosts.copy():
-                ip_addr = await self.hass.async_add_executor_job(
-                    socket.gethostbyname, host
+        # Loop through each configured host and verify that Soco attributes are available for it.
+        for host in self.hosts.copy():
+            ip_addr = await self.hass.async_add_executor_job(socket.gethostbyname, host)
+            soco = SoCo(ip_addr)
+            try:
+                visible_zones = await self.hass.async_add_executor_job(
+                    sync_get_visible_zones,
+                    soco,
                 )
-                soco = SoCo(ip_addr)
+            except (
+                OSError,
+                SoCoException,
+                Timeout,
+                TimeoutError,
+            ) as ex:
+                if not self.hosts_in_error.get(ip_addr):
+                    _LOGGER.warning(
+                        "Could not get visible Sonos devices from %s: %s",
+                        ip_addr,
+                        ex,
+                    )
+                    self.hosts_in_error[ip_addr] = True
+                else:
+                    _LOGGER.debug(
+                        "Could not get visible Sonos devices from %s: %s",
+                        ip_addr,
+                        ex,
+                    )
+                continue
+
+            if self.hosts_in_error.pop(ip_addr, None):
+                _LOGGER.warning("Connection reestablished to Sonos device %s", ip_addr)
+            # Each speaker has the topology for other online speakers, so add them in here if they were not
+            # configured. The metadata is already in Soco for these.
+            if new_hosts := {
+                x.ip_address for x in visible_zones if x.ip_address not in self.hosts
+            }:
+                _LOGGER.debug("Adding to manual hosts: %s", new_hosts)
+                self.hosts.update(new_hosts)
+
+            if self.is_device_invisible(ip_addr):
+                _LOGGER.debug("Discarding %s from manual hosts", ip_addr)
+                self.hosts.discard(ip_addr)
+
+        # Loop through each configured host that is not in error.  Send a discovery message
+        # if a speaker does not already exist, or ping the speaker if it is unavailable.
+        for host in self.hosts.copy():
+            ip_addr = await self.hass.async_add_executor_job(socket.gethostbyname, host)
+            soco = SoCo(ip_addr)
+            # Skip hosts that are in error to avoid blocking call on soco.uuid in event loop
+            if self.hosts_in_error.get(ip_addr):
+                continue
+            known_speaker = next(
+                (
+                    speaker
+                    for speaker in self.data.discovered.values()
+                    if speaker.soco.ip_address == ip_addr
+                ),
+                None,
+            )
+            if not known_speaker:
                 try:
-                    visible_zones = await self.hass.async_add_executor_job(
-                        sync_get_visible_zones,
-                        soco,
+                    await self._async_handle_discovery_message(
+                        soco.uid,
+                        ip_addr,
+                        "manual zone scan",
                     )
                 except (
                     OSError,
@@ -418,92 +473,25 @@ class SonosDiscoveryManager:
                     Timeout,
                     TimeoutError,
                 ) as ex:
-                    if not self.hosts_in_error.get(ip_addr):
-                        _LOGGER.warning(
-                            "Could not get visible Sonos devices from %s: %s",
-                            ip_addr,
-                            ex,
-                        )
-                        self.hosts_in_error[ip_addr] = True
-                    else:
-                        _LOGGER.debug(
-                            "Could not get visible Sonos devices from %s: %s",
-                            ip_addr,
-                            ex,
-                        )
-                    continue
-
-                if self.hosts_in_error.pop(ip_addr, None):
-                    _LOGGER.warning(
-                        "Connection reestablished to Sonos device %s", ip_addr
+                    _LOGGER.warning("Discovery message failed to %s : %s", ip_addr, ex)
+            elif not known_speaker.available:
+                try:
+                    await self.hass.async_add_executor_job(known_speaker.ping)
+                    # Only send the message if the ping was successful.
+                    async_dispatcher_send(
+                        self.hass,
+                        f"{SONOS_SPEAKER_ACTIVITY}-{soco.uid}",
+                        "manual zone scan",
                     )
-                # Each speaker has the topology for other online speakers, so add them in here if they were not
-                # configured. The metadata is already in Soco for these.
-                if new_hosts := {
-                    x.ip_address
-                    for x in visible_zones
-                    if x.ip_address not in self.hosts
-                }:
-                    _LOGGER.debug("Adding to manual hosts: %s", new_hosts)
-                    self.hosts.update(new_hosts)
-
-                if self.is_device_invisible(ip_addr):
-                    _LOGGER.debug("Discarding %s from manual hosts", ip_addr)
-                    self.hosts.discard(ip_addr)
-
-            # Loop through each configured host that is not in error.  Send a discovery message
-            # if a speaker does not already exist, or ping the speaker if it is unavailable.
-            for host in self.hosts.copy():
-                ip_addr = await self.hass.async_add_executor_job(
-                    socket.gethostbyname, host
-                )
-                soco = SoCo(ip_addr)
-                # Skip hosts that are in error to avoid blocking call on soco.uuid in event loop
-                if self.hosts_in_error.get(ip_addr):
-                    continue
-                known_speaker = next(
-                    (
-                        speaker
-                        for speaker in self.data.discovered.values()
-                        if speaker.soco.ip_address == ip_addr
-                    ),
-                    None,
-                )
-                if not known_speaker:
-                    try:
-                        await self._async_handle_discovery_message(
-                            soco.uid,
-                            ip_addr,
-                            "manual zone scan",
-                        )
-                    except (
-                        OSError,
-                        SoCoException,
-                        Timeout,
-                        TimeoutError,
-                    ) as ex:
-                        _LOGGER.warning(
-                            "Discovery message failed to %s : %s", ip_addr, ex
-                        )
-                elif not known_speaker.available:
-                    try:
-                        await self.hass.async_add_executor_job(known_speaker.ping)
-                        # Only send the message if the ping was successful.
-                        async_dispatcher_send(
-                            self.hass,
-                            f"{SONOS_SPEAKER_ACTIVITY}-{soco.uid}",
-                            "manual zone scan",
-                        )
-                    except SonosUpdateError:
-                        _LOGGER.debug(
-                            "Manual poll to %s failed, keeping unavailable", ip_addr
-                        )
-        finally:
-            self.data.hosts_heartbeat = async_call_later(
-                self.hass,
-                DISCOVERY_INTERVAL.total_seconds(),
-                self.async_poll_manual_hosts,
-            )
+                except SonosUpdateError:
+                    _LOGGER.debug(
+                        "Manual poll to %s failed, keeping unavailable", ip_addr
+                    )
+        self.data.hosts_heartbeat = async_call_later(
+            self.hass,
+            DISCOVERY_INTERVAL.total_seconds(),
+            self.async_poll_manual_hosts,
+        )
 
     async def _async_handle_discovery_message(
         self,

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -483,6 +483,7 @@ class SonosDiscoveryManager:
                     _LOGGER.debug(
                         "Manual poll to %s failed, keeping unavailable", ip_addr
                     )
+
         self.data.hosts_heartbeat = async_call_later(
             self.hass, DISCOVERY_INTERVAL.total_seconds(), self.async_poll_manual_hosts
         )

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -400,68 +400,17 @@ class SonosDiscoveryManager:
     ) -> None:
         """Add and maintain Sonos devices from a manual configuration."""
 
-        # Loop through each configured host and verify that Soco attributes are available for it.
-        for host in self.hosts.copy():
-            ip_addr = await self.hass.async_add_executor_job(socket.gethostbyname, host)
-            soco = SoCo(ip_addr)
-            try:
-                visible_zones = await self.hass.async_add_executor_job(
-                    sync_get_visible_zones,
-                    soco,
+        try:
+            # Loop through each configured host and verify that Soco attributes are available for it.
+            for host in self.hosts.copy():
+                ip_addr = await self.hass.async_add_executor_job(
+                    socket.gethostbyname, host
                 )
-            except (
-                OSError,
-                SoCoException,
-                Timeout,
-                TimeoutError,
-            ) as ex:
-                if not self.hosts_in_error.get(ip_addr):
-                    _LOGGER.warning(
-                        "Could not get visible Sonos devices from %s: %s", ip_addr, ex
-                    )
-                    self.hosts_in_error[ip_addr] = True
-                else:
-                    _LOGGER.debug(
-                        "Could not get visible Sonos devices from %s: %s", ip_addr, ex
-                    )
-                continue
-
-            if self.hosts_in_error.pop(ip_addr, None):
-                _LOGGER.warning("Connection reestablished to Sonos device %s", ip_addr)
-            # Each speaker has the topology for other online speakers, so add them in here if they were not
-            # configured. The metadata is already in Soco for these.
-            if new_hosts := {
-                x.ip_address for x in visible_zones if x.ip_address not in self.hosts
-            }:
-                _LOGGER.debug("Adding to manual hosts: %s", new_hosts)
-                self.hosts.update(new_hosts)
-
-            if self.is_device_invisible(ip_addr):
-                _LOGGER.debug("Discarding %s from manual hosts", ip_addr)
-                self.hosts.discard(ip_addr)
-
-        # Loop through each configured host that is not in error.  Send a discovery message
-        # if a speaker does not already exist, or ping the speaker if it is unavailable.
-        for host in self.hosts.copy():
-            ip_addr = await self.hass.async_add_executor_job(socket.gethostbyname, host)
-            soco = SoCo(ip_addr)
-            # Skip hosts that are in error to avoid blocking call on soco.uuid in event loop
-            if self.hosts_in_error.get(ip_addr):
-                continue
-            known_speaker = next(
-                (
-                    speaker
-                    for speaker in self.data.discovered.values()
-                    if speaker.soco.ip_address == ip_addr
-                ),
-                None,
-            )
-            if not known_speaker:
+                soco = SoCo(ip_addr)
                 try:
-                    await self._async_handle_discovery_message(
-                        soco.uid,
-                        ip_addr,
-                        "manual zone scan",
+                    visible_zones = await self.hass.async_add_executor_job(
+                        sync_get_visible_zones,
+                        soco,
                     )
                 except (
                     OSError,
@@ -469,24 +418,92 @@ class SonosDiscoveryManager:
                     Timeout,
                     TimeoutError,
                 ) as ex:
-                    _LOGGER.warning("Discovery message failed to %s : %s", ip_addr, ex)
-            elif not known_speaker.available:
-                try:
-                    await self.hass.async_add_executor_job(known_speaker.ping)
-                    # Only send the message if the ping was successful.
-                    async_dispatcher_send(
-                        self.hass,
-                        f"{SONOS_SPEAKER_ACTIVITY}-{soco.uid}",
-                        "manual zone scan",
-                    )
-                except SonosUpdateError:
-                    _LOGGER.debug(
-                        "Manual poll to %s failed, keeping unavailable", ip_addr
-                    )
+                    if not self.hosts_in_error.get(ip_addr):
+                        _LOGGER.warning(
+                            "Could not get visible Sonos devices from %s: %s",
+                            ip_addr,
+                            ex,
+                        )
+                        self.hosts_in_error[ip_addr] = True
+                    else:
+                        _LOGGER.debug(
+                            "Could not get visible Sonos devices from %s: %s",
+                            ip_addr,
+                            ex,
+                        )
+                    continue
 
-        self.data.hosts_heartbeat = async_call_later(
-            self.hass, DISCOVERY_INTERVAL.total_seconds(), self.async_poll_manual_hosts
-        )
+                if self.hosts_in_error.pop(ip_addr, None):
+                    _LOGGER.warning(
+                        "Connection reestablished to Sonos device %s", ip_addr
+                    )
+                # Each speaker has the topology for other online speakers, so add them in here if they were not
+                # configured. The metadata is already in Soco for these.
+                if new_hosts := {
+                    x.ip_address
+                    for x in visible_zones
+                    if x.ip_address not in self.hosts
+                }:
+                    _LOGGER.debug("Adding to manual hosts: %s", new_hosts)
+                    self.hosts.update(new_hosts)
+
+                if self.is_device_invisible(ip_addr):
+                    _LOGGER.debug("Discarding %s from manual hosts", ip_addr)
+                    self.hosts.discard(ip_addr)
+
+            # Loop through each configured host that is not in error.  Send a discovery message
+            # if a speaker does not already exist, or ping the speaker if it is unavailable.
+            for host in self.hosts.copy():
+                ip_addr = await self.hass.async_add_executor_job(
+                    socket.gethostbyname, host
+                )
+                soco = SoCo(ip_addr)
+                # Skip hosts that are in error to avoid blocking call on soco.uuid in event loop
+                if self.hosts_in_error.get(ip_addr):
+                    continue
+                known_speaker = next(
+                    (
+                        speaker
+                        for speaker in self.data.discovered.values()
+                        if speaker.soco.ip_address == ip_addr
+                    ),
+                    None,
+                )
+                if not known_speaker:
+                    try:
+                        await self._async_handle_discovery_message(
+                            soco.uid,
+                            ip_addr,
+                            "manual zone scan",
+                        )
+                    except (
+                        OSError,
+                        SoCoException,
+                        Timeout,
+                        TimeoutError,
+                    ) as ex:
+                        _LOGGER.warning(
+                            "Discovery message failed to %s : %s", ip_addr, ex
+                        )
+                elif not known_speaker.available:
+                    try:
+                        await self.hass.async_add_executor_job(known_speaker.ping)
+                        # Only send the message if the ping was successful.
+                        async_dispatcher_send(
+                            self.hass,
+                            f"{SONOS_SPEAKER_ACTIVITY}-{soco.uid}",
+                            "manual zone scan",
+                        )
+                    except SonosUpdateError:
+                        _LOGGER.debug(
+                            "Manual poll to %s failed, keeping unavailable", ip_addr
+                        )
+        finally:
+            self.data.hosts_heartbeat = async_call_later(
+                self.hass,
+                DISCOVERY_INTERVAL.total_seconds(),
+                self.async_poll_manual_hosts,
+            )
 
     async def _async_handle_discovery_message(
         self,

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -417,16 +417,12 @@ class SonosDiscoveryManager:
             ) as ex:
                 if not self.hosts_in_error.get(ip_addr):
                     _LOGGER.warning(
-                        "Could not get visible Sonos devices from %s: %s",
-                        ip_addr,
-                        ex,
+                        "Could not get visible Sonos devices from %s: %s", ip_addr, ex
                     )
                     self.hosts_in_error[ip_addr] = True
                 else:
                     _LOGGER.debug(
-                        "Could not get visible Sonos devices from %s: %s",
-                        ip_addr,
-                        ex,
+                        "Could not get visible Sonos devices from %s: %s", ip_addr, ex
                     )
                 continue
 

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -484,9 +484,7 @@ class SonosDiscoveryManager:
                         "Manual poll to %s failed, keeping unavailable", ip_addr
                     )
         self.data.hosts_heartbeat = async_call_later(
-            self.hass,
-            DISCOVERY_INTERVAL.total_seconds(),
-            self.async_poll_manual_hosts,
+            self.hass, DISCOVERY_INTERVAL.total_seconds(), self.async_poll_manual_hosts
         )
 
     async def _async_handle_discovery_message(

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -85,6 +85,15 @@ class SonosMockService:
         self.subscribe = AsyncMock(return_value=SonosMockSubscribe(ip_address))
 
 
+class SonosMockRenderingService(SonosMockService):
+    """Mock rendering service."""
+
+    def __init__(self, return_value: dict[str, str], ip_address="192.168.42.2") -> None:
+        """Initialize the instance."""
+        super().__init__("RenderingControl", ip_address)
+        self.GetVolume = Mock(return_value=30)
+
+
 class SonosMockAlarmClock(SonosMockService):
     """Mock a Sonos AlarmClock Service used in callbacks."""
 
@@ -239,7 +248,7 @@ class SoCoMockFactory:
         mock_soco.avTransport.GetPositionInfo = Mock(
             return_value=self.current_track_info
         )
-        mock_soco.renderingControl = SonosMockService("RenderingControl", ip_address)
+        mock_soco.renderingControl = SonosMockRenderingService(ip_address)
         mock_soco.zoneGroupTopology = SonosMockService("ZoneGroupTopology", ip_address)
         mock_soco.contentDirectory = SonosMockService("ContentDirectory", ip_address)
         mock_soco.deviceProperties = SonosMockService("DeviceProperties", ip_address)

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -105,16 +105,11 @@ async def test_async_poll_manual_hosts_warnings(
         mock_visible_zones.side_effect = OSError()
         caplog.clear()
         await _setup_hass(hass)
-        record = next(
-            (
-                rec
-                for rec in caplog.records
-                if "Could not get visible Sonos devices from" in rec.message
-            ),
-            None,
-        )
-        assert record is not None
-        assert record.levelname == "WARNING"
+        assert [
+            rec.levelname
+            for rec in caplog.records
+            if "Could not get visible Sonos devices from" in rec.message
+        ] == ["WARNING"]
 
         # Second call fails again, it should be logged as a DEBUG message
         mock_visible_zones.side_effect = OSError()
@@ -122,16 +117,11 @@ async def test_async_poll_manual_hosts_warnings(
         freezer.tick(DISCOVERY_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
-        record = next(
-            (
-                rec
-                for rec in caplog.records
-                if "Could not get visible Sonos devices from" in rec.message
-            ),
-            None,
-        )
-        assert record is not None
-        assert record.levelname == "DEBUG"
+        assert [
+            rec.levelname
+            for rec in caplog.records
+            if "Could not get visible Sonos devices from" in rec.message
+        ] == ["DEBUG"]
 
         # Third call succeeds, logs message indicating reconnect
         mock_visible_zones.return_value = {soco}
@@ -140,16 +130,11 @@ async def test_async_poll_manual_hosts_warnings(
         freezer.tick(DISCOVERY_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
-        record = next(
-            (
-                rec
-                for rec in caplog.records
-                if "Connection reestablished to Sonos device" in rec.message
-            ),
-            None,
-        )
-        assert record is not None
-        assert record.levelname == "WARNING"
+        assert [
+            rec.levelname
+            for rec in caplog.records
+            if "Connection reestablished to Sonos device" in rec.message
+        ] == ["WARNING"]
 
         # Fourth call succeeds, it should log nothing
         caplog.clear()
@@ -164,16 +149,11 @@ async def test_async_poll_manual_hosts_warnings(
         freezer.tick(DISCOVERY_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
-        record = next(
-            (
-                rec
-                for rec in caplog.records
-                if "Could not get visible Sonos devices from" in rec.message
-            ),
-            None,
-        )
-        assert record is not None
-        assert record.levelname == "WARNING"
+        assert [
+            rec.levelname
+            for rec in caplog.records
+            if "Could not get visible Sonos devices from" in rec.message
+        ] == ["WARNING"]
 
 
 class _MockSoCoOsError(MockSoCo):

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -3,15 +3,15 @@
 import asyncio
 from datetime import timedelta
 import logging
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import sonos
-from homeassistant.components.sonos import SonosDiscoveryManager
 from homeassistant.components.sonos.const import (
-    DATA_SONOS_DISCOVERY_MANAGER,
+    DISCOVERY_INTERVAL,
     SONOS_SPEAKER_ACTIVITY,
 )
 from homeassistant.components.sonos.exception import SonosUpdateError
@@ -87,76 +87,93 @@ async def test_not_configuring_sonos_not_creates_entry(hass: HomeAssistant) -> N
 
 
 async def test_async_poll_manual_hosts_warnings(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    soco_factory: SoCoMockFactory,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that host warnings are not logged repeatedly."""
-    await async_setup_component(
-        hass,
-        sonos.DOMAIN,
-        {"sonos": {"media_player": {"interface_addr": "127.0.0.1"}}},
-    )
-    await hass.async_block_till_done()
-    manager: SonosDiscoveryManager = hass.data[DATA_SONOS_DISCOVERY_MANAGER]
-    manager.hosts.add("10.10.10.10")
+
+    soco = soco_factory.cache_mock(MockSoCo(), "10.10.10.1", "Bedroom")
     with (
         caplog.at_level(logging.DEBUG),
-        patch.object(manager, "_async_handle_discovery_message"),
-        patch(
-            "homeassistant.components.sonos.async_call_later"
-        ) as mock_async_call_later,
-        patch("homeassistant.components.sonos.async_dispatcher_send"),
-        patch(
-            "homeassistant.components.sonos.sync_get_visible_zones",
-            side_effect=[
-                OSError(),
-                OSError(),
-                [],
-                [],
-                OSError(),
-            ],
-        ),
+        patch.object(
+            type(soco), "visible_zones", new_callable=PropertyMock
+        ) as mock_visible_zones,
     ):
         # First call fails, it should be logged as a WARNING message
+        mock_visible_zones.side_effect = OSError()
         caplog.clear()
-        await manager.async_poll_manual_hosts()
-        assert len(caplog.messages) == 1
-        record = caplog.records[0]
+        await _setup_hass(hass)
+        record = next(
+            (
+                rec
+                for rec in caplog.records
+                if "Could not get visible Sonos devices from" in rec.message
+            ),
+            None,
+        )
+        assert record is not None
         assert record.levelname == "WARNING"
-        assert "Could not get visible Sonos devices from" in record.message
-        assert mock_async_call_later.call_count == 1
 
         # Second call fails again, it should be logged as a DEBUG message
+        mock_visible_zones.side_effect = OSError()
         caplog.clear()
-        await manager.async_poll_manual_hosts()
-        assert len(caplog.messages) == 1
-        record = caplog.records[0]
+        freezer.tick(DISCOVERY_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        record = next(
+            (
+                rec
+                for rec in caplog.records
+                if "Could not get visible Sonos devices from" in rec.message
+            ),
+            None,
+        )
+        assert record is not None
         assert record.levelname == "DEBUG"
-        assert "Could not get visible Sonos devices from" in record.message
-        assert mock_async_call_later.call_count == 2
 
-        # Third call succeeds, it should log an info message
+        # Third call succeeds, logs message indicating reconnect
+        mock_visible_zones.return_value = {soco}
+        mock_visible_zones.side_effect = None
         caplog.clear()
-        await manager.async_poll_manual_hosts()
-        assert len(caplog.messages) == 1
-        record = caplog.records[0]
+        freezer.tick(DISCOVERY_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        record = next(
+            (
+                rec
+                for rec in caplog.records
+                if "Connection reestablished to Sonos device" in rec.message
+            ),
+            None,
+        )
+        assert record is not None
         assert record.levelname == "WARNING"
-        assert "Connection reestablished to Sonos device" in record.message
-        assert mock_async_call_later.call_count == 3
 
-        # Fourth call succeeds again, no need to log
+        # Fourth call succeeds, it should log nothing
         caplog.clear()
-        await manager.async_poll_manual_hosts()
-        assert len(caplog.messages) == 0
-        assert mock_async_call_later.call_count == 4
+        freezer.tick(DISCOVERY_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert "Connection reestablished to Sonos device" not in caplog.text
 
-        # Fifth call fail again again, should be logged as a WARNING message
+        # Fifth call fails again again, should be logged as a WARNING message
+        mock_visible_zones.side_effect = OSError()
         caplog.clear()
-        await manager.async_poll_manual_hosts()
-        assert len(caplog.messages) == 1
-        record = caplog.records[0]
+        freezer.tick(DISCOVERY_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        record = next(
+            (
+                rec
+                for rec in caplog.records
+                if "Could not get visible Sonos devices from" in rec.message
+            ),
+            None,
+        )
+        assert record is not None
         assert record.levelname == "WARNING"
-        assert "Could not get visible Sonos devices from" in record.message
-        assert mock_async_call_later.call_count == 5
 
 
 class _MockSoCoOsError(MockSoCo):


### PR DESCRIPTION
## Proposed change
Refactor the test to remove patching of integration and hass internals. Add additional mock that is needed.

test_async_poll_manual_hosts_warnings

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
