### PR TITLE
Use default title for migrated Google Generative AI entries

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -37,6 +37,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_PROMPT,
+    DEFAULT_TITLE,
     DEFAULT_TTS_NAME,
     DOMAIN,
     FILE_POLLING_INTERVAL_SECONDS,
@@ -289,6 +290,7 @@ async def async_migrate_integration(hass: HomeAssistant) -> None:
         else:
             hass.config_entries.async_update_entry(
                 entry,
+                title=DEFAULT_TITLE,
                 options={},
                 version=2,
             )

--- a/homeassistant/components/google_generative_ai_conversation/config_flow.py
+++ b/homeassistant/components/google_generative_ai_conversation/config_flow.py
@@ -47,6 +47,7 @@ from .const import (
     CONF_TOP_P,
     CONF_USE_GOOGLE_SEARCH_TOOL,
     DEFAULT_CONVERSATION_NAME,
+    DEFAULT_TITLE,
     DEFAULT_TTS_NAME,
     DOMAIN,
     RECOMMENDED_CHAT_MODEL,
@@ -116,7 +117,7 @@ class GoogleGenerativeAIConfigFlow(ConfigFlow, domain=DOMAIN):
                         data=user_input,
                     )
                 return self.async_create_entry(
-                    title="Google Generative AI",
+                    title=DEFAULT_TITLE,
                     data=user_input,
                     subentries=[
                         {

--- a/homeassistant/components/google_generative_ai_conversation/const.py
+++ b/homeassistant/components/google_generative_ai_conversation/const.py
@@ -6,6 +6,7 @@ from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.helpers import llm
 
 DOMAIN = "google_generative_ai_conversation"
+DEFAULT_TITLE = "Google Generative AI"
 LOGGER = logging.getLogger(__package__)
 CONF_PROMPT = "prompt"
 

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -8,6 +8,7 @@ from requests.exceptions import Timeout
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.google_generative_ai_conversation.const import (
+    DEFAULT_TITLE,
     DEFAULT_TTS_NAME,
     DOMAIN,
     RECOMMENDED_TTS_OPTIONS,
@@ -473,6 +474,7 @@ async def test_migration_from_v1_to_v2(
     entry = entries[0]
     assert entry.version == 2
     assert not entry.options
+    assert entry.title == DEFAULT_TITLE
     assert len(entry.subentries) == 3
     conversation_subentries = [
         subentry
@@ -609,6 +611,7 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
     for entry in entries:
         assert entry.version == 2
         assert not entry.options
+        assert entry.title == DEFAULT_TITLE
         assert len(entry.subentries) == 2
         subentry = list(entry.subentries.values())[0]
         assert subentry.subentry_type == "conversation"
@@ -702,6 +705,7 @@ async def test_migration_from_v1_to_v2_with_same_keys(
     entry = entries[0]
     assert entry.version == 2
     assert not entry.options
+    assert entry.title == DEFAULT_TITLE
     assert len(entry.subentries) == 3
     conversation_subentries = [
         subentry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use default title for migrated Google Generative AI entries
Otherwise you get some weird titles. E.g. assume you have 3 config entries: GLaDOS, Super Mario, Google Search. They will be grouped together and before this fix the title would be GLaDOS.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
