### PR TITLE
Hide unnamed paths when selecting a USB Z-Wave adapter

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -145,17 +145,8 @@ def get_usb_ports() -> dict[str, str]:
         if not desc.lower().startswith("n/a")
     }
 
-    # If we have non-"n/a" ports, return only those; otherwise return all ports sorted with "n/a" last
-    return (
-        non_na_ports
-        if non_na_ports
-        else dict(
-            sorted(
-                port_descriptions.items(),
-                key=lambda x: x[1].lower().startswith("n/a"),
-            )
-        )
-    )
+    # If we have non-"n/a" ports, return only those; otherwise return all ports as-is
+    return non_na_ports if non_na_ports else port_descriptions
 
 
 async def async_get_usb_ports(hass: HomeAssistant) -> dict[str, str]:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -138,11 +138,22 @@ def get_usb_ports() -> dict[str, str]:
         )
         port_descriptions[dev_path] = human_name
 
-    # Sort the dictionary by description, putting "n/a" last
-    return dict(
-        sorted(
-            port_descriptions.items(),
-            key=lambda x: x[1].lower().startswith("n/a"),
+    # Filter out "n/a" descriptions only if there are other ports available
+    non_na_ports = {
+        path: desc
+        for path, desc in port_descriptions.items()
+        if not desc.lower().startswith("n/a")
+    }
+
+    # If we have non-"n/a" ports, return only those; otherwise return all ports sorted with "n/a" last
+    return (
+        non_na_ports
+        if non_na_ports
+        else dict(
+            sorted(
+                port_descriptions.items(),
+                key=lambda x: x[1].lower().startswith("n/a"),
+            )
         )
     )
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -4435,8 +4435,8 @@ async def test_configure_addon_usb_ports_failure(
         assert result["reason"] == "usb_ports_failed"
 
 
-async def test_get_usb_ports_sorting() -> None:
-    """Test that get_usb_ports sorts ports with 'n/a' descriptions last."""
+async def test_get_usb_ports_filtering() -> None:
+    """Test that get_usb_ports filters out 'n/a' descriptions when other ports are available."""
     mock_ports = [
         ListPortInfo("/dev/ttyUSB0"),
         ListPortInfo("/dev/ttyUSB1"),
@@ -4453,13 +4453,105 @@ async def test_get_usb_ports_sorting() -> None:
 
         descriptions = list(result.values())
 
-        # Verify that descriptions containing "n/a" are at the end
-
+        # Verify that only non-"n/a" descriptions are returned
         assert descriptions == [
             "Device A - /dev/ttyUSB1, s/n: n/a",
             "Device B - /dev/ttyUSB3, s/n: n/a",
+        ]
+
+
+async def test_get_usb_ports_all_na_sorting() -> None:
+    """Test that get_usb_ports returns all ports sorted when only 'n/a' descriptions exist."""
+    mock_ports = [
+        ListPortInfo("/dev/ttyUSB0"),
+        ListPortInfo("/dev/ttyUSB1"),
+        ListPortInfo("/dev/ttyUSB2"),
+    ]
+    mock_ports[0].description = "n/a"
+    mock_ports[1].description = "N/A"
+    mock_ports[2].description = "n/a"
+
+    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
+        result = get_usb_ports()
+
+        descriptions = list(result.values())
+
+        # Verify that all ports are returned since they all have "n/a" descriptions
+        assert len(descriptions) == 3
+        # Verify that all descriptions contain "n/a" (case-insensitive)
+        assert all("n/a" in desc.lower() for desc in descriptions)
+        # Verify that all expected device paths are present
+        device_paths = [desc.split(" - ")[1].split(",")[0] for desc in descriptions]
+        assert "/dev/ttyUSB0" in device_paths
+        assert "/dev/ttyUSB1" in device_paths
+        assert "/dev/ttyUSB2" in device_paths
+
+
+async def test_get_usb_ports_mixed_case_filtering() -> None:
+    """Test that get_usb_ports filters out 'n/a' descriptions with different case variations."""
+    mock_ports = [
+        ListPortInfo("/dev/ttyUSB0"),
+        ListPortInfo("/dev/ttyUSB1"),
+        ListPortInfo("/dev/ttyUSB2"),
+        ListPortInfo("/dev/ttyUSB3"),
+        ListPortInfo("/dev/ttyUSB4"),
+    ]
+    mock_ports[0].description = "n/a"
+    mock_ports[1].description = "Device A"
+    mock_ports[2].description = "N/A"
+    mock_ports[3].description = "n/A"
+    mock_ports[4].description = "Device B"
+
+    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
+        result = get_usb_ports()
+
+        descriptions = list(result.values())
+
+        # Verify that only non-"n/a" descriptions are returned (case-insensitive filtering)
+        assert descriptions == [
+            "Device A - /dev/ttyUSB1, s/n: n/a",
+            "Device B - /dev/ttyUSB4, s/n: n/a",
+        ]
+
+
+async def test_get_usb_ports_empty_list() -> None:
+    """Test that get_usb_ports handles empty port list."""
+    with patch("serial.tools.list_ports.comports", return_value=[]):
+        result = get_usb_ports()
+
+        # Verify that empty dict is returned
+        assert result == {}
+
+
+async def test_get_usb_ports_single_na_port() -> None:
+    """Test that get_usb_ports returns single 'n/a' port when it's the only one available."""
+    mock_ports = [ListPortInfo("/dev/ttyUSB0")]
+    mock_ports[0].description = "n/a"
+
+    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
+        result = get_usb_ports()
+
+        descriptions = list(result.values())
+
+        # Verify that the single "n/a" port is returned
+        assert descriptions == [
             "n/a - /dev/ttyUSB0, s/n: n/a",
-            "N/A - /dev/ttyUSB2, s/n: n/a",
+        ]
+
+
+async def test_get_usb_ports_single_valid_port() -> None:
+    """Test that get_usb_ports returns single valid port."""
+    mock_ports = [ListPortInfo("/dev/ttyUSB0")]
+    mock_ports[0].description = "Device A"
+
+    with patch("serial.tools.list_ports.comports", return_value=mock_ports):
+        result = get_usb_ports()
+
+        descriptions = list(result.values())
+
+        # Verify that the single valid port is returned
+        assert descriptions == [
+            "Device A - /dev/ttyUSB0, s/n: n/a",
         ]
 
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -4460,8 +4460,8 @@ async def test_get_usb_ports_filtering() -> None:
         ]
 
 
-async def test_get_usb_ports_all_na_sorting() -> None:
-    """Test that get_usb_ports returns all ports sorted when only 'n/a' descriptions exist."""
+async def test_get_usb_ports_all_na() -> None:
+    """Test that get_usb_ports returns all ports as-is when only 'n/a' descriptions exist."""
     mock_ports = [
         ListPortInfo("/dev/ttyUSB0"),
         ListPortInfo("/dev/ttyUSB1"),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/zwave-js/backlog/issues/107
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
