### PR TITLE
Add container arch to system info

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -12,7 +12,6 @@ import re
 import struct
 from typing import Any, NamedTuple
 
-import aiofiles
 from aiohasupervisor import SupervisorError
 import voluptuous as vol
 
@@ -237,12 +236,6 @@ SCHEMA_RESTORE_PARTIAL = SCHEMA_RESTORE_FULL.extend(
 def _is_32_bit() -> bool:
     size = struct.calcsize("P")
     return size * 8 == 32
-
-
-async def _get_arch() -> str:
-    async with aiofiles.open("/etc/apk/arch") as arch_file:
-        raw_arch = await arch_file.read()
-    return {"x86": "i386"}.get(raw_arch, raw_arch)
 
 
 class APIEndpointSettings(NamedTuple):
@@ -566,8 +559,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
     hass.data[ADDONS_COORDINATOR] = coordinator
 
-    arch = await _get_arch()
-
     def deprecated_setup_issue() -> None:
         os_info = get_os_info(hass)
         info = get_info(hass)
@@ -575,6 +566,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return
         is_haos = info.get("hassos") is not None
         board = os_info.get("board")
+        arch = info.get("arch", "unknown")
         unsupported_board = board in {"tinker", "odroid-xu4", "rpi2"}
         unsupported_os_on_board = board in {"rpi3", "rpi4"}
         if is_haos and (unsupported_board or unsupported_os_on_board):

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -7,7 +7,6 @@ import logging
 import struct
 from typing import Any
 
-import aiofiles
 import voluptuous as vol
 
 from homeassistant import config as conf_util, core_config
@@ -99,12 +98,6 @@ DEPRECATION_URL = (
 def _is_32_bit() -> bool:
     size = struct.calcsize("P")
     return size * 8 == 32
-
-
-async def _get_arch() -> str:
-    async with aiofiles.open("/etc/apk/arch") as arch_file:
-        raw_arch = (await arch_file.read()).strip()
-    return {"x86": "i386", "x86_64": "amd64"}.get(raw_arch, raw_arch)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa: C901
@@ -419,7 +412,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         bit32 = _is_32_bit()
         arch = info["arch"]
         if bit32 and installation_type == "Container":
-            arch = await _get_arch()
+            arch = info.get("container_arch", arch)
             ir.async_create_issue(
                 hass,
                 DOMAIN,

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    EVENT_HOMEASSISTANT_STARTED,
     RESTART_EXIT_CODE,
     SERVICE_RELOAD,
     SERVICE_SAVE_PERSISTENT_STATES,
@@ -25,6 +26,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
 )
 from homeassistant.core import (
+    Event,
     HomeAssistant,
     ServiceCall,
     ServiceResponse,
@@ -404,45 +406,50 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
     hass.data[DATA_EXPOSED_ENTITIES] = exposed_entities
     async_set_stop_handler(hass, _async_stop)
 
-    info = await async_get_system_info(hass)
+    async def _async_check_deprecation(event: Event) -> None:
+        """Check and create deprecation issues after startup."""
+        info = await async_get_system_info(hass)
 
-    installation_type = info["installation_type"][15:]
-    if installation_type in {"Core", "Container"}:
-        deprecated_method = installation_type == "Core"
-        bit32 = _is_32_bit()
-        arch = info["arch"]
-        if bit32 and installation_type == "Container":
-            arch = info.get("container_arch", arch)
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                "deprecated_container",
-                learn_more_url=DEPRECATION_URL,
-                is_fixable=False,
-                severity=IssueSeverity.WARNING,
-                translation_key="deprecated_container",
-                translation_placeholders={"arch": arch},
-            )
-        deprecated_architecture = bit32 and installation_type != "Container"
-        if deprecated_method or deprecated_architecture:
-            issue_id = "deprecated"
-            if deprecated_method:
-                issue_id += "_method"
-            if deprecated_architecture:
-                issue_id += "_architecture"
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                issue_id,
-                learn_more_url=DEPRECATION_URL,
-                is_fixable=False,
-                severity=IssueSeverity.WARNING,
-                translation_key=issue_id,
-                translation_placeholders={
-                    "installation_type": installation_type,
-                    "arch": arch,
-                },
-            )
+        installation_type = info["installation_type"][15:]
+        if installation_type in {"Core", "Container"}:
+            deprecated_method = installation_type == "Core"
+            bit32 = _is_32_bit()
+            arch = info["arch"]
+            if bit32 and installation_type == "Container":
+                arch = info.get("container_arch", arch)
+                ir.async_create_issue(
+                    hass,
+                    DOMAIN,
+                    "deprecated_container",
+                    learn_more_url=DEPRECATION_URL,
+                    is_fixable=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="deprecated_container",
+                    translation_placeholders={"arch": arch},
+                )
+            deprecated_architecture = bit32 and installation_type != "Container"
+            if deprecated_method or deprecated_architecture:
+                issue_id = "deprecated"
+                if deprecated_method:
+                    issue_id += "_method"
+                if deprecated_architecture:
+                    issue_id += "_architecture"
+                ir.async_create_issue(
+                    hass,
+                    DOMAIN,
+                    issue_id,
+                    learn_more_url=DEPRECATION_URL,
+                    is_fixable=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key=issue_id,
+                    translation_placeholders={
+                        "installation_type": installation_type,
+                        "arch": arch,
+                    },
+                )
+
+    # Delay deprecation check to make sure installation method is determined correctly
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_check_deprecation)
 
     return True
 

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -124,6 +124,7 @@
     "info": {
       "arch": "CPU architecture",
       "config_dir": "Configuration directory",
+      "container_arch": "Container architecture",
       "dev": "Development",
       "docker": "Docker",
       "hassio": "Supervisor",

--- a/homeassistant/components/homeassistant/system_health.py
+++ b/homeassistant/components/homeassistant/system_health.py
@@ -27,6 +27,7 @@ async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
         "dev": info.get("dev"),
         "hassio": info.get("hassio"),
         "docker": info.get("docker"),
+        "container_arch": info.get("container_arch"),
         "user": info.get("user"),
         "virtualenv": info.get("virtualenv"),
         "python_version": info.get("python_version"),

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -21,12 +21,29 @@ from .singleton import singleton
 _LOGGER = logging.getLogger(__name__)
 
 _DATA_MAC_VER = "system_info_mac_ver"
+_DATA_CONTAINER_ARCH = "system_info_container_arch"
 
 
 @singleton(_DATA_MAC_VER)
 async def async_get_mac_ver(hass: HomeAssistant) -> str:
     """Return the macOS version."""
     return (await hass.async_add_executor_job(platform.mac_ver))[0]
+
+
+@singleton(_DATA_CONTAINER_ARCH)
+async def async_get_container_arch(hass: HomeAssistant) -> str:
+    """Return the container architecture."""
+
+    def _read_arch_file() -> str:
+        """Read the architecture from /etc/apk/arch."""
+        with open("/etc/apk/arch", encoding="utf-8") as arch_file:
+            return arch_file.read().strip()
+
+    try:
+        raw_arch = await hass.async_add_executor_job(_read_arch_file)
+    except FileNotFoundError:
+        return "unknown"
+    return {"x86": "i386", "x86_64": "amd64"}.get(raw_arch, raw_arch)
 
 
 # Cache the result of getuser() because it can call getpwuid() which
@@ -79,6 +96,7 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     if info_object["docker"]:
         if info_object["user"] == "root" and is_official_image():
             info_object["installation_type"] = "Home Assistant Container"
+            info_object["container_arch"] = await async_get_container_arch(hass)
         else:
             info_object["installation_type"] = "Unsupported Third Party Container"
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -3,7 +3,6 @@
 aiodhcpwatcher==1.2.0
 aiodiscover==2.7.0
 aiodns==3.5.0
-aiofiles==24.1.0
 aiohasupervisor==0.3.1
 aiohttp-asyncmdnsresolver==0.1.1
 aiohttp-fast-zlib==0.3.0
@@ -200,6 +199,14 @@ tenacity!=8.4.0
 # 5.0.0 breaks Timeout as a context manager
 # TypeError: 'Timeout' object does not support the context manager protocol
 async-timeout==4.0.3
+
+# aiofiles keeps getting downgraded by custom components
+# causing newer methods to not be available and breaking
+# some integrations at startup
+# https://github.com/home-assistant/core/issues/127529
+# https://github.com/home-assistant/core/issues/122508
+# https://github.com/home-assistant/core/issues/118004
+aiofiles>=24.1.0
 
 # multidict < 6.4.0 has memory leaks
 # https://github.com/aio-libs/multidict/issues/1134

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 requires-python = ">=3.13.2"
 dependencies = [
   "aiodns==3.5.0",
-  "aiofiles==24.1.0",
   # Integrations may depend on hassio integration without listing it to
   # change behavior based on presence of supervisor. Deprecated with #127228
   # Lib can be removed with 2025.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 
 # Home Assistant Core
 aiodns==3.5.0
-aiofiles==24.1.0
 aiohasupervisor==0.3.1
 aiohttp==3.12.13
 aiohttp_cors==0.8.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -226,6 +226,14 @@ tenacity!=8.4.0
 # TypeError: 'Timeout' object does not support the context manager protocol
 async-timeout==4.0.3
 
+# aiofiles keeps getting downgraded by custom components
+# causing newer methods to not be available and breaking
+# some integrations at startup
+# https://github.com/home-assistant/core/issues/127529
+# https://github.com/home-assistant/core/issues/122508
+# https://github.com/home-assistant/core/issues/118004
+aiofiles>=24.1.0
+
 # multidict < 6.4.0 has memory leaks
 # https://github.com/aio-libs/multidict/issues/1134
 # https://github.com/aio-libs/multidict/issues/1131

--- a/tests/components/cloud/snapshots/test_http_api.ambr
+++ b/tests/components/cloud/snapshots/test_http_api.ambr
@@ -9,6 +9,7 @@
   dev | False
   hassio | False
   docker | False
+  container_arch | None
   user | hass
   virtualenv | False
   python_version | 3.13.1

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -1931,6 +1931,7 @@ async def test_download_support_package(
                 "virtualenv": False,
                 "python_version": "3.13.1",
                 "docker": False,
+                "container_arch": None,
                 "arch": "x86_64",
                 "timezone": "US/Pacific",
                 "os_name": "Linux",

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -260,16 +260,3 @@ def all_setup_requests(
             },
         },
     )
-
-
-@pytest.fixture
-def arch() -> str:
-    """Arch found in apk file."""
-    return "amd64"
-
-
-@pytest.fixture(autouse=True)
-def mock_arch_file(arch: str) -> Generator[None]:
-    """Mock arch file."""
-    with patch("homeassistant.components.hassio._get_arch", return_value=arch):
-        yield

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -1156,17 +1156,12 @@ def test_deprecated_constants(
         ("rpi2", "deprecated_os_armv7"),
     ],
 )
-@pytest.mark.parametrize(
-    "arch",
-    ["armv7"],
-)
 async def test_deprecated_installation_issue_os_armv7(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,
     freezer: FrozenDateTimeFactory,
     board: str,
     issue_id: str,
-    arch: str,
 ) -> None:
     """Test deprecated installation issue."""
     with (

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -1166,17 +1166,11 @@ async def test_deprecated_installation_issue_os_armv7(
     freezer: FrozenDateTimeFactory,
     board: str,
     issue_id: str,
+    arch: str,
 ) -> None:
     """Test deprecated installation issue."""
     with (
         patch.dict(os.environ, MOCK_ENVIRON),
-        patch(
-            "homeassistant.components.homeassistant.async_get_system_info",
-            return_value={
-                "installation_type": "Home Assistant OS",
-                "arch": "armv7",
-            },
-        ),
         patch(
             "homeassistant.components.hassio._is_32_bit",
             return_value=True,
@@ -1185,7 +1179,8 @@ async def test_deprecated_installation_issue_os_armv7(
             "homeassistant.components.hassio.get_os_info", return_value={"board": board}
         ),
         patch(
-            "homeassistant.components.hassio.get_info", return_value={"hassos": True}
+            "homeassistant.components.hassio.get_info",
+            return_value={"hassos": True, "arch": "armv7"},
         ),
         patch("homeassistant.components.hardware.async_setup", return_value=True),
     ):
@@ -1239,13 +1234,6 @@ async def test_deprecated_installation_issue_32bit_os(
     with (
         patch.dict(os.environ, MOCK_ENVIRON),
         patch(
-            "homeassistant.components.homeassistant.async_get_system_info",
-            return_value={
-                "installation_type": "Home Assistant OS",
-                "arch": arch,
-            },
-        ),
-        patch(
             "homeassistant.components.hassio._is_32_bit",
             return_value=True,
         ),
@@ -1254,7 +1242,8 @@ async def test_deprecated_installation_issue_32bit_os(
             return_value={"board": "rpi3-64"},
         ),
         patch(
-            "homeassistant.components.hassio.get_info", return_value={"hassos": True}
+            "homeassistant.components.hassio.get_info",
+            return_value={"hassos": True, "arch": arch},
         ),
         patch("homeassistant.components.hardware.async_setup", return_value=True),
     ):
@@ -1306,13 +1295,6 @@ async def test_deprecated_installation_issue_32bit_supervised(
     with (
         patch.dict(os.environ, MOCK_ENVIRON),
         patch(
-            "homeassistant.components.homeassistant.async_get_system_info",
-            return_value={
-                "installation_type": "Home Assistant Supervised",
-                "arch": arch,
-            },
-        ),
-        patch(
             "homeassistant.components.hassio._is_32_bit",
             return_value=True,
         ),
@@ -1321,7 +1303,8 @@ async def test_deprecated_installation_issue_32bit_supervised(
             return_value={"board": "rpi3-64"},
         ),
         patch(
-            "homeassistant.components.hassio.get_info", return_value={"hassos": None}
+            "homeassistant.components.hassio.get_info",
+            return_value={"hassos": None, "arch": arch},
         ),
         patch("homeassistant.components.hardware.async_setup", return_value=True),
     ):
@@ -1377,13 +1360,6 @@ async def test_deprecated_installation_issue_64bit_supervised(
     with (
         patch.dict(os.environ, MOCK_ENVIRON),
         patch(
-            "homeassistant.components.homeassistant.async_get_system_info",
-            return_value={
-                "installation_type": "Home Assistant Supervised",
-                "arch": arch,
-            },
-        ),
-        patch(
             "homeassistant.components.hassio._is_32_bit",
             return_value=False,
         ),
@@ -1392,7 +1368,8 @@ async def test_deprecated_installation_issue_64bit_supervised(
             return_value={"board": "generic-x86-64"},
         ),
         patch(
-            "homeassistant.components.hassio.get_info", return_value={"hassos": None}
+            "homeassistant.components.hassio.get_info",
+            return_value={"hassos": None, "arch": arch},
         ),
         patch("homeassistant.components.hardware.async_setup", return_value=True),
     ):
@@ -1446,13 +1423,6 @@ async def test_deprecated_installation_issue_supported_board(
     with (
         patch.dict(os.environ, MOCK_ENVIRON),
         patch(
-            "homeassistant.components.homeassistant.async_get_system_info",
-            return_value={
-                "installation_type": "Home Assistant OS",
-                "arch": "aarch64",
-            },
-        ),
-        patch(
             "homeassistant.components.hassio._is_32_bit",
             return_value=False,
         ),
@@ -1460,7 +1430,8 @@ async def test_deprecated_installation_issue_supported_board(
             "homeassistant.components.hassio.get_os_info", return_value={"board": board}
         ),
         patch(
-            "homeassistant.components.hassio.get_info", return_value={"hassos": True}
+            "homeassistant.components.hassio.get_info",
+            return_value={"hassos": True, "arch": "aarch64"},
         ),
     ):
         assert await async_setup_component(hass, "homeassistant", {})

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -738,16 +738,13 @@ async def test_deprecated_installation_issue_32bit(
             "homeassistant.components.homeassistant.async_get_system_info",
             return_value={
                 "installation_type": "Home Assistant Container",
+                "container_arch": arch,
                 "arch": arch,
             },
         ),
         patch(
             "homeassistant.components.homeassistant._is_32_bit",
             return_value=True,
-        ),
-        patch(
-            "homeassistant.components.homeassistant._get_arch",
-            return_value=arch,
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
     EVENT_CORE_CONFIG_UPDATE,
+    EVENT_HOMEASSISTANT_STARTED,
     SERVICE_SAVE_PERSISTENT_STATES,
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
@@ -668,6 +669,7 @@ async def test_deprecated_installation_issue_32bit_core(
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
     assert len(issue_registry.issues) == 1
@@ -707,6 +709,7 @@ async def test_deprecated_installation_issue_64bit_core(
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
     assert len(issue_registry.issues) == 1
@@ -748,6 +751,7 @@ async def test_deprecated_installation_issue_32bit(
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
     assert len(issue_registry.issues) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
This is a follow-up for #146537 and #146561. It removed aiofiles from the core requirements as suggested in https://github.com/home-assistant/core/pull/146561#issuecomment-2963862553. It also makes the detected architecture available through system info. The container architecture can be different from the reported CPU architecture in cases where the underlying OS is capable of running other architectures (typically x86 on x86_64 or armv7 on aarch64 operating systems).

For Supervisor based installations it also uses the architecture already available from Supervisor. This makes the information more coherent and avoids unnecessary code duplication.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
