### PR TITLE
Correct Chlorine unit definition in flipr integration

### DIFF
--- a/homeassistant/components/flipr/sensor.py
+++ b/homeassistant/components/flipr/sensor.py
@@ -8,7 +8,12 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfElectricPotential, UnitOfTemperature
+from homeassistant.const import (
+    CHLORINE_UNIT,
+    PERCENTAGE,
+    UnitOfElectricPotential,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -19,7 +24,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="chlorine",
         translation_key="chlorine",
-        native_unit_of_measurement="mg/l",
+        native_unit_of_measurement=CHLORINE_UNIT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(

--- a/homeassistant/components/flipr/sensor.py
+++ b/homeassistant/components/flipr/sensor.py
@@ -8,12 +8,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import (
-    CONCENTRATION_MILLIGRAMS_PER_LITER,
-    PERCENTAGE,
-    UnitOfElectricPotential,
-    UnitOfTemperature,
-)
+from homeassistant.const import PERCENTAGE, UnitOfElectricPotential, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -24,7 +19,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="chlorine",
         translation_key="chlorine",
-        native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_LITER,
+        native_unit_of_measurement="mg/L",
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(

--- a/homeassistant/components/flipr/sensor.py
+++ b/homeassistant/components/flipr/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    CHLORINE_UNIT,
+    CONCENTRATION_MILLIGRAMS_PER_LITER,
     PERCENTAGE,
     UnitOfElectricPotential,
     UnitOfTemperature,
@@ -24,7 +24,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="chlorine",
         translation_key="chlorine",
-        native_unit_of_measurement=CHLORINE_UNIT,
+        native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_LITER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(

--- a/homeassistant/components/flipr/sensor.py
+++ b/homeassistant/components/flipr/sensor.py
@@ -19,7 +19,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="chlorine",
         translation_key="chlorine",
-        native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
+        native_unit_of_measurement="mg/l",
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -910,15 +910,13 @@ class UnitOfPrecipitationDepth(StrEnum):
 
 
 # Concentration units
+CONCENTRATION_MILLIGRAMS_PER_LITER: Final = "mg/L"
 CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: Final = "µg/m³"
 CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: Final = "mg/m³"
 CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT: Final = "μg/ft³"
 CONCENTRATION_PARTS_PER_CUBIC_METER: Final = "p/m³"
 CONCENTRATION_PARTS_PER_MILLION: Final = "ppm"
 CONCENTRATION_PARTS_PER_BILLION: Final = "ppb"
-
-# Pool chlorine unit
-CHLORINE_UNIT: Final = "mg/L"
 
 
 class UnitOfBloodGlucoseConcentration(StrEnum):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -910,7 +910,6 @@ class UnitOfPrecipitationDepth(StrEnum):
 
 
 # Concentration units
-CONCENTRATION_MILLIGRAMS_PER_LITER: Final = "mg/L"
 CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: Final = "µg/m³"
 CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: Final = "mg/m³"
 CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT: Final = "μg/ft³"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -917,6 +917,9 @@ CONCENTRATION_PARTS_PER_CUBIC_METER: Final = "p/m³"
 CONCENTRATION_PARTS_PER_MILLION: Final = "ppm"
 CONCENTRATION_PARTS_PER_BILLION: Final = "ppb"
 
+# Pool chlorine unit
+CHLORINE_UNIT: Final = "mg/L"
+
 
 class UnitOfBloodGlucoseConcentration(StrEnum):
     """Blood glucose concentration units."""

--- a/tests/components/flipr/test_sensor.py
+++ b/tests/components/flipr/test_sensor.py
@@ -5,12 +5,7 @@ from unittest.mock import AsyncMock
 from flipr_api.exceptions import FliprError
 
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
-from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT,
-    CONCENTRATION_MILLIGRAMS_PER_LITER,
-    PERCENTAGE,
-    UnitOfTemperature,
-)
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -59,10 +54,7 @@ async def test_sensors(
 
     state = hass.states.get("sensor.flipr_myfliprid_chlorine")
     assert state
-    assert (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        == CONCENTRATION_MILLIGRAMS_PER_LITER
-    )
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "mg/L"
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.state == "0.23654886"
 

--- a/tests/components/flipr/test_sensor.py
+++ b/tests/components/flipr/test_sensor.py
@@ -7,7 +7,7 @@ from flipr_api.exceptions import FliprError
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
-    CHLORINE_UNIT,
+    CONCENTRATION_MILLIGRAMS_PER_LITER,
     PERCENTAGE,
     UnitOfTemperature,
 )
@@ -59,7 +59,10 @@ async def test_sensors(
 
     state = hass.states.get("sensor.flipr_myfliprid_chlorine")
     assert state
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == CHLORINE_UNIT
+    assert (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == CONCENTRATION_MILLIGRAMS_PER_LITER
+    )
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.state == "0.23654886"
 

--- a/tests/components/flipr/test_sensor.py
+++ b/tests/components/flipr/test_sensor.py
@@ -54,7 +54,7 @@ async def test_sensors(
 
     state = hass.states.get("sensor.flipr_myfliprid_chlorine")
     assert state
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "mV"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "mg/l"
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.state == "0.23654886"
 

--- a/tests/components/flipr/test_sensor.py
+++ b/tests/components/flipr/test_sensor.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock
 from flipr_api.exceptions import FliprError
 
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, UnitOfTemperature
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    CHLORINE_UNIT,
+    PERCENTAGE,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -54,7 +59,7 @@ async def test_sensors(
 
     state = hass.states.get("sensor.flipr_myfliprid_chlorine")
     assert state
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "mg/l"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == CHLORINE_UNIT
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.state == "0.23654886"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Correction of bug https://github.com/home-assistant/core/issues/145683

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #145683
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
