### PR TITLE
Add config flow to compensation helper

### DIFF
--- a/homeassistant/components/compensation/__init__.py
+++ b/homeassistant/components/compensation/__init__.py
@@ -168,11 +168,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Compensation from a config entry."""
     config = dict(entry.options)
-    data_points = config[CONF_DATAPOINTS]
-    new_data_points = []
-    for data_point in data_points:
-        values = data_point.split(",", maxsplit=1)
-        new_data_points.append([float(values[0]), float(values[1])])
+    data_points: list[dict[str, float]] = config[CONF_DATAPOINTS]
+    new_data_points = [
+        [data_point["compensated_value"], data_point["uncompensated_value"]]
+        for data_point in data_points
+    ]
     config[CONF_DATAPOINTS] = new_data_points
 
     await create_compensation_data(hass, entry.entry_id, config, True)

--- a/homeassistant/components/compensation/__init__.py
+++ b/homeassistant/components/compensation/__init__.py
@@ -177,7 +177,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await create_compensation_data(hass, entry.entry_id, config, True)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     return True
 
@@ -185,8 +184,3 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Compensation config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle options update."""
-    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/compensation/__init__.py
+++ b/homeassistant/components/compensation/__init__.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_DEGREE,
     CONF_LOWER_LIMIT,
     CONF_POLYNOMIAL,
+    CONF_POLYNOMIAL_CONFIG,
     CONF_PRECISION,
     CONF_UPPER_LIMIT,
     DATA_COMPENSATION,
@@ -168,11 +169,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Compensation from a config entry."""
     config = dict(entry.options)
-    data_points: list[dict[str, float]] = config[CONF_DATAPOINTS]
+    data_points: list[dict[str, float]] = config[CONF_POLYNOMIAL_CONFIG][
+        CONF_DATAPOINTS
+    ]
     new_data_points = [
         [data_point["compensated_value"], data_point["uncompensated_value"]]
         for data_point in data_points
     ]
+    config[CONF_DEGREE] = config[CONF_POLYNOMIAL_CONFIG][CONF_DEGREE]
     config[CONF_DATAPOINTS] = new_data_points
 
     await create_compensation_data(hass, entry.entry_id, config, True)

--- a/homeassistant/components/compensation/__init__.py
+++ b/homeassistant/components/compensation/__init__.py
@@ -187,4 +187,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Compensation config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DATA_COMPENSATION].pop(entry.entry_id, None)
+    return unload_ok

--- a/homeassistant/components/compensation/__init__.py
+++ b/homeassistant/components/compensation/__init__.py
@@ -30,6 +30,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    CONF_COMPENSATED_VALUE,
     CONF_COMPENSATION,
     CONF_DATAPOINTS,
     CONF_DEGREE,
@@ -37,6 +38,7 @@ from .const import (
     CONF_POLYNOMIAL,
     CONF_POLYNOMIAL_CONFIG,
     CONF_PRECISION,
+    CONF_UNCOMPENSATED_VALUE,
     CONF_UPPER_LIMIT,
     DATA_COMPENSATION,
     DEFAULT_DEGREE,
@@ -173,7 +175,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_DATAPOINTS
     ]
     new_data_points = [
-        [data_point["uncompensated_value"], data_point["compensated_value"]]
+        [data_point[CONF_UNCOMPENSATED_VALUE], data_point[CONF_COMPENSATED_VALUE]]
         for data_point in data_points
     ]
     config[CONF_DEGREE] = config[CONF_POLYNOMIAL_CONFIG][CONF_DEGREE]

--- a/homeassistant/components/compensation/__init__.py
+++ b/homeassistant/components/compensation/__init__.py
@@ -173,7 +173,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_DATAPOINTS
     ]
     new_data_points = [
-        [data_point["compensated_value"], data_point["uncompensated_value"]]
+        [data_point["uncompensated_value"], data_point["compensated_value"]]
         for data_point in data_points
     ]
     config[CONF_DEGREE] = config[CONF_POLYNOMIAL_CONFIG][CONF_DEGREE]

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -86,22 +86,6 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
     )
 
 
-def _is_valid_data_points(check_data_points: list[str]) -> bool:
-    """Validate data points."""
-    result = False
-    for data_point in check_data_points:
-        if not data_point.find(",") > 0:
-            return False
-        values = data_point.split(",", maxsplit=1)
-        for value in values:
-            try:
-                float(value)
-            except ValueError:
-                return False
-        result = True
-    return result
-
-
 async def validate_options(
     handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
 ) -> dict[str, Any]:
@@ -109,9 +93,6 @@ async def validate_options(
 
     user_input[CONF_PRECISION] = int(user_input[CONF_PRECISION])
     user_input[CONF_DEGREE] = int(user_input[CONF_DEGREE])
-
-    if not _is_valid_data_points(user_input[CONF_DATAPOINTS]):
-        raise SchemaFlowError("incorrect_datapoints")
 
     if len(user_input[CONF_DATAPOINTS]) <= user_input[CONF_DEGREE]:
         raise SchemaFlowError("not_enough_datapoints")

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -136,6 +136,7 @@ class CompensationConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
 
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW
+    options_flow_reloads = True
 
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -61,11 +61,15 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
                     fields={
                         "uncompensated_value": ObjectSelectorField(
                             required=True,
-                            selector=TextSelector(),
+                            selector=NumberSelector(
+                                NumberSelectorConfig(mode=NumberSelectorMode.BOX)
+                            ),
                         ),
                         "compensated_value": ObjectSelectorField(
                             required=True,
-                            selector=TextSelector(),
+                            selector=NumberSelector(
+                                NumberSelectorConfig(mode=NumberSelectorMode.BOX)
+                            ),
                         ),
                     },
                 )

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -1,0 +1,157 @@
+"""Config flow for statistics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_ATTRIBUTE,
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    CONF_UNIT_OF_MEASUREMENT,
+)
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
+    SchemaConfigFlowHandler,
+    SchemaFlowError,
+    SchemaFlowFormStep,
+)
+from homeassistant.helpers.selector import (
+    AttributeSelector,
+    AttributeSelectorConfig,
+    BooleanSelector,
+    EntitySelector,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    ObjectSelector,
+    ObjectSelectorConfig,
+    ObjectSelectorField,
+    TextSelector,
+)
+
+from .const import (
+    CONF_DATAPOINTS,
+    CONF_DEGREE,
+    CONF_LOWER_LIMIT,
+    CONF_PRECISION,
+    CONF_UPPER_LIMIT,
+    DEFAULT_DEGREE,
+    DEFAULT_NAME,
+    DEFAULT_PRECISION,
+    DOMAIN,
+)
+
+
+async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
+    """Get options schema."""
+    entity_id = handler.options[CONF_ENTITY_ID]
+
+    return vol.Schema(
+        {
+            vol.Required(CONF_DATAPOINTS): ObjectSelector(
+                ObjectSelectorConfig(
+                    label_field="uncompensated_value",
+                    description_field="compensated_value",
+                    multiple=True,
+                    translation_key=CONF_DATAPOINTS,
+                    fields={
+                        "uncompensated_value": ObjectSelectorField(
+                            required=True,
+                            selector=TextSelector(),
+                        ),
+                        "compensated_value": ObjectSelectorField(
+                            required=True,
+                            selector=TextSelector(),
+                        ),
+                    },
+                )
+            ),
+            vol.Optional(CONF_ATTRIBUTE): AttributeSelector(
+                AttributeSelectorConfig(entity_id=entity_id)
+            ),
+            vol.Optional(CONF_UPPER_LIMIT, default=False): BooleanSelector(),
+            vol.Optional(CONF_LOWER_LIMIT, default=False): BooleanSelector(),
+            vol.Optional(CONF_PRECISION, default=DEFAULT_PRECISION): NumberSelector(
+                NumberSelectorConfig(min=0, step=1, mode=NumberSelectorMode.BOX)
+            ),
+            vol.Optional(CONF_DEGREE, default=DEFAULT_DEGREE): NumberSelector(
+                NumberSelectorConfig(min=0, max=7, step=1, mode=NumberSelectorMode.BOX)
+            ),
+            vol.Optional(CONF_UNIT_OF_MEASUREMENT): TextSelector(),
+        }
+    )
+
+
+def _is_valid_data_points(check_data_points: list[str]) -> bool:
+    """Validate data points."""
+    result = False
+    for data_point in check_data_points:
+        if not data_point.find(",") > 0:
+            return False
+        values = data_point.split(",", maxsplit=1)
+        for value in values:
+            try:
+                float(value)
+            except ValueError:
+                return False
+        result = True
+    return result
+
+
+async def validate_options(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate options selected."""
+
+    user_input[CONF_PRECISION] = int(user_input[CONF_PRECISION])
+    user_input[CONF_DEGREE] = int(user_input[CONF_DEGREE])
+
+    if not _is_valid_data_points(user_input[CONF_DATAPOINTS]):
+        raise SchemaFlowError("incorrect_datapoints")
+
+    if len(user_input[CONF_DATAPOINTS]) <= user_input[CONF_DEGREE]:
+        raise SchemaFlowError("not_enough_datapoints")
+
+    handler.parent_handler._async_abort_entries_match({**handler.options, **user_input})  # noqa: SLF001
+
+    return user_input
+
+
+DATA_SCHEMA_SETUP = vol.Schema(
+    {
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
+        vol.Required(CONF_ENTITY_ID): EntitySelector(),
+    }
+)
+
+CONFIG_FLOW = {
+    "user": SchemaFlowFormStep(
+        schema=DATA_SCHEMA_SETUP,
+        next_step="options",
+    ),
+    "options": SchemaFlowFormStep(
+        schema=get_options_schema,
+        validate_user_input=validate_options,
+    ),
+}
+OPTIONS_FLOW = {
+    "init": SchemaFlowFormStep(
+        get_options_schema,
+        validate_user_input=validate_options,
+    ),
+}
+
+
+class CompensationConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config flow for Compensation."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return cast(str, options[CONF_NAME])

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_UNIT_OF_MEASUREMENT,
 )
+from homeassistant.data_entry_flow import SectionConfig, section
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
     SchemaConfigFlowHandler,
@@ -37,6 +38,7 @@ from .const import (
     CONF_DATAPOINTS,
     CONF_DEGREE,
     CONF_LOWER_LIMIT,
+    CONF_POLYNOMIAL_CONFIG,
     CONF_PRECISION,
     CONF_UPPER_LIMIT,
     DEFAULT_DEGREE,
@@ -52,27 +54,45 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
 
     return vol.Schema(
         {
-            vol.Required(CONF_DATAPOINTS): ObjectSelector(
-                ObjectSelectorConfig(
-                    label_field="uncompensated_value",
-                    description_field="compensated_value",
-                    multiple=True,
-                    translation_key=CONF_DATAPOINTS,
-                    fields={
-                        "uncompensated_value": ObjectSelectorField(
-                            required=True,
-                            selector=NumberSelector(
-                                NumberSelectorConfig(mode=NumberSelectorMode.BOX)
-                            ),
+            vol.Required(CONF_POLYNOMIAL_CONFIG): section(
+                vol.Schema(
+                    {
+                        vol.Required(CONF_DATAPOINTS): ObjectSelector(
+                            ObjectSelectorConfig(
+                                label_field="uncompensated_value",
+                                description_field="compensated_value",
+                                multiple=True,
+                                translation_key=CONF_DATAPOINTS,
+                                fields={
+                                    "uncompensated_value": ObjectSelectorField(
+                                        required=True,
+                                        selector=NumberSelector(
+                                            NumberSelectorConfig(
+                                                mode=NumberSelectorMode.BOX
+                                            )
+                                        ),
+                                    ),
+                                    "compensated_value": ObjectSelectorField(
+                                        required=True,
+                                        selector=NumberSelector(
+                                            NumberSelectorConfig(
+                                                mode=NumberSelectorMode.BOX
+                                            )
+                                        ),
+                                    ),
+                                },
+                            )
                         ),
-                        "compensated_value": ObjectSelectorField(
-                            required=True,
-                            selector=NumberSelector(
-                                NumberSelectorConfig(mode=NumberSelectorMode.BOX)
-                            ),
+                        vol.Optional(
+                            CONF_DEGREE, default=DEFAULT_DEGREE
+                        ): NumberSelector(
+                            NumberSelectorConfig(
+                                min=0, max=7, step=1, mode=NumberSelectorMode.BOX
+                            )
                         ),
                     },
-                )
+                ),
+                SectionConfig(collapsed=False),
             ),
             vol.Optional(CONF_ATTRIBUTE): AttributeSelector(
                 AttributeSelectorConfig(entity_id=entity_id)
@@ -81,9 +101,6 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
             vol.Optional(CONF_LOWER_LIMIT, default=False): BooleanSelector(),
             vol.Optional(CONF_PRECISION, default=DEFAULT_PRECISION): NumberSelector(
                 NumberSelectorConfig(min=0, step=1, mode=NumberSelectorMode.BOX)
-            ),
-            vol.Optional(CONF_DEGREE, default=DEFAULT_DEGREE): NumberSelector(
-                NumberSelectorConfig(min=0, max=7, step=1, mode=NumberSelectorMode.BOX)
             ),
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): TextSelector(),
         }

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -87,7 +87,7 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
                             CONF_DEGREE, default=DEFAULT_DEGREE
                         ): NumberSelector(
                             NumberSelectorConfig(
-                                min=0, max=7, step=1, mode=NumberSelectorMode.BOX
+                                min=1, max=7, step=1, mode=NumberSelectorMode.BOX
                             )
                         ),
                     },

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -35,11 +35,13 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
+    CONF_COMPENSATED_VALUE,
     CONF_DATAPOINTS,
     CONF_DEGREE,
     CONF_LOWER_LIMIT,
     CONF_POLYNOMIAL_CONFIG,
     CONF_PRECISION,
+    CONF_UNCOMPENSATED_VALUE,
     CONF_UPPER_LIMIT,
     DEFAULT_DEGREE,
     DEFAULT_NAME,
@@ -64,7 +66,7 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
                                 multiple=True,
                                 translation_key=CONF_DATAPOINTS,
                                 fields={
-                                    "uncompensated_value": ObjectSelectorField(
+                                    CONF_UNCOMPENSATED_VALUE: ObjectSelectorField(
                                         required=True,
                                         selector=NumberSelector(
                                             NumberSelectorConfig(
@@ -72,7 +74,7 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
                                             )
                                         ),
                                     ),
-                                    "compensated_value": ObjectSelectorField(
+                                    CONF_COMPENSATED_VALUE: ObjectSelectorField(
                                         required=True,
                                         selector=NumberSelector(
                                             NumberSelectorConfig(

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -57,7 +57,7 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
             vol.Required(CONF_POLYNOMIAL_CONFIG): section(
                 vol.Schema(
                     {
-                        vol.Required(CONF_DATAPOINTS): ObjectSelector(
+                        vol.Optional(CONF_DATAPOINTS): ObjectSelector(
                             ObjectSelectorConfig(
                                 label_field="uncompensated_value",
                                 description_field="compensated_value",
@@ -112,10 +112,18 @@ async def validate_options(
 ) -> dict[str, Any]:
     """Validate options selected."""
 
-    user_input[CONF_PRECISION] = int(user_input[CONF_PRECISION])
-    user_input[CONF_DEGREE] = int(user_input[CONF_DEGREE])
+    if not user_input[CONF_POLYNOMIAL_CONFIG].get(CONF_DATAPOINTS):
+        raise SchemaFlowError("not_enough_datapoints")
 
-    if len(user_input[CONF_DATAPOINTS]) <= user_input[CONF_DEGREE]:
+    user_input[CONF_PRECISION] = int(user_input[CONF_PRECISION])
+    user_input[CONF_POLYNOMIAL_CONFIG][CONF_DEGREE] = int(
+        user_input[CONF_POLYNOMIAL_CONFIG][CONF_DEGREE]
+    )
+
+    if (
+        len(user_input[CONF_POLYNOMIAL_CONFIG][CONF_DATAPOINTS])
+        <= user_input[CONF_POLYNOMIAL_CONFIG][CONF_DEGREE]
+    ):
         raise SchemaFlowError("not_enough_datapoints")
 
     handler.parent_handler._async_abort_entries_match({**handler.options, **user_input})  # noqa: SLF001

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for statistics."""
+"""Config flow for Compensation integration."""
 
 from __future__ import annotations
 

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -65,6 +65,7 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
                                 description_field="compensated_value",
                                 multiple=True,
                                 translation_key=CONF_DATAPOINTS,
+                                overview_labels=False,
                                 fields={
                                     CONF_UNCOMPENSATED_VALUE: ObjectSelectorField(
                                         required=True,

--- a/homeassistant/components/compensation/config_flow.py
+++ b/homeassistant/components/compensation/config_flow.py
@@ -65,7 +65,7 @@ async def get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
                                 description_field="compensated_value",
                                 multiple=True,
                                 translation_key=CONF_DATAPOINTS,
-                                overview_labels=False,
+                                overview_labels=True,
                                 fields={
                                     CONF_UNCOMPENSATED_VALUE: ObjectSelectorField(
                                         required=True,

--- a/homeassistant/components/compensation/const.py
+++ b/homeassistant/components/compensation/const.py
@@ -1,6 +1,9 @@
 """Compensation constants."""
 
+from homeassistant.const import Platform
+
 DOMAIN = "compensation"
+PLATFORMS = [Platform.SENSOR]
 
 SENSOR = "compensation"
 

--- a/homeassistant/components/compensation/const.py
+++ b/homeassistant/components/compensation/const.py
@@ -14,6 +14,7 @@ CONF_DATAPOINTS = "data_points"
 CONF_DEGREE = "degree"
 CONF_PRECISION = "precision"
 CONF_POLYNOMIAL = "polynomial"
+CONF_POLYNOMIAL_CONFIG = "polynomial_config"
 
 DATA_COMPENSATION = "compensation_data"
 

--- a/homeassistant/components/compensation/const.py
+++ b/homeassistant/components/compensation/const.py
@@ -1,6 +1,9 @@
 """Compensation constants."""
 
+from typing import Any
+
 from homeassistant.const import Platform
+from homeassistant.util.hass_dict import HassKey
 
 DOMAIN = "compensation"
 PLATFORMS = [Platform.SENSOR]
@@ -16,7 +19,8 @@ CONF_PRECISION = "precision"
 CONF_POLYNOMIAL = "polynomial"
 CONF_POLYNOMIAL_CONFIG = "polynomial_config"
 
-DATA_COMPENSATION = "compensation_data"
+
+DATA_COMPENSATION: HassKey[dict[str, Any]] = HassKey("compensation_data")
 
 DEFAULT_DEGREE = 1
 DEFAULT_NAME = "Compensation"

--- a/homeassistant/components/compensation/const.py
+++ b/homeassistant/components/compensation/const.py
@@ -18,6 +18,8 @@ CONF_DEGREE = "degree"
 CONF_PRECISION = "precision"
 CONF_POLYNOMIAL = "polynomial"
 CONF_POLYNOMIAL_CONFIG = "polynomial_config"
+CONF_COMPENSATED_VALUE = "compensated_value"
+CONF_UNCOMPENSATED_VALUE = "uncompensated_value"
 
 
 DATA_COMPENSATION: HassKey[dict[str, Any]] = HassKey("compensation_data")

--- a/homeassistant/components/compensation/manifest.json
+++ b/homeassistant/components/compensation/manifest.json
@@ -2,7 +2,9 @@
   "domain": "compensation",
   "name": "Compensation",
   "codeowners": ["@Petro31"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/compensation",
+  "integration_type": "helper",
   "iot_class": "calculated",
   "quality_scale": "legacy",
   "requirements": ["numpy==2.3.2"]

--- a/homeassistant/components/compensation/sensor.py
+++ b/homeassistant/components/compensation/sensor.py
@@ -10,11 +10,13 @@ from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
     SensorEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_ATTRIBUTE,
     CONF_DEVICE_CLASS,
+    CONF_ENTITY_ID,
     CONF_MAXIMUM,
     CONF_MINIMUM,
     CONF_NAME,
@@ -31,7 +33,10 @@ from homeassistant.core import (
     State,
     callback,
 )
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    AddEntitiesCallback,
+)
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -72,6 +77,36 @@ async def async_setup_platform(
 
     async_add_entities(
         [CompensationSensor(conf.get(CONF_UNIQUE_ID), name, source, attribute, conf)]
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Compensation sensor entry."""
+    compensation = entry.entry_id
+    conf: dict[str, Any] = hass.data[DATA_COMPENSATION][compensation]
+
+    source: str = conf[CONF_ENTITY_ID]
+    attribute: str | None = conf.get(CONF_ATTRIBUTE)
+    name = entry.title
+
+    async_add_entities(
+        [
+            CompensationSensor(
+                entry.entry_id,
+                name,
+                source,
+                attribute,
+                conf[CONF_PRECISION],
+                conf[CONF_POLYNOMIAL],
+                conf.get(CONF_UNIT_OF_MEASUREMENT),
+                conf[CONF_MINIMUM],
+                conf[CONF_MAXIMUM],
+            )
+        ]
     )
 
 

--- a/homeassistant/components/compensation/sensor.py
+++ b/homeassistant/components/compensation/sensor.py
@@ -94,7 +94,7 @@ async def async_setup_entry(
     name = entry.title
 
     async_add_entities(
-        [CompensationSensor(conf.get(CONF_UNIQUE_ID), name, source, attribute, conf)]
+        [CompensationSensor(entry.entry_id, name, source, attribute, conf)]
     )
 
 

--- a/homeassistant/components/compensation/sensor.py
+++ b/homeassistant/components/compensation/sensor.py
@@ -94,19 +94,7 @@ async def async_setup_entry(
     name = entry.title
 
     async_add_entities(
-        [
-            CompensationSensor(
-                entry.entry_id,
-                name,
-                source,
-                attribute,
-                conf[CONF_PRECISION],
-                conf[CONF_POLYNOMIAL],
-                conf.get(CONF_UNIT_OF_MEASUREMENT),
-                conf[CONF_MINIMUM],
-                conf[CONF_MAXIMUM],
-            )
-        ]
+        [CompensationSensor(conf.get(CONF_UNIQUE_ID), name, source, attribute, conf)]
     )
 
 

--- a/homeassistant/components/compensation/strings.json
+++ b/homeassistant/components/compensation/strings.json
@@ -4,7 +4,6 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
-      "incorrect_datapoints": "Datapoints needs to be provided in the right format, ex. '1.0, 0.0'.",
       "not_enough_datapoints": "The number of datapoints needs to be more than the configured degree."
     },
     "step": {
@@ -20,7 +19,7 @@
         }
       },
       "options": {
-        "description": "Read the documention for further details on how to configure the statistics sensor using these options.",
+        "description": "Read the documentation for further details on how to configure the statistics sensor using these options.",
         "data": {
           "data_points": "Data points",
           "attribute": "Attribute",
@@ -31,10 +30,10 @@
           "unit_of_measurement": "Unit of measurement"
         },
         "data_description": {
-          "data_points": "Add a collection of data point conversions with uncompensated value and the compensated value. The number of required data point sets is equal to the polynomial degree + 1.",
+          "data_points": "Add a collection of data point conversions with the uncompensated value and the compensated value. The number of required data point sets is equal to the polynomial degree + 1.",
           "attribute": "Attribute from the source to monitor/compensate.",
-          "upper_limit": "Enables an upper limit for the sensor. The upper limit is defined by the data collections (data_points) greatest uncompensated value.",
-          "lower_limit": "Enables a lower limit for the sensor. The lower limit is defined by the data collections (data_points) lowest uncompensated value.",
+          "upper_limit": "Enables an upper limit for the sensor. The upper limit is defined by the data collection's (data_points) greatest uncompensated value.",
+          "lower_limit": "Enables a lower limit for the sensor. The lower limit is defined by the data collection's (data_points) lowest uncompensated value.",
           "precision": "Defines the precision of the calculated values, through the argument of round().",
           "degree": "The degree of a polynomial.",
           "unit_of_measurement": "Defines the units of measurement of the sensor, if any."
@@ -47,7 +46,6 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     },
     "error": {
-      "incorrect_datapoints": "[%key:component::compensation::config::error::incorrect_datapoints%]",
       "not_enough_datapoints": "[%key:component::compensation::config::error::not_enough_datapoints%]"
     },
     "step": {
@@ -84,7 +82,7 @@
   },
   "exceptions": {
     "setup_error": {
-      "message": "Setup of {title} could not be setup due to {error}"
+      "message": "Setup of {title} could not be completed due to {error}"
     }
   }
 }

--- a/homeassistant/components/compensation/strings.json
+++ b/homeassistant/components/compensation/strings.json
@@ -73,7 +73,7 @@
     }
   },
   "selector": {
-    "answers": {
+    "data_points": {
       "fields": {
         "uncompensated_value": "Uncompensated value",
         "compensated_value": "Compensated value"

--- a/homeassistant/components/compensation/strings.json
+++ b/homeassistant/components/compensation/strings.json
@@ -1,0 +1,90 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "incorrect_datapoints": "Datapoints needs to be provided in the right format, ex. '1.0, 0.0'.",
+      "not_enough_datapoints": "The number of datapoints needs to be more than the configured degree."
+    },
+    "step": {
+      "user": {
+        "description": "Add a compensation sensor",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "entity_id": "Entity"
+        },
+        "data_description": {
+          "name": "Name for the created entity.",
+          "entity_id": "Entity to use as source."
+        }
+      },
+      "options": {
+        "description": "Read the documention for further details on how to configure the statistics sensor using these options.",
+        "data": {
+          "data_points": "Data points",
+          "attribute": "Attribute",
+          "upper_limit": "Upper limit",
+          "lower_limit": "Lower limit",
+          "precision": "Precision",
+          "degree": "Degree",
+          "unit_of_measurement": "Unit of measurement"
+        },
+        "data_description": {
+          "data_points": "Add a collection of data point conversions with uncompensated value and the compensated value. The number of required data point sets is equal to the polynomial degree + 1.",
+          "attribute": "Attribute from the source to monitor/compensate.",
+          "upper_limit": "Enables an upper limit for the sensor. The upper limit is defined by the data collections (data_points) greatest uncompensated value.",
+          "lower_limit": "Enables a lower limit for the sensor. The lower limit is defined by the data collections (data_points) lowest uncompensated value.",
+          "precision": "Defines the precision of the calculated values, through the argument of round().",
+          "degree": "The degree of a polynomial.",
+          "unit_of_measurement": "Defines the units of measurement of the sensor, if any."
+        }
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+    },
+    "error": {
+      "incorrect_datapoints": "[%key:component::compensation::config::error::incorrect_datapoints%]",
+      "not_enough_datapoints": "[%key:component::compensation::config::error::not_enough_datapoints%]"
+    },
+    "step": {
+      "init": {
+        "description": "[%key:component::compensation::config::step::options::description%]",
+        "data": {
+          "data_points": "[%key:component::compensation::config::step::options::data::data_points%]",
+          "attribute": "[%key:component::compensation::config::step::options::data::attribute%]",
+          "upper_limit": "[%key:component::compensation::config::step::options::data::upper_limit%]",
+          "lower_limit": "[%key:component::compensation::config::step::options::data::lower_limit%]",
+          "precision": "[%key:component::compensation::config::step::options::data::precision%]",
+          "degree": "[%key:component::compensation::config::step::options::data::degree%]",
+          "unit_of_measurement": "[%key:component::compensation::config::step::options::data::unit_of_measurement%]"
+        },
+        "data_description": {
+          "data_points": "[%key:component::compensation::config::step::options::data_description::data_points%]",
+          "attribute": "[%key:component::compensation::config::step::options::data_description::attribute%]",
+          "upper_limit": "[%key:component::compensation::config::step::options::data_description::upper_limit%]",
+          "lower_limit": "[%key:component::compensation::config::step::options::data_description::lower_limit%]",
+          "precision": "[%key:component::compensation::config::step::options::data_description::precision%]",
+          "degree": "[%key:component::compensation::config::step::options::data_description::degree%]",
+          "unit_of_measurement": "[%key:component::compensation::config::step::options::data_description::unit_of_measurement%]"
+        }
+      }
+    }
+  },
+  "selector": {
+    "answers": {
+      "fields": {
+        "uncompensated_value": "Uncompensated value",
+        "compensated_value": "Compensated value"
+      }
+    }
+  },
+  "exceptions": {
+    "setup_error": {
+      "message": "Setup of {title} could not be setup due to {error}"
+    }
+  }
+}

--- a/homeassistant/components/compensation/strings.json
+++ b/homeassistant/components/compensation/strings.json
@@ -21,22 +21,32 @@
       "options": {
         "description": "Refer to the documentation for further details on how to configure the compensation sensor using these options.",
         "data": {
-          "data_points": "Data points",
           "attribute": "Attribute",
           "upper_limit": "Upper limit",
           "lower_limit": "Lower limit",
           "precision": "Precision",
-          "degree": "Degree",
+
           "unit_of_measurement": "Unit of measurement"
         },
         "data_description": {
-          "data_points": "Add a collection of data point conversions with the uncompensated value and the compensated value. The number of required data point sets is equal to the polynomial degree + 1.",
           "attribute": "Attribute from the source to monitor/compensate.",
           "upper_limit": "Enables a upper limit for the sensor. The upper limit is defined by the data points highest uncompensated value.",
           "lower_limit": "Enables a lower limit for the sensor. The lower limit is defined by the data points lowest uncompensated value.",
           "precision": "Defines the precision of the calculated values, through the argument of round().",
-          "degree": "The degree of the polynomial.",
           "unit_of_measurement": "The unit of measurement of the compensation sensor, if any."
+        },
+        "sections": {
+          "polynomial_config": {
+            "name": "Polynomial configuration",
+            "description": "Configure the polynomial used for compensation.",
+            "data": {
+              "data_points": "Data points",
+              "degree": "Degree"
+            },
+            "data_description": {
+              "degree": "The degree of the polynomial."
+            }
+          }
         }
       }
     }
@@ -52,22 +62,32 @@
       "init": {
         "description": "[%key:component::compensation::config::step::options::description%]",
         "data": {
-          "data_points": "[%key:component::compensation::config::step::options::data::data_points%]",
           "attribute": "[%key:component::compensation::config::step::options::data::attribute%]",
           "upper_limit": "[%key:component::compensation::config::step::options::data::upper_limit%]",
           "lower_limit": "[%key:component::compensation::config::step::options::data::lower_limit%]",
           "precision": "[%key:component::compensation::config::step::options::data::precision%]",
-          "degree": "[%key:component::compensation::config::step::options::data::degree%]",
           "unit_of_measurement": "[%key:component::compensation::config::step::options::data::unit_of_measurement%]"
         },
         "data_description": {
-          "data_points": "[%key:component::compensation::config::step::options::data_description::data_points%]",
           "attribute": "[%key:component::compensation::config::step::options::data_description::attribute%]",
           "upper_limit": "[%key:component::compensation::config::step::options::data_description::upper_limit%]",
           "lower_limit": "[%key:component::compensation::config::step::options::data_description::lower_limit%]",
           "precision": "[%key:component::compensation::config::step::options::data_description::precision%]",
-          "degree": "[%key:component::compensation::config::step::options::data_description::degree%]",
           "unit_of_measurement": "[%key:component::compensation::config::step::options::data_description::unit_of_measurement%]"
+        },
+
+        "sections": {
+          "polynomial_config": {
+            "name": "[%key:component::compensation::config::step::options::sections::polynomial_config::name%]",
+            "description": "[%key:component::compensation::config::step::options::sections::polynomial_config::description%]",
+            "data": {
+              "data_points": "[%key:component::compensation::config::step::options::sections::polynomial_config::data::data_points%]",
+              "degree": "[%key:component::compensation::config::step::options::sections::polynomial_config::data::degree%]"
+            },
+            "data_description": {
+              "degree": "[%key:component::compensation::config::step::options::sections::polynomial_config::data_description::degree%]"
+            }
+          }
         }
       }
     }

--- a/homeassistant/components/compensation/strings.json
+++ b/homeassistant/components/compensation/strings.json
@@ -8,18 +8,18 @@
     },
     "step": {
       "user": {
-        "description": "Add a compensation sensor",
+        "description": "Create a compensation sensor that enhances the accuracy of a source sensors value. This is done by calculating a new state using an nth degree polynomial with the source sensors value.",
         "data": {
           "name": "[%key:common::config_flow::data::name%]",
-          "entity_id": "Entity"
+          "entity_id": "Source entity"
         },
         "data_description": {
-          "name": "Name for the created entity.",
+          "name": "Name of the compensation sensor.",
           "entity_id": "Entity to use as source."
         }
       },
       "options": {
-        "description": "Read the documentation for further details on how to configure the statistics sensor using these options.",
+        "description": "Refer to the documentation for further details on how to configure the compensation sensor using these options.",
         "data": {
           "data_points": "Data points",
           "attribute": "Attribute",
@@ -32,11 +32,11 @@
         "data_description": {
           "data_points": "Add a collection of data point conversions with the uncompensated value and the compensated value. The number of required data point sets is equal to the polynomial degree + 1.",
           "attribute": "Attribute from the source to monitor/compensate.",
-          "upper_limit": "Enables an upper limit for the sensor. The upper limit is defined by the data collection's (data_points) greatest uncompensated value.",
-          "lower_limit": "Enables a lower limit for the sensor. The lower limit is defined by the data collection's (data_points) lowest uncompensated value.",
+          "upper_limit": "Enables a upper limit for the sensor. The upper limit is defined by the data points highest uncompensated value.",
+          "lower_limit": "Enables a lower limit for the sensor. The lower limit is defined by the data points lowest uncompensated value.",
           "precision": "Defines the precision of the calculated values, through the argument of round().",
-          "degree": "The degree of a polynomial.",
-          "unit_of_measurement": "Defines the units of measurement of the sensor, if any."
+          "degree": "The degree of the polynomial.",
+          "unit_of_measurement": "The unit of measurement of the compensation sensor, if any."
         }
       }
     }

--- a/homeassistant/components/compensation/strings.json
+++ b/homeassistant/components/compensation/strings.json
@@ -1,54 +1,59 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     },
     "error": {
       "not_enough_datapoints": "The number of datapoints needs to be more than the configured degree."
     },
     "step": {
-      "user": {
-        "description": "Create a compensation sensor that enhances the accuracy of a source sensors value. This is done by calculating a new state using an nth degree polynomial with the source sensors value.",
-        "data": {
-          "name": "[%key:common::config_flow::data::name%]",
-          "entity_id": "Source entity"
-        },
-        "data_description": {
-          "name": "Name of the compensation sensor.",
-          "entity_id": "Entity to use as source."
-        }
-      },
       "options": {
-        "description": "Refer to the documentation for further details on how to configure the compensation sensor using these options.",
         "data": {
           "attribute": "Attribute",
-          "upper_limit": "Upper limit",
           "lower_limit": "Lower limit",
           "precision": "Precision",
 
-          "unit_of_measurement": "Unit of measurement"
+          "unit_of_measurement": "Unit of measurement",
+          "upper_limit": "Upper limit"
         },
         "data_description": {
           "attribute": "Attribute from the source to monitor/compensate.",
-          "upper_limit": "Enables a upper limit for the sensor. The upper limit is defined by the data points highest uncompensated value.",
-          "lower_limit": "Enables a lower limit for the sensor. The lower limit is defined by the data points lowest uncompensated value.",
+          "lower_limit": "Enables a lower limit for the sensor. The lower limit is defined by the data point's lowest uncompensated value.",
           "precision": "Defines the precision of the calculated values, through the argument of round().",
-          "unit_of_measurement": "The unit of measurement of the compensation sensor, if any."
+          "unit_of_measurement": "The unit of measurement of the compensation sensor, if any.",
+          "upper_limit": "Enables an upper limit for the sensor. The upper limit is defined by the data point's highest uncompensated value."
         },
+        "description": "Refer to the documentation for further details on how to configure the compensation sensor using these options.",
         "sections": {
           "polynomial_config": {
-            "name": "Polynomial configuration",
-            "description": "Configure the polynomial used for compensation.",
             "data": {
               "data_points": "Data points",
               "degree": "Degree"
             },
             "data_description": {
               "degree": "The degree of the polynomial."
-            }
+            },
+            "description": "Configure the polynomial used for compensation.",
+            "name": "Polynomial configuration"
           }
         }
+      },
+      "user": {
+        "data": {
+          "entity_id": "Source entity",
+          "name": "[%key:common::config_flow::data::name%]"
+        },
+        "data_description": {
+          "entity_id": "Entity to use as source.",
+          "name": "Name of the compensation sensor."
+        },
+        "description": "Create a compensation sensor that enhances the accuracy of a source sensors value. This is done by calculating a new state using an nth degree polynomial with the source sensors value."
       }
+    }
+  },
+  "exceptions": {
+    "setup_error": {
+      "message": "Setup of {title} could not be completed due to {error}"
     }
   },
   "options": {
@@ -60,33 +65,33 @@
     },
     "step": {
       "init": {
-        "description": "[%key:component::compensation::config::step::options::description%]",
         "data": {
           "attribute": "[%key:component::compensation::config::step::options::data::attribute%]",
-          "upper_limit": "[%key:component::compensation::config::step::options::data::upper_limit%]",
           "lower_limit": "[%key:component::compensation::config::step::options::data::lower_limit%]",
           "precision": "[%key:component::compensation::config::step::options::data::precision%]",
-          "unit_of_measurement": "[%key:component::compensation::config::step::options::data::unit_of_measurement%]"
+          "unit_of_measurement": "[%key:component::compensation::config::step::options::data::unit_of_measurement%]",
+          "upper_limit": "[%key:component::compensation::config::step::options::data::upper_limit%]"
         },
         "data_description": {
           "attribute": "[%key:component::compensation::config::step::options::data_description::attribute%]",
-          "upper_limit": "[%key:component::compensation::config::step::options::data_description::upper_limit%]",
           "lower_limit": "[%key:component::compensation::config::step::options::data_description::lower_limit%]",
           "precision": "[%key:component::compensation::config::step::options::data_description::precision%]",
-          "unit_of_measurement": "[%key:component::compensation::config::step::options::data_description::unit_of_measurement%]"
+          "unit_of_measurement": "[%key:component::compensation::config::step::options::data_description::unit_of_measurement%]",
+          "upper_limit": "[%key:component::compensation::config::step::options::data_description::upper_limit%]"
         },
 
+        "description": "[%key:component::compensation::config::step::options::description%]",
         "sections": {
           "polynomial_config": {
-            "name": "[%key:component::compensation::config::step::options::sections::polynomial_config::name%]",
-            "description": "[%key:component::compensation::config::step::options::sections::polynomial_config::description%]",
             "data": {
               "data_points": "[%key:component::compensation::config::step::options::sections::polynomial_config::data::data_points%]",
               "degree": "[%key:component::compensation::config::step::options::sections::polynomial_config::data::degree%]"
             },
             "data_description": {
               "degree": "[%key:component::compensation::config::step::options::sections::polynomial_config::data_description::degree%]"
-            }
+            },
+            "description": "[%key:component::compensation::config::step::options::sections::polynomial_config::description%]",
+            "name": "[%key:component::compensation::config::step::options::sections::polynomial_config::name%]"
           }
         }
       }
@@ -95,14 +100,9 @@
   "selector": {
     "data_points": {
       "fields": {
-        "uncompensated_value": "Uncompensated value",
-        "compensated_value": "Compensated value"
+        "compensated_value": "Compensated value",
+        "uncompensated_value": "Uncompensated value"
       }
-    }
-  },
-  "exceptions": {
-    "setup_error": {
-      "message": "Setup of {title} could not be completed due to {error}"
     }
   }
 }

--- a/homeassistant/components/compensation/strings.json
+++ b/homeassistant/components/compensation/strings.json
@@ -47,7 +47,7 @@
           "entity_id": "Entity to use as source.",
           "name": "Name of the compensation sensor."
         },
-        "description": "Create a compensation sensor that enhances the accuracy of a source sensors value. This is done by calculating a new state using an nth degree polynomial with the source sensors value."
+        "description": "Create a compensation sensor that enhances the accuracy of a source sensor's value. This is done by calculating a new state using an nth degree polynomial with the source sensor's value."
       }
     }
   },

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -5,6 +5,7 @@ To update, run python3 -m script.hassfest
 
 FLOWS = {
     "helper": [
+        "compensation",
         "derivative",
         "filter",
         "generic_hygrostat",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1147,12 +1147,6 @@
       "config_flow": false,
       "iot_class": "local_polling"
     },
-    "compensation": {
-      "name": "Compensation",
-      "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "calculated"
-    },
     "compit": {
       "name": "Compit",
       "integration_type": "hub",
@@ -8244,6 +8238,12 @@
     }
   },
   "helper": {
+    "compensation": {
+      "name": "Compensation",
+      "integration_type": "helper",
+      "config_flow": true,
+      "iot_class": "calculated"
+    },
     "counter": {
       "integration_type": "helper",
       "config_flow": false

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1701,10 +1701,9 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
                     raise vol.Invalid(f"Field {field} is required")
                 if field in _config:
                     if isinstance(field_data["selector"], Selector):
-                        field_data["selector"] = field_data["selector"].serialize()[
-                            "selector"
-                        ]
-                    selector(field_data["selector"])(_config[field])  # type: ignore[operator]
+                        field_data["selector"](_config[field])  # type: ignore[operator]
+                    else:
+                        selector(field_data["selector"])(_config[field])  # type: ignore[operator]
 
             for key in _config:
                 if key not in self.config["fields"]:

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1698,6 +1698,10 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
                 if field_data.get("required") and field not in _config:
                     raise vol.Invalid(f"Field {field} is required")
                 if field in _config:
+                    if isinstance(field_data["selector"], Selector):
+                        field_data["selector"] = field_data["selector"].serialize()[
+                            "selector"
+                        ]
                     selector(field_data["selector"])(_config[field])  # type: ignore[operator]
 
             for key in _config:

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1641,6 +1641,7 @@ class ObjectSelectorConfig(BaseSelectorConfig, total=False):
     label_field: str
     description_field: str
     translation_key: str
+    overview_labels: bool
 
 
 @SELECTORS.register("object")
@@ -1662,6 +1663,7 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
             vol.Optional("label_field"): str,
             vol.Optional("description_field"): str,
             vol.Optional("translation_key"): str,
+            vol.Optional("overview_labels", default=False): bool,
         }
     )
 

--- a/tests/components/compensation/conftest.py
+++ b/tests/components/compensation/conftest.py
@@ -1,0 +1,16 @@
+"""Compensation fixtures."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.compensation.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/compensation/test_config_flow.py
+++ b/tests/components/compensation/test_config_flow.py
@@ -1,0 +1,72 @@
+"""Test for compensation config flow."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.components.compensation.const import (
+    CONF_DATAPOINTS,
+    CONF_DEGREE,
+    CONF_LOWER_LIMIT,
+    CONF_POLYNOMIAL_CONFIG,
+    CONF_PRECISION,
+    CONF_UPPER_LIMIT,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_ENTITY_ID, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+async def test_user_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test full flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_NAME: DEFAULT_NAME, CONF_ENTITY_ID: "sensor.test_sensor"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "options"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_LOWER_LIMIT: False,
+            CONF_POLYNOMIAL_CONFIG: {
+                CONF_DATAPOINTS: [
+                    {"compensated_value": 6, "uncompensated_value": 5},
+                    {"compensated_value": 8, "uncompensated_value": 7},
+                ],
+                CONF_DEGREE: 1,
+            },
+            CONF_PRECISION: 2,
+            CONF_UPPER_LIMIT: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+    assert result["data"] == {}
+    assert result["options"] == {
+        CONF_ENTITY_ID: "sensor.test_sensor",
+        CONF_LOWER_LIMIT: False,
+        CONF_NAME: "Compensation",
+        CONF_POLYNOMIAL_CONFIG: {
+            CONF_DATAPOINTS: [
+                {"compensated_value": 6, "uncompensated_value": 5},
+                {"compensated_value": 8, "uncompensated_value": 7},
+            ],
+            CONF_DEGREE: 1,
+        },
+        CONF_PRECISION: 2,
+        CONF_UPPER_LIMIT: False,
+    }

--- a/tests/components/compensation/test_config_flow.py
+++ b/tests/components/compensation/test_config_flow.py
@@ -3,11 +3,13 @@
 from unittest.mock import AsyncMock
 
 from homeassistant.components.compensation.const import (
+    CONF_COMPENSATED_VALUE,
     CONF_DATAPOINTS,
     CONF_DEGREE,
     CONF_LOWER_LIMIT,
     CONF_POLYNOMIAL_CONFIG,
     CONF_PRECISION,
+    CONF_UNCOMPENSATED_VALUE,
     CONF_UPPER_LIMIT,
     DEFAULT_NAME,
     DOMAIN,
@@ -43,8 +45,8 @@ async def test_user_flow(
             CONF_LOWER_LIMIT: False,
             CONF_POLYNOMIAL_CONFIG: {
                 CONF_DATAPOINTS: [
-                    {"compensated_value": 6, "uncompensated_value": 5},
-                    {"compensated_value": 8, "uncompensated_value": 7},
+                    {CONF_COMPENSATED_VALUE: 6, CONF_UNCOMPENSATED_VALUE: 5},
+                    {CONF_COMPENSATED_VALUE: 8, CONF_UNCOMPENSATED_VALUE: 7},
                 ],
                 CONF_DEGREE: 1,
             },
@@ -62,8 +64,8 @@ async def test_user_flow(
         CONF_NAME: "Compensation",
         CONF_POLYNOMIAL_CONFIG: {
             CONF_DATAPOINTS: [
-                {"compensated_value": 6, "uncompensated_value": 5},
-                {"compensated_value": 8, "uncompensated_value": 7},
+                {CONF_COMPENSATED_VALUE: 6, CONF_UNCOMPENSATED_VALUE: 5},
+                {CONF_COMPENSATED_VALUE: 8, CONF_UNCOMPENSATED_VALUE: 7},
             ],
             CONF_DEGREE: 1,
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds config flow to `compensation` now when we have a way to provide multiple sets of inputs (extension of `ObjectSelector`)

<img width="448" height="376" alt="Untitled" src="https://github.com/user-attachments/assets/d88c0524-4934-4628-acb4-35629177139f" />
<img width="448" height="812" alt="Untitled 2" src="https://github.com/user-attachments/assets/61a1339c-17e6-4b98-b93e-e8609e9db473" />
<img width="448" height="863" alt="Untitled 3" src="https://github.com/user-attachments/assets/1f126fd5-de6e-4ab8-8ab2-5e5f57c322a4" />
<img width="448" height="354" alt="Untitled 4" src="https://github.com/user-attachments/assets/632bf224-0955-489c-b107-3bb83bbeda51" />

With a frontend PR it could look like (https://github.com/home-assistant/frontend/pull/51840):
<img width="432" height="325" alt="Untitled" src="https://github.com/user-attachments/assets/420610c2-5293-4bdb-b32d-9c5976fd67d5" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39835

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 