### PR TITLE
Include chat ID in Telegram bot subentry title

### DIFF
--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -237,12 +237,13 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
 
             subentries: list[ConfigSubentryData] = []
             allowed_chat_ids: list[int] = import_data[CONF_ALLOWED_CHAT_IDS]
+            assert self._bot is not None, "Bot should be initialized during import"
             for chat_id in allowed_chat_ids:
                 chat_name: str = await _async_get_chat_name(self._bot, chat_id)
                 subentry: ConfigSubentryData = ConfigSubentryData(
                     data={CONF_CHAT_ID: chat_id},
                     subentry_type=CONF_ALLOWED_CHAT_IDS,
-                    title=chat_name,
+                    title=f"{chat_name} ({chat_id})",
                     unique_id=str(chat_id),
                 )
                 subentries.append(subentry)
@@ -375,7 +376,6 @@ class TelgramBotConfigFlow(ConfigFlow, domain=DOMAIN):
         """Shutdown the bot if it exists."""
         if self._bot:
             await self._bot.shutdown()
-            self._bot = None
 
     async def _validate_bot(
         self,
@@ -651,10 +651,7 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
         )
 
 
-async def _async_get_chat_name(bot: Bot | None, chat_id: int) -> str:
-    if not bot:
-        return str(chat_id)
-
+async def _async_get_chat_name(bot: Bot, chat_id: int) -> str:
     try:
         chat_info: ChatFullInfo = await bot.get_chat(chat_id)
         return chat_info.effective_name or str(chat_id)

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -637,7 +637,7 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
             chat_name = await _async_get_chat_name(bot, chat_id)
             if chat_name:
                 return self.async_create_entry(
-                    title=chat_name,
+                    title=f"{chat_name} ({chat_id})",
                     data={CONF_CHAT_ID: chat_id},
                     unique_id=str(chat_id),
                 )

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -499,9 +499,22 @@ async def test_import_multiple(
         CONF_BOT_COUNT: 2,
     }
 
-    with patch(
-        "homeassistant.components.telegram_bot.config_flow.Bot.get_me",
-        return_value=User(123456, "Testbot", True),
+    with (
+        patch(
+            "homeassistant.components.telegram_bot.config_flow.Bot.get_me",
+            return_value=User(123456, "Testbot", True),
+        ),
+        patch(
+            "homeassistant.components.telegram_bot.config_flow.Bot.get_chat",
+            return_value=ChatFullInfo(
+                id=987654321,
+                title="mock title",
+                first_name="mock first_name",
+                type="PRIVATE",
+                max_reaction_count=100,
+                accent_color_id=AccentColor.COLOR_000,
+            ),
+        ),
     ):
         # test: import first entry success
 

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -382,7 +382,7 @@ async def test_subentry_flow(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert subentry.subentry_type == SUBENTRY_TYPE_ALLOWED_CHAT_IDS
-    assert subentry.title == "mock title"
+    assert subentry.title == "mock title (987654321)"
     assert subentry.unique_id == "987654321"
     assert subentry.data == {CONF_CHAT_ID: 987654321}
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a minor quality-of-life-improvement to include the chat ID in the config subentry title so that users can easily reference the chat IDs when using service actions such as send message.

Current: chat name is used as subentry title

New: chat name with chat ID is used as subentry title in the format: `chat_name` (`chat_id`)

![image](https://github.com/user-attachments/assets/b13d5589-1e73-42bf-be4a-732347c3a762)

This change does not rename existing subentry title.
Beta users can opt to do either of the following:
- reimport the config entry by deleting it and restarting HA.
- delete the subentry and add the chat ID again

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #147610
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
