### PR TITLE
Add entity pictures to PlayStation Network integration

### DIFF
--- a/homeassistant/components/playstation_network/const.py
+++ b/homeassistant/components/playstation_network/const.py
@@ -18,5 +18,4 @@ SUPPORTED_PLATFORMS = {
 
 NPSSO_LINK: Final = "https://ca.account.sony.com/api/v1/ssocookie"
 PSN_LINK: Final = "https://playstation.com"
-TROPHIES_URL: Final = "https://dn721902.ca.archive.org/0/items/psn_trophy_images/"
-TIER_URL: Final = "https://ia800908.us.archive.org/34/items/psn_trophy_images/"
+ASSETS_URL: Final = "https://ia600908.us.archive.org/34/items/psn_trophy_images/"

--- a/homeassistant/components/playstation_network/const.py
+++ b/homeassistant/components/playstation_network/const.py
@@ -7,7 +7,7 @@ from psnawp_api.models.trophies import PlatformType
 DOMAIN = "playstation_network"
 CONF_NPSSO: Final = "npsso"
 CONF_ACCOUNT_ID: Final = "account_id"
-
+CONF_SHOW_ENTITY_PICTURES: Final = "show_entity_pictures"
 SUPPORTED_PLATFORMS = {
     PlatformType.PS_VITA,
     PlatformType.PS3,
@@ -18,3 +18,5 @@ SUPPORTED_PLATFORMS = {
 
 NPSSO_LINK: Final = "https://ca.account.sony.com/api/v1/ssocookie"
 PSN_LINK: Final = "https://playstation.com"
+TROPHIES_URL: Final = "https://dn721902.ca.archive.org/0/items/psn_trophy_images/"
+TIER_URL: Final = "https://ia800908.us.archive.org/34/items/psn_trophy_images/"

--- a/homeassistant/components/playstation_network/icons.json
+++ b/homeassistant/components/playstation_network/icons.json
@@ -21,13 +21,13 @@
         "default": "mdi:trophy"
       },
       "earned_trophies_gold": {
-        "default": "mdi:trophy-variant"
+        "default": "mdi:trophy-outline"
       },
       "earned_trophies_silver": {
         "default": "mdi:trophy-variant"
       },
       "earned_trophies_bronze": {
-        "default": "mdi:trophy-variant"
+        "default": "mdi:trophy-variant-outline"
       },
       "online_id": {
         "default": "mdi:account"

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_SHOW_ENTITY_PICTURES, TIER_URL, TROPHIES_URL
+from .const import ASSETS_URL, CONF_SHOW_ENTITY_PICTURES
 from .coordinator import (
     PlayStationNetworkBaseCoordinator,
     PlaystationNetworkConfigEntry,
@@ -64,7 +64,7 @@ SENSOR_DESCRIPTIONS_TROPHY: tuple[PlaystationNetworkSensorEntityDescription, ...
             lambda psn: psn.trophy_summary.trophy_level if psn.trophy_summary else None
         ),
         entity_picture=(
-            lambda psn: f"{TIER_URL}tier_{psn.trophy_summary.tier}.png"
+            lambda psn: f"{ASSETS_URL}tier_{psn.trophy_summary.tier}.png"
             if psn.trophy_summary
             else None
         ),
@@ -85,7 +85,7 @@ SENSOR_DESCRIPTIONS_TROPHY: tuple[PlaystationNetworkSensorEntityDescription, ...
             if psn.trophy_summary
             else None
         ),
-        entity_picture=f"{TROPHIES_URL}platinum.png",
+        entity_picture=f"{ASSETS_URL}platinum.png",
     ),
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.EARNED_TROPHIES_GOLD,
@@ -95,7 +95,7 @@ SENSOR_DESCRIPTIONS_TROPHY: tuple[PlaystationNetworkSensorEntityDescription, ...
             if psn.trophy_summary
             else None
         ),
-        entity_picture=f"{TROPHIES_URL}gold.png",
+        entity_picture=f"{ASSETS_URL}gold.png",
     ),
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.EARNED_TROPHIES_SILVER,
@@ -105,7 +105,7 @@ SENSOR_DESCRIPTIONS_TROPHY: tuple[PlaystationNetworkSensorEntityDescription, ...
             if psn.trophy_summary
             else None
         ),
-        entity_picture=f"{TROPHIES_URL}silver.png",
+        entity_picture=f"{ASSETS_URL}silver.png",
     ),
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.EARNED_TROPHIES_BRONZE,
@@ -115,7 +115,7 @@ SENSOR_DESCRIPTIONS_TROPHY: tuple[PlaystationNetworkSensorEntityDescription, ...
             if psn.trophy_summary
             else None
         ),
-        entity_picture=f"{TROPHIES_URL}bronze.png",
+        entity_picture=f"{ASSETS_URL}bronze.png",
     ),
 )
 SENSOR_DESCRIPTIONS_USER: tuple[PlaystationNetworkSensorEntityDescription, ...] = (

--- a/homeassistant/components/playstation_network/strings.json
+++ b/homeassistant/components/playstation_network/strings.json
@@ -74,6 +74,18 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "show_entity_pictures": "Show entity pictures"
+        },
+        "data_description": {
+          "show_entity_pictures": "Displays authentic PlayStation icons for trophy-related sensors, including bronze, silver, gold, platinum trophies, and trophy level."
+        }
+      }
+    }
+  },
   "exceptions": {
     "not_ready": {
       "message": "Authentication to the PlayStation Network failed."

--- a/tests/components/playstation_network/snapshots/test_sensor.ambr
+++ b/tests/components/playstation_network/snapshots/test_sensor.ambr
@@ -745,7 +745,7 @@
 # name: test_sensors_entity_pictures_enabled[sensor.testuser_bronze_trophies-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'entity_picture': 'https://dn721902.ca.archive.org/0/items/psn_trophy_images/bronze.png',
+      'entity_picture': 'https://ia600908.us.archive.org/34/items/psn_trophy_images/bronze.png',
       'friendly_name': 'testuser Bronze trophies',
       'unit_of_measurement': 'trophies',
     }),
@@ -795,7 +795,7 @@
 # name: test_sensors_entity_pictures_enabled[sensor.testuser_gold_trophies-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'entity_picture': 'https://dn721902.ca.archive.org/0/items/psn_trophy_images/gold.png',
+      'entity_picture': 'https://ia600908.us.archive.org/34/items/psn_trophy_images/gold.png',
       'friendly_name': 'testuser Gold trophies',
       'unit_of_measurement': 'trophies',
     }),
@@ -1102,7 +1102,7 @@
 # name: test_sensors_entity_pictures_enabled[sensor.testuser_platinum_trophies-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'entity_picture': 'https://dn721902.ca.archive.org/0/items/psn_trophy_images/platinum.png',
+      'entity_picture': 'https://ia600908.us.archive.org/34/items/psn_trophy_images/platinum.png',
       'friendly_name': 'testuser Platinum trophies',
       'unit_of_measurement': 'trophies',
     }),
@@ -1152,7 +1152,7 @@
 # name: test_sensors_entity_pictures_enabled[sensor.testuser_silver_trophies-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'entity_picture': 'https://dn721902.ca.archive.org/0/items/psn_trophy_images/silver.png',
+      'entity_picture': 'https://ia600908.us.archive.org/34/items/psn_trophy_images/silver.png',
       'friendly_name': 'testuser Silver trophies',
       'unit_of_measurement': 'trophies',
     }),
@@ -1202,7 +1202,7 @@
 # name: test_sensors_entity_pictures_enabled[sensor.testuser_trophy_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'entity_picture': 'https://ia800908.us.archive.org/34/items/psn_trophy_images/tier_10.png',
+      'entity_picture': 'https://ia600908.us.archive.org/34/items/psn_trophy_images/tier_10.png',
       'friendly_name': 'testuser Trophy level',
     }),
     'context': <ANY>,

--- a/tests/components/playstation_network/snapshots/test_sensor.ambr
+++ b/tests/components/playstation_network/snapshots/test_sensor.ambr
@@ -707,3 +707,509 @@
     'state': '1079',
   })
 # ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_bronze_trophies-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_bronze_trophies',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bronze trophies',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.EARNED_TROPHIES_BRONZE: 'earned_trophies_bronze'>,
+    'unique_id': 'my-psn-id_earned_trophies_bronze',
+    'unit_of_measurement': 'trophies',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_bronze_trophies-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'https://dn721902.ca.archive.org/0/items/psn_trophy_images/bronze.png',
+      'friendly_name': 'testuser Bronze trophies',
+      'unit_of_measurement': 'trophies',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_bronze_trophies',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '14450',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_gold_trophies-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_gold_trophies',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Gold trophies',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.EARNED_TROPHIES_GOLD: 'earned_trophies_gold'>,
+    'unique_id': 'my-psn-id_earned_trophies_gold',
+    'unit_of_measurement': 'trophies',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_gold_trophies-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'https://dn721902.ca.archive.org/0/items/psn_trophy_images/gold.png',
+      'friendly_name': 'testuser Gold trophies',
+      'unit_of_measurement': 'trophies',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_gold_trophies',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11754',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_last_online-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_last_online',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last online',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.LAST_ONLINE: 'last_online'>,
+    'unique_id': 'my-psn-id_last_online',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_last_online-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'testuser Last online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_last_online',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-06-30T01:42:15+00:00',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_next_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_next_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Next level',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.TROPHY_LEVEL_PROGRESS: 'trophy_level_progress'>,
+    'unique_id': 'my-psn-id_trophy_level_progress',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_next_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'testuser Next level',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_next_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '19',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_now_playing-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_now_playing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Now playing',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.NOW_PLAYING: 'now_playing'>,
+    'unique_id': 'my-psn-id_now_playing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_now_playing-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'testuser Now playing',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_now_playing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'STAR WARS Jedi: Survivor™',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_online_id-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_online_id',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Online ID',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.ONLINE_ID: 'online_id'>,
+    'unique_id': 'my-psn-id_online_id',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_online_id-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'http://static-resource.np.community.playstation.net/avatar_xl/WWS_A/UP90001312L24_DD96EB6A4FF5FE883C09_XL.png',
+      'friendly_name': 'testuser Online ID',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_online_id',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'testuser',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_online_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'offline',
+        'availabletoplay',
+        'availabletocommunicate',
+        'busy',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_online_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Online status',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.ONLINE_STATUS: 'online_status'>,
+    'unique_id': 'my-psn-id_online_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_online_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'testuser Online status',
+      'options': list([
+        'offline',
+        'availabletoplay',
+        'availabletocommunicate',
+        'busy',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_online_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'availabletoplay',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_platinum_trophies-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_platinum_trophies',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Platinum trophies',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.EARNED_TROPHIES_PLATINUM: 'earned_trophies_platinum'>,
+    'unique_id': 'my-psn-id_earned_trophies_platinum',
+    'unit_of_measurement': 'trophies',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_platinum_trophies-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'https://dn721902.ca.archive.org/0/items/psn_trophy_images/platinum.png',
+      'friendly_name': 'testuser Platinum trophies',
+      'unit_of_measurement': 'trophies',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_platinum_trophies',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1398',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_silver_trophies-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_silver_trophies',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Silver trophies',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.EARNED_TROPHIES_SILVER: 'earned_trophies_silver'>,
+    'unique_id': 'my-psn-id_earned_trophies_silver',
+    'unit_of_measurement': 'trophies',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_silver_trophies-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'https://dn721902.ca.archive.org/0/items/psn_trophy_images/silver.png',
+      'friendly_name': 'testuser Silver trophies',
+      'unit_of_measurement': 'trophies',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_silver_trophies',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '8722',
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_trophy_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_trophy_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Trophy level',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.TROPHY_LEVEL: 'trophy_level'>,
+    'unique_id': 'my-psn-id_trophy_level',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors_entity_pictures_enabled[sensor.testuser_trophy_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'https://ia800908.us.archive.org/34/items/psn_trophy_images/tier_10.png',
+      'friendly_name': 'testuser Trophy level',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_trophy_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1079',
+  })
+# ---

--- a/tests/components/playstation_network/test_sensor.py
+++ b/tests/components/playstation_network/test_sensor.py
@@ -6,10 +6,13 @@ from unittest.mock import patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.playstation_network.const import CONF_NPSSO, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+
+from .conftest import NPSSO_TOKEN, PSN_ID
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -33,6 +36,31 @@ async def test_sensors(
 ) -> None:
     """Test setup of the PlayStation Network sensor platform."""
 
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_psnawpapi")
+async def test_sensors_entity_pictures_enabled(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test setup of the PlayStation Network sensor platform."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        data={
+            CONF_NPSSO: NPSSO_TOKEN,
+        },
+        options={"show_entity_pictures": True},
+        unique_id=PSN_ID,
+    )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Adds entity pictures for Platinum, Gold, Silver and Bronze trophies. Trophy level picture is based on the trophy level tier of the user, there are 10 tiers.

To allow the user to decide if they want the entity pictures or not a switch was added to settings so they can decide on integration level.

Images are hosted on archive.org 

![entity_pics](https://github.com/user-attachments/assets/9607e677-c644-451d-8d31-0c8d768d7950)

<img width="602" height="253" alt="image" src="https://github.com/user-attachments/assets/a791c400-0304-4b00-9aed-8747ec22284b" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
