### PR TITLE
Support streaming TTS in wyoming

### DIFF
--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -1,13 +1,22 @@
 """Support for Wyoming text-to-speech services."""
 
+import asyncio
 from collections import defaultdict
+from collections.abc import AsyncGenerator
 import io
 import logging
 import wave
 
-from wyoming.audio import AudioChunk, AudioStop
+from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.client import AsyncTcpClient
-from wyoming.tts import Synthesize, SynthesizeVoice
+from wyoming.tts import (
+    Synthesize,
+    SynthesizeChunk,
+    SynthesizeStart,
+    SynthesizeStop,
+    SynthesizeStopped,
+    SynthesizeVoice,
+)
 
 from homeassistant.components import tts
 from homeassistant.config_entries import ConfigEntry
@@ -45,6 +54,7 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
         service: WyomingService,
     ) -> None:
         """Set up provider."""
+        self.config_entry = config_entry
         self.service = service
         self._tts_service = next(tts for tts in service.info.tts if tts.installed)
 
@@ -150,3 +160,120 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
             return (None, None)
 
         return ("wav", data)
+
+    def async_supports_streaming_input(self) -> bool:
+        """Return if the TTS engine supports streaming input."""
+        return self._tts_service.supports_synthesize_streaming
+
+    async def async_stream_tts_audio(
+        self, request: tts.TTSAudioRequest
+    ) -> tts.TTSAudioResponse:
+        """Generate speech from an incoming message."""
+        audio_event_stream = self._generate_tts_audio(request)
+        audio_start_received = False
+
+        async def data_gen():
+            nonlocal audio_start_received
+
+            async for audio_event in audio_event_stream:
+                if audio_start_received and isinstance(audio_event, AudioChunk):
+                    yield audio_event.audio
+                elif (not audio_start_received) and isinstance(audio_event, AudioStart):
+                    # Send WAV header once
+                    audio_start_received = True
+
+                    with io.BytesIO() as wav_io:
+                        wav_file: wave.Wave_write = wave.open(wav_io, "wb")
+                        with wav_file:
+                            wav_file.setframerate(audio_event.rate)
+                            wav_file.setsampwidth(audio_event.width)
+                            wav_file.setnchannels(audio_event.channels)
+
+                        wav_io.seek(0)
+                        yield wav_io.getvalue()
+
+        return tts.TTSAudioResponse("wav", data_gen())
+
+    async def _generate_tts_audio(
+        self, request: tts.TTSAudioRequest
+    ) -> AsyncGenerator[AudioStart | AudioChunk]:
+        """Generate speech from an incoming message."""
+        voice_name: str | None = request.options.get(tts.ATTR_VOICE)
+        voice_speaker: str | None = request.options.get(ATTR_SPEAKER)
+
+        message = ""
+
+        try:
+            async with AsyncTcpClient(self.service.host, self.service.port) as client:
+                voice: SynthesizeVoice | None = None
+                if voice_name is not None:
+                    voice = SynthesizeVoice(name=voice_name, speaker=voice_speaker)
+
+                # Start stream
+                await client.write_event(SynthesizeStart(voice=voice).event())
+
+                async def write_text_chunks():
+                    nonlocal message
+                    async for text_chunk in request.message_gen:
+                        message += text_chunk
+                        await client.write_event(
+                            SynthesizeChunk(text=text_chunk).event()
+                        )
+
+                write_task = self.config_entry.async_create_background_task(
+                    self.hass, write_text_chunks(), "wyoming tts write"
+                )
+                read_task = self.config_entry.async_create_background_task(
+                    self.hass, client.read_event(), "wyoming tts read"
+                )
+                pending = {read_task, write_task}
+
+                while pending:
+                    done, pending = await asyncio.wait(
+                        pending, return_when=asyncio.FIRST_COMPLETED
+                    )
+
+                    if write_task in done:
+                        break
+
+                    if read_task in done:
+                        # Process event from client
+                        event = await read_task
+                        if event is None:
+                            _LOGGER.debug("Connection lost")
+                            return
+
+                        if AudioChunk.is_type(event.type):
+                            yield AudioChunk.from_event(event)
+                        elif AudioStart.is_type(event.type):
+                            yield AudioStart.from_event(event)
+
+                        read_task = self.config_entry.async_create_background_task(
+                            self.hass, client.read_event(), "wyoming tts read"
+                        )
+                        pending.add(read_task)
+
+                # Send entire message for backwards compatibility
+                synthesize = Synthesize(text=message, voice=voice)
+                await client.write_event(synthesize.event())
+
+                # End stream
+                await client.write_event(SynthesizeStop().event())
+
+                # Wait for final audio.
+                # This may include the audio-start message if the text was small enough.
+                event = await read_task
+                while event is not None:
+                    if AudioChunk.is_type(event.type):
+                        yield AudioChunk.from_event(event)
+                    elif AudioStart.is_type(event.type):
+                        yield AudioStart.from_event(event)
+                    elif SynthesizeStopped.is_type(event.type):
+                        # End of final audio
+                        break
+
+                    event = await client.read_event()
+
+        except (OSError, WyomingError):
+            # Disconnected
+            pass

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -69,6 +69,29 @@ TTS_INFO = Info(
         )
     ]
 )
+TTS_STREAMING_INFO = Info(
+    tts=[
+        TtsProgram(
+            name="Test Streaming TTS",
+            description="Test Streaming TTS",
+            installed=True,
+            attribution=TEST_ATTR,
+            voices=[
+                TtsVoice(
+                    name="Test Voice",
+                    description="Test Voice",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["en-US"],
+                    speakers=[TtsVoiceSpeaker(name="Test Speaker")],
+                    version=None,
+                )
+            ],
+            version=None,
+            supports_synthesize_streaming=True,
+        )
+    ]
+)
 WAKE_WORD_INFO = Info(
     wake=[
         WakeProgram(

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -178,9 +178,15 @@ class MockAsyncTcpClient:
         self.port: int | None = None
         self.written: list[Event] = []
         self.responses = responses
+        self.is_connected: bool | None = None
 
     async def connect(self) -> None:
         """Connect."""
+        self.is_connected = True
+
+    async def disconnect(self) -> None:
+        """Disconnect."""
+        self.is_connected = False
 
     async def write_event(self, event: Event):
         """Send."""

--- a/tests/components/wyoming/conftest.py
+++ b/tests/components/wyoming/conftest.py
@@ -19,6 +19,7 @@ from . import (
     SATELLITE_INFO,
     STT_INFO,
     TTS_INFO,
+    TTS_STREAMING_INFO,
     WAKE_WORD_INFO,
 )
 
@@ -142,6 +143,20 @@ async def init_wyoming_tts(
     with patch(
         "homeassistant.components.wyoming.data.load_wyoming_info",
         return_value=TTS_INFO,
+    ):
+        await hass.config_entries.async_setup(tts_config_entry.entry_id)
+
+    return tts_config_entry
+
+
+@pytest.fixture
+async def init_wyoming_streaming_tts(
+    hass: HomeAssistant, tts_config_entry: ConfigEntry
+) -> ConfigEntry:
+    """Initialize Wyoming streaming TTS."""
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=TTS_STREAMING_INFO,
     ):
         await hass.config_entries.async_setup(tts_config_entry.entry_id)
 

--- a/tests/components/wyoming/snapshots/test_tts.ambr
+++ b/tests/components/wyoming/snapshots/test_tts.ambr
@@ -32,6 +32,43 @@
     }),
   ])
 # ---
+# name: test_get_tts_audio_streaming
+  list([
+    dict({
+      'data': dict({
+      }),
+      'payload': None,
+      'type': 'synthesize-start',
+    }),
+    dict({
+      'data': dict({
+        'text': 'Hello ',
+      }),
+      'payload': None,
+      'type': 'synthesize-chunk',
+    }),
+    dict({
+      'data': dict({
+        'text': 'Word.',
+      }),
+      'payload': None,
+      'type': 'synthesize-chunk',
+    }),
+    dict({
+      'data': dict({
+        'text': 'Hello Word.',
+      }),
+      'payload': None,
+      'type': 'synthesize',
+    }),
+    dict({
+      'data': dict({
+      }),
+      'payload': None,
+      'type': 'synthesize-stop',
+    }),
+  ])
+# ---
 # name: test_voice_speaker
   list([
     dict({

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -253,6 +253,9 @@ async def test_get_tts_audio_streaming(
         stream.async_set_message_stream(message_gen())
         data = b"".join([chunk async for chunk in stream.async_stream_result()])
 
+        # Ensure client was disconnected properly
+        assert mock_client.is_connected is False
+
     assert data is not None
     with io.BytesIO(data) as wav_io, wave.open(wav_io, "rb") as wav_file:
         assert wav_file.getframerate() == 16000

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -8,7 +8,8 @@ import wave
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from wyoming.audio import AudioChunk, AudioStop
+from wyoming.audio import AudioChunk, AudioStart, AudioStop
+from wyoming.tts import SynthesizeStopped
 
 from homeassistant.components import tts, wyoming
 from homeassistant.core import HomeAssistant
@@ -43,11 +44,11 @@ async def test_get_tts_audio(
     hass: HomeAssistant, init_wyoming_tts, snapshot: SnapshotAssertion
 ) -> None:
     """Test get audio."""
+    entity = hass.data[DATA_INSTANCES]["tts"].get_entity("tts.test_tts")
+    assert entity is not None
+    assert not entity.async_supports_streaming_input()
+
     audio = bytes(100)
-    audio_events = [
-        AudioChunk(audio=audio, rate=16000, width=2, channels=1).event(),
-        AudioStop().event(),
-    ]
 
     # Verify audio
     audio_events = [
@@ -215,3 +216,49 @@ async def test_voice_speaker(
             ),
         )
         assert mock_client.written == snapshot
+
+
+async def test_get_tts_audio_streaming(
+    hass: HomeAssistant, init_wyoming_streaming_tts, snapshot: SnapshotAssertion
+) -> None:
+    """Test get audio with streaming."""
+    entity = hass.data[DATA_INSTANCES]["tts"].get_entity("tts.test_streaming_tts")
+    assert entity is not None
+    assert entity.async_supports_streaming_input()
+
+    audio = bytes(100)
+
+    # Verify audio
+    audio_events = [
+        AudioStart(rate=16000, width=2, channels=1).event(),
+        AudioChunk(audio=audio, rate=16000, width=2, channels=1).event(),
+        AudioStop().event(),
+        SynthesizeStopped().event(),
+    ]
+
+    async def message_gen():
+        yield "Hello "
+        yield "Word."
+
+    with patch(
+        "homeassistant.components.wyoming.tts.AsyncTcpClient",
+        MockAsyncTcpClient(audio_events),
+    ) as mock_client:
+        stream = tts.async_create_stream(
+            hass,
+            "tts.test_streaming_tts",
+            "en-US",
+            options={tts.ATTR_PREFERRED_FORMAT: "wav"},
+        )
+        stream.async_set_message_stream(message_gen())
+        data = b"".join([chunk async for chunk in stream.async_stream_result()])
+
+    assert data is not None
+    with io.BytesIO(data) as wav_io, wave.open(wav_io, "rb") as wav_file:
+        assert wav_file.getframerate() == 16000
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getnframes() == 0  # streaming
+        assert data[44:] == audio  # WAV header is 44 bytes
+
+    assert mock_client.written == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds streaming support to `wyoming` text-to-speech entities. If supported, text is streamed to the TTS endpoint and audio is streamed back into Home Assistant.

Text chunks are not guaranteed to be on a sentence or even a word boundary, so it is up to the TTS endpoint to store and combine/split them appropriately for the underlying models.

Requires https://github.com/home-assistant/core/pull/147385

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
