### PR TITLE
Use PEP 695 TypeVar syntax for unifi

### DIFF
--- a/homeassistant/components/unifi/button.py
+++ b/homeassistant/components/unifi/button.py
@@ -11,11 +11,11 @@ import secrets
 from typing import TYPE_CHECKING, Any
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
 from aiounifi.interfaces.devices import Devices
 from aiounifi.interfaces.ports import Ports
 from aiounifi.interfaces.wlans import Wlans
-from aiounifi.models.api import ApiItemT
+from aiounifi.models.api import ApiItem
 from aiounifi.models.device import (
     Device,
     DevicePowerCyclePortRequest,
@@ -35,7 +35,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import UnifiConfigEntry
 from .entity import (
-    HandlerT,
     UnifiEntity,
     UnifiEntityDescription,
     async_device_available_fn,
@@ -81,7 +80,7 @@ async def async_regenerate_password_control_fn(
 
 
 @dataclass(frozen=True, kw_only=True)
-class UnifiButtonEntityDescription(
+class UnifiButtonEntityDescription[HandlerT: APIHandler, ApiItemT: ApiItem](
     ButtonEntityDescription, UnifiEntityDescription[HandlerT, ApiItemT]
 ):
     """Class describing UniFi button entity."""
@@ -143,7 +142,9 @@ async def async_setup_entry(
     )
 
 
-class UnifiButtonEntity(UnifiEntity[HandlerT, ApiItemT], ButtonEntity):
+class UnifiButtonEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
+    UnifiEntity[HandlerT, ApiItemT], ButtonEntity
+):
     """Base representation of a UniFi button."""
 
     entity_description: UnifiButtonEntityDescription[HandlerT, ApiItemT]

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -9,10 +9,10 @@ import logging
 from typing import Any
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
 from aiounifi.interfaces.clients import Clients
 from aiounifi.interfaces.devices import Devices
-from aiounifi.models.api import ApiItemT
+from aiounifi.models.api import ApiItem
 from aiounifi.models.client import Client
 from aiounifi.models.device import Device
 from aiounifi.models.event import Event, EventKey
@@ -31,12 +31,7 @@ from homeassistant.util import dt as dt_util
 
 from . import UnifiConfigEntry
 from .const import DOMAIN
-from .entity import (
-    HandlerT,
-    UnifiEntity,
-    UnifiEntityDescription,
-    async_device_available_fn,
-)
+from .entity import UnifiEntity, UnifiEntityDescription, async_device_available_fn
 from .hub import UnifiHub
 
 LOGGER = logging.getLogger(__name__)
@@ -142,7 +137,7 @@ def async_device_heartbeat_timedelta_fn(hub: UnifiHub, obj_id: str) -> timedelta
 
 
 @dataclass(frozen=True, kw_only=True)
-class UnifiTrackerEntityDescription(
+class UnifiTrackerEntityDescription[HandlerT: APIHandler, ApiItemT: ApiItem](
     UnifiEntityDescription[HandlerT, ApiItemT], ScannerEntityDescription
 ):
     """Class describing UniFi device tracker entity."""
@@ -229,7 +224,9 @@ async def async_setup_entry(
     )
 
 
-class UnifiScannerEntity(UnifiEntity[HandlerT, ApiItemT], ScannerEntity):
+class UnifiScannerEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
+    UnifiEntity[HandlerT, ApiItemT], ScannerEntity
+):
     """Representation of a UniFi scanner."""
 
     entity_description: UnifiTrackerEntityDescription

--- a/homeassistant/components/unifi/entity.py
+++ b/homeassistant/components/unifi/entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING
 
 import aiounifi
 from aiounifi.interfaces.api_handlers import (
@@ -14,7 +14,7 @@ from aiounifi.interfaces.api_handlers import (
     ItemEvent,
     UnsubscribeType,
 )
-from aiounifi.models.api import ApiItemT
+from aiounifi.models.api import ApiItem
 from aiounifi.models.event import Event, EventKey
 
 from homeassistant.core import callback
@@ -32,8 +32,7 @@ from .const import ATTR_MANUFACTURER, DOMAIN
 if TYPE_CHECKING:
     from .hub import UnifiHub
 
-HandlerT = TypeVar("HandlerT", bound=APIHandler)
-SubscriptionT = Callable[[CallbackType, ItemEvent], UnsubscribeType]
+type SubscriptionType = Callable[[CallbackType, ItemEvent], UnsubscribeType]
 
 
 @callback
@@ -95,7 +94,9 @@ def async_client_device_info_fn(hub: UnifiHub, obj_id: str) -> DeviceInfo:
 
 
 @dataclass(frozen=True, kw_only=True)
-class UnifiEntityDescription(EntityDescription, Generic[HandlerT, ApiItemT]):
+class UnifiEntityDescription[HandlerT: APIHandler, ApiItemT: ApiItem](
+    EntityDescription
+):
     """UniFi Entity Description."""
 
     api_handler_fn: Callable[[aiounifi.Controller], HandlerT]
@@ -128,7 +129,7 @@ class UnifiEntityDescription(EntityDescription, Generic[HandlerT, ApiItemT]):
     """If entity needs to do regular checks on state."""
 
 
-class UnifiEntity(Entity, Generic[HandlerT, ApiItemT]):
+class UnifiEntity[HandlerT: APIHandler, ApiItemT: ApiItem](Entity):
     """Representation of a UniFi entity."""
 
     entity_description: UnifiEntityDescription[HandlerT, ApiItemT]

--- a/homeassistant/components/unifi/image.py
+++ b/homeassistant/components/unifi/image.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
 from aiounifi.interfaces.wlans import Wlans
-from aiounifi.models.api import ApiItemT
+from aiounifi.models.api import ApiItem
 from aiounifi.models.wlan import Wlan
 
 from homeassistant.components.image import ImageEntity, ImageEntityDescription
@@ -21,7 +21,6 @@ from homeassistant.util import dt as dt_util
 
 from . import UnifiConfigEntry
 from .entity import (
-    HandlerT,
     UnifiEntity,
     UnifiEntityDescription,
     async_wlan_available_fn,
@@ -37,7 +36,7 @@ def async_wlan_qr_code_image_fn(hub: UnifiHub, wlan: Wlan) -> bytes:
 
 
 @dataclass(frozen=True, kw_only=True)
-class UnifiImageEntityDescription(
+class UnifiImageEntityDescription[HandlerT: APIHandler, ApiItemT: ApiItem](
     ImageEntityDescription, UnifiEntityDescription[HandlerT, ApiItemT]
 ):
     """Class describing UniFi image entity."""
@@ -75,7 +74,9 @@ async def async_setup_entry(
     )
 
 
-class UnifiImageEntity(UnifiEntity[HandlerT, ApiItemT], ImageEntity):
+class UnifiImageEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
+    UnifiEntity[HandlerT, ApiItemT], ImageEntity
+):
     """Base representation of a UniFi image."""
 
     entity_description: UnifiImageEntityDescription[HandlerT, ApiItemT]

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -13,13 +13,13 @@ from decimal import Decimal
 from functools import partial
 from typing import TYPE_CHECKING, Literal
 
-from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
 from aiounifi.interfaces.clients import Clients
 from aiounifi.interfaces.devices import Devices
 from aiounifi.interfaces.outlets import Outlets
 from aiounifi.interfaces.ports import Ports
 from aiounifi.interfaces.wlans import Wlans
-from aiounifi.models.api import ApiItemT
+from aiounifi.models.api import ApiItem
 from aiounifi.models.client import Client
 from aiounifi.models.device import (
     Device,
@@ -53,7 +53,6 @@ from homeassistant.util import dt as dt_util, slugify
 from . import UnifiConfigEntry
 from .const import DEVICE_STATES
 from .entity import (
-    HandlerT,
     UnifiEntity,
     UnifiEntityDescription,
     async_client_device_info_fn,
@@ -356,7 +355,7 @@ def make_device_temperatur_sensors() -> tuple[UnifiSensorEntityDescription, ...]
 
 
 @dataclass(frozen=True, kw_only=True)
-class UnifiSensorEntityDescription(
+class UnifiSensorEntityDescription[HandlerT: APIHandler, ApiItemT: ApiItem](
     SensorEntityDescription, UnifiEntityDescription[HandlerT, ApiItemT]
 ):
     """Class describing UniFi sensor entity."""
@@ -652,7 +651,9 @@ async def async_setup_entry(
     )
 
 
-class UnifiSensorEntity(UnifiEntity[HandlerT, ApiItemT], SensorEntity):
+class UnifiSensorEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
+    UnifiEntity[HandlerT, ApiItemT], SensorEntity
+):
     """Base representation of a UniFi sensor."""
 
     entity_description: UnifiSensorEntityDescription[HandlerT, ApiItemT]

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import aiounifi
-from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
 from aiounifi.interfaces.clients import Clients
 from aiounifi.interfaces.dpi_restriction_groups import DPIRestrictionGroups
 from aiounifi.interfaces.firewall_policies import FirewallPolicies
@@ -25,7 +25,7 @@ from aiounifi.interfaces.ports import Ports
 from aiounifi.interfaces.traffic_routes import TrafficRoutes
 from aiounifi.interfaces.traffic_rules import TrafficRules
 from aiounifi.interfaces.wlans import Wlans
-from aiounifi.models.api import ApiItemT
+from aiounifi.models.api import ApiItem
 from aiounifi.models.client import Client, ClientBlockRequest
 from aiounifi.models.device import DeviceSetOutletRelayRequest
 from aiounifi.models.dpi_restriction_app import DPIRestrictionAppEnableRequest
@@ -54,8 +54,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import UnifiConfigEntry
 from .const import ATTR_MANUFACTURER, DOMAIN
 from .entity import (
-    HandlerT,
-    SubscriptionT,
+    SubscriptionType,
     UnifiEntity,
     UnifiEntityDescription,
     async_client_device_info_fn,
@@ -209,7 +208,7 @@ async def async_wlan_control_fn(hub: UnifiHub, obj_id: str, target: bool) -> Non
 
 
 @dataclass(frozen=True, kw_only=True)
-class UnifiSwitchEntityDescription(
+class UnifiSwitchEntityDescription[HandlerT: APIHandler, ApiItemT: ApiItem](
     SwitchEntityDescription, UnifiEntityDescription[HandlerT, ApiItemT]
 ):
     """Class describing UniFi switch entity."""
@@ -218,7 +217,7 @@ class UnifiSwitchEntityDescription(
     is_on_fn: Callable[[UnifiHub, ApiItemT], bool]
 
     # Optional
-    custom_subscribe: Callable[[aiounifi.Controller], SubscriptionT] | None = None
+    custom_subscribe: Callable[[aiounifi.Controller], SubscriptionType] | None = None
     """Callback for additional subscriptions to any UniFi handler."""
     only_event_for_state_change: bool = False
     """Use only UniFi events to trigger state changes."""
@@ -397,7 +396,9 @@ async def async_setup_entry(
     )
 
 
-class UnifiSwitchEntity(UnifiEntity[HandlerT, ApiItemT], SwitchEntity):
+class UnifiSwitchEntity[HandlerT: APIHandler, ApiItemT: ApiItem](
+    UnifiEntity[HandlerT, ApiItemT], SwitchEntity
+):
     """Base representation of a UniFi switch."""
 
     entity_description: UnifiSwitchEntityDescription[HandlerT, ApiItemT]

--- a/homeassistant/components/unifi/update.py
+++ b/homeassistant/components/unifi/update.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import Any, TypeVar
+from typing import Any
 
 import aiounifi
 from aiounifi.interfaces.api_handlers import ItemEvent
@@ -31,9 +31,6 @@ from .entity import (
 
 LOGGER = logging.getLogger(__name__)
 
-_DataT = TypeVar("_DataT", bound=Device)
-_HandlerT = TypeVar("_HandlerT", bound=Devices)
-
 
 async def async_device_control_fn(api: aiounifi.Controller, obj_id: str) -> None:
     """Control upgrade of device."""
@@ -41,7 +38,7 @@ async def async_device_control_fn(api: aiounifi.Controller, obj_id: str) -> None
 
 
 @dataclass(frozen=True, kw_only=True)
-class UnifiUpdateEntityDescription(
+class UnifiUpdateEntityDescription[_HandlerT: Devices, _DataT: Device](
     UpdateEntityDescription, UnifiEntityDescription[_HandlerT, _DataT]
 ):
     """Class describing UniFi update entity."""
@@ -78,7 +75,9 @@ async def async_setup_entry(
     )
 
 
-class UnifiDeviceUpdateEntity(UnifiEntity[_HandlerT, _DataT], UpdateEntity):
+class UnifiDeviceUpdateEntity[_HandlerT: Devices, _DataT: Device](
+    UnifiEntity[_HandlerT, _DataT], UpdateEntity
+):
     """Representation of a UniFi device update entity."""
 
     entity_description: UnifiUpdateEntityDescription[_HandlerT, _DataT]


### PR DESCRIPTION
## Proposed change
Use the new TypeVar syntax in a few more places.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
