### PR TITLE
Use brightness stored in hardware device when switching LCN lights

### DIFF
--- a/homeassistant/components/lcn/light.py
+++ b/homeassistant/components/lcn/light.py
@@ -18,6 +18,7 @@ from homeassistant.const import CONF_DOMAIN, CONF_ENTITIES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.color import brightness_to_value, value_to_brightness
 
 from .const import (
     CONF_DIMMABLE,
@@ -28,6 +29,8 @@ from .const import (
 )
 from .entity import LcnEntity
 from .helpers import InputType, LcnConfigEntry
+
+BRIGHTNESS_SCALE = (1, 100)
 
 PARALLEL_UPDATES = 0
 
@@ -91,8 +94,6 @@ class LcnOutputLight(LcnEntity, LightEntity):
         )
         self.dimmable = config[CONF_DOMAIN_DATA][CONF_DIMMABLE]
 
-        self._is_dimming_to_zero = False
-
         if self.dimmable:
             self._attr_color_mode = ColorMode.BRIGHTNESS
         else:
@@ -113,10 +114,6 @@ class LcnOutputLight(LcnEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        if ATTR_BRIGHTNESS in kwargs:
-            percent = int(kwargs[ATTR_BRIGHTNESS] / 255.0 * 100)
-        else:
-            percent = 100
         if ATTR_TRANSITION in kwargs:
             transition = pypck.lcn_defs.time_to_ramp_value(
                 kwargs[ATTR_TRANSITION] * 1000
@@ -124,12 +121,23 @@ class LcnOutputLight(LcnEntity, LightEntity):
         else:
             transition = self._transition
 
-        if not await self.device_connection.dim_output(
-            self.output.value, percent, transition
-        ):
+        if ATTR_BRIGHTNESS in kwargs:
+            percent = int(
+                brightness_to_value(BRIGHTNESS_SCALE, kwargs[ATTR_BRIGHTNESS])
+            )
+            if not await self.device_connection.dim_output(
+                self.output.value, percent, transition
+            ):
+                return
+        elif not self.is_on:
+            if not await self.device_connection.toggle_output(
+                self.output.value, transition, to_memory=True
+            ):
+                return
+        else:
             return
+
         self._attr_is_on = True
-        self._is_dimming_to_zero = False
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -141,13 +149,13 @@ class LcnOutputLight(LcnEntity, LightEntity):
         else:
             transition = self._transition
 
-        if not await self.device_connection.dim_output(
-            self.output.value, 0, transition
-        ):
-            return
-        self._is_dimming_to_zero = bool(transition)
-        self._attr_is_on = False
-        self.async_write_ha_state()
+        if self.is_on:
+            if not await self.device_connection.toggle_output(
+                self.output.value, transition, to_memory=True
+            ):
+                return
+            self._attr_is_on = False
+            self.async_write_ha_state()
 
     def input_received(self, input_obj: InputType) -> None:
         """Set light state when LCN input object (command) is received."""
@@ -157,11 +165,9 @@ class LcnOutputLight(LcnEntity, LightEntity):
         ):
             return
 
-        self._attr_brightness = int(input_obj.get_percent() / 100.0 * 255)
-        if self._attr_brightness == 0:
-            self._is_dimming_to_zero = False
-        if not self._is_dimming_to_zero and self._attr_brightness is not None:
-            self._attr_is_on = self._attr_brightness > 0
+        percent = input_obj.get_percent()
+        self._attr_brightness = value_to_brightness(BRIGHTNESS_SCALE, percent)
+        self._attr_is_on = bool(percent)
         self.async_write_ha_state()
 
 

--- a/tests/components/lcn/test_light.py
+++ b/tests/components/lcn/test_light.py
@@ -51,9 +51,9 @@ async def test_output_turn_on(hass: HomeAssistant, entry: MockConfigEntry) -> No
     """Test the output light turns on."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "dim_output") as dim_output:
+    with patch.object(MockModuleConnection, "toggle_output") as toggle_output:
         # command failed
-        dim_output.return_value = False
+        toggle_output.return_value = False
 
         await hass.services.async_call(
             DOMAIN_LIGHT,
@@ -62,15 +62,15 @@ async def test_output_turn_on(hass: HomeAssistant, entry: MockConfigEntry) -> No
             blocking=True,
         )
 
-        dim_output.assert_awaited_with(0, 100, 9)
+        toggle_output.assert_awaited_with(0, 9, to_memory=True)
 
         state = hass.states.get(LIGHT_OUTPUT1)
         assert state is not None
         assert state.state != STATE_ON
 
         # command success
-        dim_output.reset_mock(return_value=True)
-        dim_output.return_value = True
+        toggle_output.reset_mock(return_value=True)
+        toggle_output.return_value = True
 
         await hass.services.async_call(
             DOMAIN_LIGHT,
@@ -79,7 +79,7 @@ async def test_output_turn_on(hass: HomeAssistant, entry: MockConfigEntry) -> No
             blocking=True,
         )
 
-        dim_output.assert_awaited_with(0, 100, 9)
+        toggle_output.assert_awaited_with(0, 9, to_memory=True)
 
         state = hass.states.get(LIGHT_OUTPUT1)
         assert state is not None
@@ -117,12 +117,16 @@ async def test_output_turn_off(hass: HomeAssistant, entry: MockConfigEntry) -> N
     """Test the output light turns off."""
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "dim_output") as dim_output:
-        state = hass.states.get(LIGHT_OUTPUT1)
-        state.state = STATE_ON
+    with patch.object(MockModuleConnection, "toggle_output") as toggle_output:
+        await hass.services.async_call(
+            DOMAIN_LIGHT,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: LIGHT_OUTPUT1},
+            blocking=True,
+        )
 
         # command failed
-        dim_output.return_value = False
+        toggle_output.return_value = False
 
         await hass.services.async_call(
             DOMAIN_LIGHT,
@@ -131,15 +135,15 @@ async def test_output_turn_off(hass: HomeAssistant, entry: MockConfigEntry) -> N
             blocking=True,
         )
 
-        dim_output.assert_awaited_with(0, 0, 9)
+        toggle_output.assert_awaited_with(0, 9, to_memory=True)
 
         state = hass.states.get(LIGHT_OUTPUT1)
         assert state is not None
         assert state.state != STATE_OFF
 
         # command success
-        dim_output.reset_mock(return_value=True)
-        dim_output.return_value = True
+        toggle_output.reset_mock(return_value=True)
+        toggle_output.return_value = True
 
         await hass.services.async_call(
             DOMAIN_LIGHT,
@@ -148,36 +152,7 @@ async def test_output_turn_off(hass: HomeAssistant, entry: MockConfigEntry) -> N
             blocking=True,
         )
 
-        dim_output.assert_awaited_with(0, 0, 9)
-
-        state = hass.states.get(LIGHT_OUTPUT1)
-        assert state is not None
-        assert state.state == STATE_OFF
-
-
-async def test_output_turn_off_with_attributes(
-    hass: HomeAssistant, entry: MockConfigEntry
-) -> None:
-    """Test the output light turns off."""
-    await init_integration(hass, entry)
-
-    with patch.object(MockModuleConnection, "dim_output") as dim_output:
-        dim_output.return_value = True
-
-        state = hass.states.get(LIGHT_OUTPUT1)
-        state.state = STATE_ON
-
-        await hass.services.async_call(
-            DOMAIN_LIGHT,
-            SERVICE_TURN_OFF,
-            {
-                ATTR_ENTITY_ID: LIGHT_OUTPUT1,
-                ATTR_TRANSITION: 2,
-            },
-            blocking=True,
-        )
-
-        dim_output.assert_awaited_with(0, 0, 6)
+        toggle_output.assert_awaited_with(0, 9, to_memory=True)
 
         state = hass.states.get(LIGHT_OUTPUT1)
         assert state is not None
@@ -288,7 +263,7 @@ async def test_pushed_output_status_change(
     state = hass.states.get(LIGHT_OUTPUT1)
     assert state is not None
     assert state.state == STATE_ON
-    assert state.attributes[ATTR_BRIGHTNESS] == 127
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
 
     # push status "off"
     inp = ModStatusOutput(address, 0, 0)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
LCN hardware devices are able to store/restore the current voltage setting for load outputs whcih are usually used for lights.
Unfortunately, the LCN system does not offer this option for _on/off_ commands but only for _toggle_ commands.

However, together with the current state of the light and a little additional logic, the on/off commands can be implemented using the LCN _toggle_ command.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
