### PR TITLE
Add weekdays to time trigger

### DIFF
--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    WEEKDAYS,
 )
 from homeassistant.core import (
     CALLBACK_TYPE,
@@ -36,6 +37,8 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
+
+CONF_WEEKDAY = "weekday"
 
 _TIME_TRIGGER_ENTITY = vol.All(str, cv.entity_domain(["input_datetime", "sensor"]))
 _TIME_AT_SCHEMA = vol.Any(cv.time, _TIME_TRIGGER_ENTITY)
@@ -74,6 +77,10 @@ TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): "time",
         vol.Required(CONF_AT): vol.All(cv.ensure_list, [_TIME_TRIGGER_SCHEMA]),
+        vol.Optional(CONF_WEEKDAY): vol.Any(
+            vol.In(WEEKDAYS),
+            vol.All(cv.ensure_list, [vol.In(WEEKDAYS)]),
+        ),
     }
 )
 
@@ -85,7 +92,7 @@ class TrackEntity(NamedTuple):
     callback: Callable
 
 
-async def async_attach_trigger(
+async def async_attach_trigger(  # noqa: C901
     hass: HomeAssistant,
     config: ConfigType,
     action: TriggerActionType,
@@ -103,6 +110,18 @@ async def async_attach_trigger(
         description: str, now: datetime, *, entity_id: str | None = None
     ) -> None:
         """Listen for time changes and calls action."""
+        # Check weekday filter if configured
+        if CONF_WEEKDAY in config:
+            weekday_config = config[CONF_WEEKDAY]
+            current_weekday = WEEKDAYS[now.weekday()]
+
+            # Check if current weekday matches the configuration
+            if isinstance(weekday_config, str):
+                if current_weekday != weekday_config:
+                    return
+            elif current_weekday not in weekday_config:
+                return
+
         hass.async_run_hass_job(
             job,
             {

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -916,7 +916,7 @@ async def test_if_fires_using_weekday_single(
 
     # Fire on Tuesday at the same time - should not trigger
     tuesday_trigger = dt_util.as_utc(datetime(2023, 1, 3, 5, 0, 0, 0))
-    async_fire_time_changed(hass, tuesday_trigger + timedelta(seconds=1))
+    async_fire_time_changed(hass, tuesday_trigger)
     await hass.async_block_till_done()
 
     # Should still be only 1 call
@@ -963,20 +963,20 @@ async def test_if_fires_using_weekday_multiple(
 
     # Fire on Tuesday - should not trigger
     tuesday_trigger = dt_util.as_utc(datetime(2023, 1, 3, 5, 0, 0, 0))
-    async_fire_time_changed(hass, tuesday_trigger + timedelta(seconds=1))
+    async_fire_time_changed(hass, tuesday_trigger)
     await hass.async_block_till_done()
     assert len(service_calls) == 1
 
     # Fire on Wednesday - should trigger
     wednesday_trigger = dt_util.as_utc(datetime(2023, 1, 4, 5, 0, 0, 0))
-    async_fire_time_changed(hass, wednesday_trigger + timedelta(seconds=1))
+    async_fire_time_changed(hass, wednesday_trigger)
     await hass.async_block_till_done()
     assert len(service_calls) == 2
     assert "Wednesday" in service_calls[1].data["some"]
 
     # Fire on Friday - should trigger
     friday_trigger = dt_util.as_utc(datetime(2023, 1, 6, 5, 0, 0, 0))
-    async_fire_time_changed(hass, friday_trigger + timedelta(seconds=1))
+    async_fire_time_changed(hass, friday_trigger)
     await hass.async_block_till_done()
     assert len(service_calls) == 3
     assert "Friday" in service_calls[2].data["some"]
@@ -1041,7 +1041,7 @@ async def test_if_fires_using_weekday_with_entity(
 
     # Fire on Tuesday - should not trigger
     tuesday_trigger = dt_util.as_utc(datetime(2023, 1, 3, 5, 0, 0, 0))
-    async_fire_time_changed(hass, tuesday_trigger + timedelta(seconds=1))
+    async_fire_time_changed(hass, tuesday_trigger)
     await hass.async_block_till_done()
     automation_calls = [call for call in service_calls if call.domain == "test"]
     assert len(automation_calls) == 1

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -1,6 +1,6 @@
 """The tests for the time automation."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -885,16 +885,10 @@ async def test_if_fires_using_weekday_single(
     service_calls: list[ServiceCall],
 ) -> None:
     """Test for firing on a specific weekday."""
-    # Freeze time to Monday, January 2, 2023 at 4:59:00
-    now = dt_util.now()
-    monday_before_trigger = now.replace(
-        year=2023, month=1, day=2, hour=4, minute=59, second=0, microsecond=0
-    )
-    monday_trigger = now.replace(
-        year=2023, month=1, day=2, hour=5, minute=0, second=0, microsecond=0
-    )
+    # Freeze time to Monday, January 2, 2023 at 5:00:00
+    monday_trigger = dt_util.as_utc(datetime(2023, 1, 2, 5, 0, 0, 0))
 
-    freezer.move_to(monday_before_trigger)
+    freezer.move_to(monday_trigger)
 
     assert await async_setup_component(
         hass,
@@ -921,9 +915,7 @@ async def test_if_fires_using_weekday_single(
     assert service_calls[0].data["some"] == "time - Monday"
 
     # Fire on Tuesday at the same time - should not trigger
-    tuesday_trigger = now.replace(
-        year=2023, month=1, day=3, hour=5, minute=0, second=0, microsecond=0
-    )
+    tuesday_trigger = dt_util.as_utc(datetime(2023, 1, 3, 5, 0, 0, 0))
     async_fire_time_changed(hass, tuesday_trigger + timedelta(seconds=1))
     await hass.async_block_till_done()
 
@@ -937,13 +929,10 @@ async def test_if_fires_using_weekday_multiple(
     service_calls: list[ServiceCall],
 ) -> None:
     """Test for firing on multiple weekdays."""
-    # Freeze time to Monday, January 2, 2023 at 4:59:00
-    now = dt_util.now()
-    monday_before_trigger = now.replace(
-        year=2023, month=1, day=2, hour=4, minute=59, second=0, microsecond=0
-    )
+    # Freeze time to Monday, January 2, 2023 at 5:00:00
+    monday_trigger = dt_util.as_utc(datetime(2023, 1, 2, 5, 0, 0, 0))
 
-    freezer.move_to(monday_before_trigger)
+    freezer.move_to(monday_trigger)
 
     assert await async_setup_component(
         hass,
@@ -967,35 +956,26 @@ async def test_if_fires_using_weekday_multiple(
     await hass.async_block_till_done()
 
     # Fire on Monday - should trigger
-    monday_trigger = now.replace(
-        year=2023, month=1, day=2, hour=5, minute=0, second=0, microsecond=0
-    )
     async_fire_time_changed(hass, monday_trigger + timedelta(seconds=1))
     await hass.async_block_till_done()
     assert len(service_calls) == 1
     assert "Monday" in service_calls[0].data["some"]
 
     # Fire on Tuesday - should not trigger
-    tuesday_trigger = now.replace(
-        year=2023, month=1, day=3, hour=5, minute=0, second=0, microsecond=0
-    )
+    tuesday_trigger = dt_util.as_utc(datetime(2023, 1, 3, 5, 0, 0, 0))
     async_fire_time_changed(hass, tuesday_trigger + timedelta(seconds=1))
     await hass.async_block_till_done()
     assert len(service_calls) == 1
 
     # Fire on Wednesday - should trigger
-    wednesday_trigger = now.replace(
-        year=2023, month=1, day=4, hour=5, minute=0, second=0, microsecond=0
-    )
+    wednesday_trigger = dt_util.as_utc(datetime(2023, 1, 4, 5, 0, 0, 0))
     async_fire_time_changed(hass, wednesday_trigger + timedelta(seconds=1))
     await hass.async_block_till_done()
     assert len(service_calls) == 2
     assert "Wednesday" in service_calls[1].data["some"]
 
     # Fire on Friday - should trigger
-    friday_trigger = now.replace(
-        year=2023, month=1, day=6, hour=5, minute=0, second=0, microsecond=0
-    )
+    friday_trigger = dt_util.as_utc(datetime(2023, 1, 6, 5, 0, 0, 0))
     async_fire_time_changed(hass, friday_trigger + timedelta(seconds=1))
     await hass.async_block_till_done()
     assert len(service_calls) == 3
@@ -1014,14 +994,8 @@ async def test_if_fires_using_weekday_with_entity(
         {"input_datetime": {"trigger": {"has_date": False, "has_time": True}}},
     )
 
-    # Freeze time to Monday, January 2, 2023 at 4:59:00
-    now = dt_util.now()
-    monday_before_trigger = now.replace(
-        year=2023, month=1, day=2, hour=4, minute=59, second=0, microsecond=0
-    )
-    monday_trigger = now.replace(
-        year=2023, month=1, day=2, hour=5, minute=0, second=0, microsecond=0
-    )
+    # Freeze time to Monday, January 2, 2023 at 5:00:00
+    monday_trigger = dt_util.as_utc(datetime(2023, 1, 2, 5, 0, 0, 0))
 
     await hass.services.async_call(
         "input_datetime",
@@ -1033,7 +1007,7 @@ async def test_if_fires_using_weekday_with_entity(
         blocking=True,
     )
 
-    freezer.move_to(monday_before_trigger)
+    freezer.move_to(monday_trigger)
 
     assert await async_setup_component(
         hass,
@@ -1066,9 +1040,7 @@ async def test_if_fires_using_weekday_with_entity(
     assert automation_calls[0].data["entity"] == "input_datetime.trigger"
 
     # Fire on Tuesday - should not trigger
-    tuesday_trigger = now.replace(
-        year=2023, month=1, day=3, hour=5, minute=0, second=0, microsecond=0
-    )
+    tuesday_trigger = dt_util.as_utc(datetime(2023, 1, 3, 5, 0, 0, 0))
     async_fire_time_changed(hass, tuesday_trigger + timedelta(seconds=1))
     await hass.async_block_till_done()
     automation_calls = [call for call in service_calls if call.domain == "test"]

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -877,3 +877,218 @@ async def test_if_at_template_limited_template(
     await hass.async_block_till_done()
 
     assert "is not supported in limited templates" in caplog.text
+
+
+async def test_if_fires_using_weekday_single(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test for firing on a specific weekday."""
+    # Set time to Monday at 5:00:00
+    monday = dt_util.now().replace(hour=5, minute=0, second=0, microsecond=0)
+    # Find the next Monday
+    days_ahead = 0 - monday.weekday()  # Monday is 0
+    if days_ahead <= 0:  # Target day already happened this week
+        days_ahead += 7
+    monday = monday + timedelta(days=days_ahead)
+
+    time_before_trigger = monday - timedelta(minutes=1)
+    freezer.move_to(time_before_trigger)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "time", "at": "5:00:00", "weekday": "mon"},
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "some": "{{ trigger.platform }} - {{ trigger.now.strftime('%A') }}",
+                    },
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Fire the trigger on Monday
+    async_fire_time_changed(hass, monday + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "time - Monday"
+
+    # Fire on Tuesday at the same time - should not trigger
+    tuesday = monday + timedelta(days=1)
+    async_fire_time_changed(hass, tuesday + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    # Should still be only 1 call
+    assert len(service_calls) == 1
+
+
+async def test_if_fires_using_weekday_multiple(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test for firing on multiple weekdays."""
+    # Set time to Monday at 5:00:00
+    monday = dt_util.now().replace(hour=5, minute=0, second=0, microsecond=0)
+    # Find the next Monday
+    days_ahead = 0 - monday.weekday()  # Monday is 0
+    if days_ahead <= 0:  # Target day already happened this week
+        days_ahead += 7
+    monday = monday + timedelta(days=days_ahead)
+
+    time_before_trigger = monday - timedelta(minutes=1)
+    freezer.move_to(time_before_trigger)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time",
+                    "at": "5:00:00",
+                    "weekday": ["mon", "wed", "fri"],
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "some": "{{ trigger.platform }} - {{ trigger.now.strftime('%A') }}",
+                    },
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Fire on Monday - should trigger
+    async_fire_time_changed(hass, monday + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+    assert "Monday" in service_calls[0].data["some"]
+
+    # Fire on Tuesday - should not trigger
+    tuesday = monday + timedelta(days=1)
+    async_fire_time_changed(hass, tuesday + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+
+    # Fire on Wednesday - should trigger
+    wednesday = monday + timedelta(days=2)
+    async_fire_time_changed(hass, wednesday + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(service_calls) == 2
+    assert "Wednesday" in service_calls[1].data["some"]
+
+    # Fire on Friday - should trigger
+    friday = monday + timedelta(days=4)
+    async_fire_time_changed(hass, friday + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(service_calls) == 3
+    assert "Friday" in service_calls[2].data["some"]
+
+
+async def test_if_fires_using_weekday_with_entity(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test for firing on weekday with input_datetime entity."""
+    await async_setup_component(
+        hass,
+        "input_datetime",
+        {"input_datetime": {"trigger": {"has_date": False, "has_time": True}}},
+    )
+
+    # Set time to Monday at 5:00:00
+    monday = dt_util.now().replace(hour=5, minute=0, second=0, microsecond=0)
+    # Find the next Monday
+    days_ahead = 0 - monday.weekday()  # Monday is 0
+    if days_ahead <= 0:  # Target day already happened this week
+        days_ahead += 7
+    monday = monday + timedelta(days=days_ahead)
+
+    await hass.services.async_call(
+        "input_datetime",
+        "set_datetime",
+        {
+            ATTR_ENTITY_ID: "input_datetime.trigger",
+            "time": "05:00:00",
+        },
+        blocking=True,
+    )
+
+    time_before_trigger = monday - timedelta(minutes=1)
+    freezer.move_to(time_before_trigger)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time",
+                    "at": "input_datetime.trigger",
+                    "weekday": "mon",
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "some": "{{ trigger.platform }} - {{ trigger.now.strftime('%A') }}",
+                        "entity": "{{ trigger.entity_id }}",
+                    },
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Fire on Monday - should trigger
+    async_fire_time_changed(hass, monday + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    automation_calls = [call for call in service_calls if call.domain == "test"]
+    assert len(automation_calls) == 1
+    assert "Monday" in automation_calls[0].data["some"]
+    assert automation_calls[0].data["entity"] == "input_datetime.trigger"
+
+    # Fire on Tuesday - should not trigger
+    tuesday = monday + timedelta(days=1)
+    async_fire_time_changed(hass, tuesday + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    automation_calls = [call for call in service_calls if call.domain == "test"]
+    assert len(automation_calls) == 1
+
+
+def test_weekday_validation() -> None:
+    """Test weekday validation in trigger schema."""
+    # Valid single weekday
+    valid_config = {"platform": "time", "at": "5:00:00", "weekday": "mon"}
+    time.TRIGGER_SCHEMA(valid_config)
+
+    # Valid multiple weekdays
+    valid_config = {
+        "platform": "time",
+        "at": "5:00:00",
+        "weekday": ["mon", "wed", "fri"],
+    }
+    time.TRIGGER_SCHEMA(valid_config)
+
+    # Invalid weekday
+    invalid_config = {"platform": "time", "at": "5:00:00", "weekday": "invalid"}
+    with pytest.raises(vol.Invalid):
+        time.TRIGGER_SCHEMA(invalid_config)
+
+    # Invalid weekday in list
+    invalid_config = {
+        "platform": "time",
+        "at": "5:00:00",
+        "weekday": ["mon", "invalid"],
+    }
+    with pytest.raises(vol.Invalid):
+        time.TRIGGER_SCHEMA(invalid_config)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As requested in: https://github.com/orgs/home-assistant/discussions/26

Adds a weekday option to the time triggers, allowing you to fire it only on certain days of the week.

![image](https://github.com/user-attachments/assets/8e64dbc6-4126-4929-b32a-68a7e7551c93)

```yaml
automation:
  - triggers:
      - trigger: time
        at: "06:30:00"
        weekday:
          - "mon"
          - "tue"
          - "wed"
          - "thu"
          - "fri"
    actions:
      - action: script.morning_routine
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39707
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/25908

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
