### PR TITLE
Add quality scale for LCN

### DIFF
--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -8,5 +8,6 @@
   "documentation": "https://www.home-assistant.io/integrations/lcn",
   "iot_class": "local_push",
   "loggers": ["pypck"],
+  "quality_scale": "bronze",
   "requirements": ["pypck==0.8.9", "lcn-frontend==0.2.5"]
 }

--- a/homeassistant/components/lcn/quality_scale.yaml
+++ b/homeassistant/components/lcn/quality_scale.yaml
@@ -1,0 +1,75 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+  # Silver
+  action-exceptions: todo
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: todo
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: |
+      Integration has no authentication.
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: todo
+  docs-data-update: todo
+  docs-examples: done
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: done
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: |
+      Device discovery has to be manually triggered in LCN. Manually adding devices is implemented.
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default:
+    status: exempt
+    comment: |
+      Since all entities are configured manually, they are enabled by default.
+  entity-translations:
+    status: exempt
+    comment: |
+      Since all entities are configured manually, names are user-defined.
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: done
+  repair-issues: done
+  stale-devices:
+    status: exempt
+    comment: |
+      Device discovery has to be manually triggered in LCN. Manually removing  devices is implemented.
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: |
+      Integration is not making any HTTP requests.
+  strict-typing: todo

--- a/homeassistant/components/lcn/quality_scale.yaml
+++ b/homeassistant/components/lcn/quality_scale.yaml
@@ -60,8 +60,8 @@ rules:
     status: exempt
     comment: |
       Since all entities are configured manually, names are user-defined.
-  exception-translations: done
-  icon-translations: done
+  exception-translations: todo
+  icon-translations: todo
   reconfiguration-flow: done
   repair-issues: done
   stale-devices:

--- a/homeassistant/components/lcn/quality_scale.yaml
+++ b/homeassistant/components/lcn/quality_scale.yaml
@@ -21,7 +21,9 @@ rules:
   # Silver
   action-exceptions: todo
   config-entry-unloading: done
-  docs-configuration-parameters: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: Integration has no configuration parameters
   docs-installation-parameters: done
   entity-unavailable: todo
   integration-owner: done

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -566,7 +566,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "lastfm",
     "launch_library",
     "laundrify",
-    "lcn",
     "ld2410_ble",
     "leaone",
     "led_ble",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1617,7 +1617,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "lametric",
     "launch_library",
     "laundrify",
-    "lcn",
     "ld2410_ble",
     "leaone",
     "led_ble",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add quality scale for LCN (target quality scale: bronze)

## Bronze

- [x] `action-setup` - Service actions are registered in async_setup
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/__init__.py#L70
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
      _Integration is classified as "Local Push"._
- [x] `brands` - Has branding assets available for the integration
      https://github.com/home-assistant/brands/tree/master/core_integrations/lcn
- [x] `common-modules` - Place common patterns in common modules
      https://github.com/home-assistant/core/blob/dev/homeassistant/components/lcn/entity.py
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
      https://github.com/home-assistant/core/blob/dev/tests/components/lcn/test_config_flow.py
- [x] `config-flow` - Integration needs to be able to be set up via the UI
      https://github.com/home-assistant/core/blob/dev/homeassistant/components/lcn/config_flow.py
  - [x] Uses `data_description` to give context to fields
        https://github.com/home-assistant/core/blob/dev/homeassistant/components/lcn/strings.json
  - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `dependency-transparency` - Dependency transparency
      https://github.com/alengwenus/pypck
      https://github.com/alengwenus/lcn-frontend
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
      https://www.home-assistant.io/integrations/lcn/#actions
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
      https://www.home-assistant.io/integrations/lcn
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
      https://www.home-assistant.io/integrations/lcn/#configuration
- [x] `docs-removal-instructions` - The documentation provides removal instructions
      https://www.home-assistant.io/integrations/lcn/#removing-the-integration
- [x] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/entity.py#L60
- [x] `entity-unique-id` - Entities have a unique ID
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/entity.py#L50
- [x] `has-entity-name` - Entities use has_entity_name = True
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/entity.py#L26
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/__init__.py#L111
- [x] `test-before-configure` - Test a connection in the config flow
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/config_flow.py#L114
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/__init__.py#L97
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/config_flow.py#L107

## Silver

- [ ] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `config-entry-unloading` - Support config entry unloading
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/__init__.py#L216
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options
      _Integration does not provide an options flow._
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
      https://www.home-assistant.io/integrations/lcn/#configuration
- [ ] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `integration-owner` - Has an integration owner
      https://github.com/home-assistant/core/blob/dev/homeassistant/components/lcn/manifest.json
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/__init__.py#L240
- [x] `parallel-updates` - Number of parallel updates is specified
- [x] `reauthentication-flow` - Reauthentication needs to be available via the UI
      _Integration doesn't require any form of authentication._
- [x] `test-coverage` - Above 95% test coverage for all integration modules

## Gold

- [x] `devices` - The integration creates devices
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/entity.py#L40
- [ ] `diagnostics` - Implements diagnostics
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `discovery` - Devices can be discovered
- [ ] `docs-data-update` - The documentation describes how data is updated
- [x] `docs-examples` - The documentation provides automation examples the user can use.
      _Documentation provides example snippets for all trigger events and actions._
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
      https://www.home-assistant.io/integrations/lcn/#supported-device-types
      https://www.home-assistant.io/integrations/lcn/#platforms
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `dynamic-devices` - Devices added after integration setup
      _Device discovery has to be manually triggered in the LCN configuration frontend. Manually adding devices is implemented._
- [ ] `entity-category` - Entities are assigned an appropriate EntityCategory
- [ ] `entity-device-class` - Entities use device classes where possible
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
      _Entities are set up deliberately by the user in a special frontend panel. No need to disable them by default._
- [x] `entity-translations` - Entities have translated names
      _Since all entities are configured manually, names are user-defined._
- [x] `exception-translations` - Exception messages are translatable
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/strings.json#L416
- [x] `icon-translations` - Entities implement icon translations
      https://github.com/home-assistant/core/blob/dev/homeassistant/components/lcn/icons.json
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
      https://github.com/home-assistant/core/blob/a11e2744341b7c7348a70e67cb355389ab12e114/homeassistant/components/lcn/config_flow.py#L131
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [x] `stale-devices` - Stale devices are removed
      _Device discovery has to be manually triggered in the LCN configuration frontend. Manually removing devices is implemented._

## Platinum

- [x] `async-dependency` - Dependency is async
      https://github.com/alengwenus/pypck
- [x] `inject-websession` - The integration dependency supports passing in a websession
      _Integration is not making any HTTP requests._
- [ ] `strict-typing` - Strict typing


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
