### PR TITLE
Add more mac address prefixes for discovery to PlayStation Network

### DIFF
--- a/homeassistant/components/playstation_network/manifest.json
+++ b/homeassistant/components/playstation_network/manifest.json
@@ -69,6 +69,12 @@
     },
     {
       "macaddress": "FC0FE6*"
+    },
+    {
+      "macaddress": "9C37CB*"
+    },
+    {
+      "macaddress": "84E657*"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/playstation_network",

--- a/homeassistant/components/playstation_network/manifest.json
+++ b/homeassistant/components/playstation_network/manifest.json
@@ -60,6 +60,9 @@
     },
     {
       "macaddress": "D44B5E*"
+    },
+    {
+      "macaddress": "F8D0AC*"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/playstation_network",

--- a/homeassistant/components/playstation_network/manifest.json
+++ b/homeassistant/components/playstation_network/manifest.json
@@ -63,6 +63,9 @@
     },
     {
       "macaddress": "F8D0AC*"
+    },
+    {
+      "macaddress": "E86E3A*"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/playstation_network",

--- a/homeassistant/components/playstation_network/manifest.json
+++ b/homeassistant/components/playstation_network/manifest.json
@@ -66,6 +66,9 @@
     },
     {
       "macaddress": "E86E3A*"
+    },
+    {
+      "macaddress": "FC0FE6*"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/playstation_network",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -540,6 +540,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "D44B5E*",
     },
     {
+        "domain": "playstation_network",
+        "macaddress": "F8D0AC*",
+    },
+    {
         "domain": "powerwall",
         "hostname": "1118431-*",
     },

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -552,6 +552,14 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "FC0FE6*",
     },
     {
+        "domain": "playstation_network",
+        "macaddress": "9C37CB*",
+    },
+    {
+        "domain": "playstation_network",
+        "macaddress": "84E657*",
+    },
+    {
         "domain": "powerwall",
         "hostname": "1118431-*",
     },

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -544,6 +544,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "F8D0AC*",
     },
     {
+        "domain": "playstation_network",
+        "macaddress": "E86E3A*",
+    },
+    {
         "domain": "powerwall",
         "hostname": "1118431-*",
     },

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -548,6 +548,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "E86E3A*",
     },
     {
+        "domain": "playstation_network",
+        "macaddress": "FC0FE6*",
+    },
+    {
         "domain": "powerwall",
         "hostname": "1118431-*",
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding additional MAC address prefixes for device discovery.
New devices:

- F8:D0:AC PS3 Wi-Fi
- E8:6E:3A PS5 Slim Wi-Fi
- FC:0F:E6 PS3
- 9C:37:CB PS5 Slim LAN
- 84:E6:57 PS5 Fat LAN


**This should be safe to add in beta or a patch release** 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
