### PR TITLE
Handle broadband_data being other types

### DIFF
--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -120,7 +120,22 @@ class VerisureEthernetStatus(
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return self.coordinator.data["broadband"]["isBroadbandConnected"]
+        broadband_data = self.coordinator.data.get("broadband")
+        if not broadband_data:
+            return False
+
+        # Handle case where broadband_data is a list
+        if isinstance(broadband_data, list):
+            # If it's a list, try to get the first item
+            if broadband_data and isinstance(broadband_data[0], dict):
+                return broadband_data[0].get("isBroadbandConnected", False)
+            return False
+
+        # Handle case where broadband_data is a dictionary
+        if isinstance(broadband_data, dict):
+            return broadband_data.get("isBroadbandConnected", False)
+
+        return False
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -120,8 +120,7 @@ class VerisureEthernetStatus(
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        broadband_data = self.coordinator.data.get("broadband")
-        if not broadband_data:
+        if not (broadband_data := self.coordinator.data.get("broadband")):
             return False
 
         # Handle case where broadband_data is a list


### PR DESCRIPTION
## Proposed change
I got this error randomly and it made Verisure auth expire for some reason. Couldn't reproduce it later, but this fix will hopefully handle the unexpected values better.

```
  File "/usr/src/homeassistant/homeassistant/components/binary_sensor/__init__.py", line 200, in state
    if (is_on := self.is_on) is None:
                 ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/verisure/binary_sensor.py", line 123, in is_on
    return self.coordinator.data["broadband"]["isBroadbandConnected"]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: list indices must be integers or slices, not str
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
