### PR TITLE
Remove obsolete routing info when migrating a Z-Wave network

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -3105,7 +3105,7 @@ async def websocket_restore_nvm(
         driver.once("driver ready", set_driver_ready),
     ]
 
-    await controller.async_restore_nvm_base64(msg["data"])
+    await controller.async_restore_nvm_base64(msg["data"], {"preserveRoutes": False})
 
     with suppress(TimeoutError):
         async with asyncio.timeout(DRIVER_READY_TIMEOUT):

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -1400,7 +1400,9 @@ class ZWaveJSConfigFlow(ConfigFlow, domain=DOMAIN):
             driver.once("driver ready", set_driver_ready),
         ]
         try:
-            await controller.async_restore_nvm(self.backup_data)
+            await controller.async_restore_nvm(
+                self.backup_data, {"preserveRoutes": False}
+            )
         except FailedCommand as err:
             raise AbortFlow(f"Failed to restore network: {err}") from err
         else:

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -5649,7 +5649,7 @@ async def test_restore_nvm(
         {
             "command": "controller.restore_nvm",
             "nvmData": "dGVzdA==",
-            "migrateOptions": {},
+            "migrateOptions": {"preserveRoutes": False},
         },
         require_schema=42,
     )
@@ -5685,7 +5685,7 @@ async def test_restore_nvm(
         {
             "command": "controller.restore_nvm",
             "nvmData": "dGVzdA==",
-            "migrateOptions": {},
+            "migrateOptions": {"preserveRoutes": False},
         },
         require_schema=42,
     )
@@ -5740,7 +5740,7 @@ async def test_restore_nvm(
         {
             "command": "controller.restore_nvm",
             "nvmData": "dGVzdA==",
-            "migrateOptions": {},
+            "migrateOptions": {"preserveRoutes": False},
         },
         require_schema=42,
     )

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -900,7 +900,7 @@ async def test_usb_discovery_migration(
 
     client.driver.async_hard_reset = AsyncMock(side_effect=mock_reset_controller)
 
-    async def mock_restore_nvm(data: bytes):
+    async def mock_restore_nvm(data: bytes, options: dict[str, bool] | None = None):
         client.driver.controller.emit(
             "nvm convert progress",
             {"event": "nvm convert progress", "bytesRead": 100, "total": 200},
@@ -1031,7 +1031,7 @@ async def test_usb_discovery_migration_restore_driver_ready_timeout(
 
     client.driver.async_hard_reset = AsyncMock(side_effect=mock_reset_controller)
 
-    async def mock_restore_nvm(data: bytes):
+    async def mock_restore_nvm(data: bytes, options: dict[str, bool] | None = None):
         client.driver.controller.emit(
             "nvm convert progress",
             {"event": "nvm convert progress", "bytesRead": 100, "total": 200},
@@ -3501,7 +3501,7 @@ async def test_reconfigure_migrate_with_addon(
 
     client.driver.async_hard_reset = AsyncMock(side_effect=mock_reset_controller)
 
-    async def mock_restore_nvm(data: bytes):
+    async def mock_restore_nvm(data: bytes, options: dict[str, bool] | None = None):
         client.driver.controller.emit(
             "nvm convert progress",
             {"event": "nvm convert progress", "bytesRead": 100, "total": 200},
@@ -3686,7 +3686,7 @@ async def test_reconfigure_migrate_reset_driver_ready_timeout(
 
     client.driver.async_hard_reset = AsyncMock(side_effect=mock_reset_controller)
 
-    async def mock_restore_nvm(data: bytes):
+    async def mock_restore_nvm(data: bytes, options: dict[str, bool] | None = None):
         client.driver.controller.emit(
             "nvm convert progress",
             {"event": "nvm convert progress", "bytesRead": 100, "total": 200},
@@ -3835,7 +3835,7 @@ async def test_reconfigure_migrate_restore_driver_ready_timeout(
 
     client.driver.async_hard_reset = AsyncMock(side_effect=mock_reset_controller)
 
-    async def mock_restore_nvm(data: bytes):
+    async def mock_restore_nvm(data: bytes, options: dict[str, bool] | None = None):
         client.driver.controller.emit(
             "nvm convert progress",
             {"event": "nvm convert progress", "bytesRead": 100, "total": 200},


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/88
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
