### PR TITLE
Use PEP 695 TypeVar syntax for ecovacs

### DIFF
--- a/homeassistant/components/ecovacs/binary_sensor.py
+++ b/homeassistant/components/ecovacs/binary_sensor.py
@@ -2,9 +2,9 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Generic
 
 from deebot_client.capabilities import CapabilityEvent
+from deebot_client.events.base import Event
 from deebot_client.events.water_info import MopAttachedEvent
 
 from homeassistant.components.binary_sensor import (
@@ -16,15 +16,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import EcovacsConfigEntry
-from .entity import EcovacsCapabilityEntityDescription, EcovacsDescriptionEntity, EventT
+from .entity import EcovacsCapabilityEntityDescription, EcovacsDescriptionEntity
 from .util import get_supported_entities
 
 
 @dataclass(kw_only=True, frozen=True)
-class EcovacsBinarySensorEntityDescription(
+class EcovacsBinarySensorEntityDescription[EventT: Event](
     BinarySensorEntityDescription,
     EcovacsCapabilityEntityDescription,
-    Generic[EventT],
 ):
     """Class describing Deebot binary sensor entity."""
 
@@ -55,7 +54,7 @@ async def async_setup_entry(
     )
 
 
-class EcovacsBinarySensor(
+class EcovacsBinarySensor[EventT: Event](
     EcovacsDescriptionEntity[CapabilityEvent[EventT]],
     BinarySensorEntity,
 ):

--- a/homeassistant/components/ecovacs/entity.py
+++ b/homeassistant/components/ecovacs/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from deebot_client.capabilities import Capabilities
 from deebot_client.device import Device
@@ -18,11 +18,8 @@ from homeassistant.helpers.entity import Entity, EntityDescription
 
 from .const import DOMAIN
 
-CapabilityEntity = TypeVar("CapabilityEntity")
-EventT = TypeVar("EventT", bound=Event)
 
-
-class EcovacsEntity(Entity, Generic[CapabilityEntity]):
+class EcovacsEntity[CapabilityEntityT](Entity):
     """Ecovacs entity."""
 
     _attr_should_poll = False
@@ -32,7 +29,7 @@ class EcovacsEntity(Entity, Generic[CapabilityEntity]):
     def __init__(
         self,
         device: Device,
-        capability: CapabilityEntity,
+        capability: CapabilityEntityT,
         **kwargs: Any,
     ) -> None:
         """Initialize entity."""
@@ -80,7 +77,7 @@ class EcovacsEntity(Entity, Generic[CapabilityEntity]):
 
             self._subscribe(AvailabilityEvent, on_available)
 
-    def _subscribe(
+    def _subscribe[EventT: Event](
         self,
         event_type: type[EventT],
         callback: Callable[[EventT], Coroutine[Any, Any, None]],
@@ -98,13 +95,13 @@ class EcovacsEntity(Entity, Generic[CapabilityEntity]):
             self._device.events.request_refresh(event_type)
 
 
-class EcovacsDescriptionEntity(EcovacsEntity[CapabilityEntity]):
+class EcovacsDescriptionEntity[CapabilityEntityT](EcovacsEntity[CapabilityEntityT]):
     """Ecovacs entity."""
 
     def __init__(
         self,
         device: Device,
-        capability: CapabilityEntity,
+        capability: CapabilityEntityT,
         entity_description: EntityDescription,
         **kwargs: Any,
     ) -> None:
@@ -114,13 +111,12 @@ class EcovacsDescriptionEntity(EcovacsEntity[CapabilityEntity]):
 
 
 @dataclass(kw_only=True, frozen=True)
-class EcovacsCapabilityEntityDescription(
+class EcovacsCapabilityEntityDescription[CapabilityEntityT](
     EntityDescription,
-    Generic[CapabilityEntity],
 ):
     """Ecovacs entity description."""
 
-    capability_fn: Callable[[Capabilities], CapabilityEntity | None]
+    capability_fn: Callable[[Capabilities], CapabilityEntityT | None]
 
 
 class EcovacsLegacyEntity(Entity):

--- a/homeassistant/components/ecovacs/number.py
+++ b/homeassistant/components/ecovacs/number.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Generic
 
 from deebot_client.capabilities import CapabilitySet
 from deebot_client.events import CleanCountEvent, CutDirectionEvent, VolumeEvent
+from deebot_client.events.base import Event
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -23,16 +23,14 @@ from .entity import (
     EcovacsCapabilityEntityDescription,
     EcovacsDescriptionEntity,
     EcovacsEntity,
-    EventT,
 )
 from .util import get_supported_entities
 
 
 @dataclass(kw_only=True, frozen=True)
-class EcovacsNumberEntityDescription(
+class EcovacsNumberEntityDescription[EventT: Event](
     NumberEntityDescription,
     EcovacsCapabilityEntityDescription,
-    Generic[EventT],
 ):
     """Ecovacs number entity description."""
 
@@ -94,7 +92,7 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
-class EcovacsNumberEntity(
+class EcovacsNumberEntity[EventT: Event](
     EcovacsDescriptionEntity[CapabilitySet[EventT, [int]]],
     NumberEntity,
 ):

--- a/homeassistant/components/ecovacs/select.py
+++ b/homeassistant/components/ecovacs/select.py
@@ -2,11 +2,12 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic
+from typing import Any
 
 from deebot_client.capabilities import CapabilitySetTypes
 from deebot_client.device import Device
 from deebot_client.events import WorkModeEvent
+from deebot_client.events.base import Event
 from deebot_client.events.water_info import WaterAmountEvent
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -15,15 +16,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import EcovacsConfigEntry
-from .entity import EcovacsCapabilityEntityDescription, EcovacsDescriptionEntity, EventT
+from .entity import EcovacsCapabilityEntityDescription, EcovacsDescriptionEntity
 from .util import get_name_key, get_supported_entities
 
 
 @dataclass(kw_only=True, frozen=True)
-class EcovacsSelectEntityDescription(
+class EcovacsSelectEntityDescription[EventT: Event](
     SelectEntityDescription,
     EcovacsCapabilityEntityDescription,
-    Generic[EventT],
 ):
     """Ecovacs select entity description."""
 
@@ -66,7 +66,7 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
-class EcovacsSelectEntity(
+class EcovacsSelectEntity[EventT: Event](
     EcovacsDescriptionEntity[CapabilitySetTypes[EventT, [str], str]],
     SelectEntity,
 ):

--- a/homeassistant/components/ecovacs/sensor.py
+++ b/homeassistant/components/ecovacs/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic
+from typing import Any
 
 from deebot_client.capabilities import CapabilityEvent, CapabilityLifeSpan, DeviceType
 from deebot_client.device import Device
@@ -46,16 +46,14 @@ from .entity import (
     EcovacsDescriptionEntity,
     EcovacsEntity,
     EcovacsLegacyEntity,
-    EventT,
 )
 from .util import get_name_key, get_options, get_supported_entities
 
 
 @dataclass(kw_only=True, frozen=True)
-class EcovacsSensorEntityDescription(
+class EcovacsSensorEntityDescription[EventT: Event](
     EcovacsCapabilityEntityDescription,
     SensorEntityDescription,
-    Generic[EventT],
 ):
     """Ecovacs sensor entity description."""
 


### PR DESCRIPTION
## Proposed change
Use the new TypeVar syntax in a few more places.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
