### PR TITLE
Add number entity to Russound RIO

### DIFF
--- a/homeassistant/components/russound_rio/__init__.py
+++ b/homeassistant/components/russound_rio/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from .const import DOMAIN, RUSSOUND_RIO_EXCEPTIONS
 
-PLATFORMS = [Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.NUMBER]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/russound_rio/entity.py
+++ b/homeassistant/components/russound_rio/entity.py
@@ -6,6 +6,7 @@ from typing import Any, Concatenate
 
 from aiorussound import Controller, RussoundClient
 from aiorussound.models import CallbackType
+from aiorussound.rio import ZoneControlSurface
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -58,6 +59,7 @@ class RussoundBaseEntity(Entity):
             self._controller.mac_address
             or f"{self._primary_mac_address}-{self._controller.controller_id}"
         )
+        self._zone_id = zone_id
         if not zone_id:
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self._device_identifier)},
@@ -73,6 +75,11 @@ class RussoundBaseEntity(Entity):
             suggested_area=zone.name,
             via_device=(DOMAIN, self._device_identifier),
         )
+
+    @property
+    def _zone(self) -> ZoneControlSurface:
+        assert self._zone_id
+        return self._controller.zones[self._zone_id]
 
     async def _state_update_callback(
         self, _client: RussoundClient, _callback_type: CallbackType

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 from aiorussound import Controller
 from aiorussound.const import FeatureFlag
 from aiorussound.models import PlayStatus, Source
-from aiorussound.rio import ZoneControlSurface
 from aiorussound.util import is_feature_supported
 
 from homeassistant.components.media_player import (
@@ -67,14 +66,9 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
     ) -> None:
         """Initialize the zone device."""
         super().__init__(controller, zone_id)
-        self._zone_id = zone_id
         _zone = self._zone
         self._sources = sources
         self._attr_unique_id = f"{self._primary_mac_address}-{_zone.device_str}"
-
-    @property
-    def _zone(self) -> ZoneControlSurface:
-        return self._controller.zones[self._zone_id]
 
     @property
     def _source(self) -> Source:

--- a/homeassistant/components/russound_rio/number.py
+++ b/homeassistant/components/russound_rio/number.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
-from aiorussound.rio import Controller, RussoundClient, ZoneControlSurface
+from aiorussound.rio import Controller, ZoneControlSurface
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.const import EntityCategory
@@ -74,14 +74,13 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Russound number entities based on a config entry."""
-    client: RussoundClient = entry.runtime_data
-    entities: list[RussoundNumberEntity] = [
+    client = entry.runtime_data
+    async_add_entities(
         RussoundNumberEntity(controller, zone_id, description)
         for controller in client.controllers.values()
         for zone_id in controller.zones
         for description in CONTROL_ENTITIES
-    ]
-    async_add_entities(entities)
+    )
 
 
 class RussoundNumberEntity(RussoundBaseEntity, NumberEntity):
@@ -98,15 +97,9 @@ class RussoundNumberEntity(RussoundBaseEntity, NumberEntity):
         """Initialize a Russound number entity."""
         super().__init__(controller, zone_id)
         self.entity_description = description
-        self._zone_id = zone_id
-        _zone = controller.zones[zone_id]
         self._attr_unique_id = (
-            f"{self._primary_mac_address}-{_zone.device_str}-{description.key}"
+            f"{self._primary_mac_address}-{self._zone.device_str}-{description.key}"
         )
-
-    @property
-    def _zone(self) -> ZoneControlSurface:
-        return self._controller.zones[self._zone_id]
 
     @property
     def native_value(self) -> float:

--- a/homeassistant/components/russound_rio/number.py
+++ b/homeassistant/components/russound_rio/number.py
@@ -1,0 +1,119 @@
+"""Support for Russound number entities."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from aiorussound.rio import Controller, RussoundClient, ZoneControlSurface
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import RussoundConfigEntry
+from .entity import RussoundBaseEntity, command
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class RussoundZoneNumberEntityDescription(NumberEntityDescription):
+    """Describes Russound number entities."""
+
+    value_fn: Callable[[ZoneControlSurface], float]
+    set_value_fn: Callable[[ZoneControlSurface, float], Awaitable[None]]
+
+
+CONTROL_ENTITIES: tuple[RussoundZoneNumberEntityDescription, ...] = (
+    RussoundZoneNumberEntityDescription(
+        key="balance",
+        translation_key="balance",
+        native_min_value=-10,
+        native_max_value=10,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda zone: zone.balance,
+        set_value_fn=lambda zone, value: zone.set_balance(int(value)),
+    ),
+    RussoundZoneNumberEntityDescription(
+        key="bass",
+        translation_key="bass",
+        native_min_value=-10,
+        native_max_value=10,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda zone: zone.bass,
+        set_value_fn=lambda zone, value: zone.set_bass(int(value)),
+    ),
+    RussoundZoneNumberEntityDescription(
+        key="treble",
+        translation_key="treble",
+        native_min_value=-10,
+        native_max_value=10,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda zone: zone.treble,
+        set_value_fn=lambda zone, value: zone.set_treble(int(value)),
+    ),
+    RussoundZoneNumberEntityDescription(
+        key="turn_on_volume",
+        translation_key="turn_on_volume",
+        native_min_value=0,
+        native_max_value=100,
+        native_step=2,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda zone: zone.turn_on_volume * 2,
+        set_value_fn=lambda zone, value: zone.set_turn_on_volume(int(value / 2)),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: RussoundConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Russound number entities based on a config entry."""
+    client: RussoundClient = entry.runtime_data
+    entities: list[RussoundNumberEntity] = [
+        RussoundNumberEntity(controller, zone_id, description)
+        for controller in client.controllers.values()
+        for zone_id in controller.zones
+        for description in CONTROL_ENTITIES
+    ]
+    async_add_entities(entities)
+
+
+class RussoundNumberEntity(RussoundBaseEntity, NumberEntity):
+    """Defines a Russound number entity."""
+
+    entity_description: RussoundZoneNumberEntityDescription
+
+    def __init__(
+        self,
+        controller: Controller,
+        zone_id: int,
+        description: RussoundZoneNumberEntityDescription,
+    ) -> None:
+        """Initialize a Russound number entity."""
+        super().__init__(controller, zone_id)
+        self.entity_description = description
+        self._zone_id = zone_id
+        _zone = controller.zones[zone_id]
+        self._attr_unique_id = (
+            f"{self._primary_mac_address}-{_zone.device_str}-{description.key}"
+        )
+
+    @property
+    def _zone(self) -> ZoneControlSurface:
+        return self._controller.zones[self._zone_id]
+
+    @property
+    def native_value(self) -> float:
+        """Return the native value of the entity."""
+        return float(self.entity_description.value_fn(self._zone))
+
+    @command
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value."""
+        await self.entity_description.set_value_fn(self._zone, value)

--- a/homeassistant/components/russound_rio/strings.json
+++ b/homeassistant/components/russound_rio/strings.json
@@ -52,7 +52,7 @@
         "name": "Treble"
       },
       "turn_on_volume": {
-        "name": "Turn on volume"
+        "name": "Turn-on volume"
       }
     }
   },

--- a/homeassistant/components/russound_rio/strings.json
+++ b/homeassistant/components/russound_rio/strings.json
@@ -52,7 +52,7 @@
         "name": "Treble"
       },
       "turn_on_volume": {
-        "name": "Turn On Volume"
+        "name": "Turn on volume"
       }
     }
   },

--- a/homeassistant/components/russound_rio/strings.json
+++ b/homeassistant/components/russound_rio/strings.json
@@ -40,6 +40,22 @@
       "wrong_device": "This Russound controller does not match the existing device ID. Please make sure you entered the correct IP address."
     }
   },
+  "entity": {
+    "number": {
+      "balance": {
+        "name": "Balance"
+      },
+      "bass": {
+        "name": "Bass"
+      },
+      "treble": {
+        "name": "Treble"
+      },
+      "turn_on_volume": {
+        "name": "Turn On Volume"
+      }
+    }
+  },
   "exceptions": {
     "entry_cannot_connect": {
       "message": "Error while connecting to {host}:{port}"

--- a/tests/components/russound_rio/conftest.py
+++ b/tests/components/russound_rio/conftest.py
@@ -79,6 +79,10 @@ def mock_russound_client() -> Generator[AsyncMock]:
                 zone.unmute = AsyncMock()
                 zone.toggle_mute = AsyncMock()
                 zone.set_seek_time = AsyncMock()
+                zone.set_balance = AsyncMock()
+                zone.set_bass = AsyncMock()
+                zone.set_treble = AsyncMock()
+                zone.set_turn_on_volume = AsyncMock()
 
         client.controllers = {
             1: Controller(

--- a/tests/components/russound_rio/snapshots/test_number.ambr
+++ b/tests/components/russound_rio/snapshots/test_number.ambr
@@ -200,7 +200,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Turn on volume',
+    'original_name': 'Turn-on volume',
     'platform': 'russound_rio',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -213,7 +213,7 @@
 # name: test_all_entities[number.backyard_turn_on_volume-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Backyard Turn on volume',
+      'friendly_name': 'Backyard Turn-on volume',
       'max': 100,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
@@ -428,7 +428,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Turn on volume',
+    'original_name': 'Turn-on volume',
     'platform': 'russound_rio',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -441,7 +441,7 @@
 # name: test_all_entities[number.bedroom_turn_on_volume-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom Turn on volume',
+      'friendly_name': 'Bedroom Turn-on volume',
       'max': 100,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
@@ -656,7 +656,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Turn on volume',
+    'original_name': 'Turn-on volume',
     'platform': 'russound_rio',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -669,7 +669,7 @@
 # name: test_all_entities[number.kitchen_turn_on_volume-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Turn on volume',
+      'friendly_name': 'Kitchen Turn-on volume',
       'max': 100,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
@@ -884,7 +884,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Turn on volume',
+    'original_name': 'Turn-on volume',
     'platform': 'russound_rio',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -897,7 +897,7 @@
 # name: test_all_entities[number.living_room_turn_on_volume-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Living Room Turn on volume',
+      'friendly_name': 'Living Room Turn-on volume',
       'max': 100,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,

--- a/tests/components/russound_rio/snapshots/test_number.ambr
+++ b/tests/components/russound_rio/snapshots/test_number.ambr
@@ -200,7 +200,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Turn On Volume',
+    'original_name': 'Turn on volume',
     'platform': 'russound_rio',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -213,7 +213,7 @@
 # name: test_all_entities[number.backyard_turn_on_volume-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Backyard Turn On Volume',
+      'friendly_name': 'Backyard Turn on volume',
       'max': 100,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
@@ -428,7 +428,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Turn On Volume',
+    'original_name': 'Turn on volume',
     'platform': 'russound_rio',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -441,7 +441,7 @@
 # name: test_all_entities[number.bedroom_turn_on_volume-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom Turn On Volume',
+      'friendly_name': 'Bedroom Turn on volume',
       'max': 100,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
@@ -656,7 +656,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Turn On Volume',
+    'original_name': 'Turn on volume',
     'platform': 'russound_rio',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -669,7 +669,7 @@
 # name: test_all_entities[number.kitchen_turn_on_volume-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Turn On Volume',
+      'friendly_name': 'Kitchen Turn on volume',
       'max': 100,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
@@ -884,7 +884,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Turn On Volume',
+    'original_name': 'Turn on volume',
     'platform': 'russound_rio',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -897,7 +897,7 @@
 # name: test_all_entities[number.living_room_turn_on_volume-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Living Room Turn On Volume',
+      'friendly_name': 'Living Room Turn on volume',
       'max': 100,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,

--- a/tests/components/russound_rio/snapshots/test_number.ambr
+++ b/tests/components/russound_rio/snapshots/test_number.ambr
@@ -1,0 +1,913 @@
+# serializer version: 1
+# name: test_all_entities[number.backyard_balance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.backyard_balance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Balance',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'balance',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[1]-balance',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.backyard_balance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Backyard Balance',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.backyard_balance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.backyard_bass-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.backyard_bass',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bass',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'bass',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[1]-bass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.backyard_bass-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Backyard Bass',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.backyard_bass',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.backyard_treble-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.backyard_treble',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Treble',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'treble',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[1]-treble',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.backyard_treble-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Backyard Treble',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.backyard_treble',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.backyard_turn_on_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 2,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.backyard_turn_on_volume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Turn On Volume',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'turn_on_volume',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[1]-turn_on_volume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.backyard_turn_on_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Backyard Turn On Volume',
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 2,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.backyard_turn_on_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.0',
+  })
+# ---
+# name: test_all_entities[number.bedroom_balance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.bedroom_balance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Balance',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'balance',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[3]-balance',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.bedroom_balance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom Balance',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.bedroom_balance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.bedroom_bass-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.bedroom_bass',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bass',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'bass',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[3]-bass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.bedroom_bass-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom Bass',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.bedroom_bass',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.bedroom_treble-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.bedroom_treble',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Treble',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'treble',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[3]-treble',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.bedroom_treble-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom Treble',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.bedroom_treble',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.bedroom_turn_on_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 2,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.bedroom_turn_on_volume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Turn On Volume',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'turn_on_volume',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[3]-turn_on_volume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.bedroom_turn_on_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom Turn On Volume',
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 2,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.bedroom_turn_on_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.0',
+  })
+# ---
+# name: test_all_entities[number.kitchen_balance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.kitchen_balance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Balance',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'balance',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[2]-balance',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.kitchen_balance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Balance',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.kitchen_balance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.kitchen_bass-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.kitchen_bass',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bass',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'bass',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[2]-bass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.kitchen_bass-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Bass',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.kitchen_bass',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.kitchen_treble-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.kitchen_treble',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Treble',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'treble',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[2]-treble',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.kitchen_treble-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Treble',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.kitchen_treble',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.kitchen_turn_on_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 2,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.kitchen_turn_on_volume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Turn On Volume',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'turn_on_volume',
+    'unique_id': '00:11:22:33:44:55-C[1].Z[2]-turn_on_volume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.kitchen_turn_on_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Turn On Volume',
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 2,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.kitchen_turn_on_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.0',
+  })
+# ---
+# name: test_all_entities[number.living_room_balance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.living_room_balance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Balance',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'balance',
+    'unique_id': '00:11:22:33:44:55-C[2].Z[9]-balance',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.living_room_balance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Living Room Balance',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.living_room_balance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.living_room_bass-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.living_room_bass',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bass',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'bass',
+    'unique_id': '00:11:22:33:44:55-C[2].Z[9]-bass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.living_room_bass-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Living Room Bass',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.living_room_bass',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.living_room_treble-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.living_room_treble',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Treble',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'treble',
+    'unique_id': '00:11:22:33:44:55-C[2].Z[9]-treble',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.living_room_treble-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Living Room Treble',
+      'max': 10,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.living_room_treble',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[number.living_room_turn_on_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 2,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.living_room_turn_on_volume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Turn On Volume',
+    'platform': 'russound_rio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'turn_on_volume',
+    'unique_id': '00:11:22:33:44:55-C[2].Z[9]-turn_on_volume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.living_room_turn_on_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Living Room Turn On Volume',
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 2,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.living_room_turn_on_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.0',
+  })
+# ---

--- a/tests/components/russound_rio/test_number.py
+++ b/tests/components/russound_rio/test_number.py
@@ -1,0 +1,70 @@
+"""Tests for the Russound RIO number platform."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+from .const import NAME_ZONE_1
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_russound_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch("homeassistant.components.russound_rio.PLATFORMS", [Platform.NUMBER]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("entity_suffix", "value", "expected_method", "expected_arg"),
+    [
+        ("bass", -5, "set_bass", -5),
+        ("balance", 3, "set_balance", 3),
+        ("treble", 7, "set_treble", 7),
+        ("turn_on_volume", 60, "set_turn_on_volume", 30),
+    ],
+)
+async def test_setting_number_value(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_suffix: str,
+    value: int,
+    expected_method: str,
+    expected_arg: int,
+) -> None:
+    """Test setting value on Russound number entity."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: f"{NUMBER_DOMAIN}.{NAME_ZONE_1}_{entity_suffix}",
+            ATTR_VALUE: value,
+        },
+        blocking=True,
+    )
+
+    zone = mock_russound_client.controllers[1].zones[1]
+    getattr(zone, expected_method).assert_called_once_with(expected_arg)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the number entity to the Russound RIO integration. Includes balance, bass, treble, and turn on volume support.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39657
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
