### PR TITLE
Skip processing request body for HTTP HEAD requests

### DIFF
--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -184,13 +184,20 @@ class HassIOIngress(HomeAssistantView):
                 content_type = "application/octet-stream"
 
             # Simple request
-            if result.status in (204, 304) or (
-                content_length is not UNDEFINED
-                and (content_length_int := int(content_length))
-                <= MAX_SIMPLE_RESPONSE_SIZE
+            if (
+                result.status in (204, 304)
+                or result.method == "HEAD"
+                or (
+                    content_length is not UNDEFINED
+                    and (content_length_int := int(content_length))
+                    <= MAX_SIMPLE_RESPONSE_SIZE
+                )
             ):
                 # Return Response
-                body = await result.read()
+                if result.method == "HEAD":
+                    body = None
+                else:
+                    body = await result.read()
                 simple_response = web.Response(
                     headers=headers,
                     status=result.status,

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -185,13 +185,13 @@ class HassIOIngress(HomeAssistantView):
                 content_type = "application/octet-stream"
 
             # Simple request
-            if must_be_empty_body(result.method, result.status) or (
+            if empty_body := must_be_empty_body(result.method, result.status) or (
                 content_length is not UNDEFINED
                 and (content_length_int := int(content_length))
                 <= MAX_SIMPLE_RESPONSE_SIZE
             ):
                 # Return Response
-                if must_be_empty_body(result.method, result.status):
+                if empty_body:
                     body = None
                 else:
                     body = await result.read()

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 
 import aiohttp
 from aiohttp import ClientTimeout, ClientWebSocketResponse, hdrs, web
+from aiohttp.helpers import must_be_empty_body
 from aiohttp.web_exceptions import HTTPBadGateway, HTTPBadRequest
 from multidict import CIMultiDict
 from yarl import URL
@@ -184,17 +185,13 @@ class HassIOIngress(HomeAssistantView):
                 content_type = "application/octet-stream"
 
             # Simple request
-            if (
-                result.status in (204, 304)
-                or result.method == "HEAD"
-                or (
-                    content_length is not UNDEFINED
-                    and (content_length_int := int(content_length))
-                    <= MAX_SIMPLE_RESPONSE_SIZE
-                )
+            if must_be_empty_body(result.method, result.status) or (
+                content_length is not UNDEFINED
+                and (content_length_int := int(content_length))
+                <= MAX_SIMPLE_RESPONSE_SIZE
             ):
                 # Return Response
-                if result.method == "HEAD":
+                if must_be_empty_body(result.method, result.status):
                     body = None
                 else:
                     body = await result.read()

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -185,7 +185,7 @@ class HassIOIngress(HomeAssistantView):
                 content_type = "application/octet-stream"
 
             # Simple request
-            if empty_body := must_be_empty_body(result.method, result.status) or (
+            if (empty_body := must_be_empty_body(result.method, result.status)) or (
                 content_length is not UNDEFINED
                 and (content_length_int := int(content_length))
                 <= MAX_SIMPLE_RESPONSE_SIZE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

All HTTP HEAD requests proxied by ingress are now handled as simple requests, with request body forwarding skipped as HTTP HEAD requests are not expected ([nor allowed](https://httpwg.org/specs/rfc9110.html#HEAD)) to have a request body despite potentially having a non-zero `Content-Length`.

This should fix ingress halting HA Core when proxying HTTP HEAD requests, which seems to be the root cause of

- https://github.com/blakeblackshear/frigate-hass-addons/issues/227
- https://github.com/alexbelgium/hassio-addons/issues/1884

and possibly other addon issues after the release of HA Core 2025.5.0b4 (see https://github.com/home-assistant/core/pull/144231).

Unfortunately still uncertain whether it fixes the original issue posted in https://github.com/home-assistant/core/issues/145592 regarding ESPHome, but it does resolve the Frigate problems that have become the main topic of discussion in that issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: May close https://github.com/home-assistant/core/issues/145592
- This PR is related to issue: https://github.com/home-assistant/core/issues/145592
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
