### PR TITLE
Fix sensor displaying unknown when getting readings from heat meters in ista EcoTrend

### DIFF
--- a/homeassistant/components/ista_ecotrend/util.py
+++ b/homeassistant/components/ista_ecotrend/util.py
@@ -108,22 +108,22 @@ def get_statistics(
     if monthly_consumptions := get_consumptions(data, value_type):
         return [
             {
-                "value": as_number(
-                    get_values_by_type(
-                        consumptions=consumptions,
-                        consumption_type=consumption_type,
-                    ).get(
-                        "additionalValue"
-                        if value_type == IstaValueType.ENERGY
-                        else "value"
-                    )
-                ),
+                "value": as_number(value),
                 "date": consumptions["date"],
             }
             for consumptions in monthly_consumptions
-            if get_values_by_type(
-                consumptions=consumptions,
-                consumption_type=consumption_type,
-            ).get("additionalValue" if value_type == IstaValueType.ENERGY else "value")
+            if (
+                value := (
+                    consumption := get_values_by_type(
+                        consumptions=consumptions,
+                        consumption_type=consumption_type,
+                    )
+                ).get(
+                    "additionalValue"
+                    if value_type == IstaValueType.ENERGY
+                    and consumption.get("additionalValue") is not None
+                    else "value"
+                )
+            )
         ]
     return None

--- a/tests/components/ista_ecotrend/conftest.py
+++ b/tests/components/ista_ecotrend/conftest.py
@@ -96,12 +96,16 @@ def get_consumption_data(obj_uuid: str | None = None) -> dict[str, Any]:
                     {
                         "type": "heating",
                         "value": "35",
+                        "unit": "Einheiten",
                         "additionalValue": "38,0",
+                        "additionalUnit": "kWh",
                     },
                     {
                         "type": "warmwater",
                         "value": "1,0",
+                        "unit": "m³",
                         "additionalValue": "57,0",
+                        "additionalUnit": "kWh",
                     },
                     {
                         "type": "water",
@@ -115,16 +119,21 @@ def get_consumption_data(obj_uuid: str | None = None) -> dict[str, Any]:
                     {
                         "type": "heating",
                         "value": "104",
+                        "unit": "Einheiten",
                         "additionalValue": "113,0",
+                        "additionalUnit": "kWh",
                     },
                     {
                         "type": "warmwater",
                         "value": "1,1",
+                        "unit": "m³",
                         "additionalValue": "61,1",
+                        "additionalUnit": "kWh",
                     },
                     {
                         "type": "water",
                         "value": "6,8",
+                        "unit": "m³",
                     },
                 ],
             },
@@ -200,16 +209,21 @@ def extend_statistics(obj_uuid: str | None = None) -> dict[str, Any]:
                 {
                     "type": "heating",
                     "value": "9000",
+                    "unit": "Einheiten",
                     "additionalValue": "9000,0",
+                    "additionalUnit": "kWh",
                 },
                 {
                     "type": "warmwater",
                     "value": "9999,0",
+                    "unit": "m³",
                     "additionalValue": "90000,0",
+                    "additionalUnit": "kWh",
                 },
                 {
                     "type": "water",
                     "value": "9000,0",
+                    "unit": "m³",
                 },
             ],
         },

--- a/tests/components/ista_ecotrend/snapshots/test_diagnostics.ambr
+++ b/tests/components/ista_ecotrend/snapshots/test_diagnostics.ambr
@@ -12,13 +12,17 @@
             }),
             'readings': list([
               dict({
+                'additionalUnit': 'kWh',
                 'additionalValue': '38,0',
                 'type': 'heating',
+                'unit': 'Einheiten',
                 'value': '35',
               }),
               dict({
+                'additionalUnit': 'kWh',
                 'additionalValue': '57,0',
                 'type': 'warmwater',
+                'unit': 'm³',
                 'value': '1,0',
               }),
               dict({
@@ -34,17 +38,22 @@
             }),
             'readings': list([
               dict({
+                'additionalUnit': 'kWh',
                 'additionalValue': '113,0',
                 'type': 'heating',
+                'unit': 'Einheiten',
                 'value': '104',
               }),
               dict({
+                'additionalUnit': 'kWh',
                 'additionalValue': '61,1',
                 'type': 'warmwater',
+                'unit': 'm³',
                 'value': '1,1',
               }),
               dict({
                 'type': 'water',
+                'unit': 'm³',
                 'value': '6,8',
               }),
             ]),
@@ -103,13 +112,17 @@
             }),
             'readings': list([
               dict({
+                'additionalUnit': 'kWh',
                 'additionalValue': '38,0',
                 'type': 'heating',
+                'unit': 'Einheiten',
                 'value': '35',
               }),
               dict({
+                'additionalUnit': 'kWh',
                 'additionalValue': '57,0',
                 'type': 'warmwater',
+                'unit': 'm³',
                 'value': '1,0',
               }),
               dict({
@@ -125,17 +138,22 @@
             }),
             'readings': list([
               dict({
+                'additionalUnit': 'kWh',
                 'additionalValue': '113,0',
                 'type': 'heating',
+                'unit': 'Einheiten',
                 'value': '104',
               }),
               dict({
+                'additionalUnit': 'kWh',
                 'additionalValue': '61,1',
                 'type': 'warmwater',
+                'unit': 'm³',
                 'value': '1,1',
               }),
               dict({
                 'type': 'water',
+                'unit': 'm³',
                 'value': '6,8',
               }),
             ]),

--- a/tests/components/ista_ecotrend/snapshots/test_util.ambr
+++ b/tests/components/ista_ecotrend/snapshots/test_util.ambr
@@ -97,12 +97,22 @@
 # ---
 # name: test_get_statistics[water-energy]
   list([
+    dict({
+      'date': datetime.datetime(2024, 4, 30, 0, 0, tzinfo=datetime.timezone.utc),
+      'value': 6.8,
+    }),
+    dict({
+      'date': datetime.datetime(2024, 5, 31, 0, 0, tzinfo=datetime.timezone.utc),
+      'value': 5.0,
+    }),
   ])
 # ---
 # name: test_get_values_by_type[heating]
   dict({
+    'additionalUnit': 'kWh',
     'additionalValue': '38,0',
     'type': 'heating',
+    'unit': 'Einheiten',
     'value': '35',
   })
 # ---
@@ -114,8 +124,10 @@
 # ---
 # name: test_get_values_by_type[warmwater]
   dict({
+    'additionalUnit': 'kWh',
     'additionalValue': '57,0',
     'type': 'warmwater',
+    'unit': 'm³',
     'value': '1,0',
   })
 # ---
@@ -128,6 +140,7 @@
 # name: test_get_values_by_type[water]
   dict({
     'type': 'water',
+    'unit': 'm³',
     'value': '5,0',
   })
 # ---

--- a/tests/components/ista_ecotrend/test_util.py
+++ b/tests/components/ista_ecotrend/test_util.py
@@ -52,16 +52,21 @@ def test_get_values_by_type(
             {
                 "type": "heating",
                 "value": "35",
+                "unit": "Einheiten",
                 "additionalValue": "38,0",
+                "additionalUnit": "kWh",
             },
             {
                 "type": "warmwater",
                 "value": "1,0",
+                "unit": "m³",
                 "additionalValue": "57,0",
+                "additionalUnit": "kWh",
             },
             {
                 "type": "water",
                 "value": "5,0",
+                "unit": "m³",
             },
         ],
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When ista provides readings for heating consumption that come from a heating meter instead of a heat cost allocator the main value for heating is `kWh` instead of `Einheiten` (units) and the `additionalValue`, which is an estimation, is not  provided in the API response. In this case it will now fall back to the main `value` and the sensor for heating energy will show consumption correctly.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143784
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
