### PR TITLE
Fix operational state and vacuum state for matter vacuum

### DIFF
--- a/homeassistant/components/matter/vacuum.py
+++ b/homeassistant/components/matter/vacuum.py
@@ -200,7 +200,7 @@ DISCOVERY_SCHEMAS = [
         entity_class=MatterVacuum,
         required_attributes=(
             clusters.RvcRunMode.Attributes.CurrentMode,
-            clusters.RvcOperationalState.Attributes.CurrentPhase,
+            clusters.RvcOperationalState.Attributes.OperationalState,
         ),
         optional_attributes=(
             clusters.RvcCleanMode.Attributes.CurrentMode,

--- a/homeassistant/components/matter/vacuum.py
+++ b/homeassistant/components/matter/vacuum.py
@@ -30,10 +30,10 @@ class OperationalState(IntEnum):
     Combination of generic OperationalState and RvcOperationalState.
     """
 
-    NO_ERROR = 0x00
-    UNABLE_TO_START_OR_RESUME = 0x01
-    UNABLE_TO_COMPLETE_OPERATION = 0x02
-    COMMAND_INVALID_IN_STATE = 0x03
+    STOPPED = 0x00
+    RUNNING = 0x01
+    PAUSED = 0x02
+    ERROR = 0x03
     SEEKING_CHARGER = 0x40
     CHARGING = 0x41
     DOCKED = 0x42
@@ -95,7 +95,7 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
 
     async def async_pause(self) -> None:
         """Pause the cleaning task."""
-        await self.send_device_command(clusters.OperationalState.Commands.Pause())
+        await self.send_device_command(clusters.RvcOperationalState.Commands.Pause())
 
     @callback
     def _update_from_device(self) -> None:
@@ -120,11 +120,10 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
             state = VacuumActivity.DOCKED
         elif operational_state == OperationalState.SEEKING_CHARGER:
             state = VacuumActivity.RETURNING
-        elif operational_state in (
-            OperationalState.UNABLE_TO_COMPLETE_OPERATION,
-            OperationalState.UNABLE_TO_START_OR_RESUME,
-        ):
+        elif operational_state == OperationalState.ERROR:
             state = VacuumActivity.ERROR
+        elif operational_state == OperationalState.PAUSED:
+            state = VacuumActivity.PAUSED
         elif (run_mode := self._supported_run_modes.get(run_mode_raw)) is not None:
             tags = {x.value for x in run_mode.modeTags}
             if ModeTag.CLEANING in tags:

--- a/tests/components/matter/snapshots/test_sensor.ambr
+++ b/tests/components/matter/snapshots/test_sensor.ambr
@@ -3775,7 +3775,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'running',
   })
 # ---
 # name: test_sensors[oven][sensor.mock_oven_temperature_2-entry]
@@ -6433,7 +6433,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'stopped',
   })
 # ---
 # name: test_sensors[window_covering_full][sensor.mock_full_window_covering_target_opening_position-entry]

--- a/tests/components/matter/test_vacuum.py
+++ b/tests/components/matter/test_vacuum.py
@@ -168,19 +168,26 @@ async def test_vacuum_updates(
     assert state
     assert state.state == "returning"
 
-    # confirm state is 'error' by setting the operational state to 0x01
+    # confirm state is 'idle' by setting the operational state to 0x01 (running) but mode is idle
     set_node_attribute(matter_node, 1, 97, 4, 0x01)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == "error"
+    assert state.state == "idle"
 
-    # confirm state is 'error' by setting the operational state to 0x02
+    # confirm state is 'idle' by setting the operational state to 0x01 (running) but mode is cleaning
+    set_node_attribute(matter_node, 1, 97, 4, 0x01)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "idle"
+
+    # confirm state is 'paused' by setting the operational state to 0x02
     set_node_attribute(matter_node, 1, 97, 4, 0x02)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == "error"
+    assert state.state == "paused"
 
     # confirm state is 'cleaning' by setting;
     # - the operational state to 0x00
@@ -211,3 +218,11 @@ async def test_vacuum_updates(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "unknown"
+
+    # confirm state is 'error' by setting;
+    # - the operational state to 0x03
+    set_node_attribute(matter_node, 1, 97, 4, 3)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "error"

--- a/tests/components/matter/test_vacuum.py
+++ b/tests/components/matter/test_vacuum.py
@@ -93,7 +93,7 @@ async def test_vacuum_actions(
     assert matter_client.send_device_command.call_args == call(
         node_id=matter_node.node_id,
         endpoint_id=1,
-        command=clusters.OperationalState.Commands.Pause(),
+        command=clusters.RvcOperationalState.Commands.Pause(),
     )
     matter_client.send_device_command.reset_mock()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixing the issue described in #145884. There are three main fixes:

- The Operational State sensor was always looking for the OperationalState cluster (0x60), but vacuums use RvcOperationalState (0x61) which mean that the state for this sensor was always Unknown. The attribute to use is now configurable in the Entity Descriptor. I also split the mapping from code to translation key so that the correct mappings are used.
- The vacuum entity defines an OperationalState enum, but the first 4 values were coming from the ErrorState enum rather than the OperationalState enum. This meant that the state of the vacuum would change to Error whenever it was not docked. Now it shows the correct state.
- Updated the async_pause command to use the RvcOperationalState cluster. Previously it would result in the `InteractionModelError: UnsupportedCluster (0xc3)`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #145884
- This PR is related to issue: #145884
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
