### PR TITLE
Use PEP 695 TypeVar syntax for eheimdigital

### DIFF
--- a/homeassistant/components/eheimdigital/number.py
+++ b/homeassistant/components/eheimdigital/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Generic, TypeVar, override
+from typing import Any, override
 
 from eheimdigital.classic_vario import EheimDigitalClassicVario
 from eheimdigital.device import EheimDigitalDevice
@@ -30,16 +30,16 @@ from .entity import EheimDigitalEntity, exception_handler
 
 PARALLEL_UPDATES = 0
 
-_DeviceT_co = TypeVar("_DeviceT_co", bound=EheimDigitalDevice, covariant=True)
-
 
 @dataclass(frozen=True, kw_only=True)
-class EheimDigitalNumberDescription(NumberEntityDescription, Generic[_DeviceT_co]):
+class EheimDigitalNumberDescription[_DeviceT: EheimDigitalDevice](
+    NumberEntityDescription
+):
     """Class describing EHEIM Digital sensor entities."""
 
-    value_fn: Callable[[_DeviceT_co], float | None]
-    set_value_fn: Callable[[_DeviceT_co, float], Awaitable[None]]
-    uom_fn: Callable[[_DeviceT_co], str] | None = None
+    value_fn: Callable[[_DeviceT], float | None]
+    set_value_fn: Callable[[_DeviceT, float], Awaitable[None]]
+    uom_fn: Callable[[_DeviceT], str] | None = None
 
 
 CLASSICVARIO_DESCRIPTIONS: tuple[
@@ -136,7 +136,7 @@ async def async_setup_entry(
         device_address: dict[str, EheimDigitalDevice],
     ) -> None:
         """Set up the number entities for one or multiple devices."""
-        entities: list[EheimDigitalNumber[EheimDigitalDevice]] = []
+        entities: list[EheimDigitalNumber[Any]] = []
         for device in device_address.values():
             if isinstance(device, EheimDigitalClassicVario):
                 entities.extend(
@@ -163,18 +163,18 @@ async def async_setup_entry(
     async_setup_device_entities(coordinator.hub.devices)
 
 
-class EheimDigitalNumber(
-    EheimDigitalEntity[_DeviceT_co], NumberEntity, Generic[_DeviceT_co]
+class EheimDigitalNumber[_DeviceT: EheimDigitalDevice](
+    EheimDigitalEntity[_DeviceT], NumberEntity
 ):
     """Represent a EHEIM Digital number entity."""
 
-    entity_description: EheimDigitalNumberDescription[_DeviceT_co]
+    entity_description: EheimDigitalNumberDescription[_DeviceT]
 
     def __init__(
         self,
         coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT_co,
-        description: EheimDigitalNumberDescription[_DeviceT_co],
+        device: _DeviceT,
+        description: EheimDigitalNumberDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital number entity."""
         super().__init__(coordinator, device)

--- a/homeassistant/components/eheimdigital/select.py
+++ b/homeassistant/components/eheimdigital/select.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Generic, TypeVar, override
+from typing import Any, override
 
 from eheimdigital.classic_vario import EheimDigitalClassicVario
 from eheimdigital.device import EheimDigitalDevice
@@ -17,15 +17,15 @@ from .entity import EheimDigitalEntity, exception_handler
 
 PARALLEL_UPDATES = 0
 
-_DeviceT_co = TypeVar("_DeviceT_co", bound=EheimDigitalDevice, covariant=True)
-
 
 @dataclass(frozen=True, kw_only=True)
-class EheimDigitalSelectDescription(SelectEntityDescription, Generic[_DeviceT_co]):
+class EheimDigitalSelectDescription[_DeviceT: EheimDigitalDevice](
+    SelectEntityDescription
+):
     """Class describing EHEIM Digital select entities."""
 
-    value_fn: Callable[[_DeviceT_co], str | None]
-    set_value_fn: Callable[[_DeviceT_co, str], Awaitable[None]]
+    value_fn: Callable[[_DeviceT], str | None]
+    set_value_fn: Callable[[_DeviceT, str], Awaitable[None]]
 
 
 CLASSICVARIO_DESCRIPTIONS: tuple[
@@ -59,7 +59,7 @@ async def async_setup_entry(
         device_address: dict[str, EheimDigitalDevice],
     ) -> None:
         """Set up the number entities for one or multiple devices."""
-        entities: list[EheimDigitalSelect[EheimDigitalDevice]] = []
+        entities: list[EheimDigitalSelect[Any]] = []
         for device in device_address.values():
             if isinstance(device, EheimDigitalClassicVario):
                 entities.extend(
@@ -75,18 +75,18 @@ async def async_setup_entry(
     async_setup_device_entities(coordinator.hub.devices)
 
 
-class EheimDigitalSelect(
-    EheimDigitalEntity[_DeviceT_co], SelectEntity, Generic[_DeviceT_co]
+class EheimDigitalSelect[_DeviceT: EheimDigitalDevice](
+    EheimDigitalEntity[_DeviceT], SelectEntity
 ):
     """Represent an EHEIM Digital select entity."""
 
-    entity_description: EheimDigitalSelectDescription[_DeviceT_co]
+    entity_description: EheimDigitalSelectDescription[_DeviceT]
 
     def __init__(
         self,
         coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT_co,
-        description: EheimDigitalSelectDescription[_DeviceT_co],
+        device: _DeviceT,
+        description: EheimDigitalSelectDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital select entity."""
         super().__init__(coordinator, device)

--- a/homeassistant/components/eheimdigital/sensor.py
+++ b/homeassistant/components/eheimdigital/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Generic, TypeVar, override
+from typing import Any, override
 
 from eheimdigital.classic_vario import EheimDigitalClassicVario
 from eheimdigital.device import EheimDigitalDevice
@@ -20,14 +20,14 @@ from .entity import EheimDigitalEntity
 # Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
 
-_DeviceT_co = TypeVar("_DeviceT_co", bound=EheimDigitalDevice, covariant=True)
-
 
 @dataclass(frozen=True, kw_only=True)
-class EheimDigitalSensorDescription(SensorEntityDescription, Generic[_DeviceT_co]):
+class EheimDigitalSensorDescription[_DeviceT: EheimDigitalDevice](
+    SensorEntityDescription
+):
     """Class describing EHEIM Digital sensor entities."""
 
-    value_fn: Callable[[_DeviceT_co], float | str | None]
+    value_fn: Callable[[_DeviceT], float | str | None]
 
 
 CLASSICVARIO_DESCRIPTIONS: tuple[
@@ -75,7 +75,7 @@ async def async_setup_entry(
         device_address: dict[str, EheimDigitalDevice],
     ) -> None:
         """Set up the light entities for one or multiple devices."""
-        entities: list[EheimDigitalSensor[EheimDigitalDevice]] = []
+        entities: list[EheimDigitalSensor[Any]] = []
         for device in device_address.values():
             if isinstance(device, EheimDigitalClassicVario):
                 entities += [
@@ -91,18 +91,18 @@ async def async_setup_entry(
     async_setup_device_entities(coordinator.hub.devices)
 
 
-class EheimDigitalSensor(
-    EheimDigitalEntity[_DeviceT_co], SensorEntity, Generic[_DeviceT_co]
+class EheimDigitalSensor[_DeviceT: EheimDigitalDevice](
+    EheimDigitalEntity[_DeviceT], SensorEntity
 ):
     """Represent a EHEIM Digital sensor entity."""
 
-    entity_description: EheimDigitalSensorDescription[_DeviceT_co]
+    entity_description: EheimDigitalSensorDescription[_DeviceT]
 
     def __init__(
         self,
         coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT_co,
-        description: EheimDigitalSensorDescription[_DeviceT_co],
+        device: _DeviceT,
+        description: EheimDigitalSensorDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital number entity."""
         super().__init__(coordinator, device)

--- a/homeassistant/components/eheimdigital/time.py
+++ b/homeassistant/components/eheimdigital/time.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import time
-from typing import Generic, TypeVar, final, override
+from typing import Any, final, override
 
 from eheimdigital.classic_vario import EheimDigitalClassicVario
 from eheimdigital.device import EheimDigitalDevice
@@ -19,15 +19,13 @@ from .entity import EheimDigitalEntity, exception_handler
 
 PARALLEL_UPDATES = 0
 
-_DeviceT_co = TypeVar("_DeviceT_co", bound=EheimDigitalDevice, covariant=True)
-
 
 @dataclass(frozen=True, kw_only=True)
-class EheimDigitalTimeDescription(TimeEntityDescription, Generic[_DeviceT_co]):
+class EheimDigitalTimeDescription[_DeviceT: EheimDigitalDevice](TimeEntityDescription):
     """Class describing EHEIM Digital time entities."""
 
-    value_fn: Callable[[_DeviceT_co], time | None]
-    set_value_fn: Callable[[_DeviceT_co, time], Awaitable[None]]
+    value_fn: Callable[[_DeviceT], time | None]
+    set_value_fn: Callable[[_DeviceT, time], Awaitable[None]]
 
 
 CLASSICVARIO_DESCRIPTIONS: tuple[
@@ -79,7 +77,7 @@ async def async_setup_entry(
         device_address: dict[str, EheimDigitalDevice],
     ) -> None:
         """Set up the time entities for one or multiple devices."""
-        entities: list[EheimDigitalTime[EheimDigitalDevice]] = []
+        entities: list[EheimDigitalTime[Any]] = []
         for device in device_address.values():
             if isinstance(device, EheimDigitalClassicVario):
                 entities.extend(
@@ -103,18 +101,18 @@ async def async_setup_entry(
 
 
 @final
-class EheimDigitalTime(
-    EheimDigitalEntity[_DeviceT_co], TimeEntity, Generic[_DeviceT_co]
+class EheimDigitalTime[_DeviceT: EheimDigitalDevice](
+    EheimDigitalEntity[_DeviceT], TimeEntity
 ):
     """Represent an EHEIM Digital time entity."""
 
-    entity_description: EheimDigitalTimeDescription[_DeviceT_co]
+    entity_description: EheimDigitalTimeDescription[_DeviceT]
 
     def __init__(
         self,
         coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT_co,
-        description: EheimDigitalTimeDescription[_DeviceT_co],
+        device: _DeviceT,
+        description: EheimDigitalTimeDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital time entity."""
         super().__init__(coordinator, device)


### PR DESCRIPTION
## Proposed change
Use the new TypeVar syntax in a few more places.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
