### PR TITLE
Use entity_registry_enabled_by_default fixture in dsmr_reader tests

### DIFF
--- a/tests/components/dsmr_reader/test_definitions.py
+++ b/tests/components/dsmr_reader/test_definitions.py
@@ -4,15 +4,13 @@ import pytest
 
 from homeassistant.components.dsmr_reader.const import DOMAIN
 from homeassistant.components.dsmr_reader.definitions import (
-    DSMRReaderSensorEntityDescription,
     dsmr_transform,
     tariff_transform,
 )
-from homeassistant.components.dsmr_reader.sensor import DSMRSensor
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, MockEntityPlatform, async_fire_mqtt_message
+from tests.common import MockConfigEntry, async_fire_mqtt_message
 
 
 @pytest.mark.parametrize(
@@ -71,7 +69,7 @@ async def test_entity_tariff(hass: HomeAssistant) -> None:
     assert hass.states.get(electricity_tariff).state == "low"
 
 
-@pytest.mark.usefixtures("mqtt_mock")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mqtt_mock")
 async def test_entity_dsmr_transform(hass: HomeAssistant) -> None:
     """Test the state attribute of DSMRReaderSensorEntityDescription when a dsmr transform is needed."""
     config_entry = MockConfigEntry(
@@ -84,17 +82,6 @@ async def test_entity_dsmr_transform(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-
-    # Create the entity, since it's not by default
-    description = DSMRReaderSensorEntityDescription(
-        key="dsmr/meter-stats/dsmr_version",
-        name="version_test",
-        state=dsmr_transform,
-    )
-    sensor = DSMRSensor(description, config_entry)
-    sensor.hass = hass
-    sensor.platform = MockEntityPlatform(hass)
-    await sensor.async_added_to_hass()
 
     # Test dsmr version, if it's a digit
     async_fire_mqtt_message(hass, "dsmr/meter-stats/dsmr_version", "42")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `entity_registry_enabled_by_default` fixture in dsmr_reader tests instead of manually creating disabled entities

Seen in https://github.com/home-assistant/core/pull/147882

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
