### PR TITLE
Correct openai conversation config entry migration

### DIFF
--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -361,4 +361,34 @@ async def async_migrate_integration(hass: HomeAssistant) -> None:
                 title=DEFAULT_NAME,
                 options={},
                 version=2,
+                minor_version=2,
             )
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: OpenAIConfigEntry) -> bool:
+    """Migrate entry."""
+    LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
+
+    if entry.version > 2:
+        # This means the user has downgraded from a future version
+        return False
+
+    if entry.version == 2 and entry.minor_version == 1:
+        # Correct broken device migration in Home Assistant Core 2025.7.0b0-2025.7.0b1
+        device_registry = dr.async_get(hass)
+        for device in dr.async_entries_for_config_entry(
+            device_registry, entry.entry_id
+        ):
+            device_registry.async_update_device(
+                device.id,
+                remove_config_entry_id=entry.entry_id,
+                remove_config_subentry_id=None,
+            )
+
+        hass.config_entries.async_update_entry(entry, minor_version=2)
+
+    LOGGER.debug(
+        "Migration to version %s:%s successful", entry.version, entry.minor_version
+    )
+
+    return True

--- a/homeassistant/components/openai_conversation/config_flow.py
+++ b/homeassistant/components/openai_conversation/config_flow.py
@@ -99,6 +99,7 @@ class OpenAIConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for OpenAI Conversation."""
 
     VERSION = 2
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -828,7 +828,7 @@ async def test_migration_from_v2_1_to_v2_2(
 ) -> None:
     """Test migration from version 2.1 to version 2.2.
 
-    This tests we celan up the broken migration in Home Assistant Core
+    This tests we clean up the broken migration in Home Assistant Core
     2025.7.0b0-2025.7.0b1:
     - Fix device registry (Fixed in Home Assistant Core 2025.7.0b2)
     """

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -579,7 +579,7 @@ async def test_migration_from_v1_to_v2(
         mock_config_entry.entry_id,
         config_entry=mock_config_entry,
         device_id=device.id,
-        suggested_object_id="google_generative_ai_conversation",
+        suggested_object_id="chatgpt",
     )
 
     # Run migration
@@ -591,6 +591,7 @@ async def test_migration_from_v1_to_v2(
         await hass.async_block_till_done()
 
     assert mock_config_entry.version == 2
+    assert mock_config_entry.minor_version == 2
     assert mock_config_entry.data == {"api_key": "1234"}
     assert mock_config_entry.options == {}
 
@@ -703,6 +704,7 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
 
     for idx, entry in enumerate(entries):
         assert entry.version == 2
+        assert entry.minor_version == 2
         assert not entry.options
         assert len(entry.subentries) == 1
         subentry = list(entry.subentries.values())[0]
@@ -797,6 +799,7 @@ async def test_migration_from_v1_to_v2_with_same_keys(
 
     entry = entries[0]
     assert entry.version == 2
+    assert entry.minor_version == 2
     assert not entry.options
     assert len(entry.subentries) == 2  # Two subentries from the two original entries
 

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -18,6 +18,7 @@ from syrupy.filters import props
 
 from homeassistant.components.openai_conversation import CONF_CHAT_MODEL, CONF_FILENAMES
 from homeassistant.components.openai_conversation.const import DOMAIN
+from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -818,6 +819,163 @@ async def test_migration_from_v1_to_v2_with_same_keys(
         assert dev.config_entries_subentries == {
             mock_config_entry.entry_id: {subentry.subentry_id}
         }
+
+
+async def test_migration_from_v2_1_to_v2_2(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test migration from version 2.1 to version 2.2.
+
+    This tests we celan up the broken migration in Home Assistant Core
+    2025.7.0b0-2025.7.0b1:
+    - Fix device registry (Fixed in Home Assistant Core 2025.7.0b2)
+    """
+    # Create a v2.1 config entry with 2 subentries, devices and entities
+    options = {
+        "recommended": True,
+        "llm_hass_api": ["assist"],
+        "prompt": "You are a helpful assistant",
+        "chat_model": "gpt-4o-mini",
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"api_key": "1234"},
+        entry_id="mock_entry_id",
+        version=2,
+        minor_version=1,
+        subentries_data=[
+            ConfigSubentryData(
+                data=options,
+                subentry_id="mock_id_1",
+                subentry_type="conversation",
+                title="ChatGPT",
+                unique_id=None,
+            ),
+            ConfigSubentryData(
+                data=options,
+                subentry_id="mock_id_2",
+                subentry_type="conversation",
+                title="ChatGPT 2",
+                unique_id=None,
+            ),
+        ],
+        title="ChatGPT",
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        config_subentry_id="mock_id_1",
+        identifiers={(DOMAIN, "mock_id_1")},
+        name="ChatGPT",
+        manufacturer="OpenAI",
+        model="ChatGPT",
+        entry_type=dr.DeviceEntryType.SERVICE,
+    )
+    device_1 = device_registry.async_update_device(
+        device_1.id, add_config_entry_id="mock_entry_id", add_config_subentry_id=None
+    )
+    assert device_1.config_entries_subentries == {"mock_entry_id": {None, "mock_id_1"}}
+    entity_registry.async_get_or_create(
+        "conversation",
+        DOMAIN,
+        "mock_id_1",
+        config_entry=mock_config_entry,
+        config_subentry_id="mock_id_1",
+        device_id=device_1.id,
+        suggested_object_id="chatgpt",
+    )
+
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        config_subentry_id="mock_id_2",
+        identifiers={(DOMAIN, "mock_id_2")},
+        name="ChatGPT 2",
+        manufacturer="OpenAI",
+        model="ChatGPT",
+        entry_type=dr.DeviceEntryType.SERVICE,
+    )
+    entity_registry.async_get_or_create(
+        "conversation",
+        DOMAIN,
+        "mock_id_2",
+        config_entry=mock_config_entry,
+        config_subentry_id="mock_id_2",
+        device_id=device_2.id,
+        suggested_object_id="chatgpt_2",
+    )
+
+    # Run migration
+    with patch(
+        "homeassistant.components.openai_conversation.async_setup_entry",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.version == 2
+    assert entry.minor_version == 2
+    assert not entry.options
+    assert entry.title == "ChatGPT"
+    assert len(entry.subentries) == 2
+    conversation_subentries = [
+        subentry
+        for subentry in entry.subentries.values()
+        if subentry.subentry_type == "conversation"
+    ]
+    assert len(conversation_subentries) == 2
+    for subentry in conversation_subentries:
+        assert subentry.subentry_type == "conversation"
+        assert subentry.data == options
+        assert "ChatGPT" in subentry.title
+
+    subentry = conversation_subentries[0]
+
+    entity = entity_registry.async_get("conversation.chatgpt")
+    assert entity.unique_id == subentry.subentry_id
+    assert entity.config_subentry_id == subentry.subentry_id
+    assert entity.config_entry_id == entry.entry_id
+
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    )
+    assert (
+        device := device_registry.async_get_device(
+            identifiers={(DOMAIN, subentry.subentry_id)}
+        )
+    )
+    assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
+    assert device.id == device_1.id
+    assert device.config_entries == {mock_config_entry.entry_id}
+    assert device.config_entries_subentries == {
+        mock_config_entry.entry_id: {subentry.subentry_id}
+    }
+
+    subentry = conversation_subentries[1]
+
+    entity = entity_registry.async_get("conversation.chatgpt_2")
+    assert entity.unique_id == subentry.subentry_id
+    assert entity.config_subentry_id == subentry.subentry_id
+    assert entity.config_entry_id == entry.entry_id
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    )
+    assert (
+        device := device_registry.async_get_device(
+            identifiers={(DOMAIN, subentry.subentry_id)}
+        )
+    )
+    assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
+    assert device.id == device_2.id
+    assert device.config_entries == {mock_config_entry.entry_id}
+    assert device.config_entries_subentries == {
+        mock_config_entry.entry_id: {subentry.subentry_id}
+    }
 
 
 @pytest.mark.parametrize("mock_subentry_data", [{}, {CONF_CHAT_MODEL: "gpt-1o"}])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct openai conversation config entry migration

This cleans up the broken migration in Home Assistant Core 2025.7.0b0-2025.7.0b1:
- Fix device registry (Fixed in Home Assistant Core 2025.7.0b2)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
