### PR TITLE
Make lat/long attribute names localizable in `dwd_weather_warnings`

### DIFF
--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -14,7 +14,7 @@
       "ambiguous_identifier": "The region identifier and device tracker can not be specified together.",
       "invalid_identifier": "The specified region identifier / device tracker is invalid.",
       "entity_not_found": "The specified device tracker entity was not found.",
-      "attribute_not_found": "The required 'Latitude' and 'Longitude' attributes were not found in the specified device tracker."
+      "attribute_not_found": "The required attributes 'Latitude' and 'Longitude' were not found in the specified device tracker."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -14,7 +14,7 @@
       "ambiguous_identifier": "The region identifier and device tracker can not be specified together.",
       "invalid_identifier": "The specified region identifier / device tracker is invalid.",
       "entity_not_found": "The specified device tracker entity was not found.",
-      "attribute_not_found": "The required 'Latitude' or 'Longitude' attribute was not found in the specified device tracker."
+      "attribute_not_found": "The required 'Latitude' and 'Longitude' attributes were not found in the specified device tracker."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "To identify the desired region, either the warncell ID / name or device tracker is required. The provided device tracker has to contain the attributes 'latitude' and 'longitude'.",
+        "description": "To identify the desired region, either the warncell ID / name or device tracker is required. The provided device tracker has to contain the attributes 'Latitude' and 'Longitude'.",
         "data": {
           "region_identifier": "Warncell ID or name",
           "region_device_tracker": "Device tracker entity"
@@ -14,7 +14,7 @@
       "ambiguous_identifier": "The region identifier and device tracker can not be specified together.",
       "invalid_identifier": "The specified region identifier / device tracker is invalid.",
       "entity_not_found": "The specified device tracker entity was not found.",
-      "attribute_not_found": "The required `latitude` or `longitude` attribute was not found in the specified device tracker."
+      "attribute_not_found": "The required 'Latitude' or 'Longitude' attribute was not found in the specified device tracker."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently the `latitude`and `longitude` attributes are called by their key names and quoted inconsistently.

Given that the UI shows them with translated names they should be translated in the messages, too:

![image](https://github.com/user-attachments/assets/b70ffc15-37d8-4b26-ae77-ee1c8fde3cd0)


Thus both occurrences each are changed to 'Latitude' and 'Longitude' signaling that they can be translated.

In addition the error message is changed to plural as both attributes are required and they usually come as a pair anyhow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
