### PR TITLE
Reduce idle timeout of HLS stream to conserve camera battery life

### DIFF
--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -22,7 +22,8 @@ AUDIO_CODECS = {"aac", "mp3"}
 
 FORMAT_CONTENT_TYPE = {HLS_PROVIDER: "application/vnd.apple.mpegurl"}
 
-OUTPUT_IDLE_TIMEOUT = 300  # Idle timeout due to inactivity
+OUTPUT_STARTUP_TIMEOUT = 60  # timeout due to no startup
+OUTPUT_IDLE_TIMEOUT = 30  # Idle timeout due to inactivity
 
 NUM_PLAYLIST_SEGMENTS = 3  # Number of segments to use in HLS playlist
 MAX_SEGMENTS = 5  # Max number of segments to keep around

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -234,10 +234,12 @@ class IdleTimer:
         hass: HomeAssistant,
         timeout: int,
         idle_callback: Callable[[], Coroutine[Any, Any, None]],
+        startup_timeout: int | None = None,
     ) -> None:
         """Initialize IdleTimer."""
         self._hass = hass
         self._timeout = timeout
+        self._startup_timeout = startup_timeout or timeout
         self._callback = idle_callback
         self._unsub: CALLBACK_TYPE | None = None
         self.idle = False
@@ -246,7 +248,7 @@ class IdleTimer:
         """Start the idle timer if not already started."""
         self.idle = False
         if self._unsub is None:
-            self._unsub = async_call_later(self._hass, self._timeout, self.fire)
+            self._unsub = async_call_later(self._hass, self._startup_timeout, self.fire)
 
     def awake(self) -> None:
         """Keep the idle time alive by resetting the timeout."""

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -230,8 +230,8 @@ async def test_stream_timeout(
     playlist_response = await http_client.get(parsed_url.path)
     assert playlist_response.status == HTTPStatus.OK
 
-    # Wait a minute
-    future = dt_util.utcnow() + timedelta(minutes=1)
+    # Wait 40 seconds
+    future = dt_util.utcnow() + timedelta(seconds=40)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
 
@@ -241,8 +241,8 @@ async def test_stream_timeout(
 
     stream_worker_sync.resume()
 
-    # Wait 5 minutes
-    future = dt_util.utcnow() + timedelta(minutes=5)
+    # Wait 2 minutes
+    future = dt_util.utcnow() + timedelta(minutes=2)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduce idle timeout of HLS stream to conserve camera battery life

Battery cameras such as from Reolink and Ring keep awake due to the HLS stream continuing for 5 minutes after a user closes the browser window of the stream. This drains the battery.
Moreover, the default is now the WebRTC stream of go2rtc, so this HLS stream is draining the battery while not even beeing used (except for a very usefull backup).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/135463 fixes https://github.com/home-assistant/core/issues/129987
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
