### PR TITLE
Do not make the favorite button unavailable when no content playing on a Music Assistant player

### DIFF
--- a/homeassistant/components/music_assistant/button.py
+++ b/homeassistant/components/music_assistant/button.py
@@ -41,12 +41,6 @@ class MusicAssistantFavoriteButton(MusicAssistantEntity, ButtonEntity):
         translation_key="favorite_now_playing",
     )
 
-    @property
-    def available(self) -> bool:
-        """Return availability of entity."""
-        # mark the button as unavailable if the player has no current media item
-        return super().available and self.player.current_media is not None
-
     @catch_musicassistant_error
     async def async_press(self) -> None:
         """Handle the button press command."""

--- a/tests/components/music_assistant/snapshots/test_button.ambr
+++ b/tests/components/music_assistant/snapshots/test_button.ambr
@@ -140,6 +140,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unavailable',
+    'state': 'unknown',
   })
 # ---

--- a/tests/components/music_assistant/test_button.py
+++ b/tests/components/music_assistant/test_button.py
@@ -2,14 +2,20 @@
 
 from unittest.mock import MagicMock, call
 
+from music_assistant_models.enums import EventType
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import setup_integration_from_fixtures, snapshot_music_assistant_entities
+from .common import (
+    setup_integration_from_fixtures,
+    snapshot_music_assistant_entities,
+    trigger_subscription_callback,
+)
 
 
 async def test_button_entities(
@@ -46,3 +52,35 @@ async def test_button_press_action(
         "music/favorites/add_item",
         item="spotify://track/5d95dc5be77e4f7eb4939f62cfef527b",
     )
+
+    # test again without current_media
+    mass_player_id = "00:00:00:00:00:02"
+    music_assistant_client.players._players[mass_player_id].current_media = None
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_CONFIG_UPDATED, mass_player_id
+    )
+    with pytest.raises(HomeAssistantError, match="No current item to add to favorites"):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {
+                ATTR_ENTITY_ID: entity_id,
+            },
+            blocking=True,
+        )
+
+    # test again without active source
+    mass_player_id = "00:00:00:00:00:02"
+    music_assistant_client.players._players[mass_player_id].active_source = None
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_CONFIG_UPDATED, mass_player_id
+    )
+    with pytest.raises(HomeAssistantError, match="Player has no active source"):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {
+                ATTR_ENTITY_ID: entity_id,
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change

When no content is playing we marked the "favorite current song" button as unavailable but this UX pattern was not particularly understood in the beta testing.

This PR changes this pattern so the button will stay available but raise an error if you press the button while it cant be executed,

Final solution should be implementing this FR: https://github.com/orgs/home-assistant/discussions/13


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
