### PR TITLE
Add digest auth option to downloader integration

### DIFF
--- a/homeassistant/components/downloader/const.py
+++ b/homeassistant/components/downloader/const.py
@@ -6,11 +6,13 @@ _LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "downloader"
 DEFAULT_NAME = "Downloader"
-CONF_DOWNLOAD_DIR = "download_dir"
+ATTR_AUTH_PASSWORD = "auth_password"
+ATTR_AUTH_TYPE = "auth_type"
+ATTR_AUTH_USERNAME = "auth_username"
 ATTR_FILENAME = "filename"
+ATTR_OVERWRITE = "overwrite"
 ATTR_SUBDIR = "subdir"
 ATTR_URL = "url"
-ATTR_OVERWRITE = "overwrite"
 
 CONF_DOWNLOAD_DIR = "download_dir"
 

--- a/homeassistant/components/downloader/services.py
+++ b/homeassistant/components/downloader/services.py
@@ -45,9 +45,9 @@ def download_file(service: ServiceCall) -> None:
     auth_type: str | None = service.data.get(ATTR_AUTH_TYPE)
     username: str | None = service.data.get(ATTR_AUTH_USERNAME)
     password: str | None = service.data.get(ATTR_AUTH_PASSWORD)
-    subdir = service.data.get(ATTR_SUBDIR)
-    target_filename = service.data.get(ATTR_FILENAME)
-    overwrite = service.data.get(ATTR_OVERWRITE)
+    subdir: str | None = service.data.get(ATTR_SUBDIR)
+    target_filename: str | None = service.data.get(ATTR_FILENAME)
+    overwrite: bool = service.data[ATTR_OVERWRITE]
 
     auth: AuthBase | None = None
     if auth_type:

--- a/homeassistant/components/downloader/services.yaml
+++ b/homeassistant/components/downloader/services.yaml
@@ -5,6 +5,18 @@ download_file:
       example: "http://example.org/myfile"
       selector:
         text:
+    auth_type:
+      selector:
+        select:
+          options:
+            - basic
+            - digest
+    auth_username:
+      selector:
+        text:
+    auth_password:
+      selector:
+        text:
     subdir:
       example: "download_dir"
       selector:

--- a/homeassistant/components/downloader/strings.json
+++ b/homeassistant/components/downloader/strings.json
@@ -21,6 +21,18 @@
           "name": "[%key:common::config_flow::data::url%]",
           "description": "The URL of the file to download."
         },
+        "auth_type": {
+          "name": "Authentication type",
+          "description": "Authentication type to use."
+        },
+        "auth_username": {
+          "name": "Authentication username",
+          "description": "Username to use with authentication."
+        },
+        "auth_password": {
+          "name": "Authentication password",
+          "description": "Password to use with authentication."
+        },
         "subdir": {
           "name": "Subdirectory",
           "description": "Relative download path."
@@ -34,6 +46,14 @@
           "description": "Overwrite file if it exists."
         }
       }
+    }
+  },
+  "exceptions": {
+    "invalid_subdir": {
+      "message": "Subdirectory must be valid."
+    },
+    "missing_credentials": {
+      "message": "Username and password are required."
     }
   }
 }

--- a/tests/components/downloader/conftest.py
+++ b/tests/components/downloader/conftest.py
@@ -3,7 +3,6 @@
 from unittest.mock import patch
 
 import pytest
-from requests_mock import Mocker
 
 from homeassistant.components.downloader.const import CONF_DOWNLOAD_DIR, DOMAIN
 from homeassistant.core import HomeAssistant
@@ -26,9 +25,3 @@ async def loaded_config_entry(hass: HomeAssistant) -> MockConfigEntry:
         await hass.config_entries.async_setup(config_entry.entry_id)
 
     return config_entry
-
-
-@pytest.fixture
-def auth_requests_mock(requests_mock: Mocker) -> Mocker:
-    """Set up request mock."""
-    return requests_mock

--- a/tests/components/downloader/conftest.py
+++ b/tests/components/downloader/conftest.py
@@ -1,0 +1,34 @@
+"""Configure pytest for downloader tests."""
+
+from unittest.mock import patch
+
+import pytest
+from requests_mock import Mocker
+
+from homeassistant.components.downloader.const import CONF_DOWNLOAD_DIR, DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+async def loaded_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Set up loaded config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DOWNLOAD_DIR: "/test_dir",
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch("os.path.isdir", return_value=True):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+    return config_entry
+
+
+@pytest.fixture
+def auth_requests_mock(requests_mock: Mocker) -> Mocker:
+    """Set up request mock."""
+    return requests_mock

--- a/tests/components/downloader/test_init.py
+++ b/tests/components/downloader/test_init.py
@@ -1,29 +1,16 @@
 """Tests for the downloader component init."""
 
-from unittest.mock import patch
-
-from homeassistant.components.downloader.const import (
-    CONF_DOWNLOAD_DIR,
-    DOMAIN,
-    SERVICE_DOWNLOAD_FILE,
-)
+from homeassistant.components.downloader.const import DOMAIN, SERVICE_DOWNLOAD_FILE
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def test_initialization(hass: HomeAssistant) -> None:
+async def test_initialization(
+    hass: HomeAssistant, loaded_config_entry: MockConfigEntry
+) -> None:
     """Test the initialization of the downloader component."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_DOWNLOAD_DIR: "/test_dir",
-        },
-    )
-    config_entry.add_to_hass(hass)
-    with patch("os.path.isdir", return_value=True):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
 
     assert hass.services.has_service(DOMAIN, SERVICE_DOWNLOAD_FILE)
-    assert config_entry.state is ConfigEntryState.LOADED
+    assert loaded_config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/downloader/test_services.py
+++ b/tests/components/downloader/test_services.py
@@ -4,7 +4,8 @@ from http import HTTPStatus
 from unittest.mock import mock_open, patch
 
 import pytest
-from requests_mock import Mocker
+from requests import Request
+import requests_mock
 
 from homeassistant.components.downloader.const import (
     ATTR_AUTH_PASSWORD,
@@ -20,61 +21,53 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
 
-def digest_challenge_matcher(request):
+def no_authorization_request_matcher(request: Request):
     """Match requests with no auth header."""
     return "Authorization" not in request.headers
 
 
-def digest_response_matcher(request):
+def authorization_request_matcher(request: Request):
     """Match requests with an auth header."""
     return "Authorization" in request.headers
 
 
 @pytest.mark.usefixtures("loaded_config_entry")
-async def test_service_call(hass: HomeAssistant, requests_mock: Mocker) -> None:
+async def test_service_call(hass: HomeAssistant) -> None:
     """Test downloader action."""
 
     TEST_URL = "http://example.com/resource"
 
-    requests_mock.get(
-        TEST_URL,
-        additional_matcher=digest_response_matcher,
-        status_code=HTTPStatus.OK,
-    )
-
-    with patch("builtins.open", new=mock_open(), create=True):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_DOWNLOAD_FILE,
-            {
-                ATTR_URL: TEST_URL,
-                ATTR_AUTH_TYPE: HTTP_BASIC_AUTHENTICATION,
-                ATTR_AUTH_USERNAME: "test",
-                ATTR_AUTH_PASSWORD: "test",
-            },
-            blocking=True,
+    with requests_mock.Mocker() as auth_requests_mock:
+        auth_requests_mock.get(
+            TEST_URL,
+            status_code=HTTPStatus.OK,
         )
 
-    assert requests_mock.called
+        with patch("builtins.open", new=mock_open(), create=True):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_DOWNLOAD_FILE,
+                {
+                    ATTR_URL: TEST_URL,
+                    ATTR_AUTH_TYPE: HTTP_BASIC_AUTHENTICATION,
+                    ATTR_AUTH_USERNAME: "test",
+                    ATTR_AUTH_PASSWORD: "test",
+                },
+                blocking=True,
+            )
+
+        assert auth_requests_mock.called
 
 
 @pytest.mark.usefixtures("loaded_config_entry")
-async def test_invalid_subdir(hass: HomeAssistant, requests_mock: Mocker) -> None:
+async def test_invalid_subdir(hass: HomeAssistant) -> None:
     """Test invalid subdirectory in downloader action."""
 
     TEST_URL = "http://example.com/resource"
 
-    requests_mock.get(
-        TEST_URL,
-        status_code=HTTPStatus.OK,
-    )
-
-    with (
-        pytest.raises(
-            ServiceValidationError,
-            match="Subdirectory must be valid",
-        ),
-        patch("builtins.open", new=mock_open(), create=True),
+    with pytest.raises(
+        ServiceValidationError,
+        match="Subdirectory must be valid",
     ):
         await hass.services.async_call(
             DOMAIN,
@@ -83,26 +76,16 @@ async def test_invalid_subdir(hass: HomeAssistant, requests_mock: Mocker) -> Non
             blocking=True,
         )
 
-    assert not requests_mock.called
-
 
 @pytest.mark.usefixtures("loaded_config_entry")
-async def test_invalid_credentials(hass: HomeAssistant, requests_mock: Mocker) -> None:
+async def test_invalid_credentials(hass: HomeAssistant) -> None:
     """Test invalid credentials in downloader action."""
 
     TEST_URL = "http://example.com/resource"
 
-    requests_mock.get(
-        TEST_URL,
-        status_code=HTTPStatus.OK,
-    )
-
-    with (
-        pytest.raises(
-            ServiceValidationError,
-            match="Username and password are required",
-        ),
-        patch("builtins.open", new=mock_open(), create=True),
+    with pytest.raises(
+        ServiceValidationError,
+        match="Username and password are required",
     ):
         await hass.services.async_call(
             DOMAIN,
@@ -114,86 +97,88 @@ async def test_invalid_credentials(hass: HomeAssistant, requests_mock: Mocker) -
             blocking=True,
         )
 
-    assert not requests_mock.called
-
 
 @pytest.mark.usefixtures("loaded_config_entry")
-async def test_basic_auth(hass: HomeAssistant, auth_requests_mock: Mocker) -> None:
+async def test_basic_auth(hass: HomeAssistant) -> None:
     """Test basic authentication in downloader action."""
 
     TEST_URL = "http://example.com/protected-resource"
 
-    auth_requests_mock.get(
-        TEST_URL,
-        additional_matcher=digest_challenge_matcher,
-        headers={"WWW-Authenticate": 'Basic realm="example.com"'},
-        status_code=HTTPStatus.UNAUTHORIZED,
-    )
-
-    auth_requests_mock.get(
-        TEST_URL,
-        additional_matcher=digest_response_matcher,
-        status_code=HTTPStatus.OK,
-    )
-
-    with patch("builtins.open", new=mock_open(), create=True):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_DOWNLOAD_FILE,
-            {
-                ATTR_URL: TEST_URL,
-                ATTR_AUTH_TYPE: HTTP_BASIC_AUTHENTICATION,
-                ATTR_AUTH_USERNAME: "test",
-                ATTR_AUTH_PASSWORD: "test",
-            },
-            blocking=True,
+    with requests_mock.Mocker() as auth_requests_mock:
+        auth_requests_mock.get(
+            TEST_URL,
+            additional_matcher=no_authorization_request_matcher,
+            headers={"WWW-Authenticate": 'Basic realm="example.com"'},
+            status_code=HTTPStatus.UNAUTHORIZED,
         )
 
-    assert auth_requests_mock.called
+        auth_requests_mock.get(
+            TEST_URL,
+            additional_matcher=authorization_request_matcher,
+            status_code=HTTPStatus.OK,
+        )
 
-    assert (
-        "Authorization" in auth_requests_mock.last_request.headers
-        and auth_requests_mock.last_request.headers["Authorization"].startswith("Basic")
-    )
+        with patch("builtins.open", new=mock_open(), create=True):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_DOWNLOAD_FILE,
+                {
+                    ATTR_URL: TEST_URL,
+                    ATTR_AUTH_TYPE: HTTP_BASIC_AUTHENTICATION,
+                    ATTR_AUTH_USERNAME: "test",
+                    ATTR_AUTH_PASSWORD: "test",
+                },
+                blocking=True,
+            )
+
+        assert auth_requests_mock.called
+
+        assert (
+            "Authorization" in auth_requests_mock.last_request.headers
+            and auth_requests_mock.last_request.headers["Authorization"].startswith(
+                "Basic"
+            )
+        )
 
 
 @pytest.mark.usefixtures("loaded_config_entry")
-async def test_digest_auth(hass: HomeAssistant, auth_requests_mock: Mocker) -> None:
+async def test_digest_auth(hass: HomeAssistant) -> None:
     """Test digest authentication in downloader action."""
 
     TEST_URL = "http://example.com/protected-resource"
 
-    auth_requests_mock.get(
-        TEST_URL,
-        additional_matcher=digest_challenge_matcher,
-        headers={"WWW-Authenticate": 'Digest realm="example.com", nonce="test"'},
-        status_code=HTTPStatus.UNAUTHORIZED,
-    )
-
-    auth_requests_mock.get(
-        TEST_URL,
-        additional_matcher=digest_response_matcher,
-        status_code=HTTPStatus.OK,
-    )
-
-    with patch("builtins.open", new=mock_open(), create=True):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_DOWNLOAD_FILE,
-            {
-                ATTR_URL: TEST_URL,
-                ATTR_AUTH_TYPE: HTTP_DIGEST_AUTHENTICATION,
-                ATTR_AUTH_USERNAME: "test",
-                ATTR_AUTH_PASSWORD: "test",
-            },
-            blocking=True,
+    with requests_mock.Mocker() as auth_requests_mock:
+        auth_requests_mock.get(
+            TEST_URL,
+            additional_matcher=no_authorization_request_matcher,
+            headers={"WWW-Authenticate": 'Digest realm="example.com", nonce="test"'},
+            status_code=HTTPStatus.UNAUTHORIZED,
         )
 
-    assert auth_requests_mock.called
-
-    assert (
-        "Authorization" in auth_requests_mock.last_request.headers
-        and auth_requests_mock.last_request.headers["Authorization"].startswith(
-            "Digest"
+        auth_requests_mock.get(
+            TEST_URL,
+            additional_matcher=authorization_request_matcher,
+            status_code=HTTPStatus.OK,
         )
-    )
+
+        with patch("builtins.open", new=mock_open(), create=True):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_DOWNLOAD_FILE,
+                {
+                    ATTR_URL: TEST_URL,
+                    ATTR_AUTH_TYPE: HTTP_DIGEST_AUTHENTICATION,
+                    ATTR_AUTH_USERNAME: "test",
+                    ATTR_AUTH_PASSWORD: "test",
+                },
+                blocking=True,
+            )
+
+        assert auth_requests_mock.called
+
+        assert (
+            "Authorization" in auth_requests_mock.last_request.headers
+            and auth_requests_mock.last_request.headers["Authorization"].startswith(
+                "Digest"
+            )
+        )

--- a/tests/components/downloader/test_services.py
+++ b/tests/components/downloader/test_services.py
@@ -1,0 +1,199 @@
+"""Test downloader action."""
+
+from http import HTTPStatus
+from unittest.mock import mock_open, patch
+
+import pytest
+from requests_mock import Mocker
+
+from homeassistant.components.downloader.const import (
+    ATTR_AUTH_PASSWORD,
+    ATTR_AUTH_TYPE,
+    ATTR_AUTH_USERNAME,
+    ATTR_SUBDIR,
+    ATTR_URL,
+    DOMAIN,
+    SERVICE_DOWNLOAD_FILE,
+)
+from homeassistant.const import HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+
+
+def digest_challenge_matcher(request):
+    """Match requests with no auth header."""
+    return "Authorization" not in request.headers
+
+
+def digest_response_matcher(request):
+    """Match requests with an auth header."""
+    return "Authorization" in request.headers
+
+
+@pytest.mark.usefixtures("loaded_config_entry")
+async def test_service_call(hass: HomeAssistant, requests_mock: Mocker) -> None:
+    """Test downloader action."""
+
+    TEST_URL = "http://example.com/resource"
+
+    requests_mock.get(
+        TEST_URL,
+        additional_matcher=digest_response_matcher,
+        status_code=HTTPStatus.OK,
+    )
+
+    with patch("builtins.open", new=mock_open(), create=True):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DOWNLOAD_FILE,
+            {
+                ATTR_URL: TEST_URL,
+                ATTR_AUTH_TYPE: HTTP_BASIC_AUTHENTICATION,
+                ATTR_AUTH_USERNAME: "test",
+                ATTR_AUTH_PASSWORD: "test",
+            },
+            blocking=True,
+        )
+
+    assert requests_mock.called
+
+
+@pytest.mark.usefixtures("loaded_config_entry")
+async def test_invalid_subdir(hass: HomeAssistant, requests_mock: Mocker) -> None:
+    """Test invalid subdirectory in downloader action."""
+
+    TEST_URL = "http://example.com/resource"
+
+    requests_mock.get(
+        TEST_URL,
+        status_code=HTTPStatus.OK,
+    )
+
+    with (
+        pytest.raises(
+            ServiceValidationError,
+            match="Subdirectory must be valid",
+        ),
+        patch("builtins.open", new=mock_open(), create=True),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DOWNLOAD_FILE,
+            {ATTR_URL: TEST_URL, ATTR_SUBDIR: "~"},
+            blocking=True,
+        )
+
+    assert not requests_mock.called
+
+
+@pytest.mark.usefixtures("loaded_config_entry")
+async def test_invalid_credentials(hass: HomeAssistant, requests_mock: Mocker) -> None:
+    """Test invalid credentials in downloader action."""
+
+    TEST_URL = "http://example.com/resource"
+
+    requests_mock.get(
+        TEST_URL,
+        status_code=HTTPStatus.OK,
+    )
+
+    with (
+        pytest.raises(
+            ServiceValidationError,
+            match="Username and password are required",
+        ),
+        patch("builtins.open", new=mock_open(), create=True),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DOWNLOAD_FILE,
+            {
+                ATTR_URL: TEST_URL,
+                ATTR_AUTH_TYPE: HTTP_BASIC_AUTHENTICATION,
+            },
+            blocking=True,
+        )
+
+    assert not requests_mock.called
+
+
+@pytest.mark.usefixtures("loaded_config_entry")
+async def test_basic_auth(hass: HomeAssistant, auth_requests_mock: Mocker) -> None:
+    """Test basic authentication in downloader action."""
+
+    TEST_URL = "http://example.com/protected-resource"
+
+    auth_requests_mock.get(
+        TEST_URL,
+        additional_matcher=digest_challenge_matcher,
+        headers={"WWW-Authenticate": 'Basic realm="example.com"'},
+        status_code=HTTPStatus.UNAUTHORIZED,
+    )
+
+    auth_requests_mock.get(
+        TEST_URL,
+        additional_matcher=digest_response_matcher,
+        status_code=HTTPStatus.OK,
+    )
+
+    with patch("builtins.open", new=mock_open(), create=True):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DOWNLOAD_FILE,
+            {
+                ATTR_URL: TEST_URL,
+                ATTR_AUTH_TYPE: HTTP_BASIC_AUTHENTICATION,
+                ATTR_AUTH_USERNAME: "test",
+                ATTR_AUTH_PASSWORD: "test",
+            },
+            blocking=True,
+        )
+
+    assert auth_requests_mock.called
+
+    assert (
+        "Authorization" in auth_requests_mock.last_request.headers
+        and auth_requests_mock.last_request.headers["Authorization"].startswith("Basic")
+    )
+
+
+@pytest.mark.usefixtures("loaded_config_entry")
+async def test_digest_auth(hass: HomeAssistant, auth_requests_mock: Mocker) -> None:
+    """Test digest authentication in downloader action."""
+
+    TEST_URL = "http://example.com/protected-resource"
+
+    auth_requests_mock.get(
+        TEST_URL,
+        additional_matcher=digest_challenge_matcher,
+        headers={"WWW-Authenticate": 'Digest realm="example.com", nonce="test"'},
+        status_code=HTTPStatus.UNAUTHORIZED,
+    )
+
+    auth_requests_mock.get(
+        TEST_URL,
+        additional_matcher=digest_response_matcher,
+        status_code=HTTPStatus.OK,
+    )
+
+    with patch("builtins.open", new=mock_open(), create=True):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DOWNLOAD_FILE,
+            {
+                ATTR_URL: TEST_URL,
+                ATTR_AUTH_TYPE: HTTP_DIGEST_AUTHENTICATION,
+                ATTR_AUTH_USERNAME: "test",
+                ATTR_AUTH_PASSWORD: "test",
+            },
+            blocking=True,
+        )
+
+    assert auth_requests_mock.called
+
+    assert (
+        "Authorization" in auth_requests_mock.last_request.headers
+        and auth_requests_mock.last_request.headers["Authorization"].startswith(
+            "Digest"
+        )
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<img width="664" alt="Downloader with auth options" src="https://github.com/user-attachments/assets/41f680ae-ae75-403a-80ff-aea9313d772f" />

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a digest authentication option to the downloader integration. This resolves a [feature request](https://community.home-assistant.io/t/downloader-integration-lacks-authentication-options/344244) and unblocks users downloading URLs requiring digest auth.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39642
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
