### PR TITLE
Bump ZHA to 0.0.61

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.60"],
+  "requirements": ["zha==0.0.61"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -697,6 +697,15 @@
       "number": {
         "name": "[%key:component::number::title%]"
       },
+      "tilt_open_close_and_step_time": {
+        "name": "Tilt open close and step time"
+      },
+      "tilt_position_percentage_after_move_to_level": {
+        "name": "Tilt position percentage after move to level"
+      },
+      "lift_drive_down_time": { "name": "Lift drive down time" },
+      "lift_drive_up_time": { "name": "Lift drive up time" },
+      "sound_volume": { "name": "Sound volume" },
       "detection_interval": {
         "name": "Detection interval"
       },
@@ -1158,6 +1167,12 @@
       }
     },
     "select": {
+      "switch_actions": {
+        "name": "Switch actions"
+      },
+      "switch_indication": {
+        "name": "Switch indication"
+      },
       "default_siren_tone": {
         "name": "Default siren tone"
       },
@@ -1391,6 +1406,12 @@
       }
     },
     "sensor": {
+      "auto_relock": {
+        "name": "Auto relock"
+      },
+      "opening": {
+        "name": "[%key:component::binary_sensor::entity_component::opening::name%]"
+      },
       "active_power_ph_b": {
         "name": "Power phase B"
       },
@@ -1484,6 +1505,10 @@
       "filter_run_time": {
         "name": "Filter run time"
       },
+      "last_action": { "name": "Last action" },
+      "last_action_source": { "name": "Last action source" },
+      "last_action_user": { "name": "Last action user" },
+      "last_pin_code": { "name": "Last PIN code" },
       "last_feeding_source": {
         "name": "Last feeding source"
       },

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1155,6 +1155,21 @@
       },
       "update_frequency": {
         "name": "Update frequency"
+      },
+      "sound_volume": {
+        "name": "Sound volume"
+      },
+      "lift_drive_up_time": {
+        "name": "Lift drive up time"
+      },
+      "lift_drive_down_time": {
+        "name": "Lift drive down time"
+      },
+      "tilt_open_close_and_step_time": {
+        "name": "Tilt open close and step time"
+      },
+      "tilt_position_percentage_after_move_to_level": {
+        "name": "Tilt position percentage after move to level"
       }
     },
     "select": {
@@ -1388,6 +1403,12 @@
       },
       "external_switch_type": {
         "name": "External switch type"
+      },
+      "switch_indication": {
+        "name": "Switch indication"
+      },
+      "switch_actions": {
+        "name": "Switch actions"
       }
     },
     "sensor": {
@@ -1741,6 +1762,21 @@
       },
       "lifetime": {
         "name": "Lifetime"
+      },
+      "last_action_source": {
+        "name": "Last action source"
+      },
+      "last_action": {
+        "name": "Last action"
+      },
+      "last_action_user": {
+        "name": "Last action user"
+      },
+      "last_pin_code": {
+        "name": "Last PIN code"
+      },
+      "opening": {
+        "name": "Opening"
       }
     },
     "switch": {
@@ -1956,6 +1992,9 @@
       },
       "external_temperature_sensor": {
         "name": "External temperature sensor"
+      },
+      "auto_relock": {
+        "name": "Auto relock"
       }
     }
   }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -697,15 +697,6 @@
       "number": {
         "name": "[%key:component::number::title%]"
       },
-      "tilt_open_close_and_step_time": {
-        "name": "Tilt open close and step time"
-      },
-      "tilt_position_percentage_after_move_to_level": {
-        "name": "Tilt position percentage after move to level"
-      },
-      "lift_drive_down_time": { "name": "Lift drive down time" },
-      "lift_drive_up_time": { "name": "Lift drive up time" },
-      "sound_volume": { "name": "Sound volume" },
       "detection_interval": {
         "name": "Detection interval"
       },
@@ -1167,12 +1158,6 @@
       }
     },
     "select": {
-      "switch_actions": {
-        "name": "Switch actions"
-      },
-      "switch_indication": {
-        "name": "Switch indication"
-      },
       "default_siren_tone": {
         "name": "Default siren tone"
       },
@@ -1406,12 +1391,6 @@
       }
     },
     "sensor": {
-      "auto_relock": {
-        "name": "Auto relock"
-      },
-      "opening": {
-        "name": "[%key:component::binary_sensor::entity_component::opening::name%]"
-      },
       "active_power_ph_b": {
         "name": "Power phase B"
       },
@@ -1505,10 +1484,6 @@
       "filter_run_time": {
         "name": "Filter run time"
       },
-      "last_action": { "name": "Last action" },
-      "last_action_source": { "name": "Last action source" },
-      "last_action_user": { "name": "Last action user" },
-      "last_pin_code": { "name": "Last PIN code" },
       "last_feeding_source": {
         "name": "Last feeding source"
       },

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1764,10 +1764,21 @@
         "name": "Lifetime"
       },
       "last_action_source": {
-        "name": "Last action source"
+        "name": "Last action source",
+        "state": {
+          "zigbee": "Zigbee",
+          "keypad": "Keypad",
+          "fingerprint": "Fingerprint",
+          "rfid": "RFID",
+          "self": "Self"
+        }
       },
       "last_action": {
-        "name": "Last action"
+        "name": "Last action",
+        "state": {
+          "lock": "[%key:common::state::locked%]",
+          "unlock": "[%key:common::state::unlocked%]"
+        }
       },
       "last_action_user": {
         "name": "Last action user"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3193,7 +3193,7 @@ zeroconf==0.147.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.60
+zha==0.0.61
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2634,7 +2634,7 @@ zeroconf==0.147.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.60
+zha==0.0.61
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.64.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA to [0.0.61](https://github.com/zigpy/zha/releases/tag/0.0.61).

This release includes many [quirks improvements](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.139), including the usual support for more Tuya devices, new entities for Nimly, Schneider Electric, and Aqara devices. ZHA now also supports generic `BinaryOutput` cluster entities for DIY devices (thanks @oddlama!). Included is also a small bugfix in the EZSP radio library that disables automatically-enabled source routing in newer radio firmwares.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
