### PR TITLE
Add Speech-to-Text (stt) to elevenlabs

### DIFF
--- a/homeassistant/components/elevenlabs/__init__.py
+++ b/homeassistant/components/elevenlabs/__init__.py
@@ -20,7 +20,12 @@ from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import CONF_MODEL
 
-PLATFORMS: list[Platform] = [Platform.TTS]
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [
+    Platform.STT,
+    Platform.TTS,
+]
 
 
 async def get_model_by_id(client: AsyncElevenLabs, model_id: str) -> Model | None:

--- a/homeassistant/components/elevenlabs/__init__.py
+++ b/homeassistant/components/elevenlabs/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 
 from elevenlabs import AsyncElevenLabs, Model
 from elevenlabs.core import ApiError

--- a/homeassistant/components/elevenlabs/config_flow.py
+++ b/homeassistant/components/elevenlabs/config_flow.py
@@ -167,7 +167,7 @@ class ElevenLabsOptionsFlow(OptionsFlow):
                             ]
                         )
                     ),
-                    vol.Optional(
+                    vol.Required(
                         CONF_STT_AUTO_LANGUAGE,
                         default=self.config_entry.options.get(
                             CONF_STT_AUTO_LANGUAGE, DEFAULT_STT_AUTO_LANGUAGE

--- a/homeassistant/components/elevenlabs/config_flow.py
+++ b/homeassistant/components/elevenlabs/config_flow.py
@@ -90,7 +90,11 @@ class ElevenLabsConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title="ElevenLabs",
                     data=user_input,
-                    options={CONF_MODEL: DEFAULT_MODEL, CONF_VOICE: list(voices)[0]},
+                    options={
+                        CONF_MODEL: DEFAULT_MODEL,
+                        CONF_VOICE: list(voices)[0],
+                        CONF_STT_AUTO_LANGUAGE: False,
+                    },
                 )
         return self.async_show_form(
             step_id="user", data_schema=USER_STEP_SCHEMA, errors=errors
@@ -115,6 +119,7 @@ class ElevenLabsOptionsFlow(OptionsFlow):
         self.models: dict[str, str] = {}
         self.model: str | None = None
         self.voice: str | None = None
+        self.auto_language: bool | None = None
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -128,6 +133,7 @@ class ElevenLabsOptionsFlow(OptionsFlow):
         if user_input is not None:
             self.model = user_input[CONF_MODEL]
             self.voice = user_input[CONF_VOICE]
+            self.auto_language = user_input.get(CONF_STT_AUTO_LANGUAGE, False)
             configure_voice = user_input.pop(CONF_CONFIGURE_VOICE)
             if configure_voice:
                 return await self.async_step_voice_settings()
@@ -187,6 +193,7 @@ class ElevenLabsOptionsFlow(OptionsFlow):
         if user_input is not None:
             user_input[CONF_MODEL] = self.model
             user_input[CONF_VOICE] = self.voice
+            user_input[CONF_STT_AUTO_LANGUAGE] = self.auto_language
             return self.async_create_entry(
                 title="ElevenLabs",
                 data=user_input,

--- a/homeassistant/components/elevenlabs/config_flow.py
+++ b/homeassistant/components/elevenlabs/config_flow.py
@@ -25,12 +25,14 @@ from .const import (
     CONF_MODEL,
     CONF_SIMILARITY,
     CONF_STABILITY,
+    CONF_STT_AUTO_LANGUAGE,
     CONF_STYLE,
     CONF_USE_SPEAKER_BOOST,
     CONF_VOICE,
     DEFAULT_MODEL,
     DEFAULT_SIMILARITY,
     DEFAULT_STABILITY,
+    DEFAULT_STT_AUTO_LANGUAGE,
     DEFAULT_STYLE,
     DEFAULT_USE_SPEAKER_BOOST,
     DOMAIN,
@@ -165,6 +167,12 @@ class ElevenLabsOptionsFlow(OptionsFlow):
                             ]
                         )
                     ),
+                    vol.Optional(
+                        CONF_STT_AUTO_LANGUAGE,
+                        default=self.config_entry.options.get(
+                            CONF_STT_AUTO_LANGUAGE, DEFAULT_STT_AUTO_LANGUAGE
+                        ),
+                    ): bool,
                     vol.Required(CONF_CONFIGURE_VOICE, default=False): bool,
                 }
             ),

--- a/homeassistant/components/elevenlabs/config_flow.py
+++ b/homeassistant/components/elevenlabs/config_flow.py
@@ -26,16 +26,19 @@ from .const import (
     CONF_SIMILARITY,
     CONF_STABILITY,
     CONF_STT_AUTO_LANGUAGE,
+    CONF_STT_MODEL,
     CONF_STYLE,
     CONF_USE_SPEAKER_BOOST,
     CONF_VOICE,
-    DEFAULT_MODEL,
     DEFAULT_SIMILARITY,
     DEFAULT_STABILITY,
     DEFAULT_STT_AUTO_LANGUAGE,
+    DEFAULT_STT_MODEL,
     DEFAULT_STYLE,
+    DEFAULT_TTS_MODEL,
     DEFAULT_USE_SPEAKER_BOOST,
     DOMAIN,
+    STT_MODELS,
 )
 
 USER_STEP_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
@@ -70,6 +73,7 @@ class ElevenLabsConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ElevenLabs text-to-speech."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -91,8 +95,9 @@ class ElevenLabsConfigFlow(ConfigFlow, domain=DOMAIN):
                     title="ElevenLabs",
                     data=user_input,
                     options={
-                        CONF_MODEL: DEFAULT_MODEL,
+                        CONF_MODEL: DEFAULT_TTS_MODEL,
                         CONF_VOICE: list(voices)[0],
+                        CONF_STT_MODEL: DEFAULT_STT_MODEL,
                         CONF_STT_AUTO_LANGUAGE: False,
                     },
                 )
@@ -119,6 +124,8 @@ class ElevenLabsOptionsFlow(OptionsFlow):
         self.models: dict[str, str] = {}
         self.model: str | None = None
         self.voice: str | None = None
+        self.stt_models: dict[str, str] = STT_MODELS
+        self.stt_model: str | None = None
         self.auto_language: bool | None = None
 
     async def async_step_init(
@@ -133,7 +140,8 @@ class ElevenLabsOptionsFlow(OptionsFlow):
         if user_input is not None:
             self.model = user_input[CONF_MODEL]
             self.voice = user_input[CONF_VOICE]
-            self.auto_language = user_input.get(CONF_STT_AUTO_LANGUAGE, False)
+            self.stt_model = user_input[CONF_STT_MODEL]
+            self.auto_language = user_input[CONF_STT_AUTO_LANGUAGE]
             configure_voice = user_input.pop(CONF_CONFIGURE_VOICE)
             if configure_voice:
                 return await self.async_step_voice_settings()
@@ -174,6 +182,16 @@ class ElevenLabsOptionsFlow(OptionsFlow):
                         )
                     ),
                     vol.Required(
+                        CONF_STT_MODEL,
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                SelectOptionDict(label=model_name, value=model_id)
+                                for model_id, model_name in self.stt_models.items()
+                            ]
+                        )
+                    ),
+                    vol.Required(
                         CONF_STT_AUTO_LANGUAGE,
                         default=self.config_entry.options.get(
                             CONF_STT_AUTO_LANGUAGE, DEFAULT_STT_AUTO_LANGUAGE
@@ -193,6 +211,7 @@ class ElevenLabsOptionsFlow(OptionsFlow):
         if user_input is not None:
             user_input[CONF_MODEL] = self.model
             user_input[CONF_VOICE] = self.voice
+            user_input[CONF_STT_MODEL] = self.stt_model
             user_input[CONF_STT_AUTO_LANGUAGE] = self.auto_language
             return self.async_create_entry(
                 title="ElevenLabs",

--- a/homeassistant/components/elevenlabs/const.py
+++ b/homeassistant/components/elevenlabs/const.py
@@ -8,14 +8,16 @@ CONF_CONFIGURE_VOICE = "configure_voice"
 CONF_STABILITY = "stability"
 CONF_SIMILARITY = "similarity"
 CONF_STT_AUTO_LANGUAGE = "stt_auto_language"
+CONF_STT_MODEL = "stt_model"
 CONF_STYLE = "style"
 CONF_USE_SPEAKER_BOOST = "use_speaker_boost"
 DOMAIN = "elevenlabs"
 
-DEFAULT_MODEL = "eleven_multilingual_v2"
+DEFAULT_TTS_MODEL = "eleven_multilingual_v2"
 DEFAULT_STABILITY = 0.5
 DEFAULT_SIMILARITY = 0.75
 DEFAULT_STT_AUTO_LANGUAGE = False
+DEFAULT_STT_MODEL = "scribe_v1"
 DEFAULT_STYLE = 0
 DEFAULT_USE_SPEAKER_BOOST = True
 
@@ -120,3 +122,8 @@ STT_LANGUAGES = [
     "xh-ZA",  # Xhosa
     "zu-ZA",  # Zulu
 ]
+
+STT_MODELS = {
+    "scribe_v1": "Scribe v1",
+    "scribe_v1_experimental": "Scribe v1 Experimental",
+}

--- a/homeassistant/components/elevenlabs/const.py
+++ b/homeassistant/components/elevenlabs/const.py
@@ -7,6 +7,7 @@ CONF_MODEL = "model"
 CONF_CONFIGURE_VOICE = "configure_voice"
 CONF_STABILITY = "stability"
 CONF_SIMILARITY = "similarity"
+CONF_STT_AUTO_LANGUAGE = "stt_auto_language"
 CONF_STYLE = "style"
 CONF_USE_SPEAKER_BOOST = "use_speaker_boost"
 DOMAIN = "elevenlabs"
@@ -14,5 +15,108 @@ DOMAIN = "elevenlabs"
 DEFAULT_MODEL = "eleven_multilingual_v2"
 DEFAULT_STABILITY = 0.5
 DEFAULT_SIMILARITY = 0.75
+DEFAULT_STT_AUTO_LANGUAGE = False
 DEFAULT_STYLE = 0
 DEFAULT_USE_SPEAKER_BOOST = True
+
+STT_LANGUAGES = [
+    "af-ZA",  # Afrikaans
+    "am-ET",  # Amharic
+    "ar-SA",  # Arabic
+    "hy-AM",  # Armenian
+    "as-IN",  # Assamese
+    "ast-ES",  # Asturian
+    "az-AZ",  # Azerbaijani
+    "be-BY",  # Belarusian
+    "bn-IN",  # Bengali
+    "bs-BA",  # Bosnian
+    "bg-BG",  # Bulgarian
+    "my-MM",  # Burmese
+    "yue-HK",  # Cantonese
+    "ca-ES",  # Catalan
+    "ceb-PH",  # Cebuano
+    "ny-MW",  # Chichewa
+    "hr-HR",  # Croatian
+    "cs-CZ",  # Czech
+    "da-DK",  # Danish
+    "nl-NL",  # Dutch
+    "en-US",  # English
+    "et-EE",  # Estonian
+    "fil-PH",  # Filipino
+    "fi-FI",  # Finnish
+    "fr-FR",  # French
+    "ff-SN",  # Fulah
+    "gl-ES",  # Galician
+    "lg-UG",  # Ganda
+    "ka-GE",  # Georgian
+    "de-DE",  # German
+    "el-GR",  # Greek
+    "gu-IN",  # Gujarati
+    "ha-NG",  # Hausa
+    "he-IL",  # Hebrew
+    "hi-IN",  # Hindi
+    "hu-HU",  # Hungarian
+    "is-IS",  # Icelandic
+    "ig-NG",  # Igbo
+    "id-ID",  # Indonesian
+    "ga-IE",  # Irish
+    "it-IT",  # Italian
+    "ja-JP",  # Japanese
+    "jv-ID",  # Javanese
+    "kea-CV",  # Kabuverdianu
+    "kn-IN",  # Kannada
+    "kk-KZ",  # Kazakh
+    "km-KH",  # Khmer
+    "ko-KR",  # Korean
+    "ku-TR",  # Kurdish
+    "ky-KG",  # Kyrgyz
+    "lo-LA",  # Lao
+    "lv-LV",  # Latvian
+    "ln-CD",  # Lingala
+    "lt-LT",  # Lithuanian
+    "luo-KE",  # Luo
+    "lb-LU",  # Luxembourgish
+    "mk-MK",  # Macedonian
+    "ms-MY",  # Malay
+    "ml-IN",  # Malayalam
+    "mt-MT",  # Maltese
+    "zh-CN",  # Mandarin Chinese
+    "mi-NZ",  # Māori
+    "mr-IN",  # Marathi
+    "mn-MN",  # Mongolian
+    "ne-NP",  # Nepali
+    "nso-ZA",  # Northern Sotho
+    "no-NO",  # Norwegian
+    "oc-FR",  # Occitan
+    "or-IN",  # Odia
+    "ps-AF",  # Pashto
+    "fa-IR",  # Persian
+    "pl-PL",  # Polish
+    "pt-PT",  # Portuguese
+    "pa-IN",  # Punjabi
+    "ro-RO",  # Romanian
+    "ru-RU",  # Russian
+    "sr-RS",  # Serbian
+    "sn-ZW",  # Shona
+    "sd-PK",  # Sindhi
+    "sk-SK",  # Slovak
+    "sl-SI",  # Slovenian
+    "so-SO",  # Somali
+    "es-ES",  # Spanish
+    "sw-KE",  # Swahili
+    "sv-SE",  # Swedish
+    "ta-IN",  # Tamil
+    "tg-TJ",  # Tajik
+    "te-IN",  # Telugu
+    "th-TH",  # Thai
+    "tr-TR",  # Turkish
+    "uk-UA",  # Ukrainian
+    "umb-AO",  # Umbundu
+    "ur-PK",  # Urdu
+    "uz-UZ",  # Uzbek
+    "vi-VN",  # Vietnamese
+    "cy-GB",  # Welsh
+    "wo-SN",  # Wolof
+    "xh-ZA",  # Xhosa
+    "zu-ZA",  # Zulu
+]

--- a/homeassistant/components/elevenlabs/strings.json
+++ b/homeassistant/components/elevenlabs/strings.json
@@ -46,5 +46,17 @@
         }
       }
     }
+  },
+  "entity": {
+    "tts": {
+      "elevenlabs_tts": {
+        "name": "Text-to-Speech"
+      }
+    },
+    "stt": {
+      "elevenlabs_stt": {
+        "name": "Speech-to-Text"
+      }
+    }
   }
 }

--- a/homeassistant/components/elevenlabs/strings.json
+++ b/homeassistant/components/elevenlabs/strings.json
@@ -21,12 +21,14 @@
         "data": {
           "voice": "Voice",
           "model": "Model",
+          "stt_model": "Speech-to-Text Model",
           "stt_auto_language": "Auto-detect language",
           "configure_voice": "Configure advanced voice settings"
         },
         "data_description": {
           "voice": "Voice to use for text-to-speech.",
           "model": "ElevenLabs model to use. Please note that not all models support all languages equally well.",
+          "stt_model": "Speech-to-Text model to use.",
           "stt_auto_language": "Automatically detect the spoken language for speech-to-text.",
           "configure_voice": "Configure advanced voice settings. Find more information in the ElevenLabs documentation."
         }

--- a/homeassistant/components/elevenlabs/strings.json
+++ b/homeassistant/components/elevenlabs/strings.json
@@ -25,9 +25,9 @@
           "configure_voice": "Configure advanced voice settings"
         },
         "data_description": {
-          "voice": "Voice to use for the TTS.",
+          "voice": "Voice to use for text-to-speech.",
           "model": "ElevenLabs model to use. Please note that not all models support all languages equally well.",
-          "stt_auto_language": "Automatically detect the spoken language for STT.",
+          "stt_auto_language": "Automatically detect the spoken language for speech-to-text.",
           "configure_voice": "Configure advanced voice settings. Find more information in the ElevenLabs documentation."
         }
       },

--- a/homeassistant/components/elevenlabs/strings.json
+++ b/homeassistant/components/elevenlabs/strings.json
@@ -21,11 +21,13 @@
         "data": {
           "voice": "Voice",
           "model": "Model",
+          "stt_auto_language": "Auto-detect language",
           "configure_voice": "Configure advanced voice settings"
         },
         "data_description": {
           "voice": "Voice to use for the TTS.",
           "model": "ElevenLabs model to use. Please note that not all models support all languages equally well.",
+          "stt_auto_language": "Automatically detect the spoken language for STT.",
           "configure_voice": "Configure advanced voice settings. Find more information in the ElevenLabs documentation."
         }
       },

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import AsyncIterable
 from io import BytesIO
 import logging
@@ -159,17 +158,9 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
         else:
             file_format = "other"
 
-        async def read_stream_to_bytes(stream: AsyncIterable[bytes]) -> bytes:
-            audio = b""
-            async for chunk in stream:
-                audio += chunk
-            return audio
-
-        try:
-            audio = await asyncio.wait_for(read_stream_to_bytes(stream), timeout=60)
-        except TimeoutError:
-            _LOGGER.warning("Timeout while waiting for audio data")
-            return stt.SpeechResult(None, SpeechResultState.ERROR)
+        audio = b""
+        async for chunk in stream:
+            audio += chunk
 
         _LOGGER.debug("Finished reading audio stream, total size: %d bytes", len(audio))
         if not audio:
@@ -191,6 +182,8 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
                 file_format=file_format,
                 model_id="scribe_v1",
                 language_code=lang_code,
+                tag_audio_events=False,
+                num_speakers=1,
                 diarize=False,
             )
         except ApiError as exc:

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -1,0 +1,211 @@
+"""Support for the ElevenLabs speech-to-text service."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterable
+from io import BytesIO
+import logging
+
+from elevenlabs import AsyncElevenLabs
+from elevenlabs.core import ApiError
+from elevenlabs.types import Model
+
+from homeassistant.components import stt
+from homeassistant.components.stt import (
+    AudioBitRates,
+    AudioChannels,
+    AudioCodecs,
+    AudioFormats,
+    AudioSampleRates,
+    SpeechMetadata,
+    SpeechResultState,
+    SpeechToTextEntity,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import ElevenLabsConfigEntry
+from .const import (
+    CONF_STT_AUTO_LANGUAGE,
+    DEFAULT_STT_AUTO_LANGUAGE,
+    DOMAIN,
+    STT_LANGUAGES,
+)
+
+_LOGGER = logging.getLogger(__name__)
+PARALLEL_UPDATES = 10
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ElevenLabsConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up ElevenLabs tts platform via config entry."""
+    _LOGGER.debug("STT async_setup_entry called")
+    client = config_entry.runtime_data.client
+    auto_detect = config_entry.options.get(
+        CONF_STT_AUTO_LANGUAGE, DEFAULT_STT_AUTO_LANGUAGE
+    )
+
+    async_add_entities(
+        [
+            ElevenLabsSTTEntity(
+                client,
+                config_entry.runtime_data.model,
+                config_entry.entry_id,
+                config_entry.title,
+                auto_detect_language=auto_detect,
+            )
+        ]
+    )
+
+
+class ElevenLabsSTTEntity(SpeechToTextEntity):
+    """The ElevenLabs STT API entity."""
+
+    def __init__(
+        self,
+        client: AsyncElevenLabs,
+        model: Model,
+        entry_id: str,
+        title: str,
+        auto_detect_language: bool = False,
+    ) -> None:
+        """Init ElevenLabs TTS service."""
+        self._client = client
+        self._model = model
+        self._auto_detect_language = auto_detect_language
+
+        # Entity attributes
+        self._attr_unique_id = f"{entry_id}_STT"
+        self._attr_name = f"{title} STT"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry_id)},
+            manufacturer="ElevenLabs",
+            model=model.name,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    @property
+    def supported_languages(self) -> list[str]:
+        """Return a list of supported languages."""
+        return STT_LANGUAGES
+
+    @property
+    def supported_formats(self) -> list[AudioFormats]:
+        """Return a list of supported formats."""
+        return [AudioFormats.WAV, AudioFormats.OGG]
+
+    @property
+    def supported_codecs(self) -> list[AudioCodecs]:
+        """Return a list of supported codecs."""
+        return [AudioCodecs.PCM, AudioCodecs.OPUS]
+
+    @property
+    def supported_bit_rates(self) -> list[AudioBitRates]:
+        """Return a list of supported bit rates."""
+        return [AudioBitRates.BITRATE_16]
+
+    @property
+    def supported_sample_rates(self) -> list[AudioSampleRates]:
+        """Return a list of supported sample rates."""
+        return [AudioSampleRates.SAMPLERATE_16000]
+
+    @property
+    def supported_channels(self) -> list[AudioChannels]:
+        """Return a list of supported channels."""
+        return [
+            AudioChannels.CHANNEL_MONO,
+            AudioChannels.CHANNEL_STEREO,
+        ]
+
+    async def async_process_audio_stream(
+        self, metadata: SpeechMetadata, stream: AsyncIterable[bytes]
+    ) -> stt.SpeechResult:
+        """Process an audio stream to STT service."""
+        _LOGGER.debug(
+            "Processing audio stream for STT: language=%s, format=%s, codec=%s, sample_rate=%s, channels=%s, bit_rate=%s",
+            metadata.language,
+            metadata.format,
+            metadata.codec,
+            metadata.sample_rate,
+            metadata.channel,
+            metadata.bit_rate,
+        )
+
+        if self._auto_detect_language:
+            lang_code = None
+        else:
+            language = metadata.language
+            if language.lower() not in [lang.lower() for lang in STT_LANGUAGES]:
+                _LOGGER.warning("Unsupported language: %s", language)
+                return stt.SpeechResult(None, SpeechResultState.ERROR)
+            lang_code = language.split("-")[0]
+
+        raw_pcm_compatible = (
+            metadata.codec == AudioCodecs.PCM
+            and metadata.sample_rate == AudioSampleRates.SAMPLERATE_16000
+            and metadata.channel == AudioChannels.CHANNEL_MONO
+            and metadata.bit_rate == AudioBitRates.BITRATE_16
+        )
+        if raw_pcm_compatible:
+            file_format = "pcm_s16le_16"
+        elif metadata.codec == AudioCodecs.PCM:
+            _LOGGER.warning("PCM input does not meet expected raw format requirements")
+            return stt.SpeechResult(None, SpeechResultState.ERROR)
+        else:
+            file_format = "other"
+
+        async def read_stream_to_bytes(stream: AsyncIterable[bytes]) -> bytes:
+            audio = b""
+            async for chunk in stream:
+                audio += chunk
+            return audio
+
+        try:
+            audio = await asyncio.wait_for(read_stream_to_bytes(stream), timeout=60)
+        except TimeoutError:
+            _LOGGER.warning("Timeout while waiting for audio data")
+            return stt.SpeechResult(None, SpeechResultState.ERROR)
+
+        _LOGGER.debug("Finished reading audio stream, total size: %d bytes", len(audio))
+        if not audio:
+            _LOGGER.warning("No audio received in stream")
+            return stt.SpeechResult(None, SpeechResultState.ERROR)
+
+        lang_display = lang_code if lang_code else "auto-detected"
+
+        _LOGGER.debug(
+            "Transcribing audio (%s), format: %s, size: %d bytes",
+            lang_display,
+            file_format,
+            len(audio),
+        )
+
+        try:
+            response = await self._client.speech_to_text.convert(
+                file=BytesIO(audio),
+                file_format=file_format,
+                model_id="scribe_v1",
+                language_code=lang_code,
+                diarize=False,
+            )
+        except ApiError as exc:
+            _LOGGER.error("Error during processing of STT request: %s", exc)
+            return stt.SpeechResult(None, SpeechResultState.ERROR)
+
+        text = response.text or ""
+        detected_lang_code = response.language_code or "?"
+        detected_lang_prob = response.language_probability or "?"
+
+        _LOGGER.debug(
+            "Transcribed text is in language %s (probability %s): %s",
+            detected_lang_code,
+            detected_lang_prob,
+            text,
+        )
+
+        return stt.SpeechResult(text, SpeechResultState.SUCCESS)

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -43,7 +43,6 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up ElevenLabs tts platform via config entry."""
-    _LOGGER.debug("STT async_setup_entry called")
     client = config_entry.runtime_data.client
     auto_detect = config_entry.options.get(
         CONF_STT_AUTO_LANGUAGE, DEFAULT_STT_AUTO_LANGUAGE

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -79,7 +79,7 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
         self._auto_detect_language = auto_detect_language
 
         # Entity attributes
-        self._attr_unique_id = f"{entry_id}_STT"
+        self._attr_unique_id = entry_id
         self._attr_name = f"{title} STT"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry_id)},

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -54,6 +54,7 @@ async def async_setup_entry(
             ElevenLabsSTTEntity(
                 client,
                 config_entry.runtime_data.model,
+                config_entry.runtime_data.stt_model,
                 config_entry.entry_id,
                 auto_detect_language=auto_detect,
             )
@@ -71,12 +72,14 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
         self,
         client: AsyncElevenLabs,
         model: Model,
+        stt_model: str,
         entry_id: str,
         auto_detect_language: bool = False,
     ) -> None:
         """Init ElevenLabs TTS service."""
         self._client = client
         self._auto_detect_language = auto_detect_language
+        self._stt_model = stt_model
 
         # Entity attributes
         self._attr_unique_id = entry_id
@@ -126,7 +129,8 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
     ) -> stt.SpeechResult:
         """Process an audio stream to STT service."""
         _LOGGER.debug(
-            "Processing audio stream for STT: language=%s, format=%s, codec=%s, sample_rate=%s, channels=%s, bit_rate=%s",
+            "Processing audio stream for STT: model=%s, language=%s, format=%s, codec=%s, sample_rate=%s, channels=%s, bit_rate=%s",
+            self._stt_model,
             metadata.language,
             metadata.format,
             metadata.codec,
@@ -180,7 +184,7 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
             response = await self._client.speech_to_text.convert(
                 file=BytesIO(audio),
                 file_format=file_format,
-                model_id="scribe_v1",
+                model_id=self._stt_model,
                 language_code=lang_code,
                 tag_audio_events=False,
                 num_speakers=1,

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -76,7 +76,6 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
     ) -> None:
         """Init ElevenLabs TTS service."""
         self._client = client
-        self._model = model
         self._auto_detect_language = auto_detect_language
 
         # Entity attributes

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -56,7 +56,6 @@ async def async_setup_entry(
                 client,
                 config_entry.runtime_data.model,
                 config_entry.entry_id,
-                config_entry.title,
                 auto_detect_language=auto_detect,
             )
         ]
@@ -66,12 +65,14 @@ async def async_setup_entry(
 class ElevenLabsSTTEntity(SpeechToTextEntity):
     """The ElevenLabs STT API entity."""
 
+    _attr_has_entity_name = True
+    _attr_translation_key = "elevenlabs_stt"
+
     def __init__(
         self,
         client: AsyncElevenLabs,
         model: Model,
         entry_id: str,
-        title: str,
         auto_detect_language: bool = False,
     ) -> None:
         """Init ElevenLabs TTS service."""
@@ -80,11 +81,11 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
 
         # Entity attributes
         self._attr_unique_id = entry_id
-        self._attr_name = f"{title} STT"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry_id)},
             manufacturer="ElevenLabs",
             model=model.name,
+            name="ElevenLabs",
             entry_type=DeviceEntryType.SERVICE,
         )
 

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -42,7 +42,7 @@ async def async_setup_entry(
     config_entry: ElevenLabsConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up ElevenLabs tts platform via config entry."""
+    """Set up ElevenLabs stt platform via config entry."""
     client = config_entry.runtime_data.client
     auto_detect = config_entry.options.get(
         CONF_STT_AUTO_LANGUAGE, DEFAULT_STT_AUTO_LANGUAGE

--- a/homeassistant/components/elevenlabs/tts.py
+++ b/homeassistant/components/elevenlabs/tts.py
@@ -71,7 +71,6 @@ async def async_setup_entry(
                 voices,
                 default_voice_id,
                 config_entry.entry_id,
-                config_entry.title,
                 voice_settings,
             )
         ]
@@ -83,6 +82,8 @@ class ElevenLabsTTSEntity(TextToSpeechEntity):
 
     _attr_supported_options = [ATTR_VOICE, ATTR_MODEL]
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_translation_key = "elevenlabs_tts"
 
     def __init__(
         self,
@@ -91,7 +92,6 @@ class ElevenLabsTTSEntity(TextToSpeechEntity):
         voices: list[ElevenLabsVoice],
         default_voice_id: str,
         entry_id: str,
-        title: str,
         voice_settings: VoiceSettings,
     ) -> None:
         """Init ElevenLabs TTS service."""
@@ -112,11 +112,11 @@ class ElevenLabsTTSEntity(TextToSpeechEntity):
 
         # Entity attributes
         self._attr_unique_id = entry_id
-        self._attr_name = f"{title} TTS"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry_id)},
             manufacturer="ElevenLabs",
             model=model.name,
+            name="ElevenLabs",
             entry_type=DeviceEntryType.SERVICE,
         )
         self._attr_supported_languages = [

--- a/homeassistant/components/elevenlabs/tts.py
+++ b/homeassistant/components/elevenlabs/tts.py
@@ -111,8 +111,8 @@ class ElevenLabsTTSEntity(TextToSpeechEntity):
         self._voice_settings = voice_settings
 
         # Entity attributes
-        self._attr_unique_id = entry_id
-        self._attr_name = title
+        self._attr_unique_id = entry_id + "_TTS"
+        self._attr_name = title + " TTS"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry_id)},
             manufacturer="ElevenLabs",

--- a/homeassistant/components/elevenlabs/tts.py
+++ b/homeassistant/components/elevenlabs/tts.py
@@ -111,8 +111,8 @@ class ElevenLabsTTSEntity(TextToSpeechEntity):
         self._voice_settings = voice_settings
 
         # Entity attributes
-        self._attr_unique_id = entry_id + "_TTS"
-        self._attr_name = title + " TTS"
+        self._attr_unique_id = entry_id
+        self._attr_name = f"{title} TTS"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry_id)},
             manufacturer="ElevenLabs",

--- a/tests/components/elevenlabs/conftest.py
+++ b/tests/components/elevenlabs/conftest.py
@@ -1,6 +1,7 @@
 """Common fixtures for the ElevenLabs text-to-speech tests."""
 
 from collections.abc import Generator
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from elevenlabs.core import ApiError
@@ -8,7 +9,11 @@ from elevenlabs.types import GetVoicesResponse
 from httpx import ConnectError
 import pytest
 
-from homeassistant.components.elevenlabs.const import CONF_MODEL, CONF_VOICE
+from homeassistant.components.elevenlabs.const import (
+    CONF_MODEL,
+    CONF_STT_AUTO_LANGUAGE,
+    CONF_VOICE,
+)
 from homeassistant.const import CONF_API_KEY
 
 from .const import MOCK_MODELS, MOCK_VOICES
@@ -144,7 +149,11 @@ def mock_entry() -> MockConfigEntry:
         data={
             CONF_API_KEY: "api_key",
         },
-        options={CONF_MODEL: "model1", CONF_VOICE: "voice1"},
+        options={
+            CONF_MODEL: "model1",
+            CONF_VOICE: "voice1",
+            CONF_STT_AUTO_LANGUAGE: False,
+        },
     )
     entry.models = {
         "model1": "model1",
@@ -152,3 +161,15 @@ def mock_entry() -> MockConfigEntry:
 
     entry.voices = {"voice1": "voice1"}
     return entry
+
+
+@pytest.fixture(name="config_data")
+def config_data_fixture() -> dict[str, Any]:
+    """Return config data."""
+    return {}
+
+
+@pytest.fixture(name="config_options")
+def config_options_fixture() -> dict[str, Any]:
+    """Return config options."""
+    return {}

--- a/tests/components/elevenlabs/conftest.py
+++ b/tests/components/elevenlabs/conftest.py
@@ -12,6 +12,7 @@ import pytest
 from homeassistant.components.elevenlabs.const import (
     CONF_MODEL,
     CONF_STT_AUTO_LANGUAGE,
+    CONF_STT_MODEL,
     CONF_VOICE,
 )
 from homeassistant.const import CONF_API_KEY
@@ -152,6 +153,7 @@ def mock_entry() -> MockConfigEntry:
         options={
             CONF_MODEL: "model1",
             CONF_VOICE: "voice1",
+            CONF_STT_MODEL: "stt_model1",
             CONF_STT_AUTO_LANGUAGE: False,
         },
     )
@@ -160,6 +162,7 @@ def mock_entry() -> MockConfigEntry:
     }
 
     entry.voices = {"voice1": "voice1"}
+    entry.stt_models = {"stt_model1": "stt_model1"}
     return entry
 
 

--- a/tests/components/elevenlabs/const.py
+++ b/tests/components/elevenlabs/const.py
@@ -2,7 +2,7 @@
 
 from elevenlabs.types import LanguageResponse, Model, Voice
 
-from homeassistant.components.elevenlabs.const import DEFAULT_MODEL
+from homeassistant.components.elevenlabs.const import DEFAULT_TTS_MODEL
 
 MOCK_VOICES = [
     Voice(
@@ -39,8 +39,8 @@ MOCK_MODELS = [
         ],
     ),
     Model(
-        model_id=DEFAULT_MODEL,
-        name=DEFAULT_MODEL,
+        model_id=DEFAULT_TTS_MODEL,
+        name=DEFAULT_TTS_MODEL,
         can_do_text_to_speech=True,
         languages=[
             LanguageResponse(language_id="en", name="English"),

--- a/tests/components/elevenlabs/test_config_flow.py
+++ b/tests/components/elevenlabs/test_config_flow.py
@@ -10,13 +10,15 @@ from homeassistant.components.elevenlabs.const import (
     CONF_SIMILARITY,
     CONF_STABILITY,
     CONF_STT_AUTO_LANGUAGE,
+    CONF_STT_MODEL,
     CONF_STYLE,
     CONF_USE_SPEAKER_BOOST,
     CONF_VOICE,
-    DEFAULT_MODEL,
     DEFAULT_SIMILARITY,
     DEFAULT_STABILITY,
+    DEFAULT_STT_MODEL,
     DEFAULT_STYLE,
+    DEFAULT_TTS_MODEL,
     DEFAULT_USE_SPEAKER_BOOST,
     DOMAIN,
 )
@@ -52,8 +54,9 @@ async def test_user_step(
         "api_key": "api_key",
     }
     assert result["options"] == {
-        CONF_MODEL: DEFAULT_MODEL,
+        CONF_MODEL: DEFAULT_TTS_MODEL,
         CONF_VOICE: "voice1",
+        CONF_STT_MODEL: DEFAULT_STT_MODEL,
         CONF_STT_AUTO_LANGUAGE: False,
     }
 
@@ -100,8 +103,9 @@ async def test_invalid_api_key(
         "api_key": "api_key",
     }
     assert result["options"] == {
-        CONF_MODEL: DEFAULT_MODEL,
+        CONF_MODEL: DEFAULT_TTS_MODEL,
         CONF_VOICE: "voice1",
+        CONF_STT_MODEL: DEFAULT_STT_MODEL,
         CONF_STT_AUTO_LANGUAGE: False,
     }
 
@@ -148,8 +152,9 @@ async def test_voices_error(
         "api_key": "api_key",
     }
     assert result["options"] == {
-        CONF_MODEL: DEFAULT_MODEL,
+        CONF_MODEL: DEFAULT_TTS_MODEL,
         CONF_VOICE: "voice1",
+        CONF_STT_MODEL: DEFAULT_STT_MODEL,
         CONF_STT_AUTO_LANGUAGE: False,
     }
 
@@ -196,8 +201,9 @@ async def test_models_error(
         "api_key": "api_key",
     }
     assert result["options"] == {
-        CONF_MODEL: DEFAULT_MODEL,
+        CONF_MODEL: DEFAULT_TTS_MODEL,
         CONF_VOICE: "voice1",
+        CONF_STT_MODEL: DEFAULT_STT_MODEL,
         CONF_STT_AUTO_LANGUAGE: False,
     }
 
@@ -225,6 +231,7 @@ async def test_options_flow_init(
         user_input={
             CONF_MODEL: "model1",
             CONF_VOICE: "voice1",
+            CONF_STT_MODEL: "scribe_v1_experimental",
             CONF_STT_AUTO_LANGUAGE: True,
         },
     )
@@ -233,6 +240,7 @@ async def test_options_flow_init(
     assert mock_entry.options == {
         CONF_MODEL: "model1",
         CONF_VOICE: "voice1",
+        CONF_STT_MODEL: "scribe_v1_experimental",
         CONF_STT_AUTO_LANGUAGE: True,
     }
 
@@ -259,6 +267,7 @@ async def test_options_flow_voice_settings_default(
         user_input={
             CONF_MODEL: "model1",
             CONF_VOICE: "voice1",
+            CONF_STT_MODEL: "scribe_v1_experimental",
             CONF_STT_AUTO_LANGUAGE: False,
             CONF_CONFIGURE_VOICE: True,
         },
@@ -275,6 +284,7 @@ async def test_options_flow_voice_settings_default(
     assert mock_entry.options == {
         CONF_MODEL: "model1",
         CONF_VOICE: "voice1",
+        CONF_STT_MODEL: "scribe_v1_experimental",
         CONF_STT_AUTO_LANGUAGE: False,
         CONF_SIMILARITY: DEFAULT_SIMILARITY,
         CONF_STABILITY: DEFAULT_STABILITY,

--- a/tests/components/elevenlabs/test_config_flow.py
+++ b/tests/components/elevenlabs/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.elevenlabs.const import (
     CONF_MODEL,
     CONF_SIMILARITY,
     CONF_STABILITY,
+    CONF_STT_AUTO_LANGUAGE,
     CONF_STYLE,
     CONF_USE_SPEAKER_BOOST,
     CONF_VOICE,
@@ -50,7 +51,11 @@ async def test_user_step(
     assert result["data"] == {
         "api_key": "api_key",
     }
-    assert result["options"] == {CONF_MODEL: DEFAULT_MODEL, CONF_VOICE: "voice1"}
+    assert result["options"] == {
+        CONF_MODEL: DEFAULT_MODEL,
+        CONF_VOICE: "voice1",
+        CONF_STT_AUTO_LANGUAGE: False,
+    }
 
     mock_setup_entry.assert_called_once()
 
@@ -94,7 +99,11 @@ async def test_invalid_api_key(
     assert result["data"] == {
         "api_key": "api_key",
     }
-    assert result["options"] == {CONF_MODEL: DEFAULT_MODEL, CONF_VOICE: "voice1"}
+    assert result["options"] == {
+        CONF_MODEL: DEFAULT_MODEL,
+        CONF_VOICE: "voice1",
+        CONF_STT_AUTO_LANGUAGE: False,
+    }
 
     mock_setup_entry.assert_called_once()
 
@@ -138,7 +147,11 @@ async def test_voices_error(
     assert result["data"] == {
         "api_key": "api_key",
     }
-    assert result["options"] == {CONF_MODEL: DEFAULT_MODEL, CONF_VOICE: "voice1"}
+    assert result["options"] == {
+        CONF_MODEL: DEFAULT_MODEL,
+        CONF_VOICE: "voice1",
+        CONF_STT_AUTO_LANGUAGE: False,
+    }
 
     mock_setup_entry.assert_called_once()
 
@@ -182,7 +195,11 @@ async def test_models_error(
     assert result["data"] == {
         "api_key": "api_key",
     }
-    assert result["options"] == {CONF_MODEL: DEFAULT_MODEL, CONF_VOICE: "voice1"}
+    assert result["options"] == {
+        CONF_MODEL: DEFAULT_MODEL,
+        CONF_VOICE: "voice1",
+        CONF_STT_AUTO_LANGUAGE: False,
+    }
 
     mock_setup_entry.assert_called_once()
 
@@ -205,13 +222,18 @@ async def test_options_flow_init(
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_MODEL: "model1", CONF_VOICE: "voice1"},
+        user_input={
+            CONF_MODEL: "model1",
+            CONF_VOICE: "voice1",
+            CONF_STT_AUTO_LANGUAGE: True,
+        },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_entry.options == {
         CONF_MODEL: "model1",
         CONF_VOICE: "voice1",
+        CONF_STT_AUTO_LANGUAGE: True,
     }
 
     mock_setup_entry.assert_called_once()
@@ -237,6 +259,7 @@ async def test_options_flow_voice_settings_default(
         user_input={
             CONF_MODEL: "model1",
             CONF_VOICE: "voice1",
+            CONF_STT_AUTO_LANGUAGE: False,
             CONF_CONFIGURE_VOICE: True,
         },
     )
@@ -252,6 +275,7 @@ async def test_options_flow_voice_settings_default(
     assert mock_entry.options == {
         CONF_MODEL: "model1",
         CONF_VOICE: "voice1",
+        CONF_STT_AUTO_LANGUAGE: False,
         CONF_SIMILARITY: DEFAULT_SIMILARITY,
         CONF_STABILITY: DEFAULT_STABILITY,
         CONF_STYLE: DEFAULT_STYLE,

--- a/tests/components/elevenlabs/test_stt.py
+++ b/tests/components/elevenlabs/test_stt.py
@@ -11,6 +11,7 @@ from homeassistant.components import stt
 from homeassistant.components.elevenlabs.const import (
     CONF_MODEL,
     CONF_STT_AUTO_LANGUAGE,
+    CONF_STT_MODEL,
     CONF_VOICE,
     DOMAIN,
 )
@@ -158,6 +159,8 @@ async def mock_config_entry_setup(
     default_config_options = {
         CONF_VOICE: "voice1",
         CONF_MODEL: "model1",
+        CONF_STT_MODEL: "stt_model1",
+        CONF_STT_AUTO_LANGUAGE: False,
     }
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/elevenlabs/test_stt.py
+++ b/tests/components/elevenlabs/test_stt.py
@@ -1,0 +1,309 @@
+"""Tests for the ElevenLabs STT integration."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from elevenlabs.core import ApiError
+from elevenlabs.types import GetVoicesResponse
+import pytest
+
+from homeassistant.components import stt
+from homeassistant.components.elevenlabs.const import (
+    CONF_MODEL,
+    CONF_STT_AUTO_LANGUAGE,
+    CONF_VOICE,
+    DOMAIN,
+)
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+
+from .const import MOCK_MODELS, MOCK_VOICES
+
+from tests.common import MockConfigEntry
+
+# === Fixtures ===
+
+
+@pytest.fixture(name="config_options_auto_language")
+def config_options_auto_language() -> dict:
+    """Override default config options with auto language enabled."""
+    return {
+        CONF_VOICE: "voice1",
+        CONF_MODEL: "model1",
+        CONF_STT_AUTO_LANGUAGE: True,
+    }
+
+
+@pytest.fixture(name="setup")
+async def setup_fixture(
+    hass: HomeAssistant,
+    config_data: dict[str, Any],
+    config_options: dict[str, Any],
+    config_options_auto_language: dict[str, Any],
+    request: pytest.FixtureRequest,
+    mock_async_client: AsyncMock,
+) -> AsyncMock:
+    """Set up the STT integration with mocked ElevenLabs client."""
+
+    param = getattr(request, "param", "mock_config_entry_setup")
+    if param == "mock_config_entry_setup":
+        await mock_config_entry_setup(hass, config_data, config_options)
+    elif param == "mock_config_entry_setup_auto_language":
+        await mock_config_entry_setup(hass, config_data, config_options_auto_language)
+    else:
+        raise RuntimeError("Invalid setup fixture")
+
+    await hass.async_block_till_done()
+
+    return mock_async_client
+
+
+@pytest.fixture
+def default_metadata() -> stt.SpeechMetadata:
+    """Return default metadata for valid PCM WAV input."""
+    return stt.SpeechMetadata(
+        language="en-US",
+        format=stt.AudioFormats.WAV,
+        codec=stt.AudioCodecs.PCM,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+    )
+
+
+# === Stream Fixtures ===
+
+
+@pytest.fixture
+def two_chunk_stream():
+    """Return a stream that yields two chunks of audio."""
+
+    async def _stream():
+        yield b"chunk1"
+        yield b"chunk2"
+
+    return _stream
+
+
+@pytest.fixture
+def simple_stream():
+    """Return a basic stream yielding one audio chunk."""
+
+    async def _stream():
+        yield b"data"
+
+    return _stream
+
+
+@pytest.fixture
+def empty_stream():
+    """Return an empty stream."""
+
+    async def _stream():
+        return
+        yield  # This makes it an async generator
+
+    return _stream
+
+
+# === Metadata Fixtures for Edge Cases ===
+
+
+@pytest.fixture
+def unsupported_language_metadata() -> stt.SpeechMetadata:
+    """Return metadata with unsupported language code."""
+    return stt.SpeechMetadata(
+        language="xx-XX",
+        format=stt.AudioFormats.WAV,
+        codec=stt.AudioCodecs.PCM,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+    )
+
+
+@pytest.fixture
+def incompatible_pcm_metadata() -> stt.SpeechMetadata:
+    """Return metadata that is PCM but not raw-compatible (e.g., stereo)."""
+    return stt.SpeechMetadata(
+        language="en-US",
+        format=stt.AudioFormats.WAV,
+        codec=stt.AudioCodecs.PCM,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_STEREO,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+    )
+
+
+@pytest.fixture
+def opus_metadata() -> stt.SpeechMetadata:
+    """Return valid metadata using OPUS codec."""
+    return stt.SpeechMetadata(
+        language="en-US",
+        format=stt.AudioFormats.OGG,
+        codec=stt.AudioCodecs.OPUS,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+    )
+
+
+async def mock_config_entry_setup(
+    hass: HomeAssistant, config_data: dict[str, Any], config_options: dict[str, Any]
+) -> None:
+    """Mock config entry setup."""
+    default_config_data = {
+        CONF_API_KEY: "api_key",
+    }
+    default_config_options = {
+        CONF_VOICE: "voice1",
+        CONF_MODEL: "model1",
+    }
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=default_config_data | config_data,
+        options=default_config_options | config_options,
+    )
+    config_entry.add_to_hass(hass)
+    client_mock = AsyncMock()
+    client_mock.voices.get_all.return_value = GetVoicesResponse(voices=MOCK_VOICES)
+    client_mock.models.list.return_value = MOCK_MODELS
+    stt_mock = AsyncMock()
+    stt_mock.convert.return_value = AsyncMock(
+        text="hello world", language_code="en", language_probability=0.95
+    )
+    client_mock.speech_to_text = stt_mock
+
+    with patch(
+        "homeassistant.components.elevenlabs.AsyncElevenLabs", return_value=client_mock
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+
+# === SUCCESS TESTS ===
+
+
+async def test_stt_transcription_success(
+    hass: HomeAssistant,
+    setup: AsyncMock,
+    default_metadata: stt.SpeechMetadata,
+    two_chunk_stream,
+) -> None:
+    """Test successful transcription with valid PCM/WAV input."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    result = await entity.async_process_audio_stream(
+        default_metadata, two_chunk_stream()
+    )
+    assert result.result == stt.SpeechResultState.SUCCESS
+    assert result.text == "hello world"
+    entity._client.speech_to_text.convert.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "setup", ["mock_config_entry_setup_auto_language"], indirect=True
+)
+async def test_stt_transcription_success_auto_language(
+    hass: HomeAssistant,
+    setup: AsyncMock,
+    simple_stream,
+) -> None:
+    """Test successful transcription when auto language detection is enabled."""
+    metadata = stt.SpeechMetadata(
+        language="na",
+        format=stt.AudioFormats.WAV,
+        codec=stt.AudioCodecs.PCM,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+    )
+    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    result = await entity.async_process_audio_stream(metadata, simple_stream())
+    assert result.result == stt.SpeechResultState.SUCCESS
+    assert result.text == "hello world"
+    entity._client.speech_to_text.convert.assert_called_once()
+
+
+# === ERROR CASES (PARAMETRIZED) ===
+
+
+@pytest.mark.parametrize("config_options", ["config_options_disabled"], indirect=True)
+@pytest.mark.parametrize(
+    ("metadata_fixture", "stream_fixture"),
+    [
+        ("unsupported_language_metadata", "simple_stream"),
+        ("incompatible_pcm_metadata", "simple_stream"),
+        ("opus_metadata", "empty_stream"),
+    ],
+)
+async def test_stt_edge_cases(
+    hass: HomeAssistant,
+    setup: AsyncMock,
+    request: pytest.FixtureRequest,
+    metadata_fixture: str,
+    stream_fixture: str,
+) -> None:
+    """Test various error scenarios like unsupported language or bad format."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    metadata = request.getfixturevalue(metadata_fixture)
+    stream = request.getfixturevalue(stream_fixture)
+    assert not entity._auto_detect_language
+    result = await entity.async_process_audio_stream(metadata, stream())
+    assert result.result == stt.SpeechResultState.ERROR
+    assert result.text is None
+
+
+async def test_stt_timeout_during_stream(
+    hass: HomeAssistant,
+    setup: AsyncMock,
+    default_metadata: stt.SpeechMetadata,
+    simple_stream,
+) -> None:
+    """Test timeout exception raised when stream is too slow."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+
+    async def fake_wait_for(coro, timeout):
+        try:
+            await coro  # ensure coroutine is awaited to prevent warning
+        finally:
+            raise TimeoutError
+
+    with patch("asyncio.wait_for", side_effect=fake_wait_for):
+        result = await entity.async_process_audio_stream(
+            default_metadata, simple_stream()
+        )
+    assert result.result == stt.SpeechResultState.ERROR
+    assert result.text is None
+
+
+async def test_stt_convert_api_error(
+    hass: HomeAssistant,
+    setup: AsyncMock,
+    default_metadata: stt.SpeechMetadata,
+    simple_stream,
+) -> None:
+    """Test that API errors during convert are handled properly."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    entity._client.speech_to_text.convert.side_effect = ApiError()
+    result = await entity.async_process_audio_stream(default_metadata, simple_stream())
+    assert result.result == stt.SpeechResultState.ERROR
+    assert result.text is None
+
+
+# === SUPPORTED PROPERTIES ===
+
+
+async def test_supported_properties(
+    hass: HomeAssistant,
+    setup: AsyncMock,
+) -> None:
+    """Test the advertised capabilities of the ElevenLabs STT entity."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    assert set(entity.supported_formats) == {stt.AudioFormats.WAV, stt.AudioFormats.OGG}
+    assert set(entity.supported_codecs) == {stt.AudioCodecs.PCM, stt.AudioCodecs.OPUS}
+    assert set(entity.supported_bit_rates) == {stt.AudioBitRates.BITRATE_16}
+    assert set(entity.supported_sample_rates) == {stt.AudioSampleRates.SAMPLERATE_16000}
+    assert set(entity.supported_channels) == {
+        stt.AudioChannels.CHANNEL_MONO,
+        stt.AudioChannels.CHANNEL_STEREO,
+    }
+    assert "en-US" in entity.supported_languages

--- a/tests/components/elevenlabs/test_stt.py
+++ b/tests/components/elevenlabs/test_stt.py
@@ -190,7 +190,7 @@ async def test_stt_transcription_success(
     two_chunk_stream,
 ) -> None:
     """Test successful transcription with valid PCM/WAV input."""
-    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    entity = hass.data[stt.DOMAIN].get_entity("stt.elevenlabs_speech_to_text")
     result = await entity.async_process_audio_stream(
         default_metadata, two_chunk_stream()
     )
@@ -216,7 +216,7 @@ async def test_stt_transcription_success_auto_language(
         channel=stt.AudioChannels.CHANNEL_MONO,
         bit_rate=stt.AudioBitRates.BITRATE_16,
     )
-    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    entity = hass.data[stt.DOMAIN].get_entity("stt.elevenlabs_speech_to_text")
     result = await entity.async_process_audio_stream(metadata, simple_stream())
     assert result.result == stt.SpeechResultState.SUCCESS
     assert result.text == "hello world"
@@ -243,7 +243,7 @@ async def test_stt_edge_cases(
     stream_fixture: str,
 ) -> None:
     """Test various error scenarios like unsupported language or bad format."""
-    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    entity = hass.data[stt.DOMAIN].get_entity("stt.elevenlabs_speech_to_text")
     metadata = request.getfixturevalue(metadata_fixture)
     stream = request.getfixturevalue(stream_fixture)
     assert not entity._auto_detect_language
@@ -259,7 +259,7 @@ async def test_stt_timeout_during_stream(
     simple_stream,
 ) -> None:
     """Test timeout exception raised when stream is too slow."""
-    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    entity = hass.data[stt.DOMAIN].get_entity("stt.elevenlabs_speech_to_text")
 
     async def fake_wait_for(coro, timeout):
         try:
@@ -282,7 +282,7 @@ async def test_stt_convert_api_error(
     simple_stream,
 ) -> None:
     """Test that API errors during convert are handled properly."""
-    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    entity = hass.data[stt.DOMAIN].get_entity("stt.elevenlabs_speech_to_text")
     entity._client.speech_to_text.convert.side_effect = ApiError()
     result = await entity.async_process_audio_stream(default_metadata, simple_stream())
     assert result.result == stt.SpeechResultState.ERROR
@@ -297,7 +297,7 @@ async def test_supported_properties(
     setup: AsyncMock,
 ) -> None:
     """Test the advertised capabilities of the ElevenLabs STT entity."""
-    entity = hass.data[stt.DOMAIN].get_entity("stt.mock_title_stt")
+    entity = hass.data[stt.DOMAIN].get_entity("stt.elevenlabs_speech_to_text")
     assert set(entity.supported_formats) == {stt.AudioFormats.WAV, stt.AudioFormats.OGG}
     assert set(entity.supported_codecs) == {stt.AudioCodecs.PCM, stt.AudioCodecs.OPUS}
     assert set(entity.supported_bit_rates) == {stt.AudioBitRates.BITRATE_16}

--- a/tests/components/elevenlabs/test_stt.py
+++ b/tests/components/elevenlabs/test_stt.py
@@ -252,29 +252,6 @@ async def test_stt_edge_cases(
     assert result.text is None
 
 
-async def test_stt_timeout_during_stream(
-    hass: HomeAssistant,
-    setup: AsyncMock,
-    default_metadata: stt.SpeechMetadata,
-    simple_stream,
-) -> None:
-    """Test timeout exception raised when stream is too slow."""
-    entity = hass.data[stt.DOMAIN].get_entity("stt.elevenlabs_speech_to_text")
-
-    async def fake_wait_for(coro, timeout):
-        try:
-            await coro  # ensure coroutine is awaited to prevent warning
-        finally:
-            raise TimeoutError
-
-    with patch("asyncio.wait_for", side_effect=fake_wait_for):
-        result = await entity.async_process_audio_stream(
-            default_metadata, simple_stream()
-        )
-    assert result.result == stt.SpeechResultState.ERROR
-    assert result.text is None
-
-
 async def test_stt_convert_api_error(
     hass: HomeAssistant,
     setup: AsyncMock,

--- a/tests/components/elevenlabs/test_tts.py
+++ b/tests/components/elevenlabs/test_tts.py
@@ -161,7 +161,7 @@ async def mock_config_entry_setup(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title_tts",
+                ATTR_ENTITY_ID: "tts.elevenlabs_text_to_speech",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {},
@@ -171,7 +171,7 @@ async def mock_config_entry_setup(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title_tts",
+                ATTR_ENTITY_ID: "tts.elevenlabs_text_to_speech",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {tts.ATTR_VOICE: "voice2"},
@@ -181,7 +181,7 @@ async def mock_config_entry_setup(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title_tts",
+                ATTR_ENTITY_ID: "tts.elevenlabs_text_to_speech",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {ATTR_MODEL: "model2"},
@@ -191,7 +191,7 @@ async def mock_config_entry_setup(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title_tts",
+                ATTR_ENTITY_ID: "tts.elevenlabs_text_to_speech",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {tts.ATTR_VOICE: "voice2", ATTR_MODEL: "model2"},
@@ -251,7 +251,7 @@ async def test_tts_service_speak(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title_tts",
+                ATTR_ENTITY_ID: "tts.elevenlabs_text_to_speech",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_LANGUAGE: "de",
@@ -262,7 +262,7 @@ async def test_tts_service_speak(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title_tts",
+                ATTR_ENTITY_ID: "tts.elevenlabs_text_to_speech",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_LANGUAGE: "es",
@@ -314,7 +314,7 @@ async def test_tts_service_speak_lang_config(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title_tts",
+                ATTR_ENTITY_ID: "tts.elevenlabs_text_to_speech",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {tts.ATTR_VOICE: "voice1"},
@@ -376,7 +376,7 @@ async def test_tts_service_speak_error(
             "mock_config_entry_setup_voice",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title_tts",
+                ATTR_ENTITY_ID: "tts.elevenlabs_text_to_speech",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {tts.ATTR_VOICE: "voice2"},
@@ -434,7 +434,7 @@ async def test_tts_service_speak_voice_settings(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title_tts",
+                ATTR_ENTITY_ID: "tts.elevenlabs_text_to_speech",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {},

--- a/tests/components/elevenlabs/test_tts.py
+++ b/tests/components/elevenlabs/test_tts.py
@@ -17,6 +17,8 @@ from homeassistant.components.elevenlabs.const import (
     CONF_MODEL,
     CONF_SIMILARITY,
     CONF_STABILITY,
+    CONF_STT_AUTO_LANGUAGE,
+    CONF_STT_MODEL,
     CONF_STYLE,
     CONF_USE_SPEAKER_BOOST,
     CONF_VOICE,
@@ -128,6 +130,8 @@ async def mock_config_entry_setup(
     default_config_options = {
         CONF_VOICE: "voice1",
         CONF_MODEL: "model1",
+        CONF_STT_MODEL: "stt_model1",
+        CONF_STT_AUTO_LANGUAGE: False,
     }
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/elevenlabs/test_tts.py
+++ b/tests/components/elevenlabs/test_tts.py
@@ -107,18 +107,6 @@ async def setup_fixture(
     return mock_async_client
 
 
-@pytest.fixture(name="config_data")
-def config_data_fixture() -> dict[str, Any]:
-    """Return config data."""
-    return {}
-
-
-@pytest.fixture(name="config_options")
-def config_options_fixture() -> dict[str, Any]:
-    """Return config options."""
-    return {}
-
-
 @pytest.fixture(name="config_options_voice")
 def config_options_voice_fixture(mock_similarity) -> dict[str, Any]:
     """Return config options."""
@@ -173,7 +161,7 @@ async def mock_config_entry_setup(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title",
+                ATTR_ENTITY_ID: "tts.mock_title_tts",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {},
@@ -183,7 +171,7 @@ async def mock_config_entry_setup(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title",
+                ATTR_ENTITY_ID: "tts.mock_title_tts",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {tts.ATTR_VOICE: "voice2"},
@@ -193,7 +181,7 @@ async def mock_config_entry_setup(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title",
+                ATTR_ENTITY_ID: "tts.mock_title_tts",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {ATTR_MODEL: "model2"},
@@ -203,7 +191,7 @@ async def mock_config_entry_setup(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title",
+                ATTR_ENTITY_ID: "tts.mock_title_tts",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {tts.ATTR_VOICE: "voice2", ATTR_MODEL: "model2"},
@@ -263,7 +251,7 @@ async def test_tts_service_speak(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title",
+                ATTR_ENTITY_ID: "tts.mock_title_tts",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_LANGUAGE: "de",
@@ -274,7 +262,7 @@ async def test_tts_service_speak(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title",
+                ATTR_ENTITY_ID: "tts.mock_title_tts",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_LANGUAGE: "es",
@@ -326,7 +314,7 @@ async def test_tts_service_speak_lang_config(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title",
+                ATTR_ENTITY_ID: "tts.mock_title_tts",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {tts.ATTR_VOICE: "voice1"},
@@ -388,7 +376,7 @@ async def test_tts_service_speak_error(
             "mock_config_entry_setup_voice",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title",
+                ATTR_ENTITY_ID: "tts.mock_title_tts",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {tts.ATTR_VOICE: "voice2"},
@@ -446,7 +434,7 @@ async def test_tts_service_speak_voice_settings(
             "mock_config_entry_setup",
             "speak",
             {
-                ATTR_ENTITY_ID: "tts.mock_title",
+                ATTR_ENTITY_ID: "tts.mock_title_tts",
                 tts.ATTR_MEDIA_PLAYER_ENTITY_ID: "media_player.something",
                 tts.ATTR_MESSAGE: "There is a person at the front door.",
                 tts.ATTR_OPTIONS: {},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Potentially breaking, the entity ID for TTS would be renamed from "tts.elevenlabs" to "tts.elevenlabs_text_to_speech".
Reason is because the friendly name is being set to ElevenLabs Text-to-Speech and home assistant then uses that for entity id. Not sure how I can separate it out while still allowing user to change the friendly name. Open to suggestions on this. :-)


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Speech-to-Text from ElevenLabs to integration allowing one to use STT from ElevenLabs as well.
ElevenLabs STT supports 99 different languages and has the ability to auto-detect the language spoken.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40063
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
