### PR TITLE
Add select for heating circuit to Tado zones

### DIFF
--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -41,6 +41,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.DEVICE_TRACKER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.WATER_HEATER,

--- a/homeassistant/components/tado/coordinator.py
+++ b/homeassistant/components/tado/coordinator.py
@@ -388,6 +388,20 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
         except RequestException as exc:
             raise HomeAssistantError(f"Error setting Tado child lock: {exc}") from exc
 
+    async def set_heating_circuit(self, zone_id: int, circuit_id: int | None) -> None:
+        """Set heating circuit for zone."""
+        try:
+            await self.hass.async_add_executor_job(
+                self._tado.set_zone_heating_circuit,
+                zone_id,
+                circuit_id,
+            )
+        except RequestException as exc:
+            raise HomeAssistantError(
+                f"Error setting Tado heating circuit: {exc}"
+            ) from exc
+        await self._update_zone_control(zone_id)
+
 
 class TadoMobileDeviceUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
     """Class to manage the mobile devices from Tado via PyTado."""

--- a/homeassistant/components/tado/coordinator.py
+++ b/homeassistant/components/tado/coordinator.py
@@ -184,11 +184,9 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
             raise UpdateFailed(f"Error updating Tado zones: {err}") from err
 
         mapped_zones: dict[int, dict] = {}
-        for zone in zone_states:
-            mapped_zones[int(zone)] = await self._update_zone(int(zone))
-
         mapped_zone_controls: dict[int, dict] = {}
         for zone in zone_states:
+            mapped_zones[int(zone)] = await self._update_zone(int(zone))
             mapped_zone_controls[int(zone)] = await self._update_zone_control(int(zone))
 
         return mapped_zones, mapped_zone_controls

--- a/homeassistant/components/tado/coordinator.py
+++ b/homeassistant/components/tado/coordinator.py
@@ -244,7 +244,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
 
         return {"weather": weather, "geofence": geofence}
 
-    async def _async_update_heating_circuits(self) -> dict[int, dict]:
+    async def _async_update_heating_circuits(self) -> dict[str, dict]:
         """Update the heating circuits data from Tado."""
 
         try:
@@ -255,9 +255,9 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
             _LOGGER.error("Error updating Tado heating circuits: %s", err)
             raise UpdateFailed(f"Error updating Tado heating circuits: {err}") from err
 
-        mapped_heating_circuits: dict[int, dict] = {}
+        mapped_heating_circuits: dict[str, dict] = {}
         for circuit in heating_circuits:
-            mapped_heating_circuits[circuit["number"]] = circuit
+            mapped_heating_circuits[circuit["driverShortSerialNo"]] = circuit
 
         return mapped_heating_circuits
 

--- a/homeassistant/components/tado/select.py
+++ b/homeassistant/components/tado/select.py
@@ -1,0 +1,117 @@
+"""Module for Tado select entities."""
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import TadoConfigEntry
+from .entity import TadoDataUpdateCoordinator, TadoZoneEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+TRANSLATABLE_NO_HEATING_CIRCUIT = "no_heating_circuit"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: TadoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Tado select platform."""
+
+    tado = entry.runtime_data.coordinator
+    entities: list[SelectEntity] = [
+        # Add heating circuit select
+        TadoHeatingCircuitSelectEntity(tado, zone["name"], zone["id"])
+        for zone in tado.zones
+        if zone["type"] == "HEATING"
+    ]
+
+    async_add_entities(entities, True)
+
+
+class TadoHeatingCircuitSelectEntity(TadoZoneEntity, SelectEntity):
+    """Representation of a Tado heating circuit select entity."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:water-boiler"
+    _attr_translation_key = "heating_circuit"
+
+    def __init__(
+        self,
+        coordinator: TadoDataUpdateCoordinator,
+        zone_name: str,
+        zone_id: int,
+    ) -> None:
+        """Initialize the Tado heating circuit select entity."""
+        super().__init__(zone_name, coordinator.home_id, zone_id, coordinator)
+
+        self._attr_unique_id = f"{zone_id} {coordinator.home_id} heating_circuit"
+
+        self._attr_options = []
+        self._attr_current_option = None
+
+    async def async_select_option(self, option: str) -> None:
+        """Update the selected heating circuit."""
+        heating_circuit_id = (
+            None
+            if option is TRANSLATABLE_NO_HEATING_CIRCUIT
+            else self.coordinator.data["heating_circuits"].get(option, {}).get("number")
+        )
+        await self.coordinator.set_heating_circuit(self.zone_id, heating_circuit_id)
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_callback()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_callback(self) -> None:
+        """Handle update callbacks."""
+        try:
+            # Heating circuits list
+            heating_circuits = self.coordinator.data["heating_circuits"].values()
+            self._attr_options = [TRANSLATABLE_NO_HEATING_CIRCUIT]
+            self._attr_options.extend(
+                hc["driverShortSerialNo"] for hc in heating_circuits
+            )
+
+            # Current heating circuit
+            zone_control = self.coordinator.data["zone_control"].get(self.zone_id)
+            if zone_control and "heatingCircuit" in zone_control:
+                heating_circuit_number = zone_control["heatingCircuit"]
+                if heating_circuit_number is None:
+                    self._attr_current_option = TRANSLATABLE_NO_HEATING_CIRCUIT
+                else:
+                    # Find heating circuit by driverShortSerialNo
+                    heating_circuit = next(
+                        (
+                            hc
+                            for hc in heating_circuits
+                            if hc.get("number") == heating_circuit_number
+                        ),
+                        None,
+                    )
+
+                    if heating_circuit is None:
+                        _LOGGER.error(
+                            "Heating circuit with number %s not found for zone %s",
+                            heating_circuit_number,
+                            self.zone_name,
+                        )
+                        self._attr_current_option = TRANSLATABLE_NO_HEATING_CIRCUIT
+                    else:
+                        self._attr_current_option = heating_circuit.get(
+                            "driverShortSerialNo"
+                        )
+        except KeyError:
+            _LOGGER.error(
+                "Could not update heating circuit info for zone %s",
+                self.zone_name,
+            )

--- a/homeassistant/components/tado/select.py
+++ b/homeassistant/components/tado/select.py
@@ -12,7 +12,7 @@ from .entity import TadoDataUpdateCoordinator, TadoZoneEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-TRANSLATABLE_NO_HEATING_CIRCUIT = "no_heating_circuit"
+NO_HEATING_CIRCUIT_OPTION = "no_heating_circuit"
 
 
 async def async_setup_entry(
@@ -24,7 +24,6 @@ async def async_setup_entry(
 
     tado = entry.runtime_data.coordinator
     entities: list[SelectEntity] = [
-        # Add heating circuit select
         TadoHeatingCircuitSelectEntity(tado, zone["name"], zone["id"])
         for zone in tado.zones
         if zone["type"] == "HEATING"
@@ -59,7 +58,7 @@ class TadoHeatingCircuitSelectEntity(TadoZoneEntity, SelectEntity):
         """Update the selected heating circuit."""
         heating_circuit_id = (
             None
-            if option == TRANSLATABLE_NO_HEATING_CIRCUIT
+            if option == NO_HEATING_CIRCUIT_OPTION
             else self.coordinator.data["heating_circuits"].get(option, {}).get("number")
         )
         await self.coordinator.set_heating_circuit(self.zone_id, heating_circuit_id)
@@ -77,7 +76,7 @@ class TadoHeatingCircuitSelectEntity(TadoZoneEntity, SelectEntity):
         try:
             # Heating circuits list
             heating_circuits = self.coordinator.data["heating_circuits"].values()
-            self._attr_options = [TRANSLATABLE_NO_HEATING_CIRCUIT]
+            self._attr_options = [NO_HEATING_CIRCUIT_OPTION]
             self._attr_options.extend(
                 hc["driverShortSerialNo"] for hc in heating_circuits
             )
@@ -87,9 +86,9 @@ class TadoHeatingCircuitSelectEntity(TadoZoneEntity, SelectEntity):
             if zone_control and "heatingCircuit" in zone_control:
                 heating_circuit_number = zone_control["heatingCircuit"]
                 if heating_circuit_number is None:
-                    self._attr_current_option = TRANSLATABLE_NO_HEATING_CIRCUIT
+                    self._attr_current_option = NO_HEATING_CIRCUIT_OPTION
                 else:
-                    # Find heating circuit by driverShortSerialNo
+                    # Find heating circuit by number
                     heating_circuit = next(
                         (
                             hc
@@ -105,7 +104,7 @@ class TadoHeatingCircuitSelectEntity(TadoZoneEntity, SelectEntity):
                             heating_circuit_number,
                             self.zone_name,
                         )
-                        self._attr_current_option = TRANSLATABLE_NO_HEATING_CIRCUIT
+                        self._attr_current_option = NO_HEATING_CIRCUIT_OPTION
                     else:
                         self._attr_current_option = heating_circuit.get(
                             "driverShortSerialNo"

--- a/homeassistant/components/tado/select.py
+++ b/homeassistant/components/tado/select.py
@@ -59,7 +59,7 @@ class TadoHeatingCircuitSelectEntity(TadoZoneEntity, SelectEntity):
         """Update the selected heating circuit."""
         heating_circuit_id = (
             None
-            if option is TRANSLATABLE_NO_HEATING_CIRCUIT
+            if option == TRANSLATABLE_NO_HEATING_CIRCUIT
             else self.coordinator.data["heating_circuits"].get(option, {}).get("number")
         )
         await self.coordinator.set_heating_circuit(self.zone_id, heating_circuit_id)

--- a/homeassistant/components/tado/strings.json
+++ b/homeassistant/components/tado/strings.json
@@ -62,6 +62,9 @@
     "switch": {
       "child_lock": {
         "name": "Child lock"
+      },
+      "heating_circuit": {
+        "name": "Heating circuit"
       }
     },
     "sensor": {

--- a/homeassistant/components/tado/strings.json
+++ b/homeassistant/components/tado/strings.json
@@ -59,12 +59,17 @@
         }
       }
     },
+    "select": {
+      "heating_circuit": {
+        "name": "Heating circuit",
+        "state": {
+          "no_heating_circuit": "No heating circuit"
+        }
+      }
+    },
     "switch": {
       "child_lock": {
         "name": "Child lock"
-      },
-      "heating_circuit": {
-        "name": "Heating circuit"
       }
     },
     "sensor": {

--- a/homeassistant/components/tado/strings.json
+++ b/homeassistant/components/tado/strings.json
@@ -63,7 +63,7 @@
       "heating_circuit": {
         "name": "Heating circuit",
         "state": {
-          "no_heating_circuit": "No heating circuit"
+          "no_heating_circuit": "No circuit"
         }
       }
     },

--- a/homeassistant/components/tado/switch.py
+++ b/homeassistant/components/tado/switch.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -21,20 +22,24 @@ async def async_setup_entry(
     """Set up the Tado switch platform."""
 
     tado = entry.runtime_data.coordinator
-    entities: list[TadoChildLockSwitchEntity] = []
+    entities: list[SwitchEntity] = []
+
     for zone in tado.zones:
+        # Add child lock switch
         zoneChildLockSupported = (
             len(zone["devices"]) > 0 and "childLockEnabled" in zone["devices"][0]
         )
 
-        if not zoneChildLockSupported:
-            continue
-
-        entities.append(
-            TadoChildLockSwitchEntity(
-                tado, zone["name"], zone["id"], zone["devices"][0]
+        if zoneChildLockSupported:
+            entities.append(
+                TadoChildLockSwitchEntity(
+                    tado, zone["name"], zone["id"], zone["devices"][0]
+                )
             )
-        )
+
+        # Add heating circuit switch
+        entities.append(TadoHeatingCircuitSwitchEntity(tado, zone["name"], zone["id"]))
+
     async_add_entities(entities, True)
 
 
@@ -86,3 +91,52 @@ class TadoChildLockSwitchEntity(TadoZoneEntity, SwitchEntity):
             )
         else:
             self._attr_is_on = self._device_info.get("childLockEnabled", False) is True
+
+
+class TadoHeatingCircuitSwitchEntity(TadoZoneEntity, SwitchEntity):
+    """Representation of a Tado heating circuit switch entity."""
+
+    _attr_translation_key = "heating_circuit"
+    _circuit_id = 1  # Hard-coded value to use when enabled
+
+    def __init__(
+        self,
+        coordinator: TadoDataUpdateCoordinator,
+        zone_name: str,
+        zone_id: int,
+    ) -> None:
+        """Initialize the Tado heating circuit switch entity."""
+        super().__init__(zone_name, coordinator.home_id, zone_id, coordinator)
+
+        self._attr_unique_id = f"{zone_id} {coordinator.home_id} heating-circuit"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self.coordinator.set_heating_circuit(self.zone_id, self._circuit_id)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self.coordinator.set_heating_circuit(self.zone_id, None)
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_callback()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_callback(self) -> None:
+        """Handle update callbacks."""
+        try:
+            zone_control = self.coordinator.data["zone_control"].get(self.zone_id)
+            if zone_control and "heatingCircuit" in zone_control:
+                heating_circuit_id = zone_control["heatingCircuit"]
+                self._attr_is_on = heating_circuit_id is not None
+        except (KeyError, IndexError):
+            _LOGGER.error(
+                "Could not update heating circuit info for zone %s",
+                self.zone_name,
+            )

--- a/homeassistant/components/tado/switch.py
+++ b/homeassistant/components/tado/switch.py
@@ -21,21 +21,20 @@ async def async_setup_entry(
     """Set up the Tado switch platform."""
 
     tado = entry.runtime_data.coordinator
-    entities: list[SwitchEntity] = []
-
+    entities: list[TadoChildLockSwitchEntity] = []
     for zone in tado.zones:
-        # Add child lock switch
         zoneChildLockSupported = (
             len(zone["devices"]) > 0 and "childLockEnabled" in zone["devices"][0]
         )
 
-        if zoneChildLockSupported:
-            entities.append(
-                TadoChildLockSwitchEntity(
-                    tado, zone["name"], zone["id"], zone["devices"][0]
-                )
-            )
+        if not zoneChildLockSupported:
+            continue
 
+        entities.append(
+            TadoChildLockSwitchEntity(
+                tado, zone["name"], zone["id"], zone["devices"][0]
+            )
+        )
     async_add_entities(entities, True)
 
 

--- a/tests/components/tado/fixtures/heating_circuits.json
+++ b/tests/components/tado/fixtures/heating_circuits.json
@@ -1,0 +1,7 @@
+[
+  {
+    "number": 1,
+    "driverSerialNo": "RU1234567890",
+    "driverShortSerialNo": "RU1234567890"
+  }
+]

--- a/tests/components/tado/fixtures/zone_control.json
+++ b/tests/components/tado/fixtures/zone_control.json
@@ -1,0 +1,80 @@
+{
+  "type": "HEATING",
+  "earlyStartEnabled": false,
+  "heatingCircuit": 1,
+  "duties": {
+    "type": "HEATING",
+    "leader": {
+      "deviceType": "RU01",
+      "serialNo": "RU1234567890",
+      "shortSerialNo": "RU1234567890",
+      "currentFwVersion": "54.20",
+      "connectionState": {
+        "value": true,
+        "timestamp": "2025-06-30T19:53:40.710Z"
+      },
+      "characteristics": {
+        "capabilities": ["INSIDE_TEMPERATURE_MEASUREMENT", "IDENTIFY"]
+      },
+      "batteryState": "NORMAL"
+    },
+    "drivers": [
+      {
+        "deviceType": "VA01",
+        "serialNo": "VA1234567890",
+        "shortSerialNo": "VA1234567890",
+        "currentFwVersion": "54.20",
+        "connectionState": {
+          "value": true,
+          "timestamp": "2025-06-30T19:54:15.166Z"
+        },
+        "characteristics": {
+          "capabilities": ["INSIDE_TEMPERATURE_MEASUREMENT", "IDENTIFY"]
+        },
+        "mountingState": {
+          "value": "CALIBRATED",
+          "timestamp": "2025-06-09T23:25:12.678Z"
+        },
+        "mountingStateWithError": "CALIBRATED",
+        "batteryState": "LOW",
+        "childLockEnabled": false
+      }
+    ],
+    "uis": [
+      {
+        "deviceType": "RU01",
+        "serialNo": "RU1234567890",
+        "shortSerialNo": "RU1234567890",
+        "currentFwVersion": "54.20",
+        "connectionState": {
+          "value": true,
+          "timestamp": "2025-06-30T19:53:40.710Z"
+        },
+        "characteristics": {
+          "capabilities": ["INSIDE_TEMPERATURE_MEASUREMENT", "IDENTIFY"]
+        },
+        "batteryState": "NORMAL"
+      },
+      {
+        "deviceType": "VA01",
+        "serialNo": "VA1234567890",
+        "shortSerialNo": "VA1234567890",
+        "currentFwVersion": "54.20",
+        "connectionState": {
+          "value": true,
+          "timestamp": "2025-06-30T19:54:15.166Z"
+        },
+        "characteristics": {
+          "capabilities": ["INSIDE_TEMPERATURE_MEASUREMENT", "IDENTIFY"]
+        },
+        "mountingState": {
+          "value": "CALIBRATED",
+          "timestamp": "2025-06-09T23:25:12.678Z"
+        },
+        "mountingStateWithError": "CALIBRATED",
+        "batteryState": "LOW",
+        "childLockEnabled": false
+      }
+    ]
+  }
+}

--- a/tests/components/tado/snapshots/test_diagnostics.ambr
+++ b/tests/components/tado/snapshots/test_diagnostics.ambr
@@ -62,6 +62,13 @@
         'presence': 'HOME',
         'presenceLocked': False,
       }),
+      'heating_circuits': dict({
+        'RU1234567890': dict({
+          'driverSerialNo': 'RU1234567890',
+          'driverShortSerialNo': 'RU1234567890',
+          'number': 1,
+        }),
+      }),
       'weather': dict({
         'outsideTemperature': dict({
           'celsius': 7.46,
@@ -108,6 +115,560 @@
         '6': dict({
           '__type': "<class 'PyTado.zone.my_zone.TadoZone'>",
           'repr': "TadoZone(zone_id=6, current_temp=24.3, connection=None, current_temp_timestamp='2024-06-28T22: 23: 15.679Z', current_humidity=70.9, current_humidity_timestamp='2024-06-28T22: 23: 15.679Z', is_away=False, current_hvac_action='HEATING', current_fan_speed='AUTO', current_fan_level='LEVEL3', current_hvac_mode='HEAT', current_swing_mode='OFF', current_vertical_swing_mode='ON', current_horizontal_swing_mode='ON', target_temp=25.0, available=True, power='ON', link='ONLINE', ac_power_timestamp='2022-07-13T18: 06: 58.183Z', heating_power_timestamp=None, ac_power='ON', heating_power=None, heating_power_percentage=None, tado_mode='HOME', overlay_termination_type='MANUAL', overlay_termination_timestamp=None, default_overlay_termination_type='MANUAL', default_overlay_termination_duration=None, preparation=False, open_window=False, open_window_detected=False, open_window_attr={}, precision=0.1)",
+        }),
+      }),
+      'zone_control': dict({
+        '1': dict({
+          'duties': dict({
+            'drivers': list([
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+            'leader': dict({
+              'batteryState': 'NORMAL',
+              'characteristics': dict({
+                'capabilities': list([
+                  'INSIDE_TEMPERATURE_MEASUREMENT',
+                  'IDENTIFY',
+                ]),
+              }),
+              'connectionState': dict({
+                'timestamp': '2025-06-30T19:53:40.710Z',
+                'value': True,
+              }),
+              'currentFwVersion': '54.20',
+              'deviceType': 'RU01',
+              'serialNo': 'RU1234567890',
+              'shortSerialNo': 'RU1234567890',
+            }),
+            'type': 'HEATING',
+            'uis': list([
+              dict({
+                'batteryState': 'NORMAL',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:53:40.710Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'RU01',
+                'serialNo': 'RU1234567890',
+                'shortSerialNo': 'RU1234567890',
+              }),
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+          }),
+          'earlyStartEnabled': False,
+          'heatingCircuit': 1,
+          'type': 'HEATING',
+        }),
+        '2': dict({
+          'duties': dict({
+            'drivers': list([
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+            'leader': dict({
+              'batteryState': 'NORMAL',
+              'characteristics': dict({
+                'capabilities': list([
+                  'INSIDE_TEMPERATURE_MEASUREMENT',
+                  'IDENTIFY',
+                ]),
+              }),
+              'connectionState': dict({
+                'timestamp': '2025-06-30T19:53:40.710Z',
+                'value': True,
+              }),
+              'currentFwVersion': '54.20',
+              'deviceType': 'RU01',
+              'serialNo': 'RU1234567890',
+              'shortSerialNo': 'RU1234567890',
+            }),
+            'type': 'HEATING',
+            'uis': list([
+              dict({
+                'batteryState': 'NORMAL',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:53:40.710Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'RU01',
+                'serialNo': 'RU1234567890',
+                'shortSerialNo': 'RU1234567890',
+              }),
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+          }),
+          'earlyStartEnabled': False,
+          'heatingCircuit': 1,
+          'type': 'HEATING',
+        }),
+        '3': dict({
+          'duties': dict({
+            'drivers': list([
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+            'leader': dict({
+              'batteryState': 'NORMAL',
+              'characteristics': dict({
+                'capabilities': list([
+                  'INSIDE_TEMPERATURE_MEASUREMENT',
+                  'IDENTIFY',
+                ]),
+              }),
+              'connectionState': dict({
+                'timestamp': '2025-06-30T19:53:40.710Z',
+                'value': True,
+              }),
+              'currentFwVersion': '54.20',
+              'deviceType': 'RU01',
+              'serialNo': 'RU1234567890',
+              'shortSerialNo': 'RU1234567890',
+            }),
+            'type': 'HEATING',
+            'uis': list([
+              dict({
+                'batteryState': 'NORMAL',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:53:40.710Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'RU01',
+                'serialNo': 'RU1234567890',
+                'shortSerialNo': 'RU1234567890',
+              }),
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+          }),
+          'earlyStartEnabled': False,
+          'heatingCircuit': 1,
+          'type': 'HEATING',
+        }),
+        '4': dict({
+          'duties': dict({
+            'drivers': list([
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+            'leader': dict({
+              'batteryState': 'NORMAL',
+              'characteristics': dict({
+                'capabilities': list([
+                  'INSIDE_TEMPERATURE_MEASUREMENT',
+                  'IDENTIFY',
+                ]),
+              }),
+              'connectionState': dict({
+                'timestamp': '2025-06-30T19:53:40.710Z',
+                'value': True,
+              }),
+              'currentFwVersion': '54.20',
+              'deviceType': 'RU01',
+              'serialNo': 'RU1234567890',
+              'shortSerialNo': 'RU1234567890',
+            }),
+            'type': 'HEATING',
+            'uis': list([
+              dict({
+                'batteryState': 'NORMAL',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:53:40.710Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'RU01',
+                'serialNo': 'RU1234567890',
+                'shortSerialNo': 'RU1234567890',
+              }),
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+          }),
+          'earlyStartEnabled': False,
+          'heatingCircuit': 1,
+          'type': 'HEATING',
+        }),
+        '5': dict({
+          'duties': dict({
+            'drivers': list([
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+            'leader': dict({
+              'batteryState': 'NORMAL',
+              'characteristics': dict({
+                'capabilities': list([
+                  'INSIDE_TEMPERATURE_MEASUREMENT',
+                  'IDENTIFY',
+                ]),
+              }),
+              'connectionState': dict({
+                'timestamp': '2025-06-30T19:53:40.710Z',
+                'value': True,
+              }),
+              'currentFwVersion': '54.20',
+              'deviceType': 'RU01',
+              'serialNo': 'RU1234567890',
+              'shortSerialNo': 'RU1234567890',
+            }),
+            'type': 'HEATING',
+            'uis': list([
+              dict({
+                'batteryState': 'NORMAL',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:53:40.710Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'RU01',
+                'serialNo': 'RU1234567890',
+                'shortSerialNo': 'RU1234567890',
+              }),
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+          }),
+          'earlyStartEnabled': False,
+          'heatingCircuit': 1,
+          'type': 'HEATING',
+        }),
+        '6': dict({
+          'duties': dict({
+            'drivers': list([
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+            'leader': dict({
+              'batteryState': 'NORMAL',
+              'characteristics': dict({
+                'capabilities': list([
+                  'INSIDE_TEMPERATURE_MEASUREMENT',
+                  'IDENTIFY',
+                ]),
+              }),
+              'connectionState': dict({
+                'timestamp': '2025-06-30T19:53:40.710Z',
+                'value': True,
+              }),
+              'currentFwVersion': '54.20',
+              'deviceType': 'RU01',
+              'serialNo': 'RU1234567890',
+              'shortSerialNo': 'RU1234567890',
+            }),
+            'type': 'HEATING',
+            'uis': list([
+              dict({
+                'batteryState': 'NORMAL',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:53:40.710Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'RU01',
+                'serialNo': 'RU1234567890',
+                'shortSerialNo': 'RU1234567890',
+              }),
+              dict({
+                'batteryState': 'LOW',
+                'characteristics': dict({
+                  'capabilities': list([
+                    'INSIDE_TEMPERATURE_MEASUREMENT',
+                    'IDENTIFY',
+                  ]),
+                }),
+                'childLockEnabled': False,
+                'connectionState': dict({
+                  'timestamp': '2025-06-30T19:54:15.166Z',
+                  'value': True,
+                }),
+                'currentFwVersion': '54.20',
+                'deviceType': 'VA01',
+                'mountingState': dict({
+                  'timestamp': '2025-06-09T23:25:12.678Z',
+                  'value': 'CALIBRATED',
+                }),
+                'mountingStateWithError': 'CALIBRATED',
+                'serialNo': 'VA1234567890',
+                'shortSerialNo': 'VA1234567890',
+              }),
+            ]),
+          }),
+          'earlyStartEnabled': False,
+          'heatingCircuit': 1,
+          'type': 'HEATING',
         }),
       }),
     }),

--- a/tests/components/tado/test_select.py
+++ b/tests/components/tado/test_select.py
@@ -1,0 +1,171 @@
+"""The select tests for the tado platform."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION
+from homeassistant.core import HomeAssistant
+
+from .util import async_init_integration
+
+HEATING_CIRCUIT_SELECT_ENTITY = "select.baseboard_heater_heating_circuit"
+NO_HEATING_CIRCUIT = "no_heating_circuit"
+HEATING_CIRCUIT_OPTION = "RU1234567890"
+
+
+async def test_heating_circuit_select(hass: HomeAssistant) -> None:
+    """Test creation of heating circuit select entity."""
+
+    await async_init_integration(hass)
+    state = hass.states.get(HEATING_CIRCUIT_SELECT_ENTITY)
+    assert state is not None
+    assert state.state == HEATING_CIRCUIT_OPTION
+    assert NO_HEATING_CIRCUIT in state.attributes["options"]
+    assert HEATING_CIRCUIT_OPTION in state.attributes["options"]
+
+
+async def test_select_heating_circuit(hass: HomeAssistant) -> None:
+    """Test selecting heating circuit option."""
+
+    await async_init_integration(hass)
+
+    # Test selecting a specific heating circuit
+    with (
+        patch(
+            "homeassistant.components.tado.TadoDataUpdateCoordinator.set_heating_circuit"
+        ) as mock_set_heating_circuit,
+        patch(
+            "homeassistant.components.tado.TadoDataUpdateCoordinator.async_request_refresh"
+        ) as mock_refresh,
+    ):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: HEATING_CIRCUIT_SELECT_ENTITY,
+                ATTR_OPTION: HEATING_CIRCUIT_OPTION,
+            },
+            blocking=True,
+        )
+
+    mock_set_heating_circuit.assert_called_once()
+    # The heating circuit ID should be extracted from the coordinator data
+    assert mock_refresh.called
+
+
+async def test_select_no_heating_circuit(hass: HomeAssistant) -> None:
+    """Test selecting no heating circuit option."""
+
+    await async_init_integration(hass)
+
+    # Test selecting no heating circuit
+    with (
+        patch(
+            "homeassistant.components.tado.TadoDataUpdateCoordinator.set_heating_circuit"
+        ) as mock_set_heating_circuit,
+        patch(
+            "homeassistant.components.tado.TadoDataUpdateCoordinator.async_request_refresh"
+        ) as mock_refresh,
+    ):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: HEATING_CIRCUIT_SELECT_ENTITY,
+                ATTR_OPTION: NO_HEATING_CIRCUIT,
+            },
+            blocking=True,
+        )
+
+    mock_set_heating_circuit.assert_called_once()
+    # None should be passed when selecting "no_heating_circuit"
+    assert mock_set_heating_circuit.call_args[0][1] is None
+    assert mock_refresh.called
+
+
+async def test_coordinator_update(hass: HomeAssistant) -> None:
+    """Test coordinator update handling."""
+
+    await async_init_integration(hass)
+
+    entity = hass.data["entity_components"]["select"].get_entity(
+        HEATING_CIRCUIT_SELECT_ENTITY
+    )
+    assert entity is not None
+
+    # Simulate coordinator update with new heating circuit data
+    with patch.object(entity, "_async_update_callback") as mock_update_callback:
+        await entity.coordinator.async_refresh()
+
+    assert mock_update_callback.called
+
+
+@pytest.mark.usefixtures("caplog")
+async def test_heating_circuit_not_found(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test when a heating circuit with a specific number is not found."""
+
+    await async_init_integration(hass)
+    entity = hass.data["entity_components"]["select"].get_entity(
+        HEATING_CIRCUIT_SELECT_ENTITY
+    )
+
+    # Prepare test data with a heating circuit number that doesn't exist
+    nonexistent_circuit_number = 999
+
+    # Create a modified zone_control
+    modified_zone_control = {
+        "heatingCircuit": nonexistent_circuit_number,
+        "type": "HEATING",
+    }
+
+    # Replace the zone_control data in the coordinator
+    with patch.dict(
+        entity.coordinator.data["zone_control"], {entity.zone_id: modified_zone_control}
+    ):
+        # Force an update callback
+        entity._async_update_callback()
+
+    # Check that error was logged
+    assert any(
+        f"Heating circuit with number {nonexistent_circuit_number} not found for zone"
+        in record.message
+        for record in caplog.records
+    )
+    # Check that the entity falls back to no heating circuit
+    assert entity.current_option == NO_HEATING_CIRCUIT
+
+
+@pytest.mark.usefixtures("caplog")
+async def test_keyerror_handling(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test handling of KeyError in _async_update_callback."""
+
+    await async_init_integration(hass)
+    entity = hass.data["entity_components"]["select"].get_entity(
+        HEATING_CIRCUIT_SELECT_ENTITY
+    )
+
+    # Create a coordinator with incomplete data that will trigger a KeyError
+    with patch.object(
+        entity.coordinator,
+        "data",
+        # Missing 'heating_circuits' key will trigger KeyError
+        {"zone_control": {}},
+    ):
+        # Force an update callback
+        entity._async_update_callback()
+
+    # Check that error was logged
+    assert any(
+        f"Could not update heating circuit info for zone {entity.zone_name}"
+        in record.message
+        for record in caplog.records
+    )

--- a/tests/components/tado/test_select.py
+++ b/tests/components/tado/test_select.py
@@ -16,6 +16,8 @@ from .util import async_init_integration
 HEATING_CIRCUIT_SELECT_ENTITY = "select.baseboard_heater_heating_circuit"
 NO_HEATING_CIRCUIT = "no_heating_circuit"
 HEATING_CIRCUIT_OPTION = "RU1234567890"
+ZONE_ID = 1
+HEATING_CIRCUIT_ID = 1
 
 
 async def test_heating_circuit_select(hass: HomeAssistant) -> None:
@@ -53,8 +55,7 @@ async def test_select_heating_circuit(hass: HomeAssistant) -> None:
             blocking=True,
         )
 
-    mock_set_heating_circuit.assert_called_once()
-    # The heating circuit ID should be extracted from the coordinator data
+    mock_set_heating_circuit.assert_called_with(ZONE_ID, HEATING_CIRCUIT_ID)
     assert mock_refresh.called
 
 
@@ -82,9 +83,8 @@ async def test_select_no_heating_circuit(hass: HomeAssistant) -> None:
             blocking=True,
         )
 
-    mock_set_heating_circuit.assert_called_once()
     # None should be passed when selecting "no_heating_circuit"
-    assert mock_set_heating_circuit.call_args[0][1] is None
+    mock_set_heating_circuit.assert_called_with(ZONE_ID, None)
     assert mock_refresh.called
 
 

--- a/tests/components/tado/util.py
+++ b/tests/components/tado/util.py
@@ -20,8 +20,10 @@ async def async_init_integration(
     me_fixture = "me.json"
     weather_fixture = "weather.json"
     home_fixture = "home.json"
+    home_heating_circuits_fixture = "heating_circuits.json"
     home_state_fixture = "home_state.json"
     zones_fixture = "zones.json"
+    zone_control_fixture = "zone_control.json"
     zone_states_fixture = "zone_states.json"
 
     # WR1 Device
@@ -69,6 +71,10 @@ async def async_init_integration(
         m.get(
             "https://my.tado.com/api/v2/homes/1/",
             text=await async_load_fixture(hass, home_fixture, DOMAIN),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/heatingCircuits",
+            text=await async_load_fixture(hass, home_heating_circuits_fixture, DOMAIN),
         )
         m.get(
             "https://my.tado.com/api/v2/homes/1/weather",
@@ -177,6 +183,30 @@ async def async_init_integration(
         m.get(
             "https://my.tado.com/api/v2/homes/1/zones/1/state",
             text=await async_load_fixture(hass, zone_1_state_fixture, DOMAIN),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/1/control",
+            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/2/control",
+            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/3/control",
+            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/4/control",
+            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/5/control",
+            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/6/control",
+            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
         )
         m.post(
             "https://login.tado.com/oauth2/token",

--- a/tests/components/tado/util.py
+++ b/tests/components/tado/util.py
@@ -184,30 +184,12 @@ async def async_init_integration(
             "https://my.tado.com/api/v2/homes/1/zones/1/state",
             text=await async_load_fixture(hass, zone_1_state_fixture, DOMAIN),
         )
-        m.get(
-            "https://my.tado.com/api/v2/homes/1/zones/1/control",
-            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
-        )
-        m.get(
-            "https://my.tado.com/api/v2/homes/1/zones/2/control",
-            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
-        )
-        m.get(
-            "https://my.tado.com/api/v2/homes/1/zones/3/control",
-            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
-        )
-        m.get(
-            "https://my.tado.com/api/v2/homes/1/zones/4/control",
-            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
-        )
-        m.get(
-            "https://my.tado.com/api/v2/homes/1/zones/5/control",
-            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
-        )
-        m.get(
-            "https://my.tado.com/api/v2/homes/1/zones/6/control",
-            text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
-        )
+        zone_ids = [1, 2, 3, 4, 5, 6]
+        for zone_id in zone_ids:
+            m.get(
+                f"https://my.tado.com/api/v2/homes/1/zones/{zone_id}/control",
+                text=await async_load_fixture(hass, zone_control_fixture, DOMAIN),
+            )
         m.post(
             "https://login.tado.com/oauth2/token",
             text=await async_load_fixture(hass, token_fixture, DOMAIN),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a `select` entity to Tado Zone devices, allowing users to change the heating circuit assigned to a zone. The heating circuit refers to the thermostat that controls the boiler when there is a heat demand in that zone.

Users can also choose **"No heating circuit"**, meaning that heat demand in the zone will only result in the valves being opened by Tado, without activating the boiler. In the Tado app, this setting is available under:  
**Settings → Rooms & Devices → Select a room → Heating Zone**

**Example use case:**  
An automation could enable a heating circuit when a room is occupied and disable it when unoccupied. This allows the room to benefit from residual heat when other parts of the home are heated, without initiating heating for that room alone.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39797
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
