### PR TITLE
Make entities unavailable when machine is physically off in lamarzocco

### DIFF
--- a/homeassistant/components/lamarzocco/entity.py
+++ b/homeassistant/components/lamarzocco/entity.py
@@ -69,17 +69,17 @@ class LaMarzoccoBaseEntity(
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        if (
-            self._unavailable_when_machine_off
-            and cast(
+        machine_state = (
+            cast(
                 MachineStatus,
                 self.coordinator.device.dashboard.config[WidgetType.CM_MACHINE_STATUS],
             ).status
-            is MachineState.OFF
-        ):
-            return False
-
-        return super().available
+            if WidgetType.CM_MACHINE_STATUS in self.coordinator.device.dashboard.config
+            else MachineState.OFF
+        )
+        return super().available and not (
+            self._unavailable_when_machine_off and machine_state is MachineState.OFF
+        )
 
 
 class LaMarzoccoEntity(LaMarzoccoBaseEntity):

--- a/homeassistant/components/lamarzocco/number.py
+++ b/homeassistant/components/lamarzocco/number.py
@@ -58,10 +58,6 @@ ENTITIES: tuple[LaMarzoccoNumberEntityDescription, ...] = (
                 CoffeeBoiler, machine.dashboard.config[WidgetType.CM_COFFEE_BOILER]
             ).target_temperature
         ),
-        available_fn=(
-            lambda coordinator: WidgetType.CM_COFFEE_BOILER
-            in coordinator.device.dashboard.config
-        ),
     ),
     LaMarzoccoNumberEntityDescription(
         key="smart_standby_time",

--- a/homeassistant/components/lamarzocco/sensor.py
+++ b/homeassistant/components/lamarzocco/sensor.py
@@ -57,10 +57,6 @@ ENTITIES: tuple[LaMarzoccoSensorEntityDescription, ...] = (
             ).ready_start_time
         ),
         entity_category=EntityCategory.DIAGNOSTIC,
-        available_fn=(
-            lambda coordinator: WidgetType.CM_COFFEE_BOILER
-            in coordinator.device.dashboard.config
-        ),
     ),
     LaMarzoccoSensorEntityDescription(
         key="steam_boiler_ready_time",
@@ -187,6 +183,8 @@ class LaMarzoccoSensorEntity(LaMarzoccoEntity, SensorEntity):
 
 class LaMarzoccoStatisticSensorEntity(LaMarzoccoSensorEntity):
     """Sensor for La Marzocco statistics."""
+
+    _unavailable_when_machine_off = False
 
     @property
     def native_value(self) -> StateType | datetime | None:

--- a/tests/components/lamarzocco/test_sensor.py
+++ b/tests/components/lamarzocco/test_sensor.py
@@ -2,11 +2,11 @@
 
 from unittest.mock import MagicMock, patch
 
-from pylamarzocco.const import ModelName
+from pylamarzocco.const import MachineState, ModelName, WidgetType
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -52,3 +52,27 @@ async def test_steam_ready_entity_for_all_machines(
 
     entry = entity_registry.async_get(state.entity_id)
     assert entry
+
+
+async def test_sensors_unavailable_if_machine_off(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_lamarzocco: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the La Marzocco switches are unavailable when the device is offline."""
+    SWITCHES_UNAVAILABLE = (
+        ("sensor.gs012345_steam_boiler_ready_time", True),
+        ("sensor.gs012345_coffee_boiler_ready_time", True),
+        ("sensor.gs012345_total_coffees_made", False),
+    )
+    mock_lamarzocco.dashboard.config[
+        WidgetType.CM_MACHINE_STATUS
+    ].status = MachineState.OFF
+    with patch("homeassistant.components.lamarzocco.PLATFORMS", [Platform.SENSOR]):
+        await async_init_integration(hass, mock_config_entry)
+
+    for sensor, available in SWITCHES_UNAVAILABLE:
+        state = hass.states.get(sensor)
+        assert state
+        assert (state.state == STATE_UNAVAILABLE) == available

--- a/tests/components/lamarzocco/test_switch.py
+++ b/tests/components/lamarzocco/test_switch.py
@@ -3,7 +3,7 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from pylamarzocco.const import SmartStandByType
+from pylamarzocco.const import MachineState, SmartStandByType, WidgetType
 from pylamarzocco.exceptions import RequestNotSuccessful
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -13,7 +13,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -197,3 +197,25 @@ async def test_switch_exceptions(
             blocking=True,
         )
     assert exc_info.value.translation_key == "auto_on_off_error"
+
+
+async def test_switches_unavailable_if_machine_off(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_lamarzocco: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the La Marzocco switches are unavailable when the device is offline."""
+    mock_lamarzocco.dashboard.config[
+        WidgetType.CM_MACHINE_STATUS
+    ].status = MachineState.OFF
+    with patch("homeassistant.components.lamarzocco.PLATFORMS", [Platform.SWITCH]):
+        await async_init_integration(hass, mock_config_entry)
+
+    switches = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    for switch in switches:
+        state = hass.states.get(switch.entity_id)
+        assert state
+        assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Most entities with the exception of statistics should be unavailable when the machine is physically turned off.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
