### PR TITLE
Fix unbound var and tests in PlayStation Network integration

### DIFF
--- a/homeassistant/components/playstation_network/config_flow.py
+++ b/homeassistant/components/playstation_network/config_flow.py
@@ -37,8 +37,7 @@ class PlaystationNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
                 npsso = parse_npsso_token(user_input[CONF_NPSSO])
             except PSNAWPInvalidTokenError:
                 errors["base"] = "invalid_account"
-
-            if npsso:
+            else:
                 psn = PlaystationNetwork(self.hass, npsso)
                 try:
                     user: User = await psn.get_user()

--- a/homeassistant/components/playstation_network/strings.json
+++ b/homeassistant/components/playstation_network/strings.json
@@ -6,7 +6,7 @@
           "npsso": "NPSSO token"
         },
         "data_description": {
-          "npsso": "The NPSSO token is generated during successful login of your PlayStation Network account and is used to authenticate your requests from with Home Assistant."
+          "npsso": "The NPSSO token is generated upon successful login of your PlayStation Network account and is used to authenticate your requests within Home Assistant."
         },
         "description": "To obtain your NPSSO token, log in to your [PlayStation account]({psn_link}) first. Then [click here]({npsso_link}) to retrieve the token."
       }

--- a/tests/components/playstation_network/conftest.py
+++ b/tests/components/playstation_network/conftest.py
@@ -97,12 +97,9 @@ def mock_psnawp_npsso(mock_user: MagicMock) -> Generator[MagicMock]:
     """Mock psnawp_api."""
 
     with patch(
-        "psnawp_api.utils.misc.parse_npsso_token",
-        autospec=True,
-    ) as mock_parse_npsso_token:
-        npsso = mock_parse_npsso_token.return_value
-        npsso.parse_npsso_token.return_value = NPSSO_TOKEN
-
+        "homeassistant.components.playstation_network.config_flow.parse_npsso_token",
+        side_effect=lambda token: token,
+    ) as npsso:
         yield npsso
 
 

--- a/tests/components/playstation_network/test_config_flow.py
+++ b/tests/components/playstation_network/test_config_flow.py
@@ -120,7 +120,7 @@ async def test_parse_npsso_token_failures(
     mock_psnawp_npsso: MagicMock,
 ) -> None:
     """Test parse_npsso_token raises the correct exceptions during config flow."""
-    mock_psnawp_npsso.parse_npsso_token.side_effect = PSNAWPInvalidTokenError
+    mock_psnawp_npsso.side_effect = PSNAWPInvalidTokenError
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -128,7 +128,7 @@ async def test_parse_npsso_token_failures(
     )
     assert result["errors"] == {"base": "invalid_account"}
 
-    mock_psnawp_npsso.parse_npsso_token.side_effect = None
+    mock_psnawp_npsso.side_effect = lambda token: token
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_NPSSO: NPSSO_TOKEN},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes some minor bugs, variable `npsso` is unbound if the `parse_npsso_token` function raises and the function was also not properly patched out in the tests.

Also fixes a small typo


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
