### PR TITLE
Bump Nettigo Air Monitor backend library to version 5.0.0

### DIFF
--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -44,15 +44,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: NAMConfigEntry) -> bool:
             translation_key="device_communication_error",
             translation_placeholders={"device": entry.title},
         ) from err
-
-    try:
-        await nam.async_check_credentials()
-    except (ApiError, ClientError) as err:
-        raise ConfigEntryNotReady(
-            translation_domain=DOMAIN,
-            translation_key="device_communication_error",
-            translation_placeholders={"device": entry.title},
-        ) from err
     except AuthFailedError as err:
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -135,7 +135,6 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self.async_step_confirm_discovery()
 
         await self.async_set_unique_id(format_mac(nam.mac))
-        self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
         return await self.async_step_confirm_discovery()
 

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
 import logging
 from typing import Any
 
@@ -26,15 +25,6 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
 
-
-@dataclass
-class NamConfig:
-    """NAM device configuration class."""
-
-    mac_address: str
-    auth_enabled: bool
-
-
 _LOGGER = logging.getLogger(__name__)
 
 AUTH_SCHEMA = vol.Schema(
@@ -42,29 +32,14 @@ AUTH_SCHEMA = vol.Schema(
 )
 
 
-async def async_get_config(hass: HomeAssistant, host: str) -> NamConfig:
-    """Get device MAC address and auth_enabled property."""
-    websession = async_get_clientsession(hass)
-
-    options = ConnectionOptions(host)
-    nam = await NettigoAirMonitor.create(websession, options)
-
-    mac = await nam.async_get_mac_address()
-
-    return NamConfig(mac, nam.auth_enabled)
-
-
-async def async_check_credentials(
+async def async_get_nam(
     hass: HomeAssistant, host: str, data: dict[str, Any]
-) -> None:
-    """Check if credentials are valid."""
+) -> NettigoAirMonitor:
+    """Get NAM client."""
     websession = async_get_clientsession(hass)
-
     options = ConnectionOptions(host, data.get(CONF_USERNAME), data.get(CONF_PASSWORD))
 
-    nam = await NettigoAirMonitor.create(websession, options)
-
-    await nam.async_check_credentials()
+    return await NettigoAirMonitor.create(websession, options)
 
 
 class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -72,8 +47,8 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    _config: NamConfig
     host: str
+    auth_enabled: bool = False
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -85,20 +60,19 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
             self.host = user_input[CONF_HOST]
 
             try:
-                config = await async_get_config(self.hass, self.host)
+                nam = await async_get_nam(self.hass, self.host, {})
             except (ApiError, ClientConnectorError, TimeoutError):
                 errors["base"] = "cannot_connect"
             except CannotGetMacError:
                 return self.async_abort(reason="device_unsupported")
+            except AuthFailedError:
+                return await self.async_step_credentials()
             except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(format_mac(config.mac_address))
+                await self.async_set_unique_id(format_mac(nam.mac))
                 self._abort_if_unique_id_configured({CONF_HOST: self.host})
-
-                if config.auth_enabled is True:
-                    return await self.async_step_credentials()
 
                 return self.async_create_entry(
                     title=self.host,
@@ -119,7 +93,7 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                await async_check_credentials(self.hass, self.host, user_input)
+                nam = await async_get_nam(self.hass, self.host, user_input)
             except AuthFailedError:
                 errors["base"] = "invalid_auth"
             except (ApiError, ClientConnectorError, TimeoutError):
@@ -128,6 +102,9 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
+                await self.async_set_unique_id(format_mac(nam.mac))
+                self._abort_if_unique_id_configured({CONF_HOST: self.host})
+
                 return self.async_create_entry(
                     title=self.host,
                     data={**user_input, CONF_HOST: self.host},
@@ -148,13 +125,16 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: self.host})
 
         try:
-            self._config = await async_get_config(self.hass, self.host)
+            nam = await async_get_nam(self.hass, self.host, {})
         except (ApiError, ClientConnectorError, TimeoutError):
             return self.async_abort(reason="cannot_connect")
         except CannotGetMacError:
             return self.async_abort(reason="device_unsupported")
+        except AuthFailedError:
+            self.auth_enabled = True
+            return await self.async_step_confirm_discovery()
 
-        await self.async_set_unique_id(format_mac(self._config.mac_address))
+        await self.async_set_unique_id(format_mac(nam.mac))
         self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
         return await self.async_step_confirm_discovery()
@@ -171,7 +151,7 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
                 data={CONF_HOST: self.host},
             )
 
-        if self._config.auth_enabled is True:
+        if self.auth_enabled is True:
             return await self.async_step_credentials()
 
         self._set_confirm_only()
@@ -198,7 +178,7 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                await async_check_credentials(self.hass, self.host, user_input)
+                await async_get_nam(self.hass, self.host, user_input)
             except (
                 ApiError,
                 AuthFailedError,
@@ -228,11 +208,11 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                config = await async_get_config(self.hass, user_input[CONF_HOST])
+                nam = await async_get_nam(self.hass, user_input[CONF_HOST], {})
             except (ApiError, ClientConnectorError, TimeoutError):
                 errors["base"] = "cannot_connect"
             else:
-                await self.async_set_unique_id(format_mac(config.mac_address))
+                await self.async_set_unique_id(format_mac(nam.mac))
                 self._abort_if_unique_id_mismatch(reason="another_device")
 
                 return self.async_update_reload_and_abort(

--- a/homeassistant/components/nam/manifest.json
+++ b/homeassistant/components/nam/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["nettigo_air_monitor"],
-  "requirements": ["nettigo-air-monitor==4.1.0"],
+  "requirements": ["nettigo-air-monitor==5.0.0"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1497,7 +1497,7 @@ netdata==1.3.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==4.1.0
+nettigo-air-monitor==5.0.0
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1283,7 +1283,7 @@ nessclient==1.2.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==4.1.0
+nettigo-air-monitor==5.0.0
 
 # homeassistant.components.nexia
 nexia==2.10.0

--- a/tests/components/nam/__init__.py
+++ b/tests/components/nam/__init__.py
@@ -33,7 +33,10 @@ async def init_integration(
     update_response = Mock(json=AsyncMock(return_value=nam_data))
 
     with (
-        patch("homeassistant.components.nam.NettigoAirMonitor.initialize"),
+        patch(
+            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+            return_value="AA:BB:CC:DD:EE:FF",
+        ),
         patch(
             "homeassistant.components.nam.NettigoAirMonitor._async_http_request",
             return_value=update_response,

--- a/tests/components/nam/__init__.py
+++ b/tests/components/nam/__init__.py
@@ -35,7 +35,7 @@ async def init_integration(
     with (
         patch(
             "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="AA:BB:CC:DD:EE:FF",
+            return_value="aa:bb:cc:dd:ee:ff",
         ),
         patch(
             "homeassistant.components.nam.NettigoAirMonitor._async_http_request",

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -125,8 +125,8 @@ async def test_reauth_successful(hass: HomeAssistant) -> None:
             user_input=VALID_AUTH,
         )
 
-        assert result["type"] is FlowResultType.ABORT
-        assert result["reason"] == "reauth_successful"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
 
 
 async def test_reauth_unsuccessful(hass: HomeAssistant) -> None:
@@ -151,8 +151,8 @@ async def test_reauth_unsuccessful(hass: HomeAssistant) -> None:
             user_input=VALID_AUTH,
         )
 
-        assert result["type"] is FlowResultType.ABORT
-        assert result["reason"] == "reauth_unsuccessful"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_unsuccessful"
 
 
 @pytest.mark.parametrize(
@@ -292,7 +292,9 @@ async def test_zeroconf(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> Non
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_with_auth(hass: HomeAssistant) -> None:
+async def test_zeroconf_with_auth(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test that the zeroconf step with auth works."""
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
@@ -314,14 +316,9 @@ async def test_zeroconf_with_auth(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
     assert context["title_placeholders"]["host"] == "10.10.2.3"
 
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
-        patch(
-            "homeassistant.components.nam.async_setup_entry", return_value=True
-        ) as mock_setup_entry,
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -52,7 +52,7 @@ async def test_form_create_entry_without_auth(
 
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        return_value="AA:BB:CC:DD:EE:FF",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -79,7 +79,7 @@ async def test_form_create_entry_with_auth(
 
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        side_effect=[AuthFailedError("Authorization has failed"), "AA:BB:CC:DD:EE:FF"],
+        side_effect=[AuthFailedError("Authorization has failed"), "aa:bb:cc:dd:ee:ff"],
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -118,7 +118,7 @@ async def test_reauth_successful(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        return_value="AA:BB:CC:DD:EE:FF",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -247,7 +247,7 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        return_value="AA:BB:CC:DD:EE:FF",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -265,7 +265,7 @@ async def test_zeroconf(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> Non
     """Test we get the form."""
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        return_value="AA:BB:CC:DD:EE:FF",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -399,7 +399,7 @@ async def test_reconfigure_successful(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        return_value="AA:BB:CC:DD:EE:FF",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -449,7 +449,7 @@ async def test_reconfigure_not_successful(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        return_value="AA:BB:CC:DD:EE:FF",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -486,7 +486,7 @@ async def test_reconfigure_not_the_same_device(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-        return_value="AA:BB:CC:DD:EE:FF",
+        return_value="aa:bb:cc:dd:ee:ff",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -1,7 +1,8 @@
 """Define tests for the Nettigo Air Monitor config flow."""
 
+from collections.abc import Generator
 from ipaddress import ip_address
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from nettigo_air_monitor import ApiError, AuthFailedError, CannotGetMacError
 import pytest
@@ -26,11 +27,21 @@ DISCOVERY_INFO = ZeroconfServiceInfo(
 )
 VALID_CONFIG = {"host": "10.10.2.3"}
 VALID_AUTH = {"username": "fake_username", "password": "fake_password"}
-DEVICE_CONFIG = {"www_basicauth_enabled": False}
-DEVICE_CONFIG_AUTH = {"www_basicauth_enabled": True}
 
 
-async def test_form_create_entry_without_auth(hass: HomeAssistant) -> None:
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.nam.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+async def test_form_create_entry_without_auth(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test that the user step without auth works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -39,18 +50,9 @@ async def test_form_create_entry_without_auth(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG,
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
-        patch(
-            "homeassistant.components.nam.async_setup_entry", return_value=True
-        ) as mock_setup_entry,
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="AA:BB:CC:DD:EE:FF",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -64,7 +66,9 @@ async def test_form_create_entry_without_auth(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_create_entry_with_auth(hass: HomeAssistant) -> None:
+async def test_form_create_entry_with_auth(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test that the user step with auth works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -73,18 +77,9 @@ async def test_form_create_entry_with_auth(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG_AUTH,
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
-        patch(
-            "homeassistant.components.nam.async_setup_entry", return_value=True
-        ) as mock_setup_entry,
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        side_effect=[AuthFailedError("Authorization has failed"), "AA:BB:CC:DD:EE:FF"],
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -121,15 +116,9 @@ async def test_reauth_successful(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG_AUTH,
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="AA:BB:CC:DD:EE:FF",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -154,7 +143,7 @@ async def test_reauth_unsuccessful(hass: HomeAssistant) -> None:
     assert result["step_id"] == "reauth_confirm"
 
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         side_effect=ApiError("API Error"),
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -178,15 +167,9 @@ async def test_reauth_unsuccessful(hass: HomeAssistant) -> None:
 async def test_form_with_auth_errors(hass: HomeAssistant, error) -> None:
     """Test we handle errors when auth is required."""
     exc, base_error = error
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            side_effect=AuthFailedError("Auth Error"),
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        side_effect=AuthFailedError("Authorization has failed"),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -198,7 +181,7 @@ async def test_form_with_auth_errors(hass: HomeAssistant, error) -> None:
     assert result["step_id"] == "credentials"
 
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         side_effect=exc,
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -237,10 +220,6 @@ async def test_form_abort(hass: HomeAssistant) -> None:
     """Test we handle abort after error."""
     with (
         patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG,
-        ),
-        patch(
             "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
             side_effect=CannotGetMacError("Cannot get MAC address from device"),
         ),
@@ -266,15 +245,9 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG,
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="AA:BB:CC:DD:EE:FF",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -288,17 +261,11 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
     assert entry.data["host"] == "1.1.1.1"
 
 
-async def test_zeroconf(hass: HomeAssistant) -> None:
+async def test_zeroconf(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     """Test we get the form."""
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG,
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="AA:BB:CC:DD:EE:FF",
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -316,15 +283,8 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert context["title_placeholders"]["host"] == "10.10.2.3"
     assert context["confirm_only"] is True
 
-    with patch(
-        "homeassistant.components.nam.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {},
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "10.10.2.3"
@@ -334,15 +294,9 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
 
 async def test_zeroconf_with_auth(hass: HomeAssistant) -> None:
     """Test that the zeroconf step with auth works."""
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            side_effect=AuthFailedError("Auth Error"),
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        side_effect=AuthFailedError("Auth Error"),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -361,10 +315,6 @@ async def test_zeroconf_with_auth(hass: HomeAssistant) -> None:
     assert context["title_placeholders"]["host"] == "10.10.2.3"
 
     with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG_AUTH,
-        ),
         patch(
             "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
             return_value="aa:bb:cc:dd:ee:ff",
@@ -447,15 +397,9 @@ async def test_reconfigure_successful(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG_AUTH,
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="AA:BB:CC:DD:EE:FF",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -491,7 +435,7 @@ async def test_reconfigure_not_successful(hass: HomeAssistant) -> None:
     assert result["step_id"] == "reconfigure"
 
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         side_effect=ApiError("API Error"),
     ):
         result = await hass.config_entries.flow.async_configure(
@@ -503,15 +447,9 @@ async def test_reconfigure_not_successful(hass: HomeAssistant) -> None:
     assert result["step_id"] == "reconfigure"
     assert result["errors"] == {"base": "cannot_connect"}
 
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG_AUTH,
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="AA:BB:CC:DD:EE:FF",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -546,15 +484,9 @@ async def test_reconfigure_not_the_same_device(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
-    with (
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            return_value=DEVICE_CONFIG_AUTH,
-        ),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
-            return_value="aa:bb:cc:dd:ee:ff",
-        ),
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="AA:BB:CC:DD:EE:FF",
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/nam/test_init.py
+++ b/tests/components/nam/test_init.py
@@ -44,27 +44,6 @@ async def test_config_not_ready(hass: HomeAssistant) -> None:
         assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_config_not_ready_while_checking_credentials(hass: HomeAssistant) -> None:
-    """Test for setup failure if the connection fails while checking credentials."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="10.10.2.3",
-        unique_id="aa:bb:cc:dd:ee:ff",
-        data={"host": "10.10.2.3"},
-    )
-    entry.add_to_hass(hass)
-
-    with (
-        patch("homeassistant.components.nam.NettigoAirMonitor.initialize"),
-        patch(
-            "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
-            side_effect=ApiError("API Error"),
-        ),
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        assert entry.state is ConfigEntryState.SETUP_RETRY
-
-
 async def test_config_auth_failed(hass: HomeAssistant) -> None:
     """Test for setup failure if the auth fails."""
     entry = MockConfigEntry(
@@ -76,7 +55,7 @@ async def test_config_auth_failed(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         side_effect=AuthFailedError("Authorization has failed"),
     ):
         await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps `nettigo_air_monitor` to version 5.0.0 to support devices with Sensor.Community firmware.

Changelog: https://github.com/bieniu/nettigo-air-monitor/compare/4.1.0...5.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146877
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39778
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
