### PR TITLE
Make derivative sensor unavailable when source sensor is unavailable

### DIFF
--- a/tests/components/derivative/test_init.py
+++ b/tests/components/derivative/test_init.py
@@ -99,6 +99,9 @@ async def test_setup_and_remove_config_entry(
     input_sensor_entity_id = "sensor.input"
     derivative_entity_id = "sensor.my_derivative"
 
+    hass.states.async_set(input_sensor_entity_id, "10.0", {})
+    await hass.async_block_till_done()
+
     # Setup the config entry
     config_entry = MockConfigEntry(
         data={},

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -6,16 +6,26 @@ import random
 from typing import Any
 
 from freezegun import freeze_time
+import pytest
 
 from homeassistant.components.derivative.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
-from homeassistant.const import STATE_UNAVAILABLE, UnitOfPower, UnitOfTime
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfPower,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    mock_restore_cache_with_extra_data,
+)
 
 
 async def test_state(hass: HomeAssistant) -> None:
@@ -440,16 +450,14 @@ async def test_sub_intervals_instantaneous(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         state = hass.states.get("sensor.power")
-        derivative = round(float(state.state), config["sensor"]["round"])
-        assert derivative == -0.29
+        assert state.state == STATE_UNKNOWN
 
         now += timedelta(seconds=60)
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()
 
         state = hass.states.get("sensor.power")
-        derivative = round(float(state.state), config["sensor"]["round"])
-        assert derivative == -0.29
+        assert state.state == STATE_UNKNOWN
 
         now += timedelta(seconds=10)
         freezer.move_to(now)
@@ -458,7 +466,7 @@ async def test_sub_intervals_instantaneous(hass: HomeAssistant) -> None:
 
         state = hass.states.get("sensor.power")
         derivative = round(float(state.state), config["sensor"]["round"])
-        assert derivative == -0.29
+        assert derivative == 0
 
         now += timedelta(seconds=max_sub_interval + 1)
         async_fire_time_changed(hass, now)
@@ -693,3 +701,138 @@ async def test_device_id(
     derivative_entity = entity_registry.async_get("sensor.derivative")
     assert derivative_entity is not None
     assert derivative_entity.device_id == source_entity.device_id
+
+
+@pytest.mark.parametrize("bad_state", [STATE_UNAVAILABLE, STATE_UNKNOWN, "xyzzy"])
+async def test_unavailable(
+    bad_state: str,
+    hass: HomeAssistant,
+) -> None:
+    """Test derivative sensor state when unavailable."""
+    config, entity_id = await _setup_sensor(hass, {"unit_time": "s"})
+
+    times = [0, 1, 2, 3]
+    values = [0, 1, bad_state, 2]
+    expected_state = [0, 1, STATE_UNKNOWN, 0.5]
+
+    # Testing a energy sensor with non-monotonic intervals and values
+    base = dt_util.utcnow()
+    with freeze_time(base) as freezer:
+        for time, value, expect in zip(times, values, expected_state, strict=False):
+            freezer.move_to(base + timedelta(seconds=time))
+            hass.states.async_set(entity_id, value, {})
+            await hass.async_block_till_done()
+
+            state = hass.states.get("sensor.power")
+            assert state is not None
+
+            if expect == STATE_UNKNOWN:
+                assert state.state == expect
+            else:
+                assert round(float(state.state), config["sensor"]["round"]) == expect
+
+
+@pytest.mark.parametrize("bad_state", [STATE_UNAVAILABLE, STATE_UNKNOWN, "xyzzy"])
+async def test_unavailable_2(
+    bad_state: str,
+    hass: HomeAssistant,
+) -> None:
+    """Test derivative sensor state when unavailable with a time window."""
+    config, entity_id = await _setup_sensor(
+        hass, {"unit_time": "s", "time_window": {"seconds": 10}}
+    )
+
+    # Monotonically increasing by 1, with some unavailable holes
+    times = list(range(21))
+    values = list(range(21))
+    values[3] = bad_state
+    values[6] = bad_state
+    values[7] = bad_state
+    values[8] = bad_state
+
+    base = dt_util.utcnow()
+    with freeze_time(base) as freezer:
+        for time, value in zip(times, values, strict=False):
+            freezer.move_to(base + timedelta(seconds=time))
+            hass.states.async_set(entity_id, value, {})
+            await hass.async_block_till_done()
+
+            state = hass.states.get("sensor.power")
+            assert state is not None
+
+            if value == bad_state:
+                assert state.state == STATE_UNKNOWN
+            else:
+                expect = (time / 10) if time < 10 else 1
+                assert round(float(state.state), config["sensor"]["round"]) == round(
+                    expect, config["sensor"]["round"]
+                )
+
+
+@pytest.mark.parametrize("restore_state", ["3.00", STATE_UNKNOWN])
+async def test_unavailable_boot(
+    restore_state,
+    hass: HomeAssistant,
+) -> None:
+    """Test that the booting sequence does not leave derivative in a bad state."""
+
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    "sensor.power",
+                    restore_state,
+                    {
+                        "unit_of_measurement": "W",
+                    },
+                ),
+                {
+                    "native_value": restore_state,
+                    "native_unit_of_measurement": "W",
+                },
+            ),
+        ],
+    )
+
+    config = {
+        "platform": "derivative",
+        "name": "power",
+        "source": "sensor.energy",
+        "round": 2,
+        "unit_time": "s",
+    }
+
+    config = {"sensor": config}
+    entity_id = config["sensor"]["source"]
+    hass.states.async_set(entity_id, STATE_UNKNOWN, {})
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.power")
+    assert state is not None
+    # As there was no recorded valid state for the sensor, we just hold the default or restored state.
+    assert state.state == restore_state
+
+    base = dt_util.utcnow()
+    with freeze_time(base) as freezer:
+        freezer.move_to(base + timedelta(seconds=1))
+        hass.states.async_set(entity_id, 10, {})
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.power")
+        assert state is not None
+        # The source sensor has moved to a valid value, but we need 2 points to derive,
+        # so just hold until the next tick
+        assert state.state == restore_state
+
+        freezer.move_to(base + timedelta(seconds=2))
+        hass.states.async_set(entity_id, 15, {})
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.power")
+        assert state is not None
+        # Now that the source sensor has two valid datapoints, we can calculate derivative
+        assert state.state == "5.00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Make the derivative sensor unknown when its source sensor is non-numeric. The previous behavior just persists the previous value from the most recent time before the sensor had a bad value. 

While the derivative sensor state is `Unknown` during the period its source sensor is non-numeric, as soon as the source sensor becomes available again, it calculates the derivative as if there was no gap in the source sensor, allowing brief periods of unavailability to not distort longer term derivative calculations. 

Based on this [revert PR](https://github.com/home-assistant/core/pull/88952#issue-1604418603) this feature is one of the last missing pieces to re-enable statistics for Derivative sensor, which was previously reverted partially for this reason. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
