### PR TITLE
Drop hass argument from verify_domain_control

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -162,12 +162,12 @@ def setup_service_functions(
     It appears that all TCC-compatible systems support the same three zones modes.
     """
 
-    @verify_domain_control(hass, DOMAIN)
+    @verify_domain_control(DOMAIN)
     async def force_refresh(call: ServiceCall) -> None:
         """Obtain the latest state data via the vendor's RESTful API."""
         await coordinator.async_refresh()
 
-    @verify_domain_control(hass, DOMAIN)
+    @verify_domain_control(DOMAIN)
     async def set_system_mode(call: ServiceCall) -> None:
         """Set the system mode."""
         assert coordinator.tcs is not None  # mypy
@@ -179,7 +179,7 @@ def setup_service_functions(
         }
         async_dispatcher_send(hass, DOMAIN, payload)
 
-    @verify_domain_control(hass, DOMAIN)
+    @verify_domain_control(DOMAIN)
     async def set_zone_override(call: ServiceCall) -> None:
         """Set the zone override (setpoint)."""
         entity_id = call.data[ATTR_ENTITY_ID]

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -124,7 +124,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GeniusHubConfigEntry) ->
 def setup_service_functions(hass: HomeAssistant, broker):
     """Set up the service functions."""
 
-    @verify_domain_control(hass, DOMAIN)
+    @verify_domain_control(DOMAIN)
     async def set_zone_mode(call: ServiceCall) -> None:
         """Set the system mode."""
         entity_id = call.data[ATTR_ENTITY_ID]

--- a/homeassistant/components/homematicip_cloud/services.py
+++ b/homeassistant/components/homematicip_cloud/services.py
@@ -124,7 +124,7 @@ SCHEMA_SET_HOME_COOLING_MODE = vol.Schema(
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up the HomematicIP Cloud services."""
 
-    @verify_domain_control(hass, DOMAIN)
+    @verify_domain_control(DOMAIN)
     async def async_call_hmipc_service(service: ServiceCall) -> None:
         """Call correct HomematicIP Cloud service."""
         service_name = service.service

--- a/homeassistant/components/hue/services.py
+++ b/homeassistant/components/hue/services.py
@@ -64,7 +64,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_HUE_ACTIVATE_SCENE,
-        verify_domain_control(hass, DOMAIN)(hue_activate_scene),
+        verify_domain_control(DOMAIN)(hue_activate_scene),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_GROUP_NAME): cv.string,

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -89,7 +89,7 @@ async def async_setup_entry(
             elif service_call.service == SERVICE_RESTORE:
                 entity.restore()
 
-    @service.verify_domain_control(hass, DOMAIN)
+    @service.verify_domain_control(DOMAIN)
     async def async_service_handle(service_call: core.ServiceCall) -> None:
         """Handle for services."""
         entities = await platform.async_extract_from_service(service_call)

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -290,7 +290,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SimpliSafe as config entry."""
     _async_standardize_config_entry(hass, entry)
 
-    _verify_domain_control = verify_domain_control(hass, DOMAIN)
+    _verify_domain_control = verify_domain_control(DOMAIN)
     websession = aiohttp_client.async_get_clientsession(hass)
 
     try:

--- a/homeassistant/components/sonos/services.py
+++ b/homeassistant/components/sonos/services.py
@@ -35,7 +35,7 @@ ATTR_WITH_GROUP = "with_group"
 def async_setup_services(hass: HomeAssistant) -> None:
     """Register Sonos services."""
 
-    @service.verify_domain_control(hass, DOMAIN)
+    @service.verify_domain_control(DOMAIN)
     async def async_service_handle(service_call: ServiceCall) -> None:
         """Handle dispatched services."""
         platform_entities = hass.data.get(DATA_DOMAIN_PLATFORM_ENTITIES, {}).get(

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -138,7 +138,7 @@ def deprecated_function[**_P, _R](
     return deprecated_decorator
 
 
-def deprecated_hass_binding[**_P, _T](
+def deprecated_hass_argument[**_P, _T](
     breaks_in_ha_version: str | None = None,
 ) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
     """Decorate function to indicate that first argument hass will be ignored."""

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -148,19 +148,10 @@ def deprecated_hass_argument[**_P, _T](
         def _inner(*args: _P.args, **kwargs: _P.kwargs) -> _T:
             from homeassistant.core import HomeAssistant  # noqa: PLC0415
 
-            if len(args) > 0 and isinstance(args[0], HomeAssistant):
-                _print_deprecation_warning_internal(
-                    "hass",
-                    func.__module__,
-                    f"{func.__name__} without hass argument",
-                    "argument",
-                    f"passed to {func.__name__}",
-                    breaks_in_ha_version,
-                    log_when_no_integration_is_found=True,
-                )
-                args = args[1:]  # type: ignore[assignment]
+            in_arg = len(args) > 0 and isinstance(args[0], HomeAssistant)
+            in_kwarg = "hass" in kwargs and isinstance(kwargs["hass"], HomeAssistant)
 
-            if "hass" in kwargs and isinstance(kwargs["hass"], HomeAssistant):
+            if in_arg or in_kwarg:
                 _print_deprecation_warning_internal(
                     "hass",
                     func.__module__,
@@ -170,7 +161,10 @@ def deprecated_hass_argument[**_P, _T](
                     breaks_in_ha_version,
                     log_when_no_integration_is_found=True,
                 )
-                kwargs.pop("hass")
+                if in_arg:
+                    args = args[1:]  # type: ignore[assignment]
+                if in_kwarg:
+                    kwargs.pop("hass")
 
             return func(*args, **kwargs)
 

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -138,7 +138,7 @@ def deprecated_function[**_P, _R](
     return deprecated_decorator
 
 
-def deprecate_hass_binding[**_P, _T](
+def deprecated_hass_binding[**_P, _T](
     breaks_in_ha_version: str | None = None,
 ) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
     """Decorate function to indicate that first argument hass will be ignored."""
@@ -148,7 +148,7 @@ def deprecate_hass_binding[**_P, _T](
         def _inner(*args: _P.args, **kwargs: _P.kwargs) -> _T:
             from homeassistant.core import HomeAssistant  # noqa: PLC0415
 
-            if isinstance(args[0], HomeAssistant):
+            if len(args) > 0 and isinstance(args[0], HomeAssistant):
                 _print_deprecation_warning_internal(
                     "hass",
                     func.__module__,

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -149,12 +149,14 @@ def deprecate_hass_binding[**_P, _T](
             from homeassistant.core import HomeAssistant  # noqa: PLC0415
 
             if isinstance(args[0], HomeAssistant):
-                _print_deprecation_warning(
-                    func,
-                    "without hass",
+                _print_deprecation_warning_internal(
+                    "hass",
+                    func.__module__,
+                    f"{func.__name__} without hass argument",
                     "argument",
-                    "called with hass as the first argument",
+                    f"passed to {func.__name__}",
                     breaks_in_ha_version,
+                    log_when_no_integration_is_found=True,
                 )
                 args = args[1:]  # type: ignore[assignment]
             return func(*args, **kwargs)

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -159,6 +159,19 @@ def deprecated_hass_argument[**_P, _T](
                     log_when_no_integration_is_found=True,
                 )
                 args = args[1:]  # type: ignore[assignment]
+
+            if "hass" in kwargs and isinstance(kwargs["hass"], HomeAssistant):
+                _print_deprecation_warning_internal(
+                    "hass",
+                    func.__module__,
+                    f"{func.__name__} without hass argument",
+                    "argument",
+                    f"passed to {func.__name__}",
+                    breaks_in_ha_version,
+                    log_when_no_integration_is_found=True,
+                )
+                kwargs.pop("hass")
+
             return func(*args, **kwargs)
 
         return _inner

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -60,7 +60,7 @@ from . import (
     template,
     translation,
 )
-from .deprecation import deprecated_class, deprecated_function, deprecated_hass_binding
+from .deprecation import deprecated_class, deprecated_function, deprecated_hass_argument
 from .selector import TargetSelector
 from .typing import ConfigType, TemplateVarsType, VolDictType, VolSchemaType
 
@@ -995,7 +995,7 @@ def async_register_admin_service(
     )
 
 
-@deprecated_hass_binding(breaks_in_ha_version="2026.2")
+@deprecated_hass_argument(breaks_in_ha_version="2026.10")
 @callback
 def verify_domain_control(
     domain: str,

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -60,7 +60,7 @@ from . import (
     template,
     translation,
 )
-from .deprecation import deprecate_hass_binding, deprecated_class, deprecated_function
+from .deprecation import deprecated_class, deprecated_function, deprecated_hass_binding
 from .selector import TargetSelector
 from .typing import ConfigType, TemplateVarsType, VolDictType, VolSchemaType
 
@@ -995,7 +995,7 @@ def async_register_admin_service(
     )
 
 
-@deprecate_hass_binding(breaks_in_ha_version="2026.2")
+@deprecated_hass_binding(breaks_in_ha_version="2026.2")
 @callback
 def verify_domain_control(
     domain: str,

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -10,7 +10,7 @@ from functools import cache, partial
 import inspect
 import logging
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, TypedDict, cast, overload, override
+from typing import TYPE_CHECKING, Any, TypedDict, cast, override
 
 import voluptuous as vol
 
@@ -995,19 +995,7 @@ def async_register_admin_service(
     )
 
 
-# Overloads can be dropped when all core calls have been updated to drop hass argument
-@overload
-def verify_domain_control(
-    domain: str,
-) -> Callable[[Callable[[ServiceCall], Any]], Callable[[ServiceCall], Any]]: ...
-@overload
-def verify_domain_control(
-    hass: HomeAssistant,
-    domain: str,
-) -> Callable[[Callable[[ServiceCall], Any]], Callable[[ServiceCall], Any]]: ...
-
-
-@deprecate_hass_binding(breaks_in_ha_version="2026.2")  # type: ignore[misc]
+@deprecate_hass_binding(breaks_in_ha_version="2026.2")
 @callback
 def verify_domain_control(
     domain: str,

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.deprecation import (
     check_if_deprecated_constant,
     deprecated_class,
     deprecated_function,
-    deprecated_hass_binding,
+    deprecated_hass_argument,
     deprecated_substitute,
     dir_with_deprecated_constants,
     get_deprecated,
@@ -667,7 +667,7 @@ def test_deprecated_hass_binding(
 
     calls = []
 
-    @deprecated_hass_binding(breaks_in_ha_version=breaks_in_ha_version)
+    @deprecated_hass_argument(breaks_in_ha_version=breaks_in_ha_version)
     def mock_deprecated_function(*args: str) -> None:
         calls.append(args)
 

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -712,3 +712,4 @@ def test_deprecated_hass_argument(
     # Ensure that the two calls are the same, as the second call should have been
     # modified to remove the hass argument.
     assert calls[0] == calls[1]
+    assert calls[0] == calls[2]

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -642,11 +642,23 @@ def test_enum_with_deprecated_members_integration_not_found(
 
 
 @pytest.mark.parametrize(
-    "positional_arguments",
+    ("positional_arguments", "keyword_arguments"),
     [
-        [],
-        ["first_arg"],
-        ["first_arg", "second_arg"],
+        # without kwargs
+        ([], {}),
+        (["first_arg"], {}),
+        (["first_arg", "second_arg"], {}),
+        # with single kwargs
+        ([], {"first_kwarg": "first_value"}),
+        (["first_arg"], {"first_kwarg": "first_value"}),
+        (["first_arg", "second_arg"], {"first_kwarg": "first_value"}),
+        # with double kwargs
+        ([], {"first_kwarg": "first_value", "second_kwarg": "second_value"}),
+        (["first_arg"], {"first_kwarg": "first_value", "second_kwarg": "second_value"}),
+        (
+            ["first_arg", "second_arg"],
+            {"first_kwarg": "first_value", "second_kwarg": "second_value"},
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -656,22 +668,23 @@ def test_enum_with_deprecated_members_integration_not_found(
         ("2099.1", " It will be removed in HA Core 2099.1."),
     ],
 )
-def test_deprecated_hass_binding(
+def test_deprecated_hass_argument(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     positional_arguments: list[str],
+    keyword_arguments: dict[str, str],
     breaks_in_ha_version: str | None,
     extra_msg: str,
 ) -> None:
-    """Test deprecated_hass_binding decorator."""
+    """Test deprecated_hass_argument decorator."""
 
     calls = []
 
     @deprecated_hass_argument(breaks_in_ha_version=breaks_in_ha_version)
-    def mock_deprecated_function(*args: str) -> None:
-        calls.append(args)
+    def mock_deprecated_function(*args: str, **kwargs: str) -> None:
+        calls.append((args, kwargs))
 
-    mock_deprecated_function(*positional_arguments)
+    mock_deprecated_function(*positional_arguments, **keyword_arguments)
     assert (
         "The deprecated argument hass was passed to mock_deprecated_function."
         f"{extra_msg}"
@@ -679,13 +692,22 @@ def test_deprecated_hass_binding(
     ) not in caplog.text
     assert len(calls) == 1
 
-    mock_deprecated_function(hass, *positional_arguments)
+    mock_deprecated_function(hass, *positional_arguments, **keyword_arguments)
     assert (
         "The deprecated argument hass was passed to mock_deprecated_function."
         f"{extra_msg}"
         " Use mock_deprecated_function without hass argument instead"
     ) in caplog.text
     assert len(calls) == 2
+
+    caplog.clear()
+    mock_deprecated_function(*positional_arguments, hass=hass, **keyword_arguments)
+    assert (
+        "The deprecated argument hass was passed to mock_deprecated_function."
+        f"{extra_msg}"
+        " Use mock_deprecated_function without hass argument instead"
+    ) in caplog.text
+    assert len(calls) == 3
 
     # Ensure that the two calls are the same, as the second call should have been
     # modified to remove the hass argument.

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1786,8 +1786,9 @@ async def test_register_admin_service_return_response(
 
 
 _DEPRECATED_VERIFY_DOMAIN_CONTROL_MESSAGE = (
-    "verify_domain_control is a deprecated argument which will be removed"
-    " in HA Core 2026.2. Use without hass instead"
+    "The deprecated argument hass was passed to verify_domain_control. It will be"
+    " removed in HA Core 2026.2. Use verify_domain_control without hass argument"
+    " instead"
 )
 
 

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1,7 +1,7 @@
 """Test service helpers."""
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from copy import deepcopy
 import dataclasses
 import io
@@ -1785,7 +1785,27 @@ async def test_register_admin_service_return_response(
     assert result == {"test-reply": "test-value1"}
 
 
-async def test_domain_control_not_async(hass: HomeAssistant, mock_entities) -> None:
+_DEPRECATED_VERIFY_DOMAIN_CONTROL_MESSAGE = (
+    "verify_domain_control is a deprecated argument which will be removed"
+    " in HA Core 2026.2. Use without hass instead"
+)
+
+
+@pytest.mark.parametrize(
+    # Check that with or without hass behaves the same
+    ("decorator", "in_caplog"),
+    [
+        (service.verify_domain_control, True),  # deprecated with hass
+        (lambda _, domain: service.verify_domain_control(domain), False),
+    ],
+)
+async def test_domain_control_not_async(
+    hass: HomeAssistant,
+    mock_entities,
+    decorator: Callable[[HomeAssistant, str], Any],
+    in_caplog: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test domain verification in a service call with an unknown user."""
     calls = []
 
@@ -1794,10 +1814,26 @@ async def test_domain_control_not_async(hass: HomeAssistant, mock_entities) -> N
         calls.append(call)
 
     with pytest.raises(exceptions.HomeAssistantError):
-        service.verify_domain_control(hass, "test_domain")(mock_service_log)
+        decorator(hass, "test_domain")(mock_service_log)
+
+    assert (_DEPRECATED_VERIFY_DOMAIN_CONTROL_MESSAGE in caplog.text) == in_caplog
 
 
-async def test_domain_control_unknown(hass: HomeAssistant, mock_entities) -> None:
+@pytest.mark.parametrize(
+    # Check that with or without hass behaves the same
+    ("decorator", "in_caplog"),
+    [
+        (service.verify_domain_control, True),  # deprecated with hass
+        (lambda _, domain: service.verify_domain_control(domain), False),
+    ],
+)
+async def test_domain_control_unknown(
+    hass: HomeAssistant,
+    mock_entities,
+    decorator: Callable[[HomeAssistant, str], Any],
+    in_caplog: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test domain verification in a service call with an unknown user."""
     calls = []
 
@@ -1809,9 +1845,7 @@ async def test_domain_control_unknown(hass: HomeAssistant, mock_entities) -> Non
         "homeassistant.helpers.entity_registry.async_get",
         return_value=Mock(entities=mock_entities),
     ):
-        protected_mock_service = service.verify_domain_control(hass, "test_domain")(
-            mock_service_log
-        )
+        protected_mock_service = decorator(hass, "test_domain")(mock_service_log)
 
         hass.services.async_register(
             "test_domain", "test_service", protected_mock_service, schema=None
@@ -1827,9 +1861,23 @@ async def test_domain_control_unknown(hass: HomeAssistant, mock_entities) -> Non
             )
         assert len(calls) == 0
 
+    assert (_DEPRECATED_VERIFY_DOMAIN_CONTROL_MESSAGE in caplog.text) == in_caplog
 
+
+@pytest.mark.parametrize(
+    # Check that with or without hass behaves the same
+    ("decorator", "in_caplog"),
+    [
+        (service.verify_domain_control, True),  # deprecated with hass
+        (lambda _, domain: service.verify_domain_control(domain), False),
+    ],
+)
 async def test_domain_control_unauthorized(
-    hass: HomeAssistant, hass_read_only_user: MockUser
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    decorator: Callable[[HomeAssistant, str], Any],
+    in_caplog: bool,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test domain verification in a service call with an unauthorized user."""
     mock_registry(
@@ -1849,9 +1897,7 @@ async def test_domain_control_unauthorized(
         """Define a protected service."""
         calls.append(call)
 
-    protected_mock_service = service.verify_domain_control(hass, "test_domain")(
-        mock_service_log
-    )
+    protected_mock_service = decorator(hass, "test_domain")(mock_service_log)
 
     hass.services.async_register(
         "test_domain", "test_service", protected_mock_service, schema=None
@@ -1868,9 +1914,23 @@ async def test_domain_control_unauthorized(
 
     assert len(calls) == 0
 
+    assert (_DEPRECATED_VERIFY_DOMAIN_CONTROL_MESSAGE in caplog.text) == in_caplog
 
+
+@pytest.mark.parametrize(
+    # Check that with or without hass behaves the same
+    ("decorator", "in_caplog"),
+    [
+        (service.verify_domain_control, True),  # deprecated with hass
+        (lambda _, domain: service.verify_domain_control(domain), False),
+    ],
+)
 async def test_domain_control_admin(
-    hass: HomeAssistant, hass_admin_user: MockUser
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    decorator: Callable[[HomeAssistant, str], Any],
+    in_caplog: bool,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test domain verification in a service call with an admin user."""
     mock_registry(
@@ -1890,9 +1950,7 @@ async def test_domain_control_admin(
         """Define a protected service."""
         calls.append(call)
 
-    protected_mock_service = service.verify_domain_control(hass, "test_domain")(
-        mock_service_log
-    )
+    protected_mock_service = decorator(hass, "test_domain")(mock_service_log)
 
     hass.services.async_register(
         "test_domain", "test_service", protected_mock_service, schema=None
@@ -1908,8 +1966,23 @@ async def test_domain_control_admin(
 
     assert len(calls) == 1
 
+    assert (_DEPRECATED_VERIFY_DOMAIN_CONTROL_MESSAGE in caplog.text) == in_caplog
 
-async def test_domain_control_no_user(hass: HomeAssistant) -> None:
+
+@pytest.mark.parametrize(
+    # Check that with or without hass behaves the same
+    ("decorator", "in_caplog"),
+    [
+        (service.verify_domain_control, True),  # deprecated with hass
+        (lambda _, domain: service.verify_domain_control(domain), False),
+    ],
+)
+async def test_domain_control_no_user(
+    hass: HomeAssistant,
+    decorator: Callable[[HomeAssistant, str], Any],
+    in_caplog: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test domain verification in a service call with no user."""
     mock_registry(
         hass,
@@ -1928,9 +2001,7 @@ async def test_domain_control_no_user(hass: HomeAssistant) -> None:
         """Define a protected service."""
         calls.append(call)
 
-    protected_mock_service = service.verify_domain_control(hass, "test_domain")(
-        mock_service_log
-    )
+    protected_mock_service = decorator(hass, "test_domain")(mock_service_log)
 
     hass.services.async_register(
         "test_domain", "test_service", protected_mock_service, schema=None
@@ -1945,6 +2016,8 @@ async def test_domain_control_no_user(hass: HomeAssistant) -> None:
     )
 
     assert len(calls) == 1
+
+    assert (_DEPRECATED_VERIFY_DOMAIN_CONTROL_MESSAGE in caplog.text) == in_caplog
 
 
 async def test_extract_from_service_available_device(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1795,8 +1795,8 @@ _DEPRECATED_VERIFY_DOMAIN_CONTROL_MESSAGE = (
     # Check that with or without hass behaves the same
     ("decorator", "in_caplog"),
     [
-        (service.verify_domain_control, True),  # deprecated with hass
-        (lambda _, domain: service.verify_domain_control(domain), False),
+        (service.verify_domain_control, True),  # old pass-through
+        (lambda _, domain: service.verify_domain_control(domain), False),  # new
     ],
 )
 async def test_domain_control_not_async(
@@ -1823,8 +1823,8 @@ async def test_domain_control_not_async(
     # Check that with or without hass behaves the same
     ("decorator", "in_caplog"),
     [
-        (service.verify_domain_control, True),  # deprecated with hass
-        (lambda _, domain: service.verify_domain_control(domain), False),
+        (service.verify_domain_control, True),  # old pass-through
+        (lambda _, domain: service.verify_domain_control(domain), False),  # new
     ],
 )
 async def test_domain_control_unknown(
@@ -1868,8 +1868,8 @@ async def test_domain_control_unknown(
     # Check that with or without hass behaves the same
     ("decorator", "in_caplog"),
     [
-        (service.verify_domain_control, True),  # deprecated with hass
-        (lambda _, domain: service.verify_domain_control(domain), False),
+        (service.verify_domain_control, True),  # old pass-through
+        (lambda _, domain: service.verify_domain_control(domain), False),  # new
     ],
 )
 async def test_domain_control_unauthorized(
@@ -1921,8 +1921,8 @@ async def test_domain_control_unauthorized(
     # Check that with or without hass behaves the same
     ("decorator", "in_caplog"),
     [
-        (service.verify_domain_control, True),  # deprecated with hass
-        (lambda _, domain: service.verify_domain_control(domain), False),
+        (service.verify_domain_control, True),  # old pass-through
+        (lambda _, domain: service.verify_domain_control(domain), False),  # new
     ],
 )
 async def test_domain_control_admin(
@@ -1973,8 +1973,8 @@ async def test_domain_control_admin(
     # Check that with or without hass behaves the same
     ("decorator", "in_caplog"),
     [
-        (service.verify_domain_control, True),  # deprecated with hass
-        (lambda _, domain: service.verify_domain_control(domain), False),
+        (service.verify_domain_control, True),  # old pass-through
+        (lambda _, domain: service.verify_domain_control(domain), False),  # new
     ],
 )
 async def test_domain_control_no_user(

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1787,7 +1787,7 @@ async def test_register_admin_service_return_response(
 
 _DEPRECATED_VERIFY_DOMAIN_CONTROL_MESSAGE = (
     "The deprecated argument hass was passed to verify_domain_control. It will be"
-    " removed in HA Core 2026.2. Use verify_domain_control without hass argument"
+    " removed in HA Core 2026.10. Use verify_domain_control without hass argument"
     " instead"
 )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: passing `hass` argument to `verify_domain_control` is deprecated. Please remove the argument.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted whilst reviewing #146050, this is an alternative to #146057

There should be no need to pass `hass` to `verify_domain_control`, as that is now part of the `ServiceCall` object.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2688
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
