### PR TITLE
Add sensor for online status to PlayStation Network

### DIFF
--- a/homeassistant/components/playstation_network/helpers.py
+++ b/homeassistant/components/playstation_network/helpers.py
@@ -38,7 +38,7 @@ class PlaystationNetworkData:
     presence: dict[str, Any] = field(default_factory=dict)
     username: str = ""
     account_id: str = ""
-    available: bool = False
+    available: str = "unavailable"
     active_sessions: dict[PlatformType, SessionData] = field(default_factory=dict)
     registered_platforms: set[PlatformType] = field(default_factory=set)
     trophy_summary: TrophySummary | None = None
@@ -92,10 +92,7 @@ class PlaystationNetwork:
         data.username = self.user.online_id
         data.account_id = self.user.account_id
 
-        data.available = (
-            data.presence.get("basicPresence", {}).get("availability")
-            == "availableToPlay"
-        )
+        data.available = data.presence["basicPresence"]["availability"]
 
         session = SessionData()
         session.platform = PlatformType(
@@ -127,8 +124,6 @@ class PlaystationNetwork:
             if (game_title_info := presence[0] if presence else {}) and game_title_info[
                 "onlineStatus"
             ] == "online":
-                data.available = True
-
                 platform = PlatformType(game_title_info["platform"])
 
                 if platform is PlatformType.PS4:

--- a/homeassistant/components/playstation_network/helpers.py
+++ b/homeassistant/components/playstation_network/helpers.py
@@ -38,7 +38,7 @@ class PlaystationNetworkData:
     presence: dict[str, Any] = field(default_factory=dict)
     username: str = ""
     account_id: str = ""
-    available: str = "unavailable"
+    availability: str = "unavailable"
     active_sessions: dict[PlatformType, SessionData] = field(default_factory=dict)
     registered_platforms: set[PlatformType] = field(default_factory=set)
     trophy_summary: TrophySummary | None = None
@@ -92,7 +92,7 @@ class PlaystationNetwork:
         data.username = self.user.online_id
         data.account_id = self.user.account_id
 
-        data.available = data.presence["basicPresence"]["availability"]
+        data.availability = data.presence["basicPresence"]["availability"]
 
         session = SessionData()
         session.platform = PlatformType(

--- a/homeassistant/components/playstation_network/icons.json
+++ b/homeassistant/components/playstation_network/icons.json
@@ -35,7 +35,7 @@
         "state": {
           "busy": "mdi:account-cancel",
           "availabletocommunicate": "mdi:cellphone",
-          "unavailable": "mdi:account-off-outline"
+          "offline": "mdi:account-off-outline"
         }
       }
     }

--- a/homeassistant/components/playstation_network/icons.json
+++ b/homeassistant/components/playstation_network/icons.json
@@ -29,6 +29,14 @@
       },
       "last_online": {
         "default": "mdi:account-clock"
+      },
+      "online_status": {
+        "default": "mdi:account-badge",
+        "state": {
+          "busy": "mdi:account-cancel",
+          "availabletocommunicate": "mdi:cellphone",
+          "unavailable": "mdi:account-off-outline"
+        }
       }
     }
   }

--- a/homeassistant/components/playstation_network/media_player.py
+++ b/homeassistant/components/playstation_network/media_player.py
@@ -107,7 +107,7 @@ class PsnMediaPlayerEntity(
         """Media Player state getter."""
         session = self.coordinator.data.active_sessions.get(self.key)
         if session and session.status == "online":
-            if self.coordinator.data.available and session.title_id is not None:
+            if session.title_id is not None:
                 return MediaPlayerState.PLAYING
             return MediaPlayerState.ON
         return MediaPlayerState.OFF

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -123,7 +123,7 @@ SENSOR_DESCRIPTIONS: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.ONLINE_STATUS,
         translation_key=PlaystationNetworkSensor.ONLINE_STATUS,
-        value_fn=lambda psn: psn.available.lower().replace("unavailable", "offline"),
+        value_fn=lambda psn: psn.availability.lower().replace("unavailable", "offline"),
         device_class=SensorDeviceClass.ENUM,
         options=["offline", "availabletoplay", "availabletocommunicate", "busy"],
     ),

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -123,9 +123,9 @@ SENSOR_DESCRIPTIONS: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.ONLINE_STATUS,
         translation_key=PlaystationNetworkSensor.ONLINE_STATUS,
-        value_fn=lambda psn: psn.available.lower(),
+        value_fn=lambda psn: psn.available.lower().replace("unavailable", "offline"),
         device_class=SensorDeviceClass.ENUM,
-        options=["unavailable", "availabletoplay", "availabletocommunicate", "busy"],
+        options=["offline", "availabletoplay", "availabletocommunicate", "busy"],
     ),
 )
 

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -50,6 +50,7 @@ class PlaystationNetworkSensor(StrEnum):
     EARNED_TROPHIES_BRONZE = "earned_trophies_bronze"
     ONLINE_ID = "online_id"
     LAST_ONLINE = "last_online"
+    ONLINE_STATUS = "online_status"
 
 
 SENSOR_DESCRIPTIONS: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
@@ -118,6 +119,13 @@ SENSOR_DESCRIPTIONS: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
             )
         ),
         device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    PlaystationNetworkSensorEntityDescription(
+        key=PlaystationNetworkSensor.ONLINE_STATUS,
+        translation_key=PlaystationNetworkSensor.ONLINE_STATUS,
+        value_fn=lambda psn: psn.available.lower(),
+        device_class=SensorDeviceClass.ENUM,
+        options=["unavailable", "availabletoplay", "availabletocommunicate", "busy"],
     ),
 )
 

--- a/homeassistant/components/playstation_network/strings.json
+++ b/homeassistant/components/playstation_network/strings.json
@@ -81,6 +81,15 @@
       },
       "last_online": {
         "name": "Last online"
+      },
+      "online_status": {
+        "name": "Online status",
+        "state": {
+          "unavailable": "Offline",
+          "availabletoplay": "Online",
+          "availabletocommunicate": "Online on PS App",
+          "busy": "Away"
+        }
       }
     }
   }

--- a/homeassistant/components/playstation_network/strings.json
+++ b/homeassistant/components/playstation_network/strings.json
@@ -85,7 +85,7 @@
       "online_status": {
         "name": "Online status",
         "state": {
-          "unavailable": "Offline",
+          "offline": "Offline",
           "availabletoplay": "Online",
           "availabletocommunicate": "Online on PS App",
           "busy": "Away"

--- a/tests/components/playstation_network/snapshots/test_diagnostics.ambr
+++ b/tests/components/playstation_network/snapshots/test_diagnostics.ambr
@@ -13,7 +13,7 @@
           'title_name': 'STAR WARS Jedi: Survivor™',
         }),
       }),
-      'available': 'availableToPlay',
+      'availability': 'availableToPlay',
       'presence': dict({
         'basicPresence': dict({
           'availability': 'availableToPlay',

--- a/tests/components/playstation_network/snapshots/test_diagnostics.ambr
+++ b/tests/components/playstation_network/snapshots/test_diagnostics.ambr
@@ -13,7 +13,7 @@
           'title_name': 'STAR WARS Jedi: Survivor™',
         }),
       }),
-      'available': True,
+      'available': 'availableToPlay',
       'presence': dict({
         'basicPresence': dict({
           'availability': 'availableToPlay',

--- a/tests/components/playstation_network/snapshots/test_sensor.ambr
+++ b/tests/components/playstation_network/snapshots/test_sensor.ambr
@@ -251,7 +251,7 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'unavailable',
+        'offline',
         'availabletoplay',
         'availabletocommunicate',
         'busy',
@@ -292,7 +292,7 @@
       'device_class': 'enum',
       'friendly_name': 'testuser Online status',
       'options': list([
-        'unavailable',
+        'offline',
         'availabletoplay',
         'availabletocommunicate',
         'busy',

--- a/tests/components/playstation_network/snapshots/test_sensor.ambr
+++ b/tests/components/playstation_network/snapshots/test_sensor.ambr
@@ -244,6 +244,68 @@
     'state': 'testuser',
   })
 # ---
+# name: test_sensors[sensor.testuser_online_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'unavailable',
+        'availabletoplay',
+        'availabletocommunicate',
+        'busy',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_online_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Online status',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.ONLINE_STATUS: 'online_status'>,
+    'unique_id': 'my-psn-id_online_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.testuser_online_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'testuser Online status',
+      'options': list([
+        'unavailable',
+        'availabletoplay',
+        'availabletocommunicate',
+        'busy',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_online_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'availabletoplay',
+  })
+# ---
 # name: test_sensors[sensor.testuser_platinum_trophies-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a sensor to display the users online status. Possible states are Offline, Away, Online, and Online on PS App.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39787
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
