### PR TITLE
Add fields and multiple support to object selector

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1114,7 +1114,7 @@ class NumberSelector(Selector[NumberSelectorConfig]):
 
 
 class ObjectSelectorField(TypedDict):
-    """Class to represent a select option dict."""
+    """Class to represent an object selector fields dict."""
 
     label: str
     required: bool

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1113,20 +1113,22 @@ class NumberSelector(Selector[NumberSelectorConfig]):
         return value
 
 
-class ObjectSchemaDict(TypedDict):
+class ObjectSelectorField(TypedDict):
     """Class to represent a select option dict."""
 
-    name: str
+    label: str
+    required: bool
     selector: dict[str, Any]
 
 
 class ObjectSelectorConfig(BaseSelectorConfig):
     """Class to represent an object selector config."""
 
-    schema: list[ObjectSchemaDict]
+    fields: dict[str, ObjectSelectorField]
     multiple: bool
-    label_key: str
-    description: bool
+    label_field: str
+    description_field: bool
+    translation_key: str
 
 
 @SELECTORS.register("object")
@@ -1137,15 +1139,17 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
 
     CONFIG_SCHEMA = BASE_SELECTOR_CONFIG_SCHEMA.extend(
         {
-            vol.Optional("schema"): [
-                {
-                    vol.Required("name"): str,
+            vol.Optional("fields"): {
+                str: {
                     vol.Required("selector"): dict,
+                    vol.Optional("required"): bool,
+                    vol.Optional("label"): str,
                 }
-            ],
-            vol.Optional("label_key"): str,
-            vol.Optional("description_key"): str,
+            },
             vol.Optional("multiple", default=False): bool,
+            vol.Optional("label_field"): str,
+            vol.Optional("description_field"): str,
+            vol.Optional("translation_key"): str,
         }
     )
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1113,8 +1113,20 @@ class NumberSelector(Selector[NumberSelectorConfig]):
         return value
 
 
+class ObjectSchemaDict(TypedDict):
+    """Class to represent a select option dict."""
+
+    name: str
+    selector: dict[str, Any]
+
+
 class ObjectSelectorConfig(BaseSelectorConfig):
     """Class to represent an object selector config."""
+
+    schema: list[ObjectSchemaDict]
+    multiple: bool
+    label_key: str
+    description: bool
 
 
 @SELECTORS.register("object")
@@ -1123,7 +1135,19 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
 
     selector_type = "object"
 
-    CONFIG_SCHEMA = BASE_SELECTOR_CONFIG_SCHEMA
+    CONFIG_SCHEMA = BASE_SELECTOR_CONFIG_SCHEMA.extend(
+        {
+            vol.Optional("schema"): [
+                {
+                    vol.Required("name"): str,
+                    vol.Required("selector"): dict,
+                }
+            ],
+            vol.Optional("label_key"): str,
+            vol.Optional("description_key"): str,
+            vol.Optional("multiple", default=False): bool,
+        }
+    )
 
     def __init__(self, config: ObjectSelectorConfig | None = None) -> None:
         """Instantiate a selector."""

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -594,13 +594,18 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
         ({}, ("abc123",), ()),
         (
             {
-                "schema": [
-                    {"name": "name", "selector": {"text": {}}},
-                    {"name": "percentage", "selector": {"number": {}}},
-                ],
+                "fields": {
+                    "name": {
+                        "required": True,
+                        "selector": {"text": {}},
+                    },
+                    "percentage": {
+                        "selector": {"number": {}},
+                    },
+                },
                 "multiple": True,
-                "label_key": "name",
-                "description_key": "percentage",
+                "label_field": "name",
+                "description_field": "percentage",
             },
             (),
             (),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -590,7 +590,23 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    [({}, ("abc123",), ())],
+    [
+        ({}, ("abc123",), ()),
+        (
+            {
+                "schema": [
+                    {"name": "name", "selector": {"text": {}}},
+                    {"name": "percentage", "selector": {"number": {}}},
+                ],
+                "multiple": True,
+                "label_key": "name",
+                "description_key": "percentage",
+            },
+            (),
+            (),
+        ),
+    ],
+    [],
 )
 def test_object_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test object selector."""


### PR DESCRIPTION
## Proposed change
Backend support for new options in object selector.

It will first be used to improve the `answers` editor (https://github.com/home-assistant/core/pull/147219)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39655
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/25843

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
