### PR TITLE
Set assist_satellite preannounce default to True

### DIFF
--- a/homeassistant/components/assist_satellite/__init__.py
+++ b/homeassistant/components/assist_satellite/__init__.py
@@ -72,7 +72,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 {
                     vol.Optional("message"): str,
                     vol.Optional("media_id"): _media_id_validator,
-                    vol.Optional("preannounce"): bool,
+                    vol.Optional("preannounce", default=True): bool,
                     vol.Optional("preannounce_media_id"): _media_id_validator,
                 }
             ),
@@ -89,7 +89,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 {
                     vol.Optional("start_message"): str,
                     vol.Optional("start_media_id"): _media_id_validator,
-                    vol.Optional("preannounce"): bool,
+                    vol.Optional("preannounce", default=True): bool,
                     vol.Optional("preannounce_media_id"): _media_id_validator,
                     vol.Optional("extra_system_prompt"): str,
                 }
@@ -114,7 +114,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         ask_question_args = {
             "question": call.data.get("question"),
             "question_media_id": call.data.get("question_media_id"),
-            "preannounce": call.data.get("preannounce", False),
+            "preannounce": call.data.get("preannounce", True),
             "answers": call.data.get("answers"),
         }
 
@@ -137,7 +137,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 vol.Required(ATTR_ENTITY_ID): cv.entity_domain(DOMAIN),
                 vol.Optional("question"): str,
                 vol.Optional("question_media_id"): _media_id_validator,
-                vol.Optional("preannounce"): bool,
+                vol.Optional("preannounce", default=True): bool,
                 vol.Optional("preannounce_media_id"): _media_id_validator,
                 vol.Optional("answers"): [
                     {

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -793,12 +793,19 @@ async def test_start_conversation_default_preannounce(
 
 
 @pytest.mark.parametrize(
-    ("service_data", "response_text", "expected_answer"),
+    ("service_data", "response_text", "expected_answer", "should_preannounce"),
     [
+        (
+            {},
+            "jazz",
+            AssistSatelliteAnswer(id=None, sentence="jazz"),
+            True,
+        ),
         (
             {"preannounce": False},
             "jazz",
             AssistSatelliteAnswer(id=None, sentence="jazz"),
+            False,
         ),
         (
             {
@@ -810,6 +817,7 @@ async def test_start_conversation_default_preannounce(
             },
             "Some Rock, please.",
             AssistSatelliteAnswer(id="rock", sentence="Some Rock, please."),
+            False,
         ),
         (
             {
@@ -827,7 +835,7 @@ async def test_start_conversation_default_preannounce(
                         "sentences": ["artist {artist} [please]"],
                     },
                 ],
-                "preannounce": False,
+                "preannounce": True,
             },
             "artist Pink Floyd",
             AssistSatelliteAnswer(
@@ -835,6 +843,7 @@ async def test_start_conversation_default_preannounce(
                 sentence="artist Pink Floyd",
                 slots={"artist": "Pink Floyd"},
             ),
+            True,
         ),
     ],
 )
@@ -845,6 +854,7 @@ async def test_ask_question(
     service_data: dict,
     response_text: str,
     expected_answer: AssistSatelliteAnswer,
+    should_preannounce: bool,
 ) -> None:
     """Test asking a question on a device and matching an answer."""
     entity_id = "assist_satellite.test_entity"
@@ -868,6 +878,9 @@ async def test_ask_question(
     async def async_start_conversation(start_announcement):
         # Verify state change
         assert entity.state == AssistSatelliteState.RESPONDING
+        assert (
+            start_announcement.preannounce_media_id is not None
+        ) is should_preannounce
         await original_start_conversation(start_announcement)
 
         audio_stream = object()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously, the `ask_question` service had the `preannounce` parameter incorrectly set to `False` by default, when that parameter was omitted. This change corrects the default value to `True`.
If you were relying on the previous behavior, you will need to update your service calls to explicitly set `preannounce` to `False` if that is the desired behavior.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`ask_question` was defaulting `preannounce` to `False` but the services.yaml specified that the default was `True`, which was causing inconsistent behavior on the frontend.

`announce` and `start_conversation` already defaulted to `True` in the implementation function arguments, made them consistent by adding it to the schema.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
