### PR TITLE
Allow finding relevant blueprints

### DIFF
--- a/homeassistant/components/blueprint/__init__.py
+++ b/homeassistant/components/blueprint/__init__.py
@@ -1,7 +1,13 @@
 """The blueprint integration."""
 
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_NAME, CONF_SELECTOR
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.selector import selector as create_selector
 from homeassistant.helpers.typing import ConfigType
 
 from . import websocket_api
@@ -29,3 +35,57 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the blueprint integration."""
     websocket_api.async_setup(hass)
     return True
+
+
+async def async_find_relevant_blueprints(
+    hass: HomeAssistant, device_id: str
+) -> dict[str, list[dict[str, Any]]]:
+    """Find all blueprints relevant to a specific device."""
+    results = {}
+    entities = er.async_entries_for_device(er.async_get(hass), device_id)
+
+    async def all_blueprints_generator(hass: HomeAssistant):
+        """Yield all blueprints from all domains."""
+        blueprint_domains: dict[str, DomainBlueprints] = hass.data[DOMAIN]
+        for blueprint_domain in blueprint_domains.values():
+            blueprints = await blueprint_domain.async_get_blueprints()
+            for blueprint in blueprints.values():
+                yield blueprint
+
+    async for blueprint in all_blueprints_generator(hass):
+        blueprint_input_matches: dict[str, list[str]] = {}
+
+        for info in blueprint.inputs.values():
+            if (
+                not info
+                or not (selector_conf := info.get(CONF_SELECTOR))
+                or "entity" not in selector_conf
+            ):
+                continue
+
+            selector = create_selector(selector_conf)
+
+            matched = []
+
+            for entity in entities:
+                try:
+                    entity.entity_id, selector(entity.entity_id)
+                except vol.Invalid:
+                    continue
+
+                matched.append(entity.entity_id)
+
+            if matched:
+                blueprint_input_matches[info[CONF_NAME]] = matched
+
+        if not blueprint_input_matches:
+            continue
+
+        results.setdefault(blueprint.domain, []).append(
+            {
+                "blueprint": blueprint,
+                "matched_input": blueprint_input_matches,
+            }
+        )
+
+    return results

--- a/homeassistant/components/blueprint/__init__.py
+++ b/homeassistant/components/blueprint/__init__.py
@@ -42,7 +42,11 @@ async def async_find_relevant_blueprints(
 ) -> dict[str, list[dict[str, Any]]]:
     """Find all blueprints relevant to a specific device."""
     results = {}
-    entities = er.async_entries_for_device(er.async_get(hass), device_id)
+    entities = [
+        entry
+        for entry in er.async_entries_for_device(er.async_get(hass), device_id)
+        if not entry.entity_category
+    ]
 
     async def all_blueprints_generator(hass: HomeAssistant):
         """Yield all blueprints from all domains."""

--- a/tests/components/blueprint/test_init.py
+++ b/tests/components/blueprint/test_init.py
@@ -1,1 +1,58 @@
 """Tests for the blueprint init."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from homeassistant.components import automation, blueprint
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_find_relevant_blueprints(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test finding relevant blueprints."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test_domain", "test_device")},
+        name="Test Device",
+    )
+    entity_registry.async_get_or_create(
+        "person",
+        "test_domain",
+        "test_entity",
+        device_id=device.id,
+        original_name="Test Person",
+    )
+
+    with patch.object(
+        hass.config,
+        "path",
+        return_value=Path(automation.__file__).parent / "blueprints",
+    ):
+        automation.async_get_blueprints(hass)
+        results = await blueprint.async_find_relevant_blueprints(hass, device.id)
+
+    for matches in results.values():
+        for match in matches:
+            match["blueprint"] = match["blueprint"].name
+
+    assert results == {
+        "automation": [
+            {
+                "blueprint": "Motion-activated Light",
+                "matched_input": {
+                    "Person": [
+                        "person.test_domain_test_entity",
+                    ]
+                },
+            }
+        ]
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Had a meeting today and we came up with a good idea about how to suggest blueprints to users on the device page. Decided to do a quick draft. 

In the end, I couldn't get it fully working (even if it would have been slow), because selectors are not being fully validated locally.

The idea however is as follows:

We are going to add a blueprint websocket API to allow the frontend to query which blueprints match any entities provided by the device. That data is returned to the frontend.

Now in the frontend, we will be able to start suggesting blueprints based on if a device can work with them. We can already pre-fill entities that match even.

We could bundle a blueprint about notification if garage door left open, and it would automatically show up as suggestion for every garage door.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
