### PR TITLE
Fix derivative migration from 'none' unit_prefix

### DIFF
--- a/homeassistant/components/derivative/config_flow.py
+++ b/homeassistant/components/derivative/config_flow.py
@@ -112,10 +112,6 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
 
 
 async def _get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
-    if handler.options.get("unit_prefix") == "none":
-        # Before we had support for optional selectors, "none" was used for selecting nothing
-        del handler.options["unit_prefix"]
-
     return vol.Schema(await _get_options_dict(handler))
 
 
@@ -143,6 +139,9 @@ class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
 
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW
+
+    VERSION = 1
+    MINOR_VERSION = 2
 
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""

--- a/homeassistant/components/derivative/config_flow.py
+++ b/homeassistant/components/derivative/config_flow.py
@@ -112,6 +112,10 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
 
 
 async def _get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
+    if handler.options.get("unit_prefix") == "none":
+        # Before we had support for optional selectors, "none" was used for selecting nothing
+        del handler.options["unit_prefix"]
+
     return vol.Schema(await _get_options_dict(handler))
 
 

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -123,10 +123,6 @@ async def async_setup_entry(
         source_entity_id,
     )
 
-    if (unit_prefix := config_entry.options.get(CONF_UNIT_PREFIX)) == "none":
-        # Before we had support for optional selectors, "none" was used for selecting nothing
-        unit_prefix = None
-
     if max_sub_interval_dict := config_entry.options.get(CONF_MAX_SUB_INTERVAL, None):
         max_sub_interval = cv.time_period(max_sub_interval_dict)
     else:
@@ -139,7 +135,7 @@ async def async_setup_entry(
         time_window=cv.time_period_dict(config_entry.options[CONF_TIME_WINDOW]),
         unique_id=config_entry.entry_id,
         unit_of_measurement=None,
-        unit_prefix=unit_prefix,
+        unit_prefix=config_entry.options.get(CONF_UNIT_PREFIX),
         unit_time=config_entry.options[CONF_UNIT_TIME],
         device_info=device_info,
         max_sub_interval=max_sub_interval,

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -68,18 +68,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
 
 
 @pytest.mark.parametrize("platform", ["sensor"])
-@pytest.mark.parametrize(
-    ("initial_unit_prefix", "minor_version"),
-    [
-        ({}, 1),
-        ({}, 2),
-        ({"unit_prefix": "k"}, 2),
-        ({"unit_prefix": "none"}, 1),
-    ],
-)
-async def test_options(
-    hass: HomeAssistant, platform, initial_unit_prefix, minor_version
-) -> None:
+async def test_options(hass: HomeAssistant, platform) -> None:
     """Test reconfiguring."""
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -90,12 +79,10 @@ async def test_options(
             "round": 1.0,
             "source": "sensor.input",
             "time_window": {"seconds": 0.0},
-            **initial_unit_prefix,
+            "unit_prefix": "k",
             "unit_time": "min",
             "max_sub_interval": {"seconds": 30},
         },
-        version=1,
-        minor_version=minor_version,
         title="My derivative",
     )
     config_entry.add_to_hass(hass)
@@ -112,11 +99,7 @@ async def test_options(
     schema = result["data_schema"].schema
     assert get_schema_suggested_value(schema, "round") == 1.0
     assert get_schema_suggested_value(schema, "time_window") == {"seconds": 0.0}
-    assert get_schema_suggested_value(schema, "unit_prefix") == (
-        None
-        if initial_unit_prefix.get("unit_prefix") == "none"
-        else initial_unit_prefix.get("unit_prefix")
-    )
+    assert get_schema_suggested_value(schema, "unit_prefix") == "k"
     assert get_schema_suggested_value(schema, "unit_time") == "min"
 
     source = schema["source"]

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -69,10 +69,17 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
 
 @pytest.mark.parametrize("platform", ["sensor"])
 @pytest.mark.parametrize(
-    "initial_unit_prefix",
-    [{}, {"unit_prefix": "k"}, {"unit_prefix": "none"}],
+    ("initial_unit_prefix", "minor_version"),
+    [
+        ({}, 1),
+        ({}, 2),
+        ({"unit_prefix": "k"}, 2),
+        ({"unit_prefix": "none"}, 1),
+    ],
 )
-async def test_options(hass: HomeAssistant, platform, initial_unit_prefix) -> None:
+async def test_options(
+    hass: HomeAssistant, platform, initial_unit_prefix, minor_version
+) -> None:
     """Test reconfiguring."""
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -87,6 +94,8 @@ async def test_options(hass: HomeAssistant, platform, initial_unit_prefix) -> No
             "unit_time": "min",
             "max_sub_interval": {"seconds": 30},
         },
+        version=1,
+        minor_version=minor_version,
         title="My derivative",
     )
     config_entry.add_to_hass(hass)

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -68,7 +68,11 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
 
 
 @pytest.mark.parametrize("platform", ["sensor"])
-async def test_options(hass: HomeAssistant, platform) -> None:
+@pytest.mark.parametrize(
+    "initial_unit_prefix",
+    [{}, {"unit_prefix": "k"}, {"unit_prefix": "none"}],
+)
+async def test_options(hass: HomeAssistant, platform, initial_unit_prefix) -> None:
     """Test reconfiguring."""
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -79,7 +83,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
             "round": 1.0,
             "source": "sensor.input",
             "time_window": {"seconds": 0.0},
-            "unit_prefix": "k",
+            **initial_unit_prefix,
             "unit_time": "min",
             "max_sub_interval": {"seconds": 30},
         },
@@ -99,7 +103,11 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     schema = result["data_schema"].schema
     assert get_schema_suggested_value(schema, "round") == 1.0
     assert get_schema_suggested_value(schema, "time_window") == {"seconds": 0.0}
-    assert get_schema_suggested_value(schema, "unit_prefix") == "k"
+    assert get_schema_suggested_value(schema, "unit_prefix") == (
+        None
+        if initial_unit_prefix.get("unit_prefix") == "none"
+        else initial_unit_prefix.get("unit_prefix")
+    )
     assert get_schema_suggested_value(schema, "unit_time") == "min"
 
     source = schema["source"]

--- a/tests/components/derivative/test_init.py
+++ b/tests/components/derivative/test_init.py
@@ -420,6 +420,41 @@ async def test_async_handle_source_entity_new_entity_id(
     assert events == []
 
 
+@pytest.mark.parametrize(
+    ("unit_prefix", "expect_prefix"),
+    [
+        ({}, None),
+        ({"unit_prefix": "k"}, "k"),
+        ({"unit_prefix": "none"}, None),
+    ],
+)
+async def test_migration(hass: HomeAssistant, unit_prefix, expect_prefix) -> None:
+    """Test migration from v1.1 deletes "none" unit_prefix."""
+
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My derivative",
+            "round": 1.0,
+            "source": "sensor.power",
+            "time_window": {"seconds": 0.0},
+            **unit_prefix,
+            "unit_time": "min",
+        },
+        title="My derivative",
+        version=1,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.options["unit_time"] == "min"
+    assert config_entry.options.get("unit_prefix") == expect_prefix
+
+
 async def test_migration_from_future_version(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/derivative/test_init.py
+++ b/tests/components/derivative/test_init.py
@@ -7,7 +7,7 @@ import pytest
 from homeassistant.components import derivative
 from homeassistant.components.derivative.config_flow import ConfigFlowHandler
 from homeassistant.components.derivative.const import DOMAIN
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
@@ -418,3 +418,30 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check we got the expected events
     assert events == []
+
+
+async def test_migration_from_future_version(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration from future version."""
+
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My derivative",
+            "round": 1.0,
+            "source": "sensor.power",
+            "time_window": {"seconds": 0.0},
+            "unit_prefix": "k",
+            "unit_time": "min",
+        },
+        title="My derivative",
+        version=2,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
In https://github.com/home-assistant/core/pull/101312, the option "none" was removed from derivative unit_prefix. 

A [migration](https://github.com/home-assistant/core/pull/102294) was added to the sensor creation to treat "none" as `None`, but this wasn't completely handled in the options flow.

Legacy sensors with their option still set to `"none"` still cause a problem when showing the options form, as frontend would try to resubmit `"none"` as an option when changing a different field, causing a [cryptic error](https://github.com/home-assistant/core/issues/138415).

This change completes the missing migration step by deleting the `"none"` key when presenting the options form, so that the key is removed from config_entry when the options form is resubmitted. 

Also adds coverage that was previously missing covering the migration. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #138415
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
