### PR TITLE
Use separate hassio data coordinator for Add-ons

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -92,6 +92,7 @@ from .const import (
     ATTR_LOCATION,
     ATTR_PASSWORD,
     ATTR_SLUG,
+    COORDINATOR,
     DATA_COMPONENT,
     DATA_CONFIG_STORE,
     DATA_CORE_INFO,
@@ -106,6 +107,7 @@ from .const import (
     HASSIO_UPDATE_INTERVAL,
 )
 from .coordinator import (
+    HassioAddOnDataUpdateCoordinator,
     HassioDataUpdateCoordinator,
     get_addons_info,
     get_addons_stats,  # noqa: F401
@@ -555,9 +557,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
     dev_reg = dr.async_get(hass)
+
     coordinator = HassioDataUpdateCoordinator(hass, entry, dev_reg)
     await coordinator.async_config_entry_first_refresh()
-    hass.data[ADDONS_COORDINATOR] = coordinator
+    hass.data[COORDINATOR] = coordinator
+
+    addon_coordinator = HassioAddOnDataUpdateCoordinator(hass, entry, dev_reg)
+    await addon_coordinator.async_config_entry_first_refresh()
+    hass.data[ADDONS_COORDINATOR] = addon_coordinator
 
     def deprecated_setup_issue() -> None:
         os_info = get_os_info(hass)

--- a/homeassistant/components/hassio/binary_sensor.py
+++ b/homeassistant/components/hassio/binary_sensor.py
@@ -41,15 +41,15 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Binary sensor set up for Hass.io config entry."""
-    coordinator = hass.data[ADDONS_COORDINATOR]
+    addons_coordinator = hass.data[ADDONS_COORDINATOR]
 
     async_add_entities(
         HassioAddonBinarySensor(
             addon=addon,
-            coordinator=coordinator,
+            coordinator=addons_coordinator,
             entity_description=entity_description,
         )
-        for addon in coordinator.data[DATA_KEY_ADDONS].values()
+        for addon in addons_coordinator.data[DATA_KEY_ADDONS].values()
         for entity_description in ADDON_ENTITY_DESCRIPTIONS
     )
 

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -86,6 +86,7 @@ DATA_OS_INFO = "hassio_os_info"
 DATA_NETWORK_INFO = "hassio_network_info"
 DATA_SUPERVISOR_INFO = "hassio_supervisor_info"
 DATA_SUPERVISOR_STATS = "hassio_supervisor_stats"
+DATA_ADDONS = "hassio_addons"
 DATA_ADDONS_INFO = "hassio_addons_info"
 DATA_ADDONS_STATS = "hassio_addons_stats"
 HASSIO_UPDATE_INTERVAL = timedelta(minutes=1)

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -89,8 +89,8 @@ DATA_SUPERVISOR_STATS = "hassio_supervisor_stats"
 DATA_ADDONS = "hassio_addons"
 DATA_ADDONS_INFO = "hassio_addons_info"
 DATA_ADDONS_STATS = "hassio_addons_stats"
-HASSIO_UPDATE_INTERVAL = timedelta(minutes=1)
-HASSIO_ADDON_UPDATE_INTERVAL = timedelta(minutes=2)
+HASSIO_UPDATE_INTERVAL = timedelta(minutes=5)
+HASSIO_ADDON_UPDATE_INTERVAL = timedelta(minutes=15)
 
 ATTR_AUTO_UPDATE = "auto_update"
 ATTR_VERSION = "version"

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -71,6 +71,7 @@ EVENT_ISSUE_REMOVED = "issue_removed"
 
 UPDATE_KEY_SUPERVISOR = "supervisor"
 
+COORDINATOR = "hassio_coordinator"
 ADDONS_COORDINATOR = "hassio_addons_coordinator"
 
 
@@ -87,7 +88,8 @@ DATA_SUPERVISOR_INFO = "hassio_supervisor_info"
 DATA_SUPERVISOR_STATS = "hassio_supervisor_stats"
 DATA_ADDONS_INFO = "hassio_addons_info"
 DATA_ADDONS_STATS = "hassio_addons_stats"
-HASSIO_UPDATE_INTERVAL = timedelta(minutes=5)
+HASSIO_UPDATE_INTERVAL = timedelta(minutes=1)
+HASSIO_ADDON_UPDATE_INTERVAL = timedelta(minutes=2)
 
 ATTR_AUTO_UPDATE = "auto_update"
 ATTR_VERSION = "version"

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -30,6 +30,7 @@ from .const import (
     CONTAINER_INFO,
     CONTAINER_STATS,
     CORE_CONTAINER,
+    DATA_ADDONS,
     DATA_ADDONS_INFO,
     DATA_ADDONS_STATS,
     DATA_COMPONENT,
@@ -111,6 +112,16 @@ def get_network_info(hass: HomeAssistant) -> dict[str, Any] | None:
     Async friendly.
     """
     return hass.data.get(DATA_NETWORK_INFO)
+
+
+@callback
+@bind_hass
+def get_addons(hass: HomeAssistant) -> dict[str, Any] | None:
+    """Return Addons info.
+
+    Async friendly.
+    """
+    return hass.data.get(DATA_ADDONS)
 
 
 @callback
@@ -321,7 +332,7 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Error on Supervisor API: {err}") from err
 
         new_data: dict[str, Any] = {}
-        supervisor_info = get_supervisor_info(self.hass) or {}
+        addons = get_addons(self.hass) or {}
         addons_info = get_addons_info(self.hass) or {}
         addons_stats = get_addons_stats(self.hass)
         store_data = get_store(self.hass)
@@ -345,7 +356,7 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator):
                     addon.get(ATTR_REPOSITORY), addon.get(ATTR_REPOSITORY, "")
                 ),
             }
-            for addon in supervisor_info.get("addons", [])
+            for addon in addons.get("addons", [])
         }
 
         # If this is the initial refresh, register all addons and return the dict
@@ -390,9 +401,9 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator):
         container_updates = self._container_updates
 
         data = self.hass.data
-        data[DATA_SUPERVISOR_INFO] = await self.hassio.get_supervisor_info()
+        data[DATA_ADDONS] = await self.hassio.get_addons()
 
-        _addon_data = data[DATA_SUPERVISOR_INFO].get("addons", [])
+        _addon_data = data[DATA_ADDONS].get("addons", [])
         all_addons: list[str] = []
         started_addons: list[str] = []
         for addon in _addon_data:

--- a/homeassistant/components/hassio/diagnostics.py
+++ b/homeassistant/components/hassio/diagnostics.py
@@ -10,8 +10,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .const import ADDONS_COORDINATOR
-from .coordinator import HassioDataUpdateCoordinator
+from .const import ADDONS_COORDINATOR, COORDINATOR
+from .coordinator import HassioAddOnDataUpdateCoordinator, HassioDataUpdateCoordinator
 
 
 async def async_get_config_entry_diagnostics(
@@ -19,7 +19,8 @@ async def async_get_config_entry_diagnostics(
     config_entry: ConfigEntry,
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: HassioDataUpdateCoordinator = hass.data[ADDONS_COORDINATOR]
+    coordinator: HassioDataUpdateCoordinator = hass.data[COORDINATOR]
+    addons_coordinator: HassioAddOnDataUpdateCoordinator = hass.data[ADDONS_COORDINATOR]
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
 
@@ -50,5 +51,6 @@ async def async_get_config_entry_diagnostics(
 
     return {
         "coordinator_data": coordinator.data,
+        "addons_coordinator_data": addons_coordinator.data,
         "devices": devices,
     }

--- a/homeassistant/components/hassio/entity.py
+++ b/homeassistant/components/hassio/entity.py
@@ -21,17 +21,17 @@ from .const import (
     KEY_TO_UPDATE_TYPES,
     SUPERVISOR_CONTAINER,
 )
-from .coordinator import HassioDataUpdateCoordinator
+from .coordinator import HassioAddOnDataUpdateCoordinator, HassioDataUpdateCoordinator
 
 
-class HassioAddonEntity(CoordinatorEntity[HassioDataUpdateCoordinator]):
+class HassioAddonEntity(CoordinatorEntity[HassioAddOnDataUpdateCoordinator]):
     """Base entity for a Hass.io add-on."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
-        coordinator: HassioDataUpdateCoordinator,
+        coordinator: HassioAddOnDataUpdateCoordinator,
         entity_description: EntityDescription,
         addon: dict[str, Any],
     ) -> None:

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -226,6 +226,14 @@ class HassIO:
         """
         return self.send_command("/ingress/panels", method="get")
 
+    @api_data
+    def get_addons(self) -> Coroutine:
+        """Return data installed Add-ons.
+
+        This method returns a coroutine.
+        """
+        return self.send_command("/addons", method="get")
+
     @_api_bool
     async def update_hass_api(
         self, http_config: dict[str, Any], refresh_token: RefreshToken

--- a/homeassistant/components/hassio/sensor.py
+++ b/homeassistant/components/hassio/sensor.py
@@ -19,6 +19,7 @@ from .const import (
     ATTR_MEMORY_PERCENT,
     ATTR_VERSION,
     ATTR_VERSION_LATEST,
+    COORDINATOR,
     DATA_KEY_ADDONS,
     DATA_KEY_CORE,
     DATA_KEY_HOST,
@@ -114,20 +115,21 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Sensor set up for Hass.io config entry."""
-    coordinator = hass.data[ADDONS_COORDINATOR]
+    addons_coordinator = hass.data[ADDONS_COORDINATOR]
 
     entities: list[
         HassioOSSensor | HassioAddonSensor | CoreSensor | SupervisorSensor | HostSensor
     ] = [
         HassioAddonSensor(
             addon=addon,
-            coordinator=coordinator,
+            coordinator=addons_coordinator,
             entity_description=entity_description,
         )
-        for addon in coordinator.data[DATA_KEY_ADDONS].values()
+        for addon in addons_coordinator.data[DATA_KEY_ADDONS].values()
         for entity_description in ADDON_ENTITY_DESCRIPTIONS
     ]
 
+    coordinator = hass.data[COORDINATOR]
     entities.extend(
         CoreSensor(
             coordinator=coordinator,

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -24,6 +24,7 @@ from .const import (
     ATTR_AUTO_UPDATE,
     ATTR_VERSION,
     ATTR_VERSION_LATEST,
+    COORDINATOR,
     DATA_KEY_ADDONS,
     DATA_KEY_CORE,
     DATA_KEY_OS,
@@ -49,9 +50,9 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Supervisor update based on a config entry."""
-    coordinator = hass.data[ADDONS_COORDINATOR]
+    coordinator = hass.data[COORDINATOR]
 
-    entities = [
+    entities: list[UpdateEntity] = [
         SupervisorSupervisorUpdateEntity(
             coordinator=coordinator,
             entity_description=ENTITY_DESCRIPTION,
@@ -62,15 +63,6 @@ async def async_setup_entry(
         ),
     ]
 
-    entities.extend(
-        SupervisorAddonUpdateEntity(
-            addon=addon,
-            coordinator=coordinator,
-            entity_description=ENTITY_DESCRIPTION,
-        )
-        for addon in coordinator.data[DATA_KEY_ADDONS].values()
-    )
-
     if coordinator.is_hass_os:
         entities.append(
             SupervisorOSUpdateEntity(
@@ -78,6 +70,16 @@ async def async_setup_entry(
                 entity_description=ENTITY_DESCRIPTION,
             )
         )
+
+    addons_coordinator = hass.data[ADDONS_COORDINATOR]
+    entities.extend(
+        SupervisorAddonUpdateEntity(
+            addon=addon,
+            coordinator=addons_coordinator,
+            entity_description=ENTITY_DESCRIPTION,
+        )
+        for addon in addons_coordinator.data[DATA_KEY_ADDONS].values()
+    )
 
     async_add_entities(entities)
 

--- a/tests/components/hassio/test_binary_sensor.py
+++ b/tests/components/hassio/test_binary_sensor.py
@@ -107,6 +107,38 @@ def mock_all(
         },
     )
     aioclient_mock.get(
+        "http://127.0.0.1/addons",
+        json={
+            "result": "ok",
+            "data": {
+                "addons": [
+                    {
+                        "name": "test",
+                        "slug": "test",
+                        "state": "started",
+                        "update_available": True,
+                        "icon": False,
+                        "version": "2.0.0",
+                        "version_latest": "2.0.1",
+                        "repository": "core",
+                        "url": "https://github.com/home-assistant/addons/test",
+                    },
+                    {
+                        "name": "test2",
+                        "slug": "test2",
+                        "state": "stopped",
+                        "update_available": False,
+                        "icon": False,
+                        "version": "3.1.0",
+                        "version_latest": "3.2.0",
+                        "repository": "core",
+                        "url": "https://github.com",
+                    },
+                ],
+            },
+        },
+    )
+    aioclient_mock.get(
         "http://127.0.0.1/core/stats",
         json={
             "result": "ok",

--- a/tests/components/hassio/test_diagnostics.py
+++ b/tests/components/hassio/test_diagnostics.py
@@ -110,6 +110,38 @@ def mock_all(
         },
     )
     aioclient_mock.get(
+        "http://127.0.0.1/addons",
+        json={
+            "result": "ok",
+            "data": {
+                "addons": [
+                    {
+                        "name": "test",
+                        "slug": "test",
+                        "state": "started",
+                        "update_available": True,
+                        "icon": False,
+                        "version": "2.0.0",
+                        "version_latest": "2.0.1",
+                        "repository": "core",
+                        "url": "https://github.com/home-assistant/addons/test",
+                    },
+                    {
+                        "name": "test2",
+                        "slug": "test2",
+                        "state": "stopped",
+                        "update_available": False,
+                        "icon": True,
+                        "version": "3.1.0",
+                        "version_latest": "3.1.0",
+                        "repository": "core",
+                        "url": "https://github.com",
+                    },
+                ],
+            },
+        },
+    )
+    aioclient_mock.get(
         "http://127.0.0.1/core/stats",
         json={
             "result": "ok",
@@ -177,10 +209,10 @@ async def test_diagnostics(
         hass, hass_client, config_entry
     )
 
-    assert "addons" in diagnostics["coordinator_data"]
     assert "core" in diagnostics["coordinator_data"]
     assert "supervisor" in diagnostics["coordinator_data"]
     assert "os" in diagnostics["coordinator_data"]
     assert "host" in diagnostics["coordinator_data"]
+    assert "addons" in diagnostics["addons_coordinator_data"]
 
     assert len(diagnostics["devices"]) == 6

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -143,6 +143,38 @@ def mock_all(
         },
     )
     aioclient_mock.get(
+        "http://127.0.0.1/addons",
+        json={
+            "result": "ok",
+            "data": {
+                "addons": [
+                    {
+                        "name": "test",
+                        "slug": "test",
+                        "state": "started",
+                        "update_available": True,
+                        "icon": False,
+                        "version": "2.0.0",
+                        "version_latest": "2.0.1",
+                        "repository": "core",
+                        "url": "https://github.com/home-assistant/addons/test",
+                    },
+                    {
+                        "name": "test2",
+                        "slug": "test2",
+                        "state": "stopped",
+                        "update_available": False,
+                        "icon": True,
+                        "version": "3.1.0",
+                        "version_latest": "3.1.0",
+                        "repository": "core",
+                        "url": "https://github.com",
+                    },
+                ],
+            },
+        },
+    )
+    aioclient_mock.get(
         "http://127.0.0.1/core/stats",
         json={
             "result": "ok",
@@ -232,7 +264,7 @@ async def test_setup_api_ping(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 18
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 19
     assert get_core_info(hass)["version_latest"] == "1.0.0"
     assert is_hassio(hass)
 
@@ -279,7 +311,7 @@ async def test_setup_api_push_api_data(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 18
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 19
     assert not aioclient_mock.mock_calls[0][2]["ssl"]
     assert aioclient_mock.mock_calls[0][2]["port"] == 9999
     assert "watchdog" not in aioclient_mock.mock_calls[0][2]
@@ -300,7 +332,7 @@ async def test_setup_api_push_api_data_server_host(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 18
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 19
     assert not aioclient_mock.mock_calls[0][2]["ssl"]
     assert aioclient_mock.mock_calls[0][2]["port"] == 9999
     assert not aioclient_mock.mock_calls[0][2]["watchdog"]
@@ -321,7 +353,7 @@ async def test_setup_api_push_api_data_default(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 18
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 19
     assert not aioclient_mock.mock_calls[0][2]["ssl"]
     assert aioclient_mock.mock_calls[0][2]["port"] == 8123
     refresh_token = aioclient_mock.mock_calls[0][2]["refresh_token"]
@@ -402,7 +434,7 @@ async def test_setup_api_existing_hassio_user(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 18
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 19
     assert not aioclient_mock.mock_calls[0][2]["ssl"]
     assert aioclient_mock.mock_calls[0][2]["port"] == 8123
     assert aioclient_mock.mock_calls[0][2]["refresh_token"] == token.token
@@ -421,7 +453,7 @@ async def test_setup_core_push_config(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 18
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 19
     assert aioclient_mock.mock_calls[1][2]["timezone"] == "testzone"
 
     with patch("homeassistant.util.dt.set_default_time_zone"):
@@ -445,7 +477,7 @@ async def test_setup_hassio_no_additional_data(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 18
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 19
     assert aioclient_mock.mock_calls[-1][3]["Authorization"] == "Bearer 123456"
 
 
@@ -527,14 +559,14 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 22
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 23
     assert aioclient_mock.mock_calls[-1][2] == "test"
 
     await hass.services.async_call("hassio", "host_shutdown", {})
     await hass.services.async_call("hassio", "host_reboot", {})
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 24
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 25
 
     await hass.services.async_call("hassio", "backup_full", {})
     await hass.services.async_call(
@@ -549,7 +581,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 26
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 27
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 03:48:00",
         "homeassistant": True,
@@ -574,7 +606,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 28
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 29
     assert aioclient_mock.mock_calls[-1][2] == {
         "addons": ["test"],
         "folders": ["ssl"],
@@ -593,7 +625,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 29
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 30
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "backup_name",
         "location": "backup_share",
@@ -609,7 +641,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 30
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 31
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 03:48:00",
         "location": None,
@@ -628,7 +660,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 32
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 33
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 11:48:00",
         "location": None,
@@ -683,7 +715,7 @@ async def test_addon_service_call_with_complex_slug(
     with (
         patch.dict(os.environ, MOCK_ENVIRON),
         patch(
-            "homeassistant.components.hassio.HassIO.get_supervisor_info",
+            "homeassistant.components.hassio.HassIO.get_addons",
             return_value=supervisor_mock_data,
         ),
     ):
@@ -811,7 +843,7 @@ async def test_device_registry_calls(
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done(wait_background_tasks=True)
-        assert len(device_registry.devices) == 6
+        assert len(device_registry.devices) == 5
 
     supervisor_mock_data = {
         "version": "1.0.0",
@@ -919,13 +951,13 @@ async def test_coordinator_updates(
         await hass.async_block_till_done()
 
         # Initial refresh, no update refresh call
-        supervisor_client.refresh_updates.assert_not_called()
+        supervisor_client.reload_updates.assert_not_called()
 
     async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=20))
     await hass.async_block_till_done()
 
     # Scheduled refresh, no update refresh call
-    supervisor_client.refresh_updates.assert_not_called()
+    supervisor_client.reload_updates.assert_not_called()
 
     await hass.services.async_call(
         "homeassistant",
@@ -940,15 +972,15 @@ async def test_coordinator_updates(
     )
 
     # There is a REQUEST_REFRESH_DELAYs cooldown on the debouncer
-    supervisor_client.refresh_updates.assert_not_called()
+    supervisor_client.reload_updates.assert_not_called()
     async_fire_time_changed(
         hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
     )
     await hass.async_block_till_done()
-    supervisor_client.refresh_updates.assert_called_once()
+    supervisor_client.reload_updates.assert_called_once()
 
-    supervisor_client.refresh_updates.reset_mock()
-    supervisor_client.refresh_updates.side_effect = SupervisorError("Unknown")
+    supervisor_client.reload_updates.reset_mock()
+    supervisor_client.reload_updates.side_effect = SupervisorError("Unknown")
     await hass.services.async_call(
         "homeassistant",
         "update_entity",
@@ -965,7 +997,7 @@ async def test_coordinator_updates(
         hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
     )
     await hass.async_block_till_done()
-    supervisor_client.refresh_updates.assert_called_once()
+    supervisor_client.reload_updates.assert_called_once()
     assert "Error on Supervisor API: Unknown" in caplog.text
 
 
@@ -983,7 +1015,7 @@ async def test_coordinator_updates_stats_entities_enabled(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         # Initial refresh without stats
-        supervisor_client.refresh_updates.assert_not_called()
+        supervisor_client.reload_updates.assert_not_called()
 
         # Refresh with stats once we know which ones are needed
         async_fire_time_changed(
@@ -991,12 +1023,12 @@ async def test_coordinator_updates_stats_entities_enabled(
         )
         await hass.async_block_till_done()
 
-        supervisor_client.refresh_updates.assert_called_once()
+        supervisor_client.reload_updates.assert_called_once()
 
-    supervisor_client.refresh_updates.reset_mock()
+    supervisor_client.reload_updates.reset_mock()
     async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=20))
     await hass.async_block_till_done()
-    supervisor_client.refresh_updates.assert_not_called()
+    supervisor_client.reload_updates.assert_not_called()
 
     await hass.services.async_call(
         "homeassistant",
@@ -1009,7 +1041,7 @@ async def test_coordinator_updates_stats_entities_enabled(
         },
         blocking=True,
     )
-    supervisor_client.refresh_updates.assert_not_called()
+    supervisor_client.reload_updates.assert_not_called()
 
     # There is a REQUEST_REFRESH_DELAYs cooldown on the debouncer
     async_fire_time_changed(
@@ -1017,8 +1049,8 @@ async def test_coordinator_updates_stats_entities_enabled(
     )
     await hass.async_block_till_done()
 
-    supervisor_client.refresh_updates.reset_mock()
-    supervisor_client.refresh_updates.side_effect = SupervisorError("Unknown")
+    supervisor_client.reload_updates.reset_mock()
+    supervisor_client.reload_updates.side_effect = SupervisorError("Unknown")
     await hass.services.async_call(
         "homeassistant",
         "update_entity",
@@ -1035,7 +1067,7 @@ async def test_coordinator_updates_stats_entities_enabled(
         hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
     )
     await hass.async_block_till_done()
-    supervisor_client.refresh_updates.assert_called_once()
+    supervisor_client.reload_updates.assert_called_once()
     assert "Error on Supervisor API: Unknown" in caplog.text
 
 
@@ -1074,7 +1106,7 @@ async def test_setup_hardware_integration(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert result
-    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 18
+    assert aioclient_mock.call_count + len(supervisor_client.mock_calls) == 19
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -843,7 +843,7 @@ async def test_device_registry_calls(
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done(wait_background_tasks=True)
-        assert len(device_registry.devices) == 5
+        assert len(device_registry.devices) == 6
 
     supervisor_mock_data = {
         "version": "1.0.0",
@@ -877,11 +877,11 @@ async def test_device_registry_calls(
     ):
         async_fire_time_changed(hass, dt_util.now() + timedelta(hours=1))
         await hass.async_block_till_done(wait_background_tasks=True)
-        assert len(device_registry.devices) == 5
+        assert len(device_registry.devices) == 6
 
         async_fire_time_changed(hass, dt_util.now() + timedelta(hours=2))
         await hass.async_block_till_done(wait_background_tasks=True)
-        assert len(device_registry.devices) == 5
+        assert len(device_registry.devices) == 6
 
     supervisor_mock_data = {
         "version": "1.0.0",
@@ -935,7 +935,7 @@ async def test_device_registry_calls(
     ):
         async_fire_time_changed(hass, dt_util.now() + timedelta(hours=3))
         await hass.async_block_till_done()
-        assert len(device_registry.devices) == 5
+        assert len(device_registry.devices) == 6
 
 
 @pytest.mark.usefixtures("addon_installed")

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -131,6 +131,38 @@ def mock_all(
         },
     )
     aioclient_mock.get(
+        "http://127.0.0.1/addons",
+        json={
+            "result": "ok",
+            "data": {
+                "addons": [
+                    {
+                        "name": "test",
+                        "slug": "test",
+                        "state": "started",
+                        "update_available": True,
+                        "icon": False,
+                        "version": "2.0.0",
+                        "version_latest": "2.0.1",
+                        "repository": "core",
+                        "url": "https://github.com/home-assistant/addons/test",
+                    },
+                    {
+                        "name": "test2",
+                        "slug": "test2",
+                        "state": "stopped",
+                        "update_available": False,
+                        "icon": True,
+                        "version": "3.1.0",
+                        "version_latest": "3.1.0",
+                        "repository": "core",
+                        "url": "https://github.com",
+                    },
+                ],
+            },
+        },
+    )
+    aioclient_mock.get(
         "http://127.0.0.1/core/stats",
         json={
             "result": "ok",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Use a separate data coordinator to update add-ons. So far, all add-on store git repositories got updated every 5 minutes like the main update components (Core, Supervisor, Plug-ins and Operating System). Lower the add-on store refresh to every 15 minutes.

This also avoids force refreshing the main update components on add-on update, which was often the cause of "Supervisor needs update" errors while updating add-ons (when we just pushed a new Supervisor change). It does not eliminate the error completely, as a main component update or a forced update by a user can still cause that situation.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
