### PR TITLE
Use PEP 695 TypeVar syntax for paperless_ngx

### DIFF
--- a/homeassistant/components/paperless_ngx/coordinator.py
+++ b/homeassistant/components/paperless_ngx/coordinator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TypeVar
 
 from pypaperless import Paperless
 from pypaperless.exceptions import (
@@ -25,8 +24,6 @@ from .const import DOMAIN, LOGGER
 
 type PaperlessConfigEntry = ConfigEntry[PaperlessData]
 
-TData = TypeVar("TData")
-
 UPDATE_INTERVAL_STATISTICS = timedelta(seconds=120)
 UPDATE_INTERVAL_STATUS = timedelta(seconds=300)
 
@@ -39,7 +36,7 @@ class PaperlessData:
     status: PaperlessStatusCoordinator
 
 
-class PaperlessCoordinator(DataUpdateCoordinator[TData]):
+class PaperlessCoordinator[DataT](DataUpdateCoordinator[DataT]):
     """Coordinator to manage fetching Paperless-ngx API."""
 
     config_entry: PaperlessConfigEntry
@@ -63,7 +60,7 @@ class PaperlessCoordinator(DataUpdateCoordinator[TData]):
             update_interval=update_interval,
         )
 
-    async def _async_update_data(self) -> TData:
+    async def _async_update_data(self) -> DataT:
         """Update data via internal method."""
         try:
             return await self._async_update_data_internal()
@@ -89,7 +86,7 @@ class PaperlessCoordinator(DataUpdateCoordinator[TData]):
             ) from err
 
     @abstractmethod
-    async def _async_update_data_internal(self) -> TData:
+    async def _async_update_data_internal(self) -> DataT:
         """Update data via paperless-ngx API."""
 
 

--- a/homeassistant/components/paperless_ngx/entity.py
+++ b/homeassistant/components/paperless_ngx/entity.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Generic, TypeVar
-
 from homeassistant.components.sensor import EntityDescription
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -11,17 +9,17 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import PaperlessCoordinator
 
-TCoordinator = TypeVar("TCoordinator", bound=PaperlessCoordinator)
 
-
-class PaperlessEntity(CoordinatorEntity[TCoordinator], Generic[TCoordinator]):
+class PaperlessEntity[CoordinatorT: PaperlessCoordinator](
+    CoordinatorEntity[CoordinatorT]
+):
     """Defines a base Paperless-ngx entity."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
-        coordinator: TCoordinator,
+        coordinator: CoordinatorT,
         description: EntityDescription,
     ) -> None:
         """Initialize the Paperless-ngx entity."""

--- a/homeassistant/components/paperless_ngx/sensor.py
+++ b/homeassistant/components/paperless_ngx/sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Generic
 
 from pypaperless.models import Statistic, Status
 from pypaperless.models.common import StatusType
@@ -23,23 +22,23 @@ from homeassistant.util.unit_conversion import InformationConverter
 
 from .coordinator import (
     PaperlessConfigEntry,
+    PaperlessCoordinator,
     PaperlessStatisticCoordinator,
     PaperlessStatusCoordinator,
-    TData,
 )
-from .entity import PaperlessEntity, TCoordinator
+from .entity import PaperlessEntity
 
 PARALLEL_UPDATES = 0
 
 
 @dataclass(frozen=True, kw_only=True)
-class PaperlessEntityDescription(SensorEntityDescription, Generic[TData]):
+class PaperlessEntityDescription[DataT](SensorEntityDescription):
     """Describes Paperless-ngx sensor entity."""
 
-    value_fn: Callable[[TData], StateType]
+    value_fn: Callable[[DataT], StateType]
 
 
-SENSOR_STATISTICS: tuple[PaperlessEntityDescription, ...] = (
+SENSOR_STATISTICS: tuple[PaperlessEntityDescription[Statistic], ...] = (
     PaperlessEntityDescription[Statistic](
         key="documents_total",
         translation_key="documents_total",
@@ -78,7 +77,7 @@ SENSOR_STATISTICS: tuple[PaperlessEntityDescription, ...] = (
     ),
 )
 
-SENSOR_STATUS: tuple[PaperlessEntityDescription, ...] = (
+SENSOR_STATUS: tuple[PaperlessEntityDescription[Status], ...] = (
     PaperlessEntityDescription[Status](
         key="storage_total",
         translation_key="storage_total",
@@ -258,7 +257,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PaperlessSensor(PaperlessEntity[TCoordinator], SensorEntity):
+class PaperlessSensor[CoordinatorT: PaperlessCoordinator](
+    PaperlessEntity[CoordinatorT], SensorEntity
+):
     """Defines a Paperless-ngx sensor entity."""
 
     entity_description: PaperlessEntityDescription


### PR DESCRIPTION
## Proposed change
Use the new TypeVar syntax in a few more places.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
