### PR TITLE
Improve rest error logging

### DIFF
--- a/homeassistant/components/rest/data.py
+++ b/homeassistant/components/rest/data.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 import aiohttp
+from aiohttp import hdrs
 from multidict import CIMultiDictProxy
 import xmltodict
 
@@ -77,6 +78,12 @@ class RestData:
         """Set url."""
         self._resource = url
 
+    def _is_expected_content_type(self, content_type: str) -> bool:
+        """Check if the content type is one we expect (JSON or XML)."""
+        return content_type.startswith(
+            ("application/json", "text/json", *XML_MIME_TYPES)
+        )
+
     def data_without_xml(self) -> str | None:
         """If the data is an XML string, convert it to a JSON string."""
         _LOGGER.debug("Data fetched from resource: %s", self.data)
@@ -84,7 +91,7 @@ class RestData:
             (value := self.data) is not None
             # If the http request failed, headers will be None
             and (headers := self.headers) is not None
-            and (content_type := headers.get("content-type"))
+            and (content_type := headers.get(hdrs.CONTENT_TYPE))
             and content_type.startswith(XML_MIME_TYPES)
         ):
             value = json_dumps(xmltodict.parse(value))
@@ -120,6 +127,7 @@ class RestData:
         # Handle data/content
         if self._request_data:
             request_kwargs["data"] = self._request_data
+        response = None
         try:
             # Make the request
             async with self._session.request(
@@ -143,3 +151,32 @@ class RestData:
             self.last_exception = ex
             self.data = None
             self.headers = None
+
+        # Log response details outside the try block so we always get logging
+        if response is not None:
+            # Log response details for debugging
+            content_type = response.headers.get(hdrs.CONTENT_TYPE)
+            _LOGGER.debug(
+                "REST response from %s: status=%s, content-type=%s, length=%s",
+                self._resource,
+                response.status,
+                content_type or "not set",
+                len(self.data) if self.data else 0,
+            )
+
+            # If we got an error response with non-JSON/XML content, log a sample
+            # This helps debug issues like servers blocking with HTML error pages
+            if (
+                response.status >= 400
+                and content_type
+                and not self._is_expected_content_type(content_type)
+            ):
+                sample = self.data[:500] if self.data else "empty"
+                _LOGGER.warning(
+                    "REST request to %s returned status %s with %s response: %s%s",
+                    self._resource,
+                    response.status,
+                    content_type,
+                    sample,
+                    "..." if self.data and len(self.data) > 500 else "",
+                )

--- a/tests/components/rest/test_data.py
+++ b/tests/components/rest/test_data.py
@@ -5,7 +5,6 @@ import logging
 import pytest
 
 from homeassistant.components.rest import DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -28,14 +27,17 @@ async def test_rest_data_log_warning_on_error_status(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "GET",
-                "name": "test_sensor",
-                "value_template": "{{ value_json.test }}",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value_json.test }}",
+                    }
+                ],
             }
         },
     )
@@ -65,14 +67,17 @@ async def test_rest_data_no_warning_on_200_with_wrong_content_type(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "GET",
-                "name": "test_sensor",
-                "value_template": "{{ value }}",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value }}",
+                    }
+                ],
             }
         },
     )
@@ -100,14 +105,17 @@ async def test_rest_data_no_warning_on_success_json(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "GET",
-                "name": "test_sensor",
-                "value_template": "{{ value_json.value }}",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value_json.value }}",
+                    }
+                ],
             }
         },
     )
@@ -133,14 +141,17 @@ async def test_rest_data_no_warning_on_success_xml(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "GET",
-                "name": "test_sensor",
-                "value_template": "{{ value_json.root.value }}",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value_json.root.value }}",
+                    }
+                ],
             }
         },
     )
@@ -168,14 +179,17 @@ async def test_rest_data_warning_truncates_long_responses(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "GET",
-                "name": "test_sensor",
-                "value_template": "{{ value_json.test }}",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value_json.test }}",
+                    }
+                ],
             }
         },
     )
@@ -209,14 +223,17 @@ async def test_rest_data_debug_logging_shows_response_details(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "GET",
-                "name": "test_sensor",
-                "value_template": "{{ value_json.test }}",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value_json.test }}",
+                    }
+                ],
             }
         },
     )
@@ -247,13 +264,16 @@ async def test_rest_data_no_content_type_header(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "GET",
-                "name": "test_sensor",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                    }
+                ],
             }
         },
     )
@@ -283,14 +303,19 @@ async def test_rest_data_real_world_bom_blocking_scenario(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
-                "resource": "http://www.bom.gov.au/fwo/IDN60901/IDN60901.94767.json",
+            DOMAIN: {
+                "resource": ("http://www.bom.gov.au/fwo/IDN60901/IDN60901.94767.json"),
                 "method": "GET",
-                "name": "bom_temperature",
-                "value_template": ("{{ value_json.observations.data[0].air_temp }}"),
+                "sensor": [
+                    {
+                        "name": "bom_temperature",
+                        "value_template": (
+                            "{{ value_json.observations.data[0].air_temp }}"
+                        ),
+                    }
+                ],
             }
         },
     )
@@ -299,8 +324,8 @@ async def test_rest_data_real_world_bom_blocking_scenario(
     # Check that warning was logged with clear indication of the issue
     assert (
         "REST request to http://www.bom.gov.au/fwo/IDN60901/"
-        "IDN60901.94767.json returned status 403 with text/html response" in caplog.text
-    )
+        "IDN60901.94767.json returned status 403 with text/html response"
+    ) in caplog.text
     assert "Your access is blocked" in caplog.text
 
 
@@ -320,14 +345,17 @@ async def test_rest_data_warning_on_html_error(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "GET",
-                "name": "test_sensor",
-                "value_template": "{{ value_json.test }}",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value_json.test }}",
+                    }
+                ],
             }
         },
     )
@@ -356,15 +384,18 @@ async def test_rest_data_no_warning_on_json_error(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "POST",
                 "payload": '{"data": "test"}',
-                "name": "test_sensor",
-                "value_template": "{{ value_json.error }}",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value_json.error }}",
+                    }
+                ],
             }
         },
     )
@@ -389,15 +420,18 @@ async def test_rest_data_timeout_error(
 
     assert await async_setup_component(
         hass,
-        SENSOR_DOMAIN,
+        DOMAIN,
         {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
+            DOMAIN: {
                 "resource": "http://example.com/api",
                 "method": "GET",
-                "name": "test_sensor",
                 "timeout": 10,
-                "value_template": "{{ value_json.test }}",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value_json.test }}",
+                    }
+                ],
             }
         },
     )

--- a/tests/components/rest/test_data.py
+++ b/tests/components/rest/test_data.py
@@ -1,0 +1,416 @@
+"""Test REST data module logging improvements."""
+
+import logging
+
+import pytest
+
+from homeassistant.components.rest import DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def test_rest_data_log_warning_on_error_status(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that warning is logged for error status codes."""
+    # Mock a 403 response with HTML content
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=403,
+        text="<html><body>Access Denied</body></html>",
+        headers={"Content-Type": "text/html"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "name": "test_sensor",
+                "value_template": "{{ value_json.test }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Check that warning was logged
+    assert (
+        "REST request to http://example.com/api returned status 403 with text/html response"
+        in caplog.text
+    )
+    assert "<html><body>Access Denied</body></html>" in caplog.text
+
+
+async def test_rest_data_no_warning_on_200_with_wrong_content_type(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that no warning is logged for 200 status even with unexpected content type."""
+    # Mock a 200 response with HTML - users might still want to parse this
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=200,
+        text="<p>This is HTML, not JSON!</p>",
+        headers={"Content-Type": "text/html; charset=utf-8"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "name": "test_sensor",
+                "value_template": "{{ value }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Should NOT warn for 200 status, even with HTML content type
+    assert (
+        "REST request to http://example.com/api returned status 200" not in caplog.text
+    )
+
+
+async def test_rest_data_no_warning_on_success_json(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that no warning is logged for successful JSON responses."""
+    # Mock a successful JSON response
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=200,
+        json={"status": "ok", "value": 42},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "name": "test_sensor",
+                "value_template": "{{ value_json.value }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Check that no warning was logged
+    assert "REST request to http://example.com/api returned status" not in caplog.text
+
+
+async def test_rest_data_no_warning_on_success_xml(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that no warning is logged for successful XML responses."""
+    # Mock a successful XML response
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=200,
+        text='<?xml version="1.0"?><root><value>42</value></root>',
+        headers={"Content-Type": "application/xml"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "name": "test_sensor",
+                "value_template": "{{ value_json.root.value }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Check that no warning was logged
+    assert "REST request to http://example.com/api returned status" not in caplog.text
+
+
+async def test_rest_data_warning_truncates_long_responses(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that warning truncates very long response bodies."""
+    # Create a very long error message
+    long_message = "Error: " + "x" * 1000
+
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=500,
+        text=long_message,
+        headers={"Content-Type": "text/plain"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "name": "test_sensor",
+                "value_template": "{{ value_json.test }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Check that warning was logged with truncation
+    # Set the logger filter to only check our specific logger
+    caplog.set_level(logging.WARNING, logger="homeassistant.components.rest.data")
+
+    # Verify the truncated warning appears
+    assert (
+        "REST request to http://example.com/api returned status 500 with text/plain response: Error: "
+        + "x" * 493
+        + "..."
+        in caplog.text
+    )
+
+
+async def test_rest_data_debug_logging_shows_response_details(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that debug logging shows response details."""
+    caplog.set_level(logging.DEBUG)
+
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=200,
+        json={"test": "data"},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "name": "test_sensor",
+                "value_template": "{{ value_json.test }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Check debug log
+    assert (
+        "REST response from http://example.com/api: status=200, content-type=application/json, length="
+        in caplog.text
+    )
+
+
+async def test_rest_data_no_content_type_header(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test handling of responses without Content-Type header."""
+    caplog.set_level(logging.DEBUG)
+
+    # Mock response without Content-Type header
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=200,
+        text="plain text response",
+        headers={},  # No Content-Type
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "name": "test_sensor",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Check debug log shows "not set"
+    assert "content-type=not set" in caplog.text
+    # No warning for 200 with missing content-type
+    assert "REST request to http://example.com/api returned status" not in caplog.text
+
+
+async def test_rest_data_real_world_bom_blocking_scenario(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test real-world scenario where BOM blocks with HTML response."""
+    # Mock BOM blocking response
+    bom_block_html = """<p>Your access is blocked due to the detection of a potential automated access request. The Bureau of Meteorology website does not support web scraping: if you are trying to access Bureau data through automated means, you should stop. You may like to consider the following options:</p>
+<ul>
+<li>An anonymous FTP channel: <a href="http://www.bom.gov.au/catalogue/anon-ftp.shtml">http://www.bom.gov.au/catalogue/anon-ftp.shtml</a></li>
+</ul>"""
+
+    aioclient_mock.get(
+        "http://www.bom.gov.au/fwo/IDN60901/IDN60901.94767.json",
+        status=403,
+        text=bom_block_html,
+        headers={"Content-Type": "text/html"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://www.bom.gov.au/fwo/IDN60901/IDN60901.94767.json",
+                "method": "GET",
+                "name": "bom_temperature",
+                "value_template": "{{ value_json.observations.data[0].air_temp }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Check that warning was logged with clear indication of the issue
+    assert (
+        "REST request to http://www.bom.gov.au/fwo/IDN60901/IDN60901.94767.json returned status 403 with text/html response"
+        in caplog.text
+    )
+    assert "Your access is blocked" in caplog.text
+    assert "automated access request" in caplog.text
+
+
+async def test_rest_data_warning_on_html_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that warning is logged for error status with HTML content."""
+    # Mock a 404 response with HTML error page
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=404,
+        text="<html><body><h1>404 Not Found</h1></body></html>",
+        headers={"Content-Type": "text/html"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "name": "test_sensor",
+                "value_template": "{{ value_json.test }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Should warn for error status with HTML
+    assert (
+        "REST request to http://example.com/api returned status 404 with text/html response"
+        in caplog.text
+    )
+    assert "<html><body><h1>404 Not Found</h1></body></html>" in caplog.text
+
+
+async def test_rest_data_no_warning_on_json_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test POST request that returns JSON error - no warning expected."""
+    aioclient_mock.post(
+        "http://example.com/api",
+        status=400,
+        text='{"error": "Invalid request payload"}',
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "POST",
+                "payload": '{"data": "test"}',
+                "name": "test_sensor",
+                "value_template": "{{ value_json.error }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Should NOT warn for JSON error responses - users can parse these
+    assert (
+        "REST request to http://example.com/api returned status 400" not in caplog.text
+    )
+
+
+async def test_rest_data_timeout_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test timeout error logging."""
+    aioclient_mock.get(
+        "http://example.com/api",
+        exc=TimeoutError(),
+    )
+
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "name": "test_sensor",
+                "timeout": 10,
+                "value_template": "{{ value_json.test }}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Check timeout error is logged or platform reports not ready
+    assert (
+        "Timeout while fetching data: http://example.com/api" in caplog.text
+        or "Platform rest not ready yet" in caplog.text
+    )

--- a/tests/components/rest/test_data.py
+++ b/tests/components/rest/test_data.py
@@ -43,8 +43,8 @@ async def test_rest_data_log_warning_on_error_status(
 
     # Check that warning was logged
     assert (
-        "REST request to http://example.com/api returned status 403 with text/html response"
-        in caplog.text
+        "REST request to http://example.com/api returned status 403 "
+        "with text/html response" in caplog.text
     )
     assert "<html><body>Access Denied</body></html>" in caplog.text
 
@@ -54,7 +54,7 @@ async def test_rest_data_no_warning_on_200_with_wrong_content_type(
     aioclient_mock: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that no warning is logged for 200 status even with unexpected content type."""
+    """Test that no warning is logged for 200 status with wrong content."""
     # Mock a 200 response with HTML - users might still want to parse this
     aioclient_mock.get(
         "http://example.com/api",
@@ -187,10 +187,8 @@ async def test_rest_data_warning_truncates_long_responses(
 
     # Verify the truncated warning appears
     assert (
-        "REST request to http://example.com/api returned status 500 with text/plain response: Error: "
-        + "x" * 493
-        + "..."
-        in caplog.text
+        "REST request to http://example.com/api returned status 500 "
+        "with text/plain response: Error: " + "x" * 493 + "..." in caplog.text
     )
 
 
@@ -226,8 +224,8 @@ async def test_rest_data_debug_logging_shows_response_details(
 
     # Check debug log
     assert (
-        "REST response from http://example.com/api: status=200, content-type=application/json, length="
-        in caplog.text
+        "REST response from http://example.com/api: status=200, "
+        "content-type=application/json, length=" in caplog.text
     )
 
 
@@ -295,7 +293,7 @@ async def test_rest_data_real_world_bom_blocking_scenario(
                 "resource": "http://www.bom.gov.au/fwo/IDN60901/IDN60901.94767.json",
                 "method": "GET",
                 "name": "bom_temperature",
-                "value_template": "{{ value_json.observations.data[0].air_temp }}",
+                "value_template": ("{{ value_json.observations.data[0].air_temp }}"),
             }
         },
     )
@@ -303,8 +301,8 @@ async def test_rest_data_real_world_bom_blocking_scenario(
 
     # Check that warning was logged with clear indication of the issue
     assert (
-        "REST request to http://www.bom.gov.au/fwo/IDN60901/IDN60901.94767.json returned status 403 with text/html response"
-        in caplog.text
+        "REST request to http://www.bom.gov.au/fwo/IDN60901/"
+        "IDN60901.94767.json returned status 403 with text/html response" in caplog.text
     )
     assert "Your access is blocked" in caplog.text
     assert "automated access request" in caplog.text
@@ -341,8 +339,8 @@ async def test_rest_data_warning_on_html_error(
 
     # Should warn for error status with HTML
     assert (
-        "REST request to http://example.com/api returned status 404 with text/html response"
-        in caplog.text
+        "REST request to http://example.com/api returned status 404 "
+        "with text/html response" in caplog.text
     )
     assert "<html><body><h1>404 Not Found</h1></body></html>" in caplog.text
 

--- a/tests/components/rest/test_data.py
+++ b/tests/components/rest/test_data.py
@@ -272,10 +272,7 @@ async def test_rest_data_real_world_bom_blocking_scenario(
 ) -> None:
     """Test real-world scenario where BOM blocks with HTML response."""
     # Mock BOM blocking response
-    bom_block_html = """<p>Your access is blocked due to the detection of a potential automated access request. The Bureau of Meteorology website does not support web scraping: if you are trying to access Bureau data through automated means, you should stop. You may like to consider the following options:</p>
-<ul>
-<li>An anonymous FTP channel: <a href="http://www.bom.gov.au/catalogue/anon-ftp.shtml">http://www.bom.gov.au/catalogue/anon-ftp.shtml</a></li>
-</ul>"""
+    bom_block_html = "<p>Your access is blocked due to automated access</p>"
 
     aioclient_mock.get(
         "http://www.bom.gov.au/fwo/IDN60901/IDN60901.94767.json",
@@ -305,7 +302,6 @@ async def test_rest_data_real_world_bom_blocking_scenario(
         "IDN60901.94767.json returned status 403 with text/html response" in caplog.text
     )
     assert "Your access is blocked" in caplog.text
-    assert "automated access request" in caplog.text
 
 
 async def test_rest_data_warning_on_html_error(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR improves the logging in the REST integration to help users diagnose issues when servers return unexpected responses.

### Background
Users reported that their REST sensors stopped working after updating to Home Assistant Core 2025.7.0b3, showing `'value_json' is undefined` errors. Investigation revealed that the Bureau of Meteorology (BOM) weather service was blocking requests based on the Home Assistant User-Agent, returning HTML error pages instead of the expected JSON data.

### Changes
- Added debug logging for all REST responses showing status code, content-type, and response size
- Added warning logging specifically for error responses (4xx/5xx status codes) that return HTML instead of the expected JSON/XML content
- This helps users quickly identify when a server is blocking their requests or returning error pages

### Example warning log
```
REST request to http://www.bom.gov.au/fwo/IDT60803/IDT60803.89611.json returned status 403 with text/html response: <p>Your access is blocked due to the detection of a potential automated access request...
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #147815
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr