### PR TITLE
Check badly formatted dhcp addresses in tests

### DIFF
--- a/homeassistant/helpers/service_info/dhcp.py
+++ b/homeassistant/helpers/service_info/dhcp.py
@@ -20,4 +20,7 @@ class DhcpServiceInfo(BaseServiceInfo):
     """
 
     def __post_init__(self) -> None:
-        """Post init checks."""
+        """Post init checks.
+
+        Needed so it can be overridden in tests.
+        """

--- a/homeassistant/helpers/service_info/dhcp.py
+++ b/homeassistant/helpers/service_info/dhcp.py
@@ -18,9 +18,3 @@ class DhcpServiceInfo(BaseServiceInfo):
     as a lowercase string without colons.
     eg. "AA:BB:CC:12:34:56" is stored as "aabbcc123456"
     """
-
-    def __post_init__(self) -> None:
-        """Post init checks.
-
-        Needed so it can be overridden in tests.
-        """

--- a/homeassistant/helpers/service_info/dhcp.py
+++ b/homeassistant/helpers/service_info/dhcp.py
@@ -20,7 +20,4 @@ class DhcpServiceInfo(BaseServiceInfo):
     """
 
     def __post_init__(self) -> None:
-        """Post-init processing."""
-        # Ensure macaddress is always a lowercase string without colons
-        if self.macaddress != self.macaddress.lower().replace(":", ""):
-            raise ValueError("macaddress is not correctly formatted")
+        """Post init checks."""

--- a/homeassistant/helpers/service_info/dhcp.py
+++ b/homeassistant/helpers/service_info/dhcp.py
@@ -18,3 +18,9 @@ class DhcpServiceInfo(BaseServiceInfo):
     as a lowercase string without colons.
     eg. "AA:BB:CC:12:34:56" is stored as "aabbcc123456"
     """
+
+    def __post_init__(self) -> None:
+        """Post-init processing."""
+        # Ensure macaddress is always a lowercase string without colons
+        if self.macaddress != self.macaddress.lower().replace(":", ""):
+            raise ValueError("macaddress is not correctly formatted")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,18 +156,6 @@ asyncio.set_event_loop_policy(runner.HassEventLoopPolicy(False))
 asyncio.set_event_loop_policy = lambda policy: None
 
 
-def _dhcp_service_info_post_init(self: DhcpServiceInfo) -> None:
-    """Post-init processing for DhcpServiceInfo.
-
-    Ensure that the macaddress is always in lowercase and without colons to match DHCP service.
-    """
-    if self.macaddress != self.macaddress.lower().replace(":", ""):
-        raise ValueError("macaddress is not correctly formatted")
-
-
-DhcpServiceInfo.__post_init__ = _dhcp_service_info_post_init
-
-
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register custom pytest options."""
     parser.addoption("--dburl", action="store", default="sqlite://")
@@ -2103,3 +2091,19 @@ def disable_block_async_io() -> Generator[None]:
             blocking_call.object, blocking_call.function, blocking_call.original_func
         )
     calls.clear()
+
+
+_real_dhcp_service_info_init = DhcpServiceInfo.__init__
+
+
+def _dhcp_service_info_init(self: DhcpServiceInfo, *args: Any, **kwargs: Any) -> None:
+    """Override __init__ for DhcpServiceInfo.
+
+    Ensure that the macaddress is always in lowercase and without colons to match DHCP service.
+    """
+    _real_dhcp_service_info_init(self, *args, **kwargs)
+    if self.macaddress != self.macaddress.lower().replace(":", ""):
+        raise ValueError("macaddress is not correctly formatted")
+
+
+DhcpServiceInfo.__init__ = _dhcp_service_info_init

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,7 @@ from homeassistant.helpers import (
     translation as translation_helper,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.translation import _TranslationsCacheData
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
@@ -2090,3 +2091,15 @@ def disable_block_async_io() -> Generator[None]:
             blocking_call.object, blocking_call.function, blocking_call.original_func
         )
     calls.clear()
+
+
+def _dhcp_service_info_post_init(self: DhcpServiceInfo) -> None:
+    """Post-init processing for DhcpServiceInfo.
+
+    Ensure that the macaddress is always in lowercase and without colons to match DHCP service.
+    """
+    if self.macaddress != self.macaddress.lower().replace(":", ""):
+        raise ValueError("macaddress is not correctly formatted")
+
+
+DhcpServiceInfo.__post_init__ = _dhcp_service_info_post_init

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2093,6 +2093,8 @@ def disable_block_async_io() -> Generator[None]:
     calls.clear()
 
 
+# Ensure that incorrectly formatted mac addresses are rejected during
+# DhcpServiceInfo initialisation
 _real_dhcp_service_info_init = DhcpServiceInfo.__init__
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,18 @@ asyncio.set_event_loop_policy(runner.HassEventLoopPolicy(False))
 asyncio.set_event_loop_policy = lambda policy: None
 
 
+def _dhcp_service_info_post_init(self: DhcpServiceInfo) -> None:
+    """Post-init processing for DhcpServiceInfo.
+
+    Ensure that the macaddress is always in lowercase and without colons to match DHCP service.
+    """
+    if self.macaddress != self.macaddress.lower().replace(":", ""):
+        raise ValueError("macaddress is not correctly formatted")
+
+
+DhcpServiceInfo.__post_init__ = _dhcp_service_info_post_init
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register custom pytest options."""
     parser.addoption("--dburl", action="store", default="sqlite://")
@@ -2091,15 +2103,3 @@ def disable_block_async_io() -> Generator[None]:
             blocking_call.object, blocking_call.function, blocking_call.original_func
         )
     calls.clear()
-
-
-def _dhcp_service_info_post_init(self: DhcpServiceInfo) -> None:
-    """Post-init processing for DhcpServiceInfo.
-
-    Ensure that the macaddress is always in lowercase and without colons to match DHCP service.
-    """
-    if self.macaddress != self.macaddress.lower().replace(":", ""):
-        raise ValueError("macaddress is not correctly formatted")
-
-
-DhcpServiceInfo.__post_init__ = _dhcp_service_info_post_init

--- a/tests/helpers/test_service_info.py
+++ b/tests/helpers/test_service_info.py
@@ -1,14 +1,23 @@
 """Test service_info helpers."""
 
+import pytest
+
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-# Ensure that DhcpServiceInfo.__post_init__ is called, even on a constant outside of a test
+# Ensure that incorrectly formatted mac addresses are rejected, even
+# on a constant outside of a test
 try:
     _ = DhcpServiceInfo(ip="", hostname="", macaddress="AA:BB:CC:DD:EE:FF")
 except ValueError:
     pass
 else:
     raise RuntimeError(
-        "DhcpServiceInfo.__post_init__ was not called. "
-        "Please ensure that the __post_init__ method is correctly defined."
+        "DhcpServiceInfo incorrectly formatted mac address was not rejected. "
+        "Please ensure that the DhcpServiceInfo is correctly patched."
     )
+
+
+def test_invalid_macaddress() -> None:
+    """Test that DhcpServiceInfo raises ValueError for unformatted macaddress."""
+    with pytest.raises(ValueError):
+        DhcpServiceInfo(ip="", hostname="", macaddress="AA:BB:CC:DD:EE:FF")

--- a/tests/helpers/test_service_info.py
+++ b/tests/helpers/test_service_info.py
@@ -1,0 +1,14 @@
+"""Test service_info helpers."""
+
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+
+# Ensure that DhcpServiceInfo.__post_init__ is called, even on a constant outside of a test
+try:
+    _ = DhcpServiceInfo(ip="", hostname="", macaddress="AA:BB:CC:DD:EE:FF")
+except ValueError:
+    pass
+else:
+    raise RuntimeError(
+        "DhcpServiceInfo.__post_init__ was not called. "
+        "Please ensure that the __post_init__ method is correctly defined."
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
~DO NOT MERGE~

~This is just to identify all badly formatted MAC addresses in DhcpServiceInfo tests~

Tests often use bad formatting of the MAC address in tests, and this can lead to incorrect behavior if the MAC address is used "as is" in the config-flow.

Linked to #144858

<!--I believe a specific class or function for this would be nice to have, to ensure consistency, but my first attempt at this was rejected (see #144858)-->
<!--In the meantime, just make sure that existing ones are cleaned up-->

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
