### PR TITLE
Fix sending commands to Matter vacuum

### DIFF
--- a/homeassistant/components/matter/vacuum.py
+++ b/homeassistant/components/matter/vacuum.py
@@ -62,14 +62,14 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
 
     _last_accepted_commands: list[int] | None = None
     _supported_run_modes: (
-        dict[int, clusters.RvcCleanMode.Structs.ModeOptionStruct] | None
+        dict[int, clusters.RvcRunMode.Structs.ModeOptionStruct] | None
     ) = None
     entity_description: StateVacuumEntityDescription
     _platform_translation_key = "vacuum"
 
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""
-        # We simply set the RvcCleanMode to the first runmode
+        # We simply set the RvcRunMode to the first runmode
         # that has the idle tag to stop the vacuum cleaner.
         # this is compatible with both Matter 1.2 and 1.3+ devices.
         supported_run_modes = self._supported_run_modes or {}
@@ -107,7 +107,7 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
             )
             return
 
-        # We simply set the RvcCleanMode to the first runmode
+        # We simply set the RvcRunMode to the first runmode
         # that has the cleaning tag to start the vacuum cleaner.
         # this is compatible with both Matter 1.2 and 1.3+ devices.
         supported_run_modes = self._supported_run_modes or {}
@@ -184,7 +184,7 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
         if self.get_matter_attribute_value(clusters.Identify.Attributes.IdentifyType):
             supported_features |= VacuumEntityFeature.LOCATE
         # create a map of supported run modes
-        run_modes: list[clusters.RvcCleanMode.Structs.ModeOptionStruct] = (
+        run_modes: list[clusters.RvcRunMode.Structs.ModeOptionStruct] = (
             self.get_matter_attribute_value(
                 clusters.RvcRunMode.Attributes.SupportedModes
             )
@@ -217,10 +217,7 @@ DISCOVERY_SCHEMAS = [
             clusters.RvcRunMode.Attributes.CurrentMode,
             clusters.RvcOperationalState.Attributes.OperationalState,
         ),
-        optional_attributes=(
-            clusters.RvcCleanMode.Attributes.CurrentMode,
-            clusters.PowerSource.Attributes.BatPercentRemaining,
-        ),
+        optional_attributes=(clusters.PowerSource.Attributes.BatPercentRemaining,),
         device_type=(device_types.RoboticVacuumCleaner,),
         allow_none_value=True,
     ),

--- a/homeassistant/components/matter/vacuum.py
+++ b/homeassistant/components/matter/vacuum.py
@@ -69,7 +69,18 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
 
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""
-        await self.send_device_command(clusters.OperationalState.Commands.Stop())
+        # We simply set the RvcCleanMode to the first runmode
+        # that has the idle tag to stop the vacuum cleaner.
+        # this is compatible with both Matter 1.2 and 1.3+ devices.
+        supported_run_modes = self._supported_run_modes or {}
+        for mode in supported_run_modes.values():
+            for tag in mode.modeTags:
+                if tag.value == ModeTag.IDLE:
+                    # stop the vacuum by changing the run mode to idle
+                    await self.send_device_command(
+                        clusters.RvcRunMode.Commands.ChangeToMode(newMode=mode.mode)
+                    )
+                    return
 
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Set the vacuum cleaner to return to the dock."""
@@ -83,15 +94,30 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
         """Start or resume the cleaning task."""
         if TYPE_CHECKING:
             assert self._last_accepted_commands is not None
+
+        accepted_operational_commands = self._last_accepted_commands
         if (
             clusters.RvcOperationalState.Commands.Resume.command_id
-            in self._last_accepted_commands
+            in accepted_operational_commands
+            and self.state == VacuumActivity.PAUSED
         ):
+            # vacuum is paused and supports resume command
             await self.send_device_command(
                 clusters.RvcOperationalState.Commands.Resume()
             )
-        else:
-            await self.send_device_command(clusters.OperationalState.Commands.Start())
+            return
+
+        # We simply set the RvcCleanMode to the first runmode
+        # that has the cleaning tag to start the vacuum cleaner.
+        # this is compatible with both Matter 1.2 and 1.3+ devices.
+        supported_run_modes = self._supported_run_modes or {}
+        for mode in supported_run_modes.values():
+            for tag in mode.modeTags:
+                if tag.value == ModeTag.CLEANING:
+                    await self.send_device_command(
+                        clusters.RvcRunMode.Commands.ChangeToMode(newMode=mode.mode)
+                    )
+                    return
 
     async def async_pause(self) -> None:
         """Pause the cleaning task."""
@@ -130,6 +156,8 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
                 state = VacuumActivity.CLEANING
             elif ModeTag.IDLE in tags:
                 state = VacuumActivity.IDLE
+            elif ModeTag.MAPPING in tags:
+                state = VacuumActivity.CLEANING
         self._attr_activity = state
 
     @callback
@@ -143,7 +171,10 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
             return
         self._last_accepted_commands = accepted_operational_commands
         supported_features: VacuumEntityFeature = VacuumEntityFeature(0)
+        supported_features |= VacuumEntityFeature.START
         supported_features |= VacuumEntityFeature.STATE
+        supported_features |= VacuumEntityFeature.STOP
+
         # optional battery attribute = battery feature
         if self.get_matter_attribute_value(
             clusters.PowerSource.Attributes.BatPercentRemaining
@@ -165,22 +196,6 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
             in accepted_operational_commands
         ):
             supported_features |= VacuumEntityFeature.PAUSE
-        if (
-            clusters.OperationalState.Commands.Stop.command_id
-            in accepted_operational_commands
-        ):
-            supported_features |= VacuumEntityFeature.STOP
-        if (
-            clusters.OperationalState.Commands.Start.command_id
-            in accepted_operational_commands
-        ):
-            # note that start has been replaced by resume in rev2 of the spec
-            supported_features |= VacuumEntityFeature.START
-        if (
-            clusters.RvcOperationalState.Commands.Resume.command_id
-            in accepted_operational_commands
-        ):
-            supported_features |= VacuumEntityFeature.START
         if (
             clusters.RvcOperationalState.Commands.GoHome.command_id
             in accepted_operational_commands

--- a/tests/components/matter/snapshots/test_vacuum.ambr
+++ b/tests/components/matter/snapshots/test_vacuum.ambr
@@ -28,7 +28,7 @@
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <VacuumEntityFeature: 12308>,
+    'supported_features': <VacuumEntityFeature: 12316>,
     'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000042-MatterNodeDevice-1-MatterVacuumCleaner-84-1',
     'unit_of_measurement': None,
@@ -38,7 +38,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Vacuum',
-      'supported_features': <VacuumEntityFeature: 12308>,
+      'supported_features': <VacuumEntityFeature: 12316>,
     }),
     'context': <ANY>,
     'entity_id': 'vacuum.mock_vacuum',

--- a/tests/components/matter/test_vacuum.py
+++ b/tests/components/matter/test_vacuum.py
@@ -9,7 +9,6 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceNotSupported
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -61,7 +60,29 @@ async def test_vacuum_actions(
     )
     matter_client.send_device_command.reset_mock()
 
-    # test start/resume action
+    # test start action (from idle state)
+    await hass.services.async_call(
+        "vacuum",
+        "start",
+        {
+            "entity_id": entity_id,
+        },
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.RvcRunMode.Commands.ChangeToMode(newMode=1),
+    )
+    matter_client.send_device_command.reset_mock()
+
+    # test resume action (from paused state)
+    # first set the operational state to paused
+    set_node_attribute(matter_node, 1, 97, 4, 0x02)
+    await trigger_subscription_callback(hass, matter_client)
+
     await hass.services.async_call(
         "vacuum",
         "start",
@@ -98,25 +119,6 @@ async def test_vacuum_actions(
     matter_client.send_device_command.reset_mock()
 
     # test stop action
-    # stop command is not supported by the vacuum fixture
-    with pytest.raises(
-        ServiceNotSupported,
-        match="Entity vacuum.mock_vacuum does not support action vacuum.stop",
-    ):
-        await hass.services.async_call(
-            "vacuum",
-            "stop",
-            {
-                "entity_id": entity_id,
-            },
-            blocking=True,
-        )
-
-    # update accepted command list to add support for stop command
-    set_node_attribute(
-        matter_node, 1, 97, 65529, [clusters.OperationalState.Commands.Stop.command_id]
-    )
-    await trigger_subscription_callback(hass, matter_client)
     await hass.services.async_call(
         "vacuum",
         "stop",
@@ -129,7 +131,7 @@ async def test_vacuum_actions(
     assert matter_client.send_device_command.call_args == call(
         node_id=matter_node.node_id,
         endpoint_id=1,
-        command=clusters.OperationalState.Commands.Stop(),
+        command=clusters.RvcRunMode.Commands.ChangeToMode(newMode=0),
     )
     matter_client.send_device_command.reset_mock()
 
@@ -209,11 +211,21 @@ async def test_vacuum_updates(
     assert state
     assert state.state == "idle"
 
+    # confirm state is 'cleaning' by setting;
+    # - the operational state to 0x00
+    # - the run mode is set to a mode which has mapping tag
+    set_node_attribute(matter_node, 1, 97, 4, 0)
+    set_node_attribute(matter_node, 1, 84, 1, 2)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "cleaning"
+
     # confirm state is 'unknown' by setting;
     # - the operational state to 0x00
     # - the run mode is set to a mode which has neither cleaning or idle tag
     set_node_attribute(matter_node, 1, 97, 4, 0)
-    set_node_attribute(matter_node, 1, 84, 1, 2)
+    set_node_attribute(matter_node, 1, 84, 1, 5)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state


### PR DESCRIPTION
## Proposed change

The Matter clusters related to RVC had a revision change  and our implemention was only (partially) compatible with the 2nd revision, basically breaking compatibility with vacuums running an older Matter version.

This PR addresses that so the platform is now compatible with both 1.2 and 1.3+ vacuums.

Tested with a Matter 1.2 (SwitchBot) and a Matter 1.3 (Roborock) vacuum.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
