### PR TITLE
Add reauth flow to PlayStation Network integration

### DIFF
--- a/homeassistant/components/playstation_network/config_flow.py
+++ b/homeassistant/components/playstation_network/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for the PlayStation Network integration."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -14,8 +15,9 @@ from psnawp_api.utils.misc import parse_npsso_token
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_NAME
 
-from .const import CONF_NPSSO, DOMAIN
+from .const import CONF_NPSSO, DOMAIN, NPSSO_LINK, PSN_LINK
 from .helpers import PlaystationNetwork
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,7 +65,65 @@ class PlaystationNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
             description_placeholders={
-                "npsso_link": "https://ca.account.sony.com/api/v1/ssocookie",
-                "psn_link": "https://playstation.com",
+                "npsso_link": NPSSO_LINK,
+                "psn_link": PSN_LINK,
+            },
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Perform reauth upon an API authentication error."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauthentication dialog."""
+        errors: dict[str, str] = {}
+
+        entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            try:
+                npsso = parse_npsso_token(user_input[CONF_NPSSO])
+            except PSNAWPInvalidTokenError:
+                errors["base"] = "invalid_account"
+            else:
+                psn = PlaystationNetwork(self.hass, npsso)
+                try:
+                    user: User = await psn.get_user()
+                except PSNAWPAuthenticationError:
+                    errors["base"] = "invalid_auth"
+                except PSNAWPNotFoundError:
+                    errors["base"] = "invalid_account"
+                except PSNAWPError:
+                    errors["base"] = "cannot_connect"
+                except Exception:
+                    _LOGGER.exception("Unexpected exception")
+                    errors["base"] = "unknown"
+                else:
+                    await self.async_set_unique_id(user.account_id)
+                    self._abort_if_unique_id_mismatch(
+                        description_placeholders={
+                            "wrong_account": user.online_id,
+                            CONF_NAME: entry.title,
+                        }
+                    )
+
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        data_updates={CONF_NPSSO: npsso},
+                    )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=STEP_USER_DATA_SCHEMA, suggested_values=user_input
+            ),
+            errors=errors,
+            description_placeholders={
+                "npsso_link": NPSSO_LINK,
+                "psn_link": PSN_LINK,
             },
         )

--- a/homeassistant/components/playstation_network/const.py
+++ b/homeassistant/components/playstation_network/const.py
@@ -13,3 +13,6 @@ SUPPORTED_PLATFORMS = {
     PlatformType.PS3,
     PlatformType.PSPC,
 }
+
+NPSSO_LINK: Final = "https://ca.account.sony.com/api/v1/ssocookie"
+PSN_LINK: Final = "https://playstation.com"

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -62,7 +62,12 @@ class PlaystationNetworkCoordinator(DataUpdateCoordinator[PlaystationNetworkData
         """Get the latest data from the PSN."""
         try:
             return await self.psn.get_data()
-        except (PSNAWPAuthenticationError, PSNAWPServerError) as error:
+        except PSNAWPAuthenticationError as error:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="not_ready",
+            ) from error
+        except PSNAWPServerError as error:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="update_failed",

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -13,7 +13,7 @@ from psnawp_api.models.user import User
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -53,7 +53,7 @@ class PlaystationNetworkCoordinator(DataUpdateCoordinator[PlaystationNetworkData
         try:
             self.user = await self.psn.get_user()
         except PSNAWPAuthenticationError as error:
-            raise ConfigEntryNotReady(
+            raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="not_ready",
             ) from error

--- a/homeassistant/components/playstation_network/quality_scale.yaml
+++ b/homeassistant/components/playstation_network/quality_scale.yaml
@@ -39,7 +39,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: todo
 
   # Gold

--- a/homeassistant/components/playstation_network/strings.json
+++ b/homeassistant/components/playstation_network/strings.json
@@ -9,6 +9,16 @@
           "npsso": "The NPSSO token is generated upon successful login of your PlayStation Network account and is used to authenticate your requests within Home Assistant."
         },
         "description": "To obtain your NPSSO token, log in to your [PlayStation account]({psn_link}) first. Then [click here]({npsso_link}) to retrieve the token."
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate {name} with PlayStation Network",
+        "description": "The NPSSO token for **{name}** has expired. To obtain a new one, log in to your [PlayStation account]({psn_link}) first. Then [click here]({npsso_link}) to retrieve the token.",
+        "data": {
+          "npsso": "[%key:component::playstation_network::config::step::user::data::npsso%]"
+        },
+        "data_description": {
+          "npsso": "[%key:component::playstation_network::config::step::user::data_description::npsso%]"
+        }
       }
     },
     "error": {
@@ -18,7 +28,9 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unique_id_mismatch": "The provided NPSSO token corresponds to the account {wrong_account}. Please re-authenticate with the account **{name}**"
     }
   },
   "exceptions": {

--- a/tests/components/playstation_network/test_config_flow.py
+++ b/tests/components/playstation_network/test_config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.components.playstation_network.config_flow import (
     PSNAWPNotFoundError,
 )
 from homeassistant.components.playstation_network.const import CONF_NPSSO, DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -138,3 +138,163 @@ async def test_parse_npsso_token_failures(
     assert result["data"] == {
         CONF_NPSSO: NPSSO_TOKEN,
     }
+
+
+@pytest.mark.usefixtures("mock_psnawpapi")
+async def test_flow_reauth(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test reauth flow."""
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    result = await config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_NPSSO: "NEW_NPSSO_TOKEN"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+    assert config_entry.data[CONF_NPSSO] == "NEW_NPSSO_TOKEN"
+
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.parametrize(
+    ("raise_error", "text_error"),
+    [
+        (PSNAWPNotFoundError(), "invalid_account"),
+        (PSNAWPAuthenticationError(), "invalid_auth"),
+        (PSNAWPError(), "cannot_connect"),
+        (Exception(), "unknown"),
+    ],
+)
+async def test_flow_reauth_errors(
+    hass: HomeAssistant,
+    mock_psnawpapi: MagicMock,
+    config_entry: MockConfigEntry,
+    raise_error: Exception,
+    text_error: str,
+) -> None:
+    """Test reauth flow errors."""
+
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    mock_psnawpapi.user.side_effect = raise_error
+    result = await config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_NPSSO: "NEW_NPSSO_TOKEN"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": text_error}
+
+    mock_psnawpapi.user.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_NPSSO: "NEW_NPSSO_TOKEN"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+    assert config_entry.data[CONF_NPSSO] == "NEW_NPSSO_TOKEN"
+
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.usefixtures("mock_psnawpapi")
+async def test_flow_reauth_token_error(
+    hass: HomeAssistant,
+    mock_psnawp_npsso: MagicMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test reauth flow token error."""
+
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    mock_psnawp_npsso.side_effect = PSNAWPInvalidTokenError
+    result = await config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_NPSSO: "NEW_NPSSO_TOKEN"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_account"}
+
+    mock_psnawp_npsso.side_effect = lambda token: token
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_NPSSO: "NEW_NPSSO_TOKEN"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+    assert config_entry.data[CONF_NPSSO] == "NEW_NPSSO_TOKEN"
+
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.usefixtures("mock_psnawpapi")
+async def test_flow_reauth_account_mismatch(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_user: MagicMock,
+) -> None:
+    """Test reauth flow unique_id mismatch."""
+
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    mock_user.account_id = "other_account"
+    result = await config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_NPSSO: "NEW_NPSSO_TOKEN"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"

--- a/tests/components/playstation_network/test_config_flow.py
+++ b/tests/components/playstation_network/test_config_flow.py
@@ -161,8 +161,6 @@ async def test_flow_reauth(
         {CONF_NPSSO: "NEW_NPSSO_TOKEN"},
     )
 
-    await hass.async_block_till_done()
-
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

It is crucial that this reauth flow is added before the integration is shipped in 2025.7 as the NPSSO token has to be renewed every 2 months and also sometimes gets invalidated after a Home Assistant reboot.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
