### PR TITLE
Open repair issue when outbound WebSocket is enabled for Shelly non-sleeping RPC device

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -56,7 +56,10 @@ from .coordinator import (
     ShellyRpcCoordinator,
     ShellyRpcPollingCoordinator,
 )
-from .repairs import async_manage_ble_scanner_firmware_unsupported_issue
+from .repairs import (
+    async_manage_ble_scanner_firmware_unsupported_issue,
+    async_manage_outbound_websocket_incorrectly_enabled_issue,
+)
 from .utils import (
     async_create_issue_unsupported_firmware,
     get_coap_context,
@@ -324,6 +327,10 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
             entry, runtime_data.platforms
         )
         async_manage_ble_scanner_firmware_unsupported_issue(
+            hass,
+            entry,
+        )
+        async_manage_outbound_websocket_incorrectly_enabled_issue(
             hass,
             entry,
         )

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -237,6 +237,9 @@ NOT_CALIBRATED_ISSUE_ID = "not_calibrated_{unique}"
 FIRMWARE_UNSUPPORTED_ISSUE_ID = "firmware_unsupported_{unique}"
 
 BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID = "ble_scanner_firmware_unsupported_{unique}"
+OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID = (
+    "outbound_websocket_incorrectly_enabled_{unique}"
+)
 
 GAS_VALVE_OPEN_STATES = ("opening", "opened")
 

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -106,7 +106,7 @@ def async_manage_outbound_websocket_incorrectly_enabled_issue(
     ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
-class BleScannerFirmwareUpdateFlow(RepairsFlow):
+class ShellyRpcRepairsFlow(RepairsFlow):
     """Handler for an issue fixing flow."""
 
     def __init__(self, device: RpcDevice) -> None:
@@ -124,7 +124,7 @@ class BleScannerFirmwareUpdateFlow(RepairsFlow):
     ) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
-            return await self.async_step_update_firmware()
+            return await self._async_step_confirm()
 
         issue_registry = ir.async_get(self.hass)
         description_placeholders = None
@@ -136,6 +136,18 @@ class BleScannerFirmwareUpdateFlow(RepairsFlow):
             data_schema=vol.Schema({}),
             description_placeholders=description_placeholders,
         )
+
+    async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        raise NotImplementedError
+
+
+class BleScannerFirmwareUpdateFlow(ShellyRpcRepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        return await self.async_step_update_firmware()
 
     async def async_step_update_firmware(
         self, user_input: dict[str, str] | None = None
@@ -151,36 +163,12 @@ class BleScannerFirmwareUpdateFlow(RepairsFlow):
         return self.async_create_entry(title="", data={})
 
 
-class DisableOutboundWebSocketFlow(RepairsFlow):
+class DisableOutboundWebSocketFlow(ShellyRpcRepairsFlow):
     """Handler for an issue fixing flow."""
 
-    def __init__(self, device: RpcDevice) -> None:
-        """Initialize."""
-        self._device = device
-
-    async def async_step_init(
-        self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
-        """Handle the first step of a fix flow."""
-        return await self.async_step_confirm()
-
-    async def async_step_confirm(
-        self, user_input: dict[str, str] | None = None
-    ) -> data_entry_flow.FlowResult:
+    async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""
-        if user_input is not None:
-            return await self.async_step_disable_outbound_websocket()
-
-        issue_registry = ir.async_get(self.hass)
-        description_placeholders = None
-        if issue := issue_registry.async_get_issue(self.handler, self.issue_id):
-            description_placeholders = issue.translation_placeholders
-
-        return self.async_show_form(
-            step_id="confirm",
-            data_schema=vol.Schema({}),
-            description_placeholders=description_placeholders,
-        )
+        return await self.async_step_disable_outbound_websocket()
 
     async def async_step_disable_outbound_websocket(
         self, user_input: dict[str, str] | None = None

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -143,7 +143,7 @@ class ShellyRpcRepairsFlow(RepairsFlow):
 
 
 class BleScannerFirmwareUpdateFlow(ShellyRpcRepairsFlow):
-    """Handler for an issue fixing flow."""
+    """Handler for BLE Scanner Firmware Update flow."""
 
     async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""
@@ -164,7 +164,7 @@ class BleScannerFirmwareUpdateFlow(ShellyRpcRepairsFlow):
 
 
 class DisableOutboundWebSocketFlow(ShellyRpcRepairsFlow):
-    """Handler for an issue fixing flow."""
+    """Handler for Disable Outbound WebSocket flow."""
 
     async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -11,7 +11,7 @@ from awesomeversion import AwesomeVersion
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
-from homeassistant.components.repairs import RepairsFlow
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 
@@ -20,9 +20,11 @@ from .const import (
     BLE_SCANNER_MIN_FIRMWARE,
     CONF_BLE_SCANNER_MODE,
     DOMAIN,
+    OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID,
     BLEScannerMode,
 )
 from .coordinator import ShellyConfigEntry
+from .utils import get_rpc_ws_url
 
 
 @callback
@@ -61,6 +63,45 @@ def async_manage_ble_scanner_firmware_unsupported_issue(
                 data={"entry_id": entry.entry_id},
             )
             return
+
+    ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
+@callback
+def async_manage_outbound_websocket_incorrectly_enabled_issue(
+    hass: HomeAssistant,
+    entry: ShellyConfigEntry,
+) -> None:
+    """Manage the Outbound WebSocket incorrectly enabled issue."""
+    issue_id = OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID.format(
+        unique=entry.unique_id
+    )
+
+    if TYPE_CHECKING:
+        assert entry.runtime_data.rpc is not None
+
+    device = entry.runtime_data.rpc.device
+
+    if (
+        (ws_config := device.config.get("ws"))
+        and ws_config["enable"]
+        and ws_config["server"] == get_rpc_ws_url(hass)
+    ):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="outbound_websocket_incorrectly_enabled",
+            translation_placeholders={
+                "device_name": device.name,
+                "ip_address": device.ip_address,
+            },
+            data={"entry_id": entry.entry_id},
+        )
+        return
 
     ir.async_delete_issue(hass, DOMAIN, issue_id)
 
@@ -110,6 +151,53 @@ class BleScannerFirmwareUpdateFlow(RepairsFlow):
         return self.async_create_entry(title="", data={})
 
 
+class DisableOutboundWebSocketFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    def __init__(self, device: RpcDevice) -> None:
+        """Initialize."""
+        self._device = device
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            return await self.async_step_disable_outbound_websocket()
+
+        issue_registry = ir.async_get(self.hass)
+        description_placeholders = None
+        if issue := issue_registry.async_get_issue(self.handler, self.issue_id):
+            description_placeholders = issue.translation_placeholders
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders=description_placeholders,
+        )
+
+    async def async_step_disable_outbound_websocket(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        try:
+            result = await self._device.ws_setconfig(
+                False, self._device.config["ws"]["server"]
+            )
+            if result["restart_required"]:
+                await self._device.trigger_reboot()
+        except (DeviceConnectionError, RpcCallError):
+            return self.async_abort(reason="cannot_connect")
+
+        return self.async_create_entry(title="", data={})
+
+
 async def async_create_fix_flow(
     hass: HomeAssistant, issue_id: str, data: dict[str, str] | None
 ) -> RepairsFlow:
@@ -124,4 +212,11 @@ async def async_create_fix_flow(
         assert entry is not None
 
     device = entry.runtime_data.rpc.device
-    return BleScannerFirmwareUpdateFlow(device)
+
+    if "ble_scanner_firmware_unsupported" in issue_id:
+        return BleScannerFirmwareUpdateFlow(device)
+
+    if "outbound_websocket_incorrectly_enabled" in issue_id:
+        return DisableOutboundWebSocketFlow(device)
+
+    return ConfirmRepairFlow()

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -288,6 +288,20 @@
     "unsupported_firmware": {
       "title": "Unsupported firmware for device {device_name}",
       "description": "Your Shelly device {device_name} with IP address {ip_address} is running an unsupported firmware. Please update the firmware.\n\nIf the device does not offer an update, check internet connectivity (gateway, DNS, time) and restart the device."
+    },
+    "outbound_websocket_incorrectly_enabled": {
+      "title": "Outbound WebSocket is enabled for {device_name}",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Outbound WebSocket is enabled for {device_name}",
+            "description": "Your Shelly device {device_name} with IP address {ip_address} is a non-sleeping device and Outbound WebSocket should be disabled in its configuration.\n\nSelect **Submit** button to disable Outbound WebSocket."
+          }
+        },
+        "abort": {
+          "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some users enable outbound WebSocket for non-sleeping Shelly gen2+ devices. This can cause problems that are not easy to diagnose.
With this PR, the integration will open a repair issue when detect that outbound WebSocket is enabled and WS URL points to HA instance and suggest the user to disable it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/146264
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
