### PR TITLE
Improve (and align) deprecation messages

### DIFF
--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -205,7 +205,7 @@ def _print_deprecation_warning_internal_impl(
     except MissingIntegrationFrame:
         if log_when_no_integration_is_found:
             logger.warning(
-                "%s was %s, is a deprecated %s%s. Use %s instead",
+                "%s was %s, this is a deprecated %s%s. Use %s instead",
                 obj_name,
                 verb,
                 description,

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -205,8 +205,9 @@ def _print_deprecation_warning_internal_impl(
     except MissingIntegrationFrame:
         if log_when_no_integration_is_found:
             logger.warning(
-                "%s is a deprecated %s%s. Use %s instead",
+                "%s was %s, is a deprecated %s%s. Use %s instead",
                 obj_name,
+                verb,
                 description,
                 breaks_in,
                 replacement,

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -197,7 +197,7 @@ def _print_deprecation_warning_internal_impl(
 
     logger = logging.getLogger(module_name)
     if breaks_in_ha_version:
-        breaks_in = f" which will be removed in HA Core {breaks_in_ha_version}"
+        breaks_in = f" It will be removed in HA Core {breaks_in_ha_version}."
     else:
         breaks_in = ""
     try:
@@ -205,10 +205,10 @@ def _print_deprecation_warning_internal_impl(
     except MissingIntegrationFrame:
         if log_when_no_integration_is_found:
             logger.warning(
-                "%s was %s, this is a deprecated %s%s. Use %s instead",
+                "The deprecated %s %s was %s.%s Use %s instead",
+                description,
                 obj_name,
                 verb,
-                description,
                 breaks_in,
                 replacement,
             )
@@ -220,25 +220,22 @@ def _print_deprecation_warning_internal_impl(
                 module=integration_frame.module,
             )
             logger.warning(
-                (
-                    "%s was %s from %s, this is a deprecated %s%s. Use %s instead,"
-                    " please %s"
-                ),
+                ("The deprecated %s %s was %s from %s.%s Use %s instead, please %s"),
+                description,
                 obj_name,
                 verb,
                 integration_frame.integration,
-                description,
                 breaks_in,
                 replacement,
                 report_issue,
             )
         else:
             logger.warning(
-                "%s was %s from %s, this is a deprecated %s%s. Use %s instead",
+                "The deprecated %s %s was %s from %s.%s Use %s instead",
+                description,
                 obj_name,
                 verb,
                 integration_frame.integration,
-                description,
                 breaks_in,
                 replacement,
             )

--- a/tests/common.py
+++ b/tests/common.py
@@ -1824,9 +1824,9 @@ def import_and_test_deprecated_constant(
         module.__name__,
         logging.WARNING,
         (
-            f"{constant_name} was used from test_constant_deprecation,"
-            f" this is a deprecated constant which will be removed in HA Core {breaks_in_ha_version}. "
-            f"Use {replacement_name} instead, please report "
+            f"The deprecated constant {constant_name} was used from "
+            "test_constant_deprecation. It will be removed in HA Core "
+            f"{breaks_in_ha_version}. Use {replacement_name} instead, please report "
             "it to the author of the 'test_constant_deprecation' custom integration"
         ),
     ) in caplog.record_tuples
@@ -1858,9 +1858,9 @@ def import_and_test_deprecated_alias(
         module.__name__,
         logging.WARNING,
         (
-            f"{alias_name} was used from test_constant_deprecation,"
-            f" this is a deprecated alias which will be removed in HA Core {breaks_in_ha_version}. "
-            f"Use {replacement_name} instead, please report "
+            f"The deprecated alias {alias_name} was used from "
+            "test_constant_deprecation. It will be removed in HA Core "
+            f"{breaks_in_ha_version}. Use {replacement_name} instead, please report "
             "it to the author of the 'test_constant_deprecation' custom integration"
         ),
     ) in caplog.record_tuples

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -1098,7 +1098,9 @@ def test_deprecated_function_is_hassio(
         (
             "homeassistant.components.hassio",
             logging.WARNING,
-            "is_hassio is a deprecated function which will be removed in HA Core 2025.11. Use homeassistant.helpers.hassio.is_hassio instead",
+            "is_hassio was called, this is a deprecated function which will be "
+            "removed in HA Core 2025.11. Use homeassistant.helpers"
+            ".hassio.is_hassio instead",
         )
     ]
 
@@ -1114,7 +1116,9 @@ def test_deprecated_function_get_supervisor_ip(
         (
             "homeassistant.helpers.hassio",
             logging.WARNING,
-            "get_supervisor_ip is a deprecated function which will be removed in HA Core 2025.11. Use homeassistant.helpers.hassio.get_supervisor_ip instead",
+            "get_supervisor_ip was called, this is a deprecated function which will "
+            "be removed in HA Core 2025.11. Use homeassistant.helpers"
+            ".hassio.get_supervisor_ip instead",
         )
     ]
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -1098,7 +1098,7 @@ def test_deprecated_function_is_hassio(
         (
             "homeassistant.components.hassio",
             logging.WARNING,
-            "is_hassio was called, this is a deprecated function which will be "
+            "The deprecated function is_hassio was called. It will be "
             "removed in HA Core 2025.11. Use homeassistant.helpers"
             ".hassio.is_hassio instead",
         )
@@ -1116,7 +1116,7 @@ def test_deprecated_function_get_supervisor_ip(
         (
             "homeassistant.helpers.hassio",
             logging.WARNING,
-            "get_supervisor_ip was called, this is a deprecated function which will "
+            "The deprecated function get_supervisor_ip was called. It will "
             "be removed in HA Core 2025.11. Use homeassistant.helpers"
             ".hassio.get_supervisor_ip instead",
         )

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -135,7 +135,7 @@ def test_deprecated_class(mock_get_logger) -> None:
     ("breaks_in_ha_version", "extra_msg"),
     [
         (None, ""),
-        ("2099.1", " which will be removed in HA Core 2099.1"),
+        ("2099.1", " It will be removed in HA Core 2099.1."),
     ],
 )
 def test_deprecated_function(
@@ -154,8 +154,9 @@ def test_deprecated_function(
 
     mock_deprecated_function()
     assert (
-        f"mock_deprecated_function was called, this is a deprecated function{extra_msg}. "
-        "Use new_function instead"
+        "The deprecated function mock_deprecated_function was called."
+        f"{extra_msg}"
+        " Use new_function instead"
     ) in caplog.text
 
 
@@ -163,7 +164,7 @@ def test_deprecated_function(
     ("breaks_in_ha_version", "extra_msg"),
     [
         (None, ""),
-        ("2099.1", " which will be removed in HA Core 2099.1"),
+        ("2099.1", " It will be removed in HA Core 2099.1."),
     ],
 )
 def test_deprecated_function_called_from_built_in_integration(
@@ -210,9 +211,9 @@ def test_deprecated_function_called_from_built_in_integration(
     ):
         mock_deprecated_function()
     assert (
-        "mock_deprecated_function was called from hue, "
-        f"this is a deprecated function{extra_msg}. "
-        "Use new_function instead"
+        "The deprecated function mock_deprecated_function was called from hue."
+        f"{extra_msg}"
+        " Use new_function instead"
     ) in caplog.text
 
 
@@ -220,7 +221,7 @@ def test_deprecated_function_called_from_built_in_integration(
     ("breaks_in_ha_version", "extra_msg"),
     [
         (None, ""),
-        ("2099.1", " which will be removed in HA Core 2099.1"),
+        ("2099.1", " It will be removed in HA Core 2099.1."),
     ],
 )
 def test_deprecated_function_called_from_custom_integration(
@@ -270,9 +271,9 @@ def test_deprecated_function_called_from_custom_integration(
     ):
         mock_deprecated_function()
     assert (
-        "mock_deprecated_function was called from hue, "
-        f"this is a deprecated function{extra_msg}. "
-        "Use new_function instead, please report it to the author of the "
+        "The deprecated function mock_deprecated_function was called from hue."
+        f"{extra_msg}"
+        " Use new_function instead, please report it to the author of the "
         "'hue' custom integration"
     ) in caplog.text
 
@@ -316,7 +317,7 @@ def _get_value(
         ),
         (
             DeprecatedConstant(1, "NEW_CONSTANT", "2099.1"),
-            " which will be removed in HA Core 2099.1. Use NEW_CONSTANT instead",
+            ". It will be removed in HA Core 2099.1. Use NEW_CONSTANT instead",
             "constant",
         ),
         (
@@ -326,7 +327,7 @@ def _get_value(
         ),
         (
             DeprecatedConstantEnum(TestDeprecatedConstantEnum.TEST, "2099.1"),
-            " which will be removed in HA Core 2099.1. Use TestDeprecatedConstantEnum.TEST instead",
+            ". It will be removed in HA Core 2099.1. Use TestDeprecatedConstantEnum.TEST instead",
             "constant",
         ),
         (
@@ -336,7 +337,7 @@ def _get_value(
         ),
         (
             DeprecatedAlias(1, "new_alias", "2099.1"),
-            " which will be removed in HA Core 2099.1. Use new_alias instead",
+            ". It will be removed in HA Core 2099.1. Use new_alias instead",
             "alias",
         ),
     ],
@@ -405,7 +406,7 @@ def test_check_if_deprecated_constant(
     assert (
         module_name,
         logging.WARNING,
-        f"TEST_CONSTANT was used from hue, this is a deprecated {description}{extra_msg}{extra_extra_msg}",
+        f"The deprecated {description} TEST_CONSTANT was used from hue{extra_msg}{extra_extra_msg}",
     ) in caplog.record_tuples
 
 
@@ -594,7 +595,7 @@ def test_enum_with_deprecated_members(
         "tests.helpers.test_deprecation",
         logging.WARNING,
         (
-            "TestEnum.CATS was used from hue, this is a deprecated enum member which "
+            "The deprecated enum member TestEnum.CATS was used from hue. It "
             "will be removed in HA Core 2025.11.0. Use TestEnum.CATS_PER_CM instead"
             f"{extra_extra_msg}"
         ),
@@ -603,7 +604,7 @@ def test_enum_with_deprecated_members(
         "tests.helpers.test_deprecation",
         logging.WARNING,
         (
-            "TestEnum.DOGS was used from hue, this is a deprecated enum member. Use "
+            "The deprecated enum member TestEnum.DOGS was used from hue. Use "
             f"TestEnum.DOGS_PER_CM instead{extra_extra_msg}"
         ),
     ) in caplog.record_tuples

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -154,7 +154,7 @@ def test_deprecated_function(
 
     mock_deprecated_function()
     assert (
-        f"mock_deprecated_function is a deprecated function{extra_msg}. "
+        f"mock_deprecated_function was called, this is a deprecated function{extra_msg}. "
         "Use new_function instead"
     ) in caplog.text
 

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -359,8 +359,8 @@ def test_deprecated_json_loads(caplog: pytest.LogCaptureFixture) -> None:
     """
     json_helper.json_loads("{}")
     assert (
-        "json_loads is a deprecated function which will be removed in "
-        "HA Core 2025.8. Use homeassistant.util.json.json_loads instead"
+        "json_loads was called, this is a deprecated function which will be removed "
+        "in HA Core 2025.8. Use homeassistant.util.json.json_loads instead"
     ) in caplog.text
 
 

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -359,7 +359,7 @@ def test_deprecated_json_loads(caplog: pytest.LogCaptureFixture) -> None:
     """
     json_helper.json_loads("{}")
     assert (
-        "json_loads was called, this is a deprecated function which will be removed "
+        "The deprecated function json_loads was called. It will be removed "
         "in HA Core 2025.8. Use homeassistant.util.json.json_loads instead"
     ) in caplog.text
 

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -166,8 +166,8 @@ def test_deprecated_unit_of_conductivity_members(
 
     def deprecation_message(member: str, replacement: str) -> str:
         return (
-            f"UnitOfConductivity.{member} was used from hue, this is a deprecated enum "
-            "member which will be removed in HA Core 2025.11.0. Use UnitOfConductivity."
+            f"The deprecated enum member UnitOfConductivity.{member} was used from hue. "
+            "It will be removed in HA Core 2025.11.0. Use UnitOfConductivity."
             f"{replacement} instead, please report it to the author of the 'hue' custom"
             " integration"
         )

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -121,8 +121,8 @@ def test_timestamp_to_utc(caplog: pytest.LogCaptureFixture) -> None:
     utc_now = dt_util.utcnow()
     assert dt_util.utc_to_timestamp(utc_now) == utc_now.timestamp()
     assert (
-        "utc_to_timestamp is a deprecated function which will be removed "
-        "in HA Core 2026.1. Use datetime.timestamp instead" in caplog.text
+        "utc_to_timestamp was called, this is a deprecated function which will be "
+        "removed in HA Core 2026.1. Use datetime.timestamp instead" in caplog.text
     )
 
 

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -121,7 +121,7 @@ def test_timestamp_to_utc(caplog: pytest.LogCaptureFixture) -> None:
     utc_now = dt_util.utcnow()
     assert dt_util.utc_to_timestamp(utc_now) == utc_now.timestamp()
     assert (
-        "utc_to_timestamp was called, this is a deprecated function which will be "
+        "The deprecated function utc_to_timestamp was called. It will be "
         "removed in HA Core 2026.1. Use datetime.timestamp instead" in caplog.text
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `verb` argument is used when there is a core integration or when there is a custom integration, but it is currently ignored when no integration is found in the stack trace.

This aligns the behavior to ensure the verb is always used.

Seen in #147946

Before:
- `mock_deprecated_function is a deprecated function which will be removed in HA Core 2099.1. Use new_function instead`
- `hass is a deprecated argument which will be removed in HA Core 2026.2. Use verify_domain_control without hass argument instead`

After:
- `The deprecated function mock_deprecated_function was called. It will be removed in HA Core 2099.1. Use new_function instead`
- `The deprecated argument hass was passed to verify_domain_control. It will be removed in HA Core 2026.2. Use verify_domain_control without hass argument instead`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
