### PR TITLE
Bump zwave-js-server-python to 0.64.0

### DIFF
--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.63.0"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.64.0"],
   "usb": [
     {
       "vid": "0658",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3193,7 +3193,7 @@ ziggo-mediabox-xl==1.1.0
 zm-py==0.5.4
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.63.0
+zwave-js-server-python==0.64.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2625,7 +2625,7 @@ zeversolar==0.3.2
 zha==0.0.60
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.63.0
+zwave-js-server-python==0.64.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -32,7 +32,7 @@ from zwave_js_server.model.controller import (
     ProvisioningEntry,
     QRProvisioningInformation,
 )
-from zwave_js_server.model.controller.firmware import ControllerFirmwareUpdateData
+from zwave_js_server.model.driver.firmware import DriverFirmwareUpdateData
 from zwave_js_server.model.node import Node
 from zwave_js_server.model.node.firmware import NodeFirmwareUpdateData
 from zwave_js_server.model.value import ConfigurationValue, get_value_id_str
@@ -3501,7 +3501,7 @@ async def test_firmware_upload_view(
             "homeassistant.components.zwave_js.api.update_firmware",
         ) as mock_node_cmd,
         patch(
-            "homeassistant.components.zwave_js.api.controller_firmware_update_otw",
+            "homeassistant.components.zwave_js.api.driver_firmware_update_otw",
         ) as mock_controller_cmd,
         patch.dict(
             "homeassistant.components.zwave_js.api.USER_AGENT",
@@ -3544,7 +3544,7 @@ async def test_firmware_upload_view_controller(
             "homeassistant.components.zwave_js.api.update_firmware",
         ) as mock_node_cmd,
         patch(
-            "homeassistant.components.zwave_js.api.controller_firmware_update_otw",
+            "homeassistant.components.zwave_js.api.driver_firmware_update_otw",
         ) as mock_controller_cmd,
         patch.dict(
             "homeassistant.components.zwave_js.api.USER_AGENT",
@@ -3557,7 +3557,7 @@ async def test_firmware_upload_view_controller(
         )
         mock_node_cmd.assert_not_called()
         assert mock_controller_cmd.call_args[0][1:2] == (
-            ControllerFirmwareUpdateData(
+            DriverFirmwareUpdateData(
                 "file", b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
             ),
         )
@@ -4415,7 +4415,7 @@ async def test_subscribe_controller_firmware_update_status(
     event = Event(
         type="firmware update progress",
         data={
-            "source": "controller",
+            "source": "driver",
             "event": "firmware update progress",
             "progress": {
                 "sentFragments": 1,
@@ -4424,7 +4424,7 @@ async def test_subscribe_controller_firmware_update_status(
             },
         },
     )
-    client.driver.controller.receive_event(event)
+    client.driver.receive_event(event)
 
     msg = await ws_client.receive_json()
     assert msg["event"] == {
@@ -4439,7 +4439,7 @@ async def test_subscribe_controller_firmware_update_status(
     event = Event(
         type="firmware update finished",
         data={
-            "source": "controller",
+            "source": "driver",
             "event": "firmware update finished",
             "result": {
                 "status": 255,
@@ -4447,7 +4447,7 @@ async def test_subscribe_controller_firmware_update_status(
             },
         },
     )
-    client.driver.controller.receive_event(event)
+    client.driver.receive_event(event)
 
     msg = await ws_client.receive_json()
     assert msg["event"] == {
@@ -4464,13 +4464,13 @@ async def test_subscribe_controller_firmware_update_status_initial_value(
     ws_client = await hass_ws_client(hass)
     device = get_device(hass, client.driver.controller.nodes[1])
 
-    assert client.driver.controller.firmware_update_progress is None
+    assert client.driver.firmware_update_progress is None
 
     # Send a firmware update progress event before the WS command
     event = Event(
         type="firmware update progress",
         data={
-            "source": "controller",
+            "source": "driver",
             "event": "firmware update progress",
             "progress": {
                 "sentFragments": 1,
@@ -4479,7 +4479,7 @@ async def test_subscribe_controller_firmware_update_status_initial_value(
             },
         },
     )
-    client.driver.controller.receive_event(event)
+    client.driver.receive_event(event)
 
     client.async_send_command_no_wait.return_value = {}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
With this release, you will need to update your zwave-js-server instance. You must use zwave-js-server 3.0.0 or greater (schema 41).
- If you use the Z-Wave JS add-on, you need at least version 0.15.0.
- If you use the Z-Wave JS UI add-on, you need at least version [4.0.1](https://github.com/hassio-addons/addon-zwave-js-ui/releases/tag/v4.0.1).
- If you use the Z-Wave JS UI Docker container, you need at least version [10.1.0](https://github.com/zwave-js/zwave-js-ui/releases/tag/v10.1.0).
- If you run your own Docker container or some other installation method, you will need to update your zwave-js-server instance to at least [3.0.0](https://github.com/zwave-js/zwave-js-server/releases/tag/3.0.0).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update zwave-js-server-python to use Z-Wave JS 15

https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.64.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
