### PR TITLE
Improve Home Connect diagnostics exposing more data

### DIFF
--- a/tests/components/home_connect/snapshots/test_diagnostics.ambr
+++ b/tests/components/home_connect/snapshots/test_diagnostics.ambr
@@ -12,11 +12,21 @@
       'settings': dict({
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'CookProcessor',
       'vib': 'HCS000006',
@@ -32,11 +42,21 @@
       'settings': dict({
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'DNE',
       'vib': 'HCS000000',
@@ -52,11 +72,21 @@
       'settings': dict({
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'Hob',
       'vib': 'HCS000005',
@@ -74,11 +104,21 @@
       'settings': dict({
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'WasherDryer',
       'vib': 'HCS000001',
@@ -94,11 +134,21 @@
       'settings': dict({
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'Refrigerator',
       'vib': 'HCS000002',
@@ -114,11 +164,21 @@
       'settings': dict({
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'Freezer',
       'vib': 'HCS000003',
@@ -135,21 +195,57 @@
         'Cooking.Common.Program.Hood.DelayedShutOff',
       ]),
       'settings': dict({
-        'BSH.Common.Setting.AmbientLightBrightness': 70,
-        'BSH.Common.Setting.AmbientLightColor': 'BSH.Common.EnumType.AmbientLightColor.Color43',
-        'BSH.Common.Setting.AmbientLightCustomColor': '#4a88f8',
-        'BSH.Common.Setting.AmbientLightEnabled': True,
-        'Cooking.Common.Setting.Lighting': True,
-        'Cooking.Common.Setting.LightingBrightness': 70,
-        'Cooking.Hood.Setting.ColorTemperature': 'Cooking.Hood.EnumType.ColorTemperature.warmToNeutral',
-        'Cooking.Hood.Setting.ColorTemperaturePercent': 70,
+        'BSH.Common.Setting.AmbientLightBrightness': dict({
+          'unit': '%',
+          'value': 70,
+        }),
+        'BSH.Common.Setting.AmbientLightColor': dict({
+          'value': 'BSH.Common.EnumType.AmbientLightColor.Color43',
+        }),
+        'BSH.Common.Setting.AmbientLightCustomColor': dict({
+          'value': '#4a88f8',
+        }),
+        'BSH.Common.Setting.AmbientLightEnabled': dict({
+          'value': True,
+        }),
+        'Cooking.Common.Setting.Lighting': dict({
+          'value': True,
+        }),
+        'Cooking.Common.Setting.LightingBrightness': dict({
+          'unit': '%',
+          'value': 70,
+        }),
+        'Cooking.Hood.Setting.ColorTemperature': dict({
+          'constraints': dict({
+            'allowed_values': list([
+              'Cooking.Hood.EnumType.ColorTemperature.warm',
+              'Cooking.Hood.EnumType.ColorTemperature.neutral',
+              'Cooking.Hood.EnumType.ColorTemperature.cold',
+            ]),
+          }),
+          'value': 'Cooking.Hood.EnumType.ColorTemperature.warmToNeutral',
+        }),
+        'Cooking.Hood.Setting.ColorTemperaturePercent': dict({
+          'unit': '%',
+          'value': 70,
+        }),
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'Hood',
       'vib': 'HCS000004',
@@ -166,15 +262,29 @@
         'Cooking.Oven.Program.HeatingMode.PizzaSetting',
       ]),
       'settings': dict({
-        'BSH.Common.Setting.AlarmClock': 0,
-        'BSH.Common.Setting.PowerState': 'BSH.Common.EnumType.PowerState.On',
+        'BSH.Common.Setting.AlarmClock': dict({
+          'value': 0,
+        }),
+        'BSH.Common.Setting.PowerState': dict({
+          'value': 'BSH.Common.EnumType.PowerState.On',
+        }),
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'Oven',
       'vib': 'HCS01OVN1',
@@ -193,11 +303,21 @@
       'settings': dict({
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'Dryer',
       'vib': 'HCS04DYR1',
@@ -219,11 +339,21 @@
       'settings': dict({
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'CoffeeMaker',
       'vib': 'HCS06COM1',
@@ -242,19 +372,48 @@
         'Dishcare.Dishwasher.Program.Quick45',
       ]),
       'settings': dict({
-        'BSH.Common.Setting.AmbientLightBrightness': 70,
-        'BSH.Common.Setting.AmbientLightColor': 'BSH.Common.EnumType.AmbientLightColor.Color43',
-        'BSH.Common.Setting.AmbientLightCustomColor': '#4a88f8',
-        'BSH.Common.Setting.AmbientLightEnabled': True,
-        'BSH.Common.Setting.ChildLock': False,
-        'BSH.Common.Setting.PowerState': 'BSH.Common.EnumType.PowerState.On',
+        'BSH.Common.Setting.AmbientLightBrightness': dict({
+          'unit': '%',
+          'value': 70,
+        }),
+        'BSH.Common.Setting.AmbientLightColor': dict({
+          'value': 'BSH.Common.EnumType.AmbientLightColor.Color43',
+        }),
+        'BSH.Common.Setting.AmbientLightCustomColor': dict({
+          'value': '#4a88f8',
+        }),
+        'BSH.Common.Setting.AmbientLightEnabled': dict({
+          'value': True,
+        }),
+        'BSH.Common.Setting.ChildLock': dict({
+          'value': False,
+        }),
+        'BSH.Common.Setting.PowerState': dict({
+          'constraints': dict({
+            'allowed_values': list([
+              'BSH.Common.EnumType.PowerState.On',
+              'BSH.Common.EnumType.PowerState.Off',
+            ]),
+          }),
+          'value': 'BSH.Common.EnumType.PowerState.On',
+        }),
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'Dishwasher',
       'vib': 'HCS02DWH1',
@@ -273,16 +432,32 @@
         'LaundryCare.Washer.Program.Wool',
       ]),
       'settings': dict({
-        'BSH.Common.Setting.ChildLock': False,
-        'BSH.Common.Setting.PowerState': 'BSH.Common.EnumType.PowerState.On',
-        'LaundryCare.Washer.Setting.IDos2BaseLevel': 0,
+        'BSH.Common.Setting.ChildLock': dict({
+          'value': False,
+        }),
+        'BSH.Common.Setting.PowerState': dict({
+          'value': 'BSH.Common.EnumType.PowerState.On',
+        }),
+        'LaundryCare.Washer.Setting.IDos2BaseLevel': dict({
+          'value': 0,
+        }),
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'Washer',
       'vib': 'HCS03WCH1',
@@ -296,19 +471,57 @@
       'programs': list([
       ]),
       'settings': dict({
-        'Refrigeration.Common.Setting.Dispenser.Enabled': False,
-        'Refrigeration.Common.Setting.Light.External.Brightness': 70,
-        'Refrigeration.Common.Setting.Light.External.Power': True,
-        'Refrigeration.FridgeFreezer.Setting.SetpointTemperatureRefrigerator': 8,
-        'Refrigeration.FridgeFreezer.Setting.SuperModeFreezer': False,
-        'Refrigeration.FridgeFreezer.Setting.SuperModeRefrigerator': False,
+        'Refrigeration.Common.Setting.Dispenser.Enabled': dict({
+          'constraints': dict({
+            'access': 'readWrite',
+          }),
+          'value': False,
+        }),
+        'Refrigeration.Common.Setting.Light.External.Brightness': dict({
+          'constraints': dict({
+            'access': 'readWrite',
+            'max': 100,
+            'min': 0,
+          }),
+          'unit': '%',
+          'value': 70,
+        }),
+        'Refrigeration.Common.Setting.Light.External.Power': dict({
+          'value': True,
+        }),
+        'Refrigeration.FridgeFreezer.Setting.SetpointTemperatureRefrigerator': dict({
+          'unit': '°C',
+          'value': 8,
+        }),
+        'Refrigeration.FridgeFreezer.Setting.SuperModeFreezer': dict({
+          'constraints': dict({
+            'access': 'readWrite',
+          }),
+          'value': False,
+        }),
+        'Refrigeration.FridgeFreezer.Setting.SuperModeRefrigerator': dict({
+          'constraints': dict({
+            'access': 'readWrite',
+          }),
+          'value': False,
+        }),
       }),
       'status': dict({
-        'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-        'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-        'BSH.Common.Status.RemoteControlActive': True,
-        'BSH.Common.Status.RemoteControlStartAllowed': True,
-        'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+        'BSH.Common.Status.DoorState': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Closed',
+        }),
+        'BSH.Common.Status.OperationState': dict({
+          'value': 'BSH.Common.EnumType.OperationState.Ready',
+        }),
+        'BSH.Common.Status.RemoteControlActive': dict({
+          'value': True,
+        }),
+        'BSH.Common.Status.RemoteControlStartAllowed': dict({
+          'value': True,
+        }),
+        'Refrigeration.Common.Status.Door.Refrigerator': dict({
+          'value': 'BSH.Common.EnumType.DoorState.Open',
+        }),
       }),
       'type': 'FridgeFreezer',
       'vib': 'HCS05FRF1',
@@ -330,19 +543,48 @@
       'Dishcare.Dishwasher.Program.Quick45',
     ]),
     'settings': dict({
-      'BSH.Common.Setting.AmbientLightBrightness': 70,
-      'BSH.Common.Setting.AmbientLightColor': 'BSH.Common.EnumType.AmbientLightColor.Color43',
-      'BSH.Common.Setting.AmbientLightCustomColor': '#4a88f8',
-      'BSH.Common.Setting.AmbientLightEnabled': True,
-      'BSH.Common.Setting.ChildLock': False,
-      'BSH.Common.Setting.PowerState': 'BSH.Common.EnumType.PowerState.On',
+      'BSH.Common.Setting.AmbientLightBrightness': dict({
+        'unit': '%',
+        'value': 70,
+      }),
+      'BSH.Common.Setting.AmbientLightColor': dict({
+        'value': 'BSH.Common.EnumType.AmbientLightColor.Color43',
+      }),
+      'BSH.Common.Setting.AmbientLightCustomColor': dict({
+        'value': '#4a88f8',
+      }),
+      'BSH.Common.Setting.AmbientLightEnabled': dict({
+        'value': True,
+      }),
+      'BSH.Common.Setting.ChildLock': dict({
+        'value': False,
+      }),
+      'BSH.Common.Setting.PowerState': dict({
+        'constraints': dict({
+          'allowed_values': list([
+            'BSH.Common.EnumType.PowerState.On',
+            'BSH.Common.EnumType.PowerState.Off',
+          ]),
+        }),
+        'value': 'BSH.Common.EnumType.PowerState.On',
+      }),
     }),
     'status': dict({
-      'BSH.Common.Status.DoorState': 'BSH.Common.EnumType.DoorState.Closed',
-      'BSH.Common.Status.OperationState': 'BSH.Common.EnumType.OperationState.Ready',
-      'BSH.Common.Status.RemoteControlActive': True,
-      'BSH.Common.Status.RemoteControlStartAllowed': True,
-      'Refrigeration.Common.Status.Door.Refrigerator': 'BSH.Common.EnumType.DoorState.Open',
+      'BSH.Common.Status.DoorState': dict({
+        'value': 'BSH.Common.EnumType.DoorState.Closed',
+      }),
+      'BSH.Common.Status.OperationState': dict({
+        'value': 'BSH.Common.EnumType.OperationState.Ready',
+      }),
+      'BSH.Common.Status.RemoteControlActive': dict({
+        'value': True,
+      }),
+      'BSH.Common.Status.RemoteControlStartAllowed': dict({
+        'value': True,
+      }),
+      'Refrigeration.Common.Status.Door.Refrigerator': dict({
+        'value': 'BSH.Common.EnumType.DoorState.Open',
+      }),
     }),
     'type': 'Dishwasher',
     'vib': 'HCS02DWH1',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While diagnosing at the issues, I found that asking for debug logs for getting the setting and status constraints was kind of hard, so I decided to add them to the diagnostics data. And also the units.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
