### PR TITLE
Bump python-smarttub to 0.0.43

### DIFF
--- a/homeassistant/components/smarttub/manifest.json
+++ b/homeassistant/components/smarttub/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/smarttub",
   "iot_class": "cloud_polling",
   "loggers": ["smarttub"],
-  "requirements": ["python-smarttub==0.0.40"]
+  "requirements": ["python-smarttub==0.0.41"]
 }

--- a/homeassistant/components/smarttub/manifest.json
+++ b/homeassistant/components/smarttub/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/smarttub",
   "iot_class": "cloud_polling",
   "loggers": ["smarttub"],
-  "requirements": ["python-smarttub==0.0.41"]
+  "requirements": ["python-smarttub==0.0.42"]
 }

--- a/homeassistant/components/smarttub/manifest.json
+++ b/homeassistant/components/smarttub/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/smarttub",
   "iot_class": "cloud_polling",
   "loggers": ["smarttub"],
-  "requirements": ["python-smarttub==0.0.39"]
+  "requirements": ["python-smarttub==0.0.40"]
 }

--- a/homeassistant/components/smarttub/manifest.json
+++ b/homeassistant/components/smarttub/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/smarttub",
   "iot_class": "cloud_polling",
   "loggers": ["smarttub"],
-  "requirements": ["python-smarttub==0.0.43"]
+  "requirements": ["python-smarttub==0.0.44"]
 }

--- a/homeassistant/components/smarttub/manifest.json
+++ b/homeassistant/components/smarttub/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/smarttub",
   "iot_class": "cloud_polling",
   "loggers": ["smarttub"],
-  "requirements": ["python-smarttub==0.0.42"]
+  "requirements": ["python-smarttub==0.0.43"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2499,7 +2499,7 @@ python-ripple-api==0.0.3
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.42
+python-smarttub==0.0.43
 
 # homeassistant.components.snoo
 python-snoo==0.6.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2499,7 +2499,7 @@ python-ripple-api==0.0.3
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.39
+python-smarttub==0.0.40
 
 # homeassistant.components.snoo
 python-snoo==0.6.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2499,7 +2499,7 @@ python-ripple-api==0.0.3
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.43
+python-smarttub==0.0.44
 
 # homeassistant.components.snoo
 python-snoo==0.6.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2499,7 +2499,7 @@ python-ripple-api==0.0.3
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.41
+python-smarttub==0.0.42
 
 # homeassistant.components.snoo
 python-snoo==0.6.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2499,7 +2499,7 @@ python-ripple-api==0.0.3
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.40
+python-smarttub==0.0.41
 
 # homeassistant.components.snoo
 python-snoo==0.6.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2066,7 +2066,7 @@ python-rabbitair==0.0.8
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.39
+python-smarttub==0.0.40
 
 # homeassistant.components.snoo
 python-snoo==0.6.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2066,7 +2066,7 @@ python-rabbitair==0.0.8
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.43
+python-smarttub==0.0.44
 
 # homeassistant.components.snoo
 python-snoo==0.6.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2066,7 +2066,7 @@ python-rabbitair==0.0.8
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.41
+python-smarttub==0.0.42
 
 # homeassistant.components.snoo
 python-snoo==0.6.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2066,7 +2066,7 @@ python-rabbitair==0.0.8
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.42
+python-smarttub==0.0.43
 
 # homeassistant.components.snoo
 python-snoo==0.6.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2066,7 +2066,7 @@ python-rabbitair==0.0.8
 python-roborock==2.18.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.40
+python-smarttub==0.0.41
 
 # homeassistant.components.snoo
 python-snoo==0.6.6


### PR DESCRIPTION
## Proposed change

This PR updates the `python-smarttub` dependency from version 0.0.39 to 0.0.44. This dependency upgrade brings the latest fixes and improvements from the upstream library.

The update may help resolve timing issues with switch state synchronization that have been reported by users, where switches revert to their previous state shortly after toggling before eventually settling to the correct state.

- **Changelog**: [python-smarttub releases 0.0.39 to 0.0.44](https://github.com/mdz/python-smarttub/compare/v0.0.39...v0.0.44)

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #135640
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- **Changelog**: [python-smarttub releases 0.0.39 to 0.0.44](https://github.com/mdz/python-smarttub/compare/v0.0.39...v0.0.44)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
