### PR TITLE
Use newer mock in recent Reolink test

### DIFF
--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -1156,11 +1156,11 @@ async def test_camera_wake_callback(
 
 async def test_baichaun_only(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
 ) -> None:
     """Test initializing a baichuan only device."""
-    reolink_connect.baichuan_only = True
+    reolink_host.baichuan_only = True
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SWITCH]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/home-assistant/core/pull/146684 was still using the old host mock (it was opened before the new one was introduced in test_init.py). This PR updates the test to the new one.

This also brings the coverage back to 100% for the entity.py module.

```
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
homeassistant/components/reolink/__init__.py          235      2    99%   368-376
homeassistant/components/reolink/binary_sensor.py      64      0   100%
homeassistant/components/reolink/button.py             59      0   100%
homeassistant/components/reolink/camera.py             42      0   100%
homeassistant/components/reolink/config_flow.py       157      0   100%
homeassistant/components/reolink/const.py               8      0   100%
homeassistant/components/reolink/diagnostics.py        23      0   100%
homeassistant/components/reolink/entity.py            125      0   100%
homeassistant/components/reolink/exceptions.py          6      0   100%
homeassistant/components/reolink/host.py              440      0   100%
homeassistant/components/reolink/light.py              78      0   100%
homeassistant/components/reolink/media_source.py      161      0   100%
homeassistant/components/reolink/number.py            107      0   100%
homeassistant/components/reolink/select.py            101      0   100%
homeassistant/components/reolink/sensor.py             63      0   100%
homeassistant/components/reolink/services.py           37      0   100%
homeassistant/components/reolink/siren.py              30      0   100%
homeassistant/components/reolink/switch.py             98      0   100%
homeassistant/components/reolink/update.py            139      0   100%
homeassistant/components/reolink/util.py               67      0   100%
homeassistant/components/reolink/views.py              86      0   100%
---------------------------------------------------------------------------------
TOTAL                                                2126      2    99%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
