### PR TITLE
Fix Telegram bot yaml import for webhooks containing None value for URL

### DIFF
--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -353,6 +353,7 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
         """Shutdown the bot if it exists."""
         if self._bot:
             await self._bot.shutdown()
+            self._bot = None
 
     async def _validate_bot(
         self,
@@ -389,12 +390,20 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle config flow for webhook Telegram bot."""
 
         if not user_input:
+            default_trusted_networks = ",".join(
+                [str(network) for network in DEFAULT_TRUSTED_NETWORKS]
+            )
+
             if self.source == SOURCE_RECONFIGURE:
+                suggested_values = dict(self._get_reconfigure_entry().data)
+                if CONF_TRUSTED_NETWORKS not in self._get_reconfigure_entry().data:
+                    suggested_values[CONF_TRUSTED_NETWORKS] = default_trusted_networks
+
                 return self.async_show_form(
                     step_id="webhooks",
                     data_schema=self.add_suggested_values_to_schema(
                         STEP_WEBHOOKS_DATA_SCHEMA,
-                        self._get_reconfigure_entry().data,
+                        suggested_values,
                     ),
                 )
 
@@ -403,9 +412,7 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
                 data_schema=self.add_suggested_values_to_schema(
                     STEP_WEBHOOKS_DATA_SCHEMA,
                     {
-                        CONF_TRUSTED_NETWORKS: ",".join(
-                            [str(network) for network in DEFAULT_TRUSTED_NETWORKS]
-                        ),
+                        CONF_TRUSTED_NETWORKS: default_trusted_networks,
                     },
                 ),
             )

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -116,13 +116,13 @@ async def test_reconfigure_flow_broadcast(
 
 async def test_reconfigure_flow_webhooks(
     hass: HomeAssistant,
-    mock_webhooks_config_entry: MockConfigEntry,
+    mock_broadcast_config_entry: MockConfigEntry,
     mock_external_calls: None,
 ) -> None:
     """Test reconfigure flow for webhook."""
-    mock_webhooks_config_entry.add_to_hass(hass)
+    mock_broadcast_config_entry.add_to_hass(hass)
 
-    result = await mock_webhooks_config_entry.start_reconfigure_flow(hass)
+    result = await mock_broadcast_config_entry.start_reconfigure_flow(hass)
     assert result["step_id"] == "reconfigure"
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
@@ -191,8 +191,8 @@ async def test_reconfigure_flow_webhooks(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert mock_webhooks_config_entry.data[CONF_URL] == "https://reconfigure"
-    assert mock_webhooks_config_entry.data[CONF_TRUSTED_NETWORKS] == [
+    assert mock_broadcast_config_entry.data[CONF_URL] == "https://reconfigure"
+    assert mock_broadcast_config_entry.data[CONF_TRUSTED_NETWORKS] == [
         "149.154.160.0/20"
     ]
 

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -490,9 +490,22 @@ async def test_import_multiple(
         CONF_BOT_COUNT: 2,
     }
 
-    with patch(
-        "homeassistant.components.telegram_bot.config_flow.Bot.get_me",
-        return_value=User(123456, "Testbot", True),
+    with (
+        patch(
+            "homeassistant.components.telegram_bot.config_flow.Bot.get_me",
+            return_value=User(123456, "Testbot", True),
+        ),
+        patch(
+            "homeassistant.components.telegram_bot.config_flow.Bot.get_chat",
+            return_value=ChatFullInfo(
+                id=987654321,
+                title="mock title",
+                first_name="mock first_name",
+                type="PRIVATE",
+                max_reaction_count=100,
+                accent_color_id=AccentColor.COLOR_000,
+            ),
+        ),
     ):
         # test: import first entry success
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This issue is specific to webhook Telegram bots.

`CONF_URL` is an optional configuration.
If not specified, it defaults to `None` during import (see `async_setup()` in https://github.com/home-assistant/core/blob/dev/homeassistant/components/telegram_bot/__init__.py).

Consequently, the import fails with `AttributeError: 'NoneType' object has no attribute 'startswith'` error when performing the URL validation in `config_flow.py, _validate_webhooks()`.

This change fixes the bug by handling the `None` value for `CONF_URL`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #147547
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
