### PR TITLE
Simplify reolink light tests

### DIFF
--- a/tests/components/reolink/test_light.py
+++ b/tests/components/reolink/test_light.py
@@ -22,14 +22,23 @@ from .conftest import TEST_NVR_NAME
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.parametrize(
+    ("whiteled_brightness", "expected_brightness"),
+    [
+        (100, 255),
+        (None, None),
+    ],
+)
 async def test_light_state(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     reolink_host: MagicMock,
+    whiteled_brightness: int | None,
+    expected_brightness: int | None,
 ) -> None:
     """Test light entity state with floodlight."""
     reolink_host.whiteled_state.return_value = True
-    reolink_host.whiteled_brightness.return_value = 100
+    reolink_host.whiteled_brightness.return_value = whiteled_brightness
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.LIGHT]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -40,28 +49,7 @@ async def test_light_state(
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
-    assert state.attributes["brightness"] == 255
-
-
-async def test_light_brightness_none(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    reolink_host: MagicMock,
-) -> None:
-    """Test light entity with floodlight and brightness returning None."""
-    reolink_host.whiteled_state.return_value = True
-    reolink_host.whiteled_brightness.return_value = None
-
-    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.LIGHT]):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-    assert config_entry.state is ConfigEntryState.LOADED
-
-    entity_id = f"{Platform.LIGHT}.{TEST_NVR_NAME}_floodlight"
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-    assert state.attributes["brightness"] is None
+    assert state.attributes["brightness"] == expected_brightness
 
 
 async def test_light_turn_off(
@@ -118,30 +106,36 @@ async def test_light_turn_on(
         [call(0, brightness=20), call(0, state=True)]
     )
 
-    reolink_host.set_whiteled.side_effect = ReolinkError("Test error")
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            LIGHT_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id},
-            blocking=True,
-        )
 
-    reolink_host.set_whiteled.side_effect = ReolinkError("Test error")
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            LIGHT_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 51},
-            blocking=True,
-        )
+@pytest.mark.parametrize(
+    ("exception", "service_data"),
+    [
+        (ReolinkError("Test error"), {}),
+        (ReolinkError("Test error"), {ATTR_BRIGHTNESS: 51}),
+        (InvalidParameterError("Test error"), {ATTR_BRIGHTNESS: 51}),
+    ],
+)
+async def test_light_turn_on_errors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_host: MagicMock,
+    exception: Exception,
+    service_data: dict,
+) -> None:
+    """Test light turn on service error cases."""
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.LIGHT]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
 
-    reolink_host.set_whiteled.side_effect = InvalidParameterError("Test error")
+    entity_id = f"{Platform.LIGHT}.{TEST_NVR_NAME}_floodlight"
+
+    reolink_host.set_whiteled.side_effect = exception
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 51},
+            {ATTR_ENTITY_ID: entity_id, **service_data},
             blocking=True,
         )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to copilot's suggestions from https://github.com/home-assistant/core/pull/147621

- Merge test_light_state and test_light_brightness_none, since they are mostly the same.
- Move error cases from test_light_turn_on to a separate test, using test parameters instead of testing all cases in one go.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
