### PR TITLE
Allow setup of Zigbee/Thread for ZBT-1 and Yellow without internet access

### DIFF
--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -203,7 +203,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
 
                 if probed_fw_version >= fw_version:
                     _LOGGER.debug(
-                        "Not upgrading firmware, installed %s is newer than available %s",
+                        "Not downgrading firmware, installed %s is newer than available %s",
                         probed_fw_version,
                         fw_version,
                     )

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -151,8 +151,8 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         assert self._device is not None
 
         if not self.firmware_install_task:
-            # We can be sure that firmware needs to be installed if the wrong firmware
-            # is currently installed
+            # We 100% need to install new firmware only if the wrong firmware is
+            # currently installed
             firmware_install_required = self._probed_firmware_info is None or (
                 self._probed_firmware_info.firmware_type
                 != expected_installed_firmware_type
@@ -168,6 +168,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
                     "Failed to fetch firmware update manifest", exc_info=True
                 )
 
+                # Not having internet access should not prevent setup
                 if firmware_install_required:
                     raise AbortFlow(
                         "fw_download_failed",
@@ -183,7 +184,7 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
             if not firmware_install_required:
                 assert self._probed_firmware_info is not None
 
-                # See if we need to upgrade
+                # Make sure we do not downgrade the firmware
                 fw_metadata = NabuCasaMetadata.from_json(fw_manifest.metadata)
                 fw_version = fw_metadata.get_public_version()
                 probed_fw_version = Version(self._probed_firmware_info.firmware_version)

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -36,7 +36,8 @@
         "otbr_addon_already_running": "The OpenThread Border Router add-on is already running, it cannot be installed again.",
         "zha_still_using_stick": "This {model} is in use by the Zigbee Home Automation integration. Please migrate your Zigbee network to another adapter or delete the integration and try again.",
         "otbr_still_using_stick": "This {model} is in use by the OpenThread Border Router add-on. If you use the Thread network, make sure you have alternative border routers. Uninstall the add-on and try again.",
-        "unsupported_firmware": "The radio firmware on your {model} could not be determined. Make sure that no other integration or add-on is currently trying to communicate with the device. If you are running Home Assistant OS in a virtual machine or in Docker, please make sure that permissions are set correctly for the device."
+        "unsupported_firmware": "The radio firmware on your {model} could not be determined. Make sure that no other integration or add-on is currently trying to communicate with the device. If you are running Home Assistant OS in a virtual machine or in Docker, please make sure that permissions are set correctly for the device.",
+        "fw_download_failed": "{firmware_name} firmware for your {model} failed to download. Make sure Home Assistant has internet access and try again."
       },
       "progress": {
         "install_firmware": "Please wait while {firmware_name} firmware is installed to your {model}, this will take a few minutes. Do not make any changes to your hardware or software until this finishes."

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -93,7 +93,7 @@ class SkyConnectFirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
             firmware_name="Zigbee",
             expected_installed_firmware_type=ApplicationType.EZSP,
             step_id="install_zigbee_firmware",
-            next_step_id="confirm_zigbee",
+            next_step_id="pre_confirm_zigbee",
         )
 
     async def async_step_install_thread_firmware(

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -92,7 +92,8 @@
       "otbr_addon_already_running": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_addon_already_running%]",
       "zha_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::zha_still_using_stick%]",
       "otbr_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_still_using_stick%]",
-      "unsupported_firmware": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::unsupported_firmware%]"
+      "unsupported_firmware": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::unsupported_firmware%]",
+      "fw_download_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_download_failed%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",
@@ -145,7 +146,8 @@
       "otbr_addon_already_running": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_addon_already_running%]",
       "zha_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::zha_still_using_stick%]",
       "otbr_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_still_using_stick%]",
-      "unsupported_firmware": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::unsupported_firmware%]"
+      "unsupported_firmware": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::unsupported_firmware%]",
+      "fw_download_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_download_failed%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -117,7 +117,8 @@
       "otbr_addon_already_running": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_addon_already_running%]",
       "zha_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::zha_still_using_stick%]",
       "otbr_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_still_using_stick%]",
-      "unsupported_firmware": "The radio firmware on your {model} could not be determined. Make sure that no other integration or addon is currently trying to communicate with the device."
+      "unsupported_firmware": "The radio firmware on your {model} could not be determined. Make sure that no other integration or addon is currently trying to communicate with the device.",
+      "fw_download_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_download_failed%]"
     },
     "progress": {
       "install_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::progress::install_addon%]",

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -117,7 +117,7 @@
       "otbr_addon_already_running": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_addon_already_running%]",
       "zha_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::zha_still_using_stick%]",
       "otbr_still_using_stick": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::otbr_still_using_stick%]",
-      "unsupported_firmware": "The radio firmware on your {model} could not be determined. Make sure that no other integration or addon is currently trying to communicate with the device.",
+      "unsupported_firmware": "The radio firmware on your {model} could not be determined. Make sure that no other integration or add-on is currently trying to communicate with the device.",
       "fw_download_failed": "[%key:component::homeassistant_hardware::firmware_picker::options::abort::fw_download_failed%]"
     },
     "progress": {

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -139,7 +139,7 @@ class FakeFirmwareOptionsFlowHandler(BaseFirmwareOptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Install Zigbee firmware."""
-        return await self.async_step_confirm_zigbee()
+        return await self.async_step_pre_confirm_zigbee()
 
     async def async_step_install_thread_firmware(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -243,7 +243,14 @@ def mock_firmware_info(
                 checksum="sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
                 size=123,
                 release_notes="Some release notes",
-                metadata={},
+                metadata={
+                    "baudrate": 460800,
+                    "fw_type": "openthread_rcp",
+                    "fw_variant": None,
+                    "metadata_version": 2,
+                    "ot_rcp_version": "SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4",
+                    "sdk_version": "4.4.4",
+                },
                 url=TEST_RELEASES_URL / "fake_openthread_rcp_7.4.4.0_variant.gbl",
             ),
             FirmwareMetadata(
@@ -251,7 +258,14 @@ def mock_firmware_info(
                 checksum="sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
                 size=123,
                 release_notes="Some release notes",
-                metadata={},
+                metadata={
+                    "baudrate": 115200,
+                    "ezsp_version": "7.4.4.0",
+                    "fw_type": "zigbee_ncp",
+                    "fw_variant": None,
+                    "metadata_version": 2,
+                    "sdk_version": "4.4.4",
+                },
                 url=TEST_RELEASES_URL / "fake_zigbee_ncp_7.4.4.0_variant.gbl",
             ),
         ],
@@ -263,7 +277,7 @@ def mock_firmware_info(
         probed_firmware_info = FirmwareInfo(
             device="/dev/ttyUSB0",  # Not used
             firmware_type=probe_app_type,
-            firmware_version=None,
+            firmware_version="2.4.4.0",
             owners=[],
             source="probe",
         )

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+from aiohttp import ClientError
 import pytest
 
 from homeassistant.components.hassio import AddonError, AddonInfo, AddonState
@@ -109,7 +110,7 @@ async def test_config_flow_thread_addon_info_fails(hass: HomeAssistant) -> None:
     with mock_firmware_info(
         hass,
         probe_app_type=ApplicationType.EZSP,
-    ) as mock_otbr_manager:
+    ) as (mock_otbr_manager, _):
         mock_otbr_manager.async_get_addon_info.side_effect = AddonError()
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
@@ -147,7 +148,7 @@ async def test_config_flow_thread_addon_already_configured(hass: HomeAssistant) 
             update_available=False,
             version="1.0.0",
         ),
-    ) as mock_otbr_manager:
+    ) as (mock_otbr_manager, _):
         mock_otbr_manager.async_install_addon_waiting = AsyncMock(
             side_effect=AddonError()
         )
@@ -178,7 +179,7 @@ async def test_config_flow_thread_addon_install_fails(hass: HomeAssistant) -> No
     with mock_firmware_info(
         hass,
         probe_app_type=ApplicationType.EZSP,
-    ) as mock_otbr_manager:
+    ) as (mock_otbr_manager, _):
         mock_otbr_manager.async_install_addon_waiting = AsyncMock(
             side_effect=AddonError()
         )
@@ -209,7 +210,7 @@ async def test_config_flow_thread_addon_set_config_fails(hass: HomeAssistant) ->
     with mock_firmware_info(
         hass,
         probe_app_type=ApplicationType.EZSP,
-    ) as mock_otbr_manager:
+    ) as (mock_otbr_manager, _):
 
         async def install_addon() -> None:
             mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
@@ -270,7 +271,7 @@ async def test_config_flow_thread_flasher_run_fails(hass: HomeAssistant) -> None
             update_available=False,
             version="1.0.0",
         ),
-    ) as mock_otbr_manager:
+    ) as (mock_otbr_manager, _):
         mock_otbr_manager.async_start_addon_waiting = AsyncMock(
             side_effect=AddonError()
         )
@@ -339,6 +340,40 @@ async def test_config_flow_thread_confirmation_fails(hass: HomeAssistant) -> Non
 
         assert pick_thread_progress_result["type"] is FlowResultType.ABORT
         assert pick_thread_progress_result["reason"] == "unsupported_firmware"
+
+
+@pytest.mark.parametrize(
+    "ignore_translations_for_mock_domains", ["test_firmware_domain"]
+)
+async def test_config_flow_firmware_download_fails_and_required(
+    hass: HomeAssistant,
+) -> None:
+    """Test flow aborts if firmware download fails and install is required."""
+    init_result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": "hardware"}
+    )
+
+    with (
+        mock_firmware_info(
+            hass,
+            # The wrong firmware is installed, so a new install is required
+            probe_app_type=ApplicationType.SPINEL,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.FirmwareUpdateClient"
+        ) as mock_update_client_cls,
+    ):
+        # Mock the firmware download to fail
+        mock_client = mock_update_client_cls.return_value = AsyncMock()
+        mock_client.async_fetch_firmware.side_effect = ClientError()
+
+        pick_result = await hass.config_entries.flow.async_configure(
+            init_result["flow_id"],
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
+        )
+
+        assert pick_result["type"] is FlowResultType.ABORT
+        assert pick_result["reason"] == "fw_download_failed"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -100,14 +100,22 @@ async def test_config_flow(
             ),
         ),
     ):
-        result = await hass.config_entries.flow.async_configure(
+        confirm_result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": step},
         )
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert confirm_result["type"] is FlowResultType.FORM
+        assert confirm_result["step_id"] == (
+            "confirm_zigbee" if step == STEP_PICK_FIRMWARE_ZIGBEE else "confirm_otbr"
+        )
 
-    config_entry = result["result"]
+        create_result = await hass.config_entries.flow.async_configure(
+            confirm_result["flow_id"], user_input={}
+        )
+
+    assert create_result["type"] is FlowResultType.CREATE_ENTRY
+    config_entry = create_result["result"]
     assert config_entry.data == {
         "firmware": fw_type.value,
         "firmware_version": fw_version,
@@ -171,7 +179,7 @@ async def test_options_flow(
     assert result["description_placeholders"]["model"] == model
 
     async def mock_async_step_pick_firmware_zigbee(self, data):
-        return await self.async_step_confirm_zigbee(user_input={})
+        return await self.async_step_pre_confirm_zigbee()
 
     with (
         patch(
@@ -190,13 +198,20 @@ async def test_options_flow(
             ),
         ),
     ):
-        result = await hass.config_entries.options.async_configure(
+        confirm_result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
         )
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["result"] is True
+        assert confirm_result["type"] is FlowResultType.FORM
+        assert confirm_result["step_id"] == "confirm_zigbee"
+
+        create_result = await hass.config_entries.options.async_configure(
+            confirm_result["flow_id"], user_input={}
+        )
+
+    assert create_result["type"] is FlowResultType.CREATE_ENTRY
+    assert create_result["result"] is True
 
     assert config_entry.data == {
         "firmware": "ezsp",

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -75,7 +75,7 @@ async def test_config_flow(
         next_step_id: str,
     ) -> ConfigFlowResult:
         if next_step_id == "start_otbr_addon":
-            next_step_id = "confirm_otbr"
+            next_step_id = "pre_confirm_otbr"
 
         return await getattr(self, f"async_step_{next_step_id}")(user_input={})
 

--- a/tests/components/homeassistant_yellow/test_config_flow.py
+++ b/tests/components/homeassistant_yellow/test_config_flow.py
@@ -348,7 +348,7 @@ async def test_firmware_options_flow(
     assert result["description_placeholders"]["model"] == "Home Assistant Yellow"
 
     async def mock_async_step_pick_firmware_zigbee(self, data):
-        return await self.async_step_confirm_zigbee(user_input={})
+        return await self.async_step_pre_confirm_zigbee()
 
     async def mock_install_firmware_step(
         self,
@@ -365,6 +365,11 @@ async def test_firmware_options_flow(
         return await getattr(self, f"async_step_{next_step_id}")(user_input={})
 
     with (
+        patch(
+            "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareOptionsFlow.async_step_pick_firmware_zigbee",
+            autospec=True,
+            side_effect=mock_async_step_pick_firmware_zigbee,
+        ),
         patch(
             "homeassistant.components.homeassistant_hardware.firmware_config_flow.BaseFirmwareConfigFlow._ensure_thread_addon_setup",
             return_value=None,
@@ -385,13 +390,22 @@ async def test_firmware_options_flow(
             ),
         ),
     ):
-        result = await hass.config_entries.options.async_configure(
+        confirm_result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={"next_step_id": step},
         )
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["result"] is True
+        assert confirm_result["type"] is FlowResultType.FORM
+        assert confirm_result["step_id"] == (
+            "confirm_zigbee" if step == STEP_PICK_FIRMWARE_ZIGBEE else "confirm_otbr"
+        )
+
+        create_result = await hass.config_entries.options.async_configure(
+            confirm_result["flow_id"], user_input={}
+        )
+
+    assert create_result["type"] is FlowResultType.CREATE_ENTRY
+    assert create_result["result"] is True
 
     assert config_entry.data == {
         "firmware": fw_type.value,

--- a/tests/components/homeassistant_yellow/test_config_flow.py
+++ b/tests/components/homeassistant_yellow/test_config_flow.py
@@ -360,7 +360,7 @@ async def test_firmware_options_flow(
         next_step_id: str,
     ) -> ConfigFlowResult:
         if next_step_id == "start_otbr_addon":
-            next_step_id = "confirm_otbr"
+            next_step_id = "pre_confirm_otbr"
 
         return await getattr(self, f"async_step_{next_step_id}")(user_input={})
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#145019 removed Core's dependency on firmware flashing addons to manage firmware versions. This PR allows for adapter setup to succeed without internet access by avoiding upgrading firmwares where it is not technically necessary (but still recommended):
1. The adapter is running the correct firmware type but the latest (or newer) version.
2. Internet access is down and the adapter is running out-of-date but still valid firmware.
3. The firmware update index is inaccessible for whatever reason.

All other scenarios (migrating between Zigbee and Thread, for example) will still require internet access for addon setup and downloading the correct firmware.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
