### PR TITLE
Add DHCP discovery to PlayStation Network integration

### DIFF
--- a/homeassistant/components/playstation_network/manifest.json
+++ b/homeassistant/components/playstation_network/manifest.json
@@ -3,6 +3,65 @@
   "name": "PlayStation Network",
   "codeowners": ["@jackjpowell"],
   "config_flow": true,
+  "dhcp": [
+    {
+      "macaddress": "AC8995*"
+    },
+    {
+      "macaddress": "1C98C1*"
+    },
+    {
+      "macaddress": "5C843C*"
+    },
+    {
+      "macaddress": "605BB4*"
+    },
+    {
+      "macaddress": "8060B7*"
+    },
+    {
+      "macaddress": "78C881*"
+    },
+    {
+      "macaddress": "00D9D1*"
+    },
+    {
+      "macaddress": "00E421*"
+    },
+    {
+      "macaddress": "0CFE45*"
+    },
+    {
+      "macaddress": "2CCC44*"
+    },
+    {
+      "macaddress": "BC60A7*"
+    },
+    {
+      "macaddress": "C863F1*"
+    },
+    {
+      "macaddress": "F8461C*"
+    },
+    {
+      "macaddress": "70662A*"
+    },
+    {
+      "macaddress": "09E29*"
+    },
+    {
+      "macaddress": "B40AD8*"
+    },
+    {
+      "macaddress": "A8474A*"
+    },
+    {
+      "macaddress": "280DFC*"
+    },
+    {
+      "macaddress": "D44B5E*"
+    }
+  ],
   "documentation": "https://www.home-assistant.io/integrations/playstation_network",
   "integration_type": "service",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/playstation_network/quality_scale.yaml
+++ b/homeassistant/components/playstation_network/quality_scale.yaml
@@ -48,7 +48,7 @@ rules:
   discovery-update-info:
     status: exempt
     comment: Discovery flow is not applicable for this integration
-  discovery: todo
+  discovery: done
   docs-data-update: done
   docs-examples: todo
   docs-known-limitations: done

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -464,6 +464,82 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "registered_devices": True,
     },
     {
+        "domain": "playstation_network",
+        "macaddress": "AC8995*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "1C98C1*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "5C843C*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "605BB4*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "8060B7*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "78C881*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "00D9D1*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "00E421*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "0CFE45*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "2CCC44*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "BC60A7*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "C863F1*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "F8461C*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "70662A*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "09E29*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "B40AD8*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "A8474A*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "280DFC*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "D44B5E*",
+    },
+    {
         "domain": "powerwall",
         "hostname": "1118431-*",
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds DHCP discovery to the PlayStation Network integration. No extra discovery flow has been added as the discovery_info is not needed, it is enough if a normal user flow is started. It is more to suggest to set up the integration if a PlayStation device is found in the network.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
