### PR TITLE
Replace MediaPlayerState.STANDBY with MediaPlayerState.IDLE in mediaroom

### DIFF
--- a/homeassistant/components/mediaroom/media_player.py
+++ b/homeassistant/components/mediaroom/media_player.py
@@ -134,7 +134,7 @@ class MediaroomDevice(MediaPlayerEntity):
 
         state_map = {
             State.OFF: MediaPlayerState.OFF,
-            State.STANDBY: MediaPlayerState.STANDBY,
+            State.STANDBY: MediaPlayerState.IDLE,
             State.PLAYING_LIVE_TV: MediaPlayerState.PLAYING,
             State.PLAYING_RECORDED_TV: MediaPlayerState.PLAYING,
             State.PLAYING_TIMESHIFT_TV: MediaPlayerState.PLAYING,
@@ -155,7 +155,7 @@ class MediaroomDevice(MediaPlayerEntity):
         self._channel = None
         self._optimistic = optimistic
         self._attr_state = (
-            MediaPlayerState.PLAYING if optimistic else MediaPlayerState.STANDBY
+            MediaPlayerState.PLAYING if optimistic else MediaPlayerState.IDLE
         )
         self._name = f"Mediaroom {device_id if device_id else host}"
         self._available = True
@@ -254,7 +254,7 @@ class MediaroomDevice(MediaPlayerEntity):
         try:
             self.set_state(await self.stb.turn_off())
             if self._optimistic:
-                self._attr_state = MediaPlayerState.STANDBY
+                self._attr_state = MediaPlayerState.IDLE
             self._available = True
         except PyMediaroomError:
             self._available = False


### PR DESCRIPTION
## Breaking change
`mediaroom` `media_player` entities now report state `idle` where they previously reported state `standby`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace `MediaPlayerState.STANDBY` with `MediaPlayerState.IDLE` in `mediaroom`.

Background:
- The `MediaPlayerState.STANDBY` state is deprecated as decided in https://github.com/home-assistant/architecture/discussions/799
- [Mediaroom](https://github.com/home-assistant/core/blob/52c8c80f91283dd2665cd242d33131d98dfbcb17/homeassistant/components/mediaroom/media_player.py#L160) uses `STATE_STANDBY` when device is on, but inactive. In this case, the state should `STATE_IDLE`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
