### PR TITLE
Implement suggested_display_precision for ESPHome

### DIFF
--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -81,6 +81,7 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
         # if the string is empty
         if unit_of_measurement := static_info.unit_of_measurement:
             self._attr_native_unit_of_measurement = unit_of_measurement
+        self._attr_suggested_display_precision = static_info.accuracy_decimals
         self._attr_device_class = try_parse_enum(
             SensorDeviceClass, static_info.device_class
         )
@@ -97,7 +98,7 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
             self._attr_state_class = _STATE_CLASSES.from_esphome(state_class)
 
     @property
-    def native_value(self) -> datetime | str | None:
+    def native_value(self) -> datetime | int | float | None:
         """Return the state of the entity."""
         if not self._has_state or (state := self._state).missing_state:
             return None
@@ -106,7 +107,7 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
             return None
         if self.device_class is SensorDeviceClass.TIMESTAMP:
             return dt_util.utc_from_timestamp(state_float)
-        return f"{state_float:.{self._static_info.accuracy_decimals}f}"
+        return state_float
 
 
 class EsphomeTextSensor(EsphomeEntity[TextSensorInfo, TextSensorState], SensorEntity):

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -375,7 +375,7 @@ async def test_deep_sleep_device(
     assert state.state == STATE_ON
     state = hass.states.get("sensor.test_my_sensor")
     assert state is not None
-    assert state.state == "123"
+    assert state.state == "123.0"
 
     await mock_device.mock_disconnect(False)
     await hass.async_block_till_done()
@@ -394,7 +394,7 @@ async def test_deep_sleep_device(
     assert state.state == STATE_ON
     state = hass.states.get("sensor.test_my_sensor")
     assert state is not None
-    assert state.state == "123"
+    assert state.state == "123.0"
 
     await mock_device.mock_disconnect(True)
     await hass.async_block_till_done()

--- a/tests/components/esphome/test_sensor.py
+++ b/tests/components/esphome/test_sensor.py
@@ -13,18 +13,28 @@ from aioesphomeapi import (
     TextSensorInfo,
     TextSensorState,
 )
+import pytest
 
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
     SensorStateClass,
+    async_rounded_state,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
+    PERCENTAGE,
     STATE_UNKNOWN,
     EntityCategory,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfPressure,
+    UnitOfTemperature,
+    UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -441,3 +451,63 @@ async def test_generic_numeric_sensor_empty_string_uom(
     assert state is not None
     assert state.state == "123"
     assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
+
+
+@pytest.mark.parametrize(
+    ("device_class", "unit_of_measurement", "state_value", "expected_precision"),
+    [
+        (SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, 23.456, 1),
+        (SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, 0.1, 1),
+        (SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, -25.789, 1),
+        (SensorDeviceClass.POWER, UnitOfPower.WATT, 1234.56, 0),
+        (SensorDeviceClass.POWER, UnitOfPower.WATT, 1.23456, 3),
+        (SensorDeviceClass.POWER, UnitOfPower.WATT, 0.123, 3),
+        (SensorDeviceClass.ENERGY, UnitOfEnergy.WATT_HOUR, 1234.5, 0),
+        (SensorDeviceClass.ENERGY, UnitOfEnergy.WATT_HOUR, 12.3456, 2),
+        (SensorDeviceClass.VOLTAGE, UnitOfElectricPotential.VOLT, 230.45, 1),
+        (SensorDeviceClass.VOLTAGE, UnitOfElectricPotential.VOLT, 3.3, 1),
+        (SensorDeviceClass.CURRENT, UnitOfElectricCurrent.AMPERE, 15.678, 2),
+        (SensorDeviceClass.CURRENT, UnitOfElectricCurrent.AMPERE, 0.015, 3),
+        (SensorDeviceClass.ATMOSPHERIC_PRESSURE, UnitOfPressure.HPA, 1013.25, 1),
+        (SensorDeviceClass.PRESSURE, UnitOfPressure.BAR, 1.01325, 3),
+        (SensorDeviceClass.VOLUME, UnitOfVolume.LITERS, 45.67, 1),
+        (SensorDeviceClass.VOLUME, UnitOfVolume.LITERS, 4567.0, 0),
+        (SensorDeviceClass.HUMIDITY, PERCENTAGE, 87.654, 1),
+        (SensorDeviceClass.HUMIDITY, PERCENTAGE, 45.2, 1),
+        (SensorDeviceClass.BATTERY, PERCENTAGE, 95.2, 1),
+        (SensorDeviceClass.BATTERY, PERCENTAGE, 100.0, 1),
+    ],
+)
+async def test_suggested_display_precision_by_device_class(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    device_class: SensorDeviceClass,
+    unit_of_measurement: str,
+    state_value: float,
+    expected_precision: int,
+) -> None:
+    """Test suggested display precision for different device classes."""
+    entity_info = [
+        SensorInfo(
+            object_id="mysensor",
+            key=1,
+            name="my sensor",
+            unique_id="my_sensor",
+            accuracy_decimals=expected_precision,
+            device_class=device_class.value,
+            unit_of_measurement=unit_of_measurement,
+        )
+    ]
+    states = [SensorState(key=1, state=state_value)]
+    await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert float(
+        async_rounded_state(hass, "sensor.test_my_sensor", state)
+    ) == pytest.approx(round(state_value, expected_precision))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

ESPHome will now store the raw sensor state in the database and only use the accuracy_decimals for visual effects.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Recent changes to Home Assistant sensor entities with a device class were not utilising the accuracy decimals sent by ESPHome to override.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/esphome/issues/issues/7120
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
