### PR TITLE
Improve `helpers.frame.report_usage` when called from outside the event loop

### DIFF
--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -193,7 +193,8 @@ def report_usage(
                 exclude_integrations=exclude_integrations
             )
         except MissingIntegrationFrame as err:
-            integration_frame_err = err
+            if core_behavior is ReportBehavior.ERROR:
+                integration_frame_err = err
     _report_usage_partial = functools.partial(
         _report_usage,
         hass,

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -185,6 +185,15 @@ def report_usage(
     """
     if (hass := _hass.hass) is None:
         raise RuntimeError("Frame helper not set up")
+    integration_frame: IntegrationFrame | None = None
+    integration_frame_err: MissingIntegrationFrame | None = None
+    if not integration_domain:
+        try:
+            integration_frame = get_integration_frame(
+                exclude_integrations=exclude_integrations
+            )
+        except MissingIntegrationFrame as err:
+            integration_frame_err = err
     _report_usage_partial = functools.partial(
         _report_usage,
         hass,
@@ -193,8 +202,9 @@ def report_usage(
         core_behavior=core_behavior,
         core_integration_behavior=core_integration_behavior,
         custom_integration_behavior=custom_integration_behavior,
-        exclude_integrations=exclude_integrations,
         integration_domain=integration_domain,
+        integration_frame=integration_frame,
+        integration_frame_err=integration_frame_err,
         level=level,
     )
     if hass.loop_thread_id != threading.get_ident():
@@ -212,8 +222,9 @@ def _report_usage(
     core_behavior: ReportBehavior,
     core_integration_behavior: ReportBehavior,
     custom_integration_behavior: ReportBehavior,
-    exclude_integrations: set[str] | None,
     integration_domain: str | None,
+    integration_frame: IntegrationFrame | None,
+    integration_frame_err: MissingIntegrationFrame | None,
     level: int,
 ) -> None:
     """Report incorrect code usage.
@@ -235,12 +246,10 @@ def _report_usage(
         _report_usage_no_integration(what, core_behavior, breaks_in_ha_version, None)
         return
 
-    try:
-        integration_frame = get_integration_frame(
-            exclude_integrations=exclude_integrations
+    if not integration_frame:
+        _report_usage_no_integration(
+            what, core_behavior, breaks_in_ha_version, integration_frame_err
         )
-    except MissingIntegrationFrame as err:
-        _report_usage_no_integration(what, core_behavior, breaks_in_ha_version, err)
         return
 
     integration_behavior = core_integration_behavior

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime, timedelta
+import gc
 import json
 import logging
 import math
@@ -5344,6 +5345,7 @@ async def test_cache_garbage_collection() -> None:
     del tpl
     assert template._NO_HASS_ENV.template_cache.get(template_string)
     del tpl2
+    gc.collect()
     assert not template._NO_HASS_ENV.template_cache.get(template_string)
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime, timedelta
-import gc
 import json
 import logging
 import math
@@ -5345,7 +5344,6 @@ async def test_cache_garbage_collection() -> None:
     del tpl
     assert template._NO_HASS_ENV.template_cache.get(template_string)
     del tpl2
-    gc.collect()
     assert not template._NO_HASS_ENV.template_cache.get(template_string)
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve `helpers.frame.report_usage` when called from outside the event loop

This is a follow-up to PR https://github.com/home-assistant/core/pull/139836

Example when injecting an error in the sensor integration with this PR:
```
2025-07-03 09:05:29.412 WARNING (MainThread) [homeassistant.helpers.frame] Detected that integration 'sensor' does something naughty at homeassistant/components/sensor/__init__.py, line 88: frame.report_usage("does something naughty"). Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+sensor%22
```

Without this PR:
```
2025-07-03 09:03:41.463 ERROR (MainThread) [homeassistant.setup] Error during setup of component sensor: Detected code that does something naughty. Please report this issue
Traceback (most recent call last):
  File "/home/erik/development/home-assistant_fork/homeassistant/helpers/frame.py", line 253, in _report_usage
    integration_frame = get_integration_frame(
        exclude_integrations=exclude_integrations
    )
  File "/home/erik/development/home-assistant_fork/homeassistant/helpers/frame.py", line 131, in get_integration_frame
    raise MissingIntegrationFrame
homeassistant.helpers.frame.MissingIntegrationFrame

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/erik/development/home-assistant_fork/homeassistant/setup.py", line 425, in _async_setup_component
    result = await task
             ^^^^^^^^^^
  File "/home/erik/.pyenv/versions/3.13.3/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/erik/development/home-assistant_fork/homeassistant/components/sensor/__init__.py", line 88, in setup
    frame.report_usage("does something naughty")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/erik/development/home-assistant_fork/homeassistant/helpers/frame.py", line 214, in report_usage
    future.result()
    ~~~~~~~~~~~~~^^
  File "/home/erik/.pyenv/versions/3.13.3/lib/python3.13/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/home/erik/.pyenv/versions/3.13.3/lib/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/home/erik/development/home-assistant_fork/homeassistant/util/async_.py", line 67, in run_callback
    future.set_result(callback(*args))
                      ~~~~~~~~^^^^^^^
  File "/home/erik/development/home-assistant_fork/homeassistant/helpers/frame.py", line 257, in _report_usage
    _report_usage_no_integration(what, core_behavior, breaks_in_ha_version, err)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/erik/development/home-assistant_fork/homeassistant/helpers/frame.py", line 391, in _report_usage_no_integration
    raise RuntimeError(msg) from err
RuntimeError: Detected code that does something naughty. Please report this issue
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
