### PR TITLE
Change here_travel_time update interval to 30min

### DIFF
--- a/homeassistant/components/here_travel_time/__init__.py
+++ b/homeassistant/components/here_travel_time/__init__.py
@@ -6,7 +6,11 @@ import logging
 
 from homeassistant.const import CONF_API_KEY, CONF_MODE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 from homeassistant.helpers.start import async_at_started
 
 from .const import CONF_TRAFFIC_MODE, DOMAIN, TRAVEL_MODE_PUBLIC
@@ -52,13 +56,19 @@ def alert_for_multiple_entries(hass: HomeAssistant) -> None:
             hass,
             DOMAIN,
             "multiple_here_travel_time_entries",
-            learn_more_url="https://github.com/home-assistant/home-assistant.io/pull/39653",
+            learn_more_url="https://www.home-assistant.io/integrations/here_travel_time/",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="multiple_here_travel_time_entries",
             translation_placeholders={
                 "pricing_page": "https://www.here.com/get-started/pricing",
             },
+        )
+    else:
+        async_delete_issue(
+            hass,
+            DOMAIN,
+            "multiple_here_travel_time_entries",
         )
 
 

--- a/homeassistant/components/here_travel_time/__init__.py
+++ b/homeassistant/components/here_travel_time/__init__.py
@@ -6,9 +6,10 @@ import logging
 
 from homeassistant.const import CONF_API_KEY, CONF_MODE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.start import async_at_started
 
-from .const import CONF_TRAFFIC_MODE, TRAVEL_MODE_PUBLIC
+from .const import CONF_TRAFFIC_MODE, DOMAIN, TRAVEL_MODE_PUBLIC
 from .coordinator import (
     HereConfigEntry,
     HERERoutingDataUpdateCoordinator,
@@ -23,6 +24,8 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, config_entry: HereConfigEntry) -> bool:
     """Set up HERE Travel Time from a config entry."""
     api_key = config_entry.data[CONF_API_KEY]
+
+    alert_for_multiple_entries(hass)
 
     cls: type[HERETransitDataUpdateCoordinator | HERERoutingDataUpdateCoordinator]
     if config_entry.data[CONF_MODE] in {TRAVEL_MODE_PUBLIC, "publicTransportTimeTable"}:
@@ -40,6 +43,23 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: HereConfigEntry) 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
+
+
+def alert_for_multiple_entries(hass: HomeAssistant) -> None:
+    """Check if there are multiple entries for the same API key."""
+    if len(hass.config_entries.async_entries(DOMAIN)) > 1:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "multiple_here_travel_time_entries",
+            learn_more_url="https://github.com/home-assistant/home-assistant.io/pull/39653",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="multiple_here_travel_time_entries",
+            translation_placeholders={
+                "pricing_page": "https://www.here.com/get-started/pricing",
+            },
+        )
 
 
 async def async_unload_entry(

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -44,7 +44,7 @@ from .coordinator import (
     HERETransitDataUpdateCoordinator,
 )
 
-SCAN_INTERVAL = timedelta(minutes=5)
+SCAN_INTERVAL = timedelta(minutes=30)
 
 
 def sensor_descriptions(travel_mode: str) -> tuple[SensorEntityDescription, ...]:

--- a/homeassistant/components/here_travel_time/strings.json
+++ b/homeassistant/components/here_travel_time/strings.json
@@ -107,5 +107,11 @@
         "name": "Destination"
       }
     }
+  },
+  "issues": {
+    "multiple_here_travel_time_entries": {
+      "title": "More than one HERE Travel Time integration detected",
+      "description": "HERE deprecated the previous free tier. You have change to the Base Plan which has 5000 instead of 30000 free requests per month.\n\nSince you have more than one HERE Travel Time integration configured, you will need to disable or remove the additional integrations to avoid exceeding the free request limit.\nYou can ignore this issue if you are okay with the additional cost."
+    }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
HERE deprecated the previous free tier. The new Base Plan has 5000 free requests per month. The automatic update interval of the here_travel_time integration changed from 5min to 30min so 1 route can be supported without costs.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The new Base Plan everyone has to switch to until 31.08.2025 will only allow for 5000 req/month. That means ~2,7req/h. Choosing 30min will update 1 sensor on a interval and leave room for a few forced updates in a month.

In addition to the raised issue I marked this as a breaking change because some users might have automations that rely on regular updates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39653
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
