### PR TITLE
Remove deprecated battery properties from demo vacuum

### DIFF
--- a/homeassistant/components/demo/vacuum.py
+++ b/homeassistant/components/demo/vacuum.py
@@ -19,10 +19,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 SUPPORT_MINIMAL_SERVICES = VacuumEntityFeature.TURN_ON | VacuumEntityFeature.TURN_OFF
 
 SUPPORT_BASIC_SERVICES = (
-    VacuumEntityFeature.STATE
-    | VacuumEntityFeature.START
-    | VacuumEntityFeature.STOP
-    | VacuumEntityFeature.BATTERY
+    VacuumEntityFeature.STATE | VacuumEntityFeature.START | VacuumEntityFeature.STOP
 )
 
 SUPPORT_MOST_SERVICES = (
@@ -31,7 +28,6 @@ SUPPORT_MOST_SERVICES = (
     | VacuumEntityFeature.STOP
     | VacuumEntityFeature.PAUSE
     | VacuumEntityFeature.RETURN_HOME
-    | VacuumEntityFeature.BATTERY
     | VacuumEntityFeature.FAN_SPEED
 )
 
@@ -46,7 +42,6 @@ SUPPORT_ALL_SERVICES = (
     | VacuumEntityFeature.SEND_COMMAND
     | VacuumEntityFeature.LOCATE
     | VacuumEntityFeature.STATUS
-    | VacuumEntityFeature.BATTERY
     | VacuumEntityFeature.LOCATE
     | VacuumEntityFeature.MAP
     | VacuumEntityFeature.CLEAN_SPOT
@@ -90,12 +85,6 @@ class StateDemoVacuum(StateVacuumEntity):
         self._attr_activity = VacuumActivity.DOCKED
         self._fan_speed = FAN_SPEEDS[1]
         self._cleaned_area: float = 0
-        self._battery_level = 100
-
-    @property
-    def battery_level(self) -> int:
-        """Return the current battery level of the vacuum."""
-        return max(0, min(100, self._battery_level))
 
     @property
     def fan_speed(self) -> str:
@@ -117,7 +106,6 @@ class StateDemoVacuum(StateVacuumEntity):
         if self._attr_activity != VacuumActivity.CLEANING:
             self._attr_activity = VacuumActivity.CLEANING
             self._cleaned_area += 1.32
-            self._battery_level -= 1
             self.schedule_update_ha_state()
 
     def pause(self) -> None:
@@ -142,7 +130,6 @@ class StateDemoVacuum(StateVacuumEntity):
         """Perform a spot clean-up."""
         self._attr_activity = VacuumActivity.CLEANING
         self._cleaned_area += 1.32
-        self._battery_level -= 1
         self.schedule_update_ha_state()
 
     def set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:

--- a/tests/components/demo/test_vacuum.py
+++ b/tests/components/demo/test_vacuum.py
@@ -14,7 +14,6 @@ from homeassistant.components.demo.vacuum import (
     FAN_SPEEDS,
 )
 from homeassistant.components.vacuum import (
-    ATTR_BATTERY_LEVEL,
     ATTR_COMMAND,
     ATTR_FAN_SPEED,
     ATTR_FAN_SPEED_LIST,
@@ -67,36 +66,31 @@ async def setup_demo_vacuum(hass: HomeAssistant, vacuum_only: None):
 async def test_supported_features(hass: HomeAssistant) -> None:
     """Test vacuum supported features."""
     state = hass.states.get(ENTITY_VACUUM_COMPLETE)
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 16380
-    assert state.attributes.get(ATTR_BATTERY_LEVEL) == 100
+    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 16316
     assert state.attributes.get(ATTR_FAN_SPEED) == "medium"
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == FAN_SPEEDS
     assert state.state == VacuumActivity.DOCKED
 
     state = hass.states.get(ENTITY_VACUUM_MOST)
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 12412
-    assert state.attributes.get(ATTR_BATTERY_LEVEL) == 100
+    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 12348
     assert state.attributes.get(ATTR_FAN_SPEED) == "medium"
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) == FAN_SPEEDS
     assert state.state == VacuumActivity.DOCKED
 
     state = hass.states.get(ENTITY_VACUUM_BASIC)
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 12360
-    assert state.attributes.get(ATTR_BATTERY_LEVEL) == 100
+    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 12296
     assert state.attributes.get(ATTR_FAN_SPEED) is None
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) is None
     assert state.state == VacuumActivity.DOCKED
 
     state = hass.states.get(ENTITY_VACUUM_MINIMAL)
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 3
-    assert state.attributes.get(ATTR_BATTERY_LEVEL) is None
     assert state.attributes.get(ATTR_FAN_SPEED) is None
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) is None
     assert state.state == VacuumActivity.DOCKED
 
     state = hass.states.get(ENTITY_VACUUM_NONE)
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 0
-    assert state.attributes.get(ATTR_BATTERY_LEVEL) is None
     assert state.attributes.get(ATTR_FAN_SPEED) is None
     assert state.attributes.get(ATTR_FAN_SPEED_LIST) is None
     assert state.state == VacuumActivity.DOCKED
@@ -116,7 +110,6 @@ async def test_methods(hass: HomeAssistant) -> None:
 
     state = hass.states.get(ENTITY_VACUUM_COMPLETE)
     await hass.async_block_till_done()
-    assert state.attributes.get(ATTR_BATTERY_LEVEL) == 100
     assert state.state == VacuumActivity.DOCKED
 
     await async_setup_component(hass, "notify", {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Battery props has been deprecated in `vacuum` and therefore removing them from `demo`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 