### PR TITLE
Fix has-entity-name and entity-translations in Opower

### DIFF
--- a/homeassistant/components/opower/sensor.py
+++ b/homeassistant/components/opower/sensor.py
@@ -24,6 +24,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import OpowerConfigEntry, OpowerCoordinator
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class OpowerEntityDescription(SensorEntityDescription):
@@ -38,7 +40,7 @@ class OpowerEntityDescription(SensorEntityDescription):
 ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
     OpowerEntityDescription(
         key="elec_usage_to_date",
-        name="Current bill electric usage to date",
+        translation_key="elec_usage_to_date",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         # Not TOTAL_INCREASING because it can decrease for accounts with solar
@@ -48,7 +50,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="elec_forecasted_usage",
-        name="Current bill electric forecasted usage",
+        translation_key="elec_forecasted_usage",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
@@ -57,7 +59,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="elec_typical_usage",
-        name="Typical monthly electric usage",
+        translation_key="elec_typical_usage",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
@@ -66,7 +68,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="elec_cost_to_date",
-        name="Current bill electric cost to date",
+        translation_key="elec_cost_to_date",
         device_class=SensorDeviceClass.MONETARY,
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
@@ -75,7 +77,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="elec_forecasted_cost",
-        name="Current bill electric forecasted cost",
+        translation_key="elec_forecasted_cost",
         device_class=SensorDeviceClass.MONETARY,
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
@@ -84,7 +86,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="elec_typical_cost",
-        name="Typical monthly electric cost",
+        translation_key="elec_typical_cost",
         device_class=SensorDeviceClass.MONETARY,
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
@@ -93,7 +95,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="elec_start_date",
-        name="Current bill electric start date",
+        translation_key="elec_start_date",
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -101,7 +103,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="elec_end_date",
-        name="Current bill electric end date",
+        translation_key="elec_end_date",
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -111,7 +113,7 @@ ELEC_SENSORS: tuple[OpowerEntityDescription, ...] = (
 GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
     OpowerEntityDescription(
         key="gas_usage_to_date",
-        name="Current bill gas usage to date",
+        translation_key="gas_usage_to_date",
         device_class=SensorDeviceClass.GAS,
         native_unit_of_measurement=UnitOfVolume.CENTUM_CUBIC_FEET,
         state_class=SensorStateClass.TOTAL,
@@ -120,7 +122,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="gas_forecasted_usage",
-        name="Current bill gas forecasted usage",
+        translation_key="gas_forecasted_usage",
         device_class=SensorDeviceClass.GAS,
         native_unit_of_measurement=UnitOfVolume.CENTUM_CUBIC_FEET,
         state_class=SensorStateClass.TOTAL,
@@ -129,7 +131,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="gas_typical_usage",
-        name="Typical monthly gas usage",
+        translation_key="gas_typical_usage",
         device_class=SensorDeviceClass.GAS,
         native_unit_of_measurement=UnitOfVolume.CENTUM_CUBIC_FEET,
         state_class=SensorStateClass.TOTAL,
@@ -138,7 +140,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="gas_cost_to_date",
-        name="Current bill gas cost to date",
+        translation_key="gas_cost_to_date",
         device_class=SensorDeviceClass.MONETARY,
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
@@ -147,7 +149,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="gas_forecasted_cost",
-        name="Current bill gas forecasted cost",
+        translation_key="gas_forecasted_cost",
         device_class=SensorDeviceClass.MONETARY,
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
@@ -156,7 +158,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="gas_typical_cost",
-        name="Typical monthly gas cost",
+        translation_key="gas_typical_cost",
         device_class=SensorDeviceClass.MONETARY,
         native_unit_of_measurement="USD",
         state_class=SensorStateClass.TOTAL,
@@ -165,7 +167,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="gas_start_date",
-        name="Current bill gas start date",
+        translation_key="gas_start_date",
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -173,7 +175,7 @@ GAS_SENSORS: tuple[OpowerEntityDescription, ...] = (
     ),
     OpowerEntityDescription(
         key="gas_end_date",
-        name="Current bill gas end date",
+        translation_key="gas_end_date",
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -229,6 +231,7 @@ async def async_setup_entry(
 class OpowerSensor(CoordinatorEntity[OpowerCoordinator], SensorEntity):
     """Representation of an Opower sensor."""
 
+    _attr_has_entity_name = True
     entity_description: OpowerEntityDescription
 
     def __init__(
@@ -249,8 +252,6 @@ class OpowerSensor(CoordinatorEntity[OpowerCoordinator], SensorEntity):
     @property
     def native_value(self) -> StateType | date:
         """Return the state."""
-        if self.coordinator.data is not None:
-            return self.entity_description.value_fn(
-                self.coordinator.data[self.utility_account_id]
-            )
-        return None
+        return self.entity_description.value_fn(
+            self.coordinator.data[self.utility_account_id]
+        )

--- a/homeassistant/components/opower/strings.json
+++ b/homeassistant/components/opower/strings.json
@@ -37,5 +37,57 @@
       "title": "Return to grid statistics for account: {utility_account_id}",
       "description": "We found negative values in your existing consumption statistics, likely because you have solar. We split those in separate return statistics for a better experience in the Energy dashboard.\n\nPlease visit the [Energy configuration page]({energy_settings}) to add the following statistics in the **Return to grid** section:\n\n{target_ids}\n\nOnce you have added them, ignore this issue."
     }
+  },
+  "entity": {
+    "sensor": {
+      "elec_usage_to_date": {
+        "name": "Current bill electric usage to date"
+      },
+      "elec_forecasted_usage": {
+        "name": "Current bill electric forecasted usage"
+      },
+      "elec_typical_usage": {
+        "name": "Typical monthly electric usage"
+      },
+      "elec_cost_to_date": {
+        "name": "Current bill electric cost to date"
+      },
+      "elec_forecasted_cost": {
+        "name": "Current bill electric forecasted cost"
+      },
+      "elec_typical_cost": {
+        "name": "Typical monthly electric cost"
+      },
+      "elec_start_date": {
+        "name": "Current bill electric start date"
+      },
+      "elec_end_date": {
+        "name": "Current bill electric end date"
+      },
+      "gas_usage_to_date": {
+        "name": "Current bill gas usage to date"
+      },
+      "gas_forecasted_usage": {
+        "name": "Current bill gas forecasted usage"
+      },
+      "gas_typical_usage": {
+        "name": "Typical monthly gas usage"
+      },
+      "gas_cost_to_date": {
+        "name": "Current bill gas cost to date"
+      },
+      "gas_forecasted_cost": {
+        "name": "Current bill gas forecasted cost"
+      },
+      "gas_typical_cost": {
+        "name": "Typical monthly gas cost"
+      },
+      "gas_start_date": {
+        "name": "Current bill gas start date"
+      },
+      "gas_end_date": {
+        "name": "Current bill gas end date"
+      }
+    }
   }
 }

--- a/tests/components/opower/test_sensor.py
+++ b/tests/components/opower/test_sensor.py
@@ -25,36 +25,48 @@ async def test_sensors(
     entity_registry = er.async_get(hass)
 
     # Check electric sensors
-    entry = entity_registry.async_get("sensor.current_bill_electric_usage_to_date")
+    entry = entity_registry.async_get(
+        "sensor.elec_account_111111_current_bill_electric_usage_to_date"
+    )
     assert entry
     assert entry.unique_id == "pge_111111_elec_usage_to_date"
-    state = hass.states.get("sensor.current_bill_electric_usage_to_date")
+    state = hass.states.get(
+        "sensor.elec_account_111111_current_bill_electric_usage_to_date"
+    )
     assert state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
     assert state.state == "100"
 
-    entry = entity_registry.async_get("sensor.current_bill_electric_cost_to_date")
+    entry = entity_registry.async_get(
+        "sensor.elec_account_111111_current_bill_electric_cost_to_date"
+    )
     assert entry
     assert entry.unique_id == "pge_111111_elec_cost_to_date"
-    state = hass.states.get("sensor.current_bill_electric_cost_to_date")
+    state = hass.states.get(
+        "sensor.elec_account_111111_current_bill_electric_cost_to_date"
+    )
     assert state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "USD"
     assert state.state == "20.0"
 
     # Check gas sensors
-    entry = entity_registry.async_get("sensor.current_bill_gas_usage_to_date")
+    entry = entity_registry.async_get(
+        "sensor.gas_account_222222_current_bill_gas_usage_to_date"
+    )
     assert entry
     assert entry.unique_id == "pge_222222_gas_usage_to_date"
-    state = hass.states.get("sensor.current_bill_gas_usage_to_date")
+    state = hass.states.get("sensor.gas_account_222222_current_bill_gas_usage_to_date")
     assert state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfVolume.CUBIC_METERS
     # Convert 50 CCF to m³
     assert float(state.state) == pytest.approx(50 * 2.83168, abs=1e-3)
 
-    entry = entity_registry.async_get("sensor.current_bill_gas_cost_to_date")
+    entry = entity_registry.async_get(
+        "sensor.gas_account_222222_current_bill_gas_cost_to_date"
+    )
     assert entry
     assert entry.unique_id == "pge_222222_gas_cost_to_date"
-    state = hass.states.get("sensor.current_bill_gas_cost_to_date")
+    state = hass.states.get("sensor.gas_account_222222_current_bill_gas_cost_to_date")
     assert state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "USD"
     assert state.state == "15.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change Opower sensors to have `has_entity_name = True` and translated names

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
