### PR TITLE
Add PS Vita support to PlayStation Network integration

### DIFF
--- a/homeassistant/components/playstation_network/__init__.py
+++ b/homeassistant/components/playstation_network/__init__.py
@@ -9,7 +9,7 @@ from .const import CONF_NPSSO
 from .coordinator import (
     PlaystationNetworkConfigEntry,
     PlaystationNetworkCoordinator,
-    PlayStationNetworkCoordinators,
+    PlaystationNetworkRuntimeData,
     PlaystationNetworkTrophyTitlesCoordinator,
 )
 from .helpers import PlaystationNetwork
@@ -33,7 +33,7 @@ async def async_setup_entry(
 
     trophy_titles = PlaystationNetworkTrophyTitlesCoordinator(hass, psn, entry)
 
-    entry.runtime_data = PlayStationNetworkCoordinators(coordinator, trophy_titles)
+    entry.runtime_data = PlaystationNetworkRuntimeData(coordinator, trophy_titles)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/playstation_network/__init__.py
+++ b/homeassistant/components/playstation_network/__init__.py
@@ -8,9 +8,9 @@ from homeassistant.core import HomeAssistant
 from .const import CONF_NPSSO
 from .coordinator import (
     PlaystationNetworkConfigEntry,
-    PlaystationNetworkCoordinator,
     PlaystationNetworkRuntimeData,
     PlaystationNetworkTrophyTitlesCoordinator,
+    PlaystationNetworkUserDataCoordinator,
 )
 from .helpers import PlaystationNetwork
 
@@ -28,7 +28,7 @@ async def async_setup_entry(
 
     psn = PlaystationNetwork(hass, entry.data[CONF_NPSSO])
 
-    coordinator = PlaystationNetworkCoordinator(hass, psn, entry)
+    coordinator = PlaystationNetworkUserDataCoordinator(hass, psn, entry)
     await coordinator.async_config_entry_first_refresh()
 
     trophy_titles = PlaystationNetworkTrophyTitlesCoordinator(hass, psn, entry)

--- a/homeassistant/components/playstation_network/__init__.py
+++ b/homeassistant/components/playstation_network/__init__.py
@@ -6,7 +6,12 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import CONF_NPSSO
-from .coordinator import PlaystationNetworkConfigEntry, PlaystationNetworkCoordinator
+from .coordinator import (
+    PlaystationNetworkConfigEntry,
+    PlaystationNetworkCoordinator,
+    PlayStationNetworkCoordinators,
+    PlaystationNetworkTrophyTitlesCoordinator,
+)
 from .helpers import PlaystationNetwork
 
 PLATFORMS: list[Platform] = [
@@ -25,7 +30,10 @@ async def async_setup_entry(
 
     coordinator = PlaystationNetworkCoordinator(hass, psn, entry)
     await coordinator.async_config_entry_first_refresh()
-    entry.runtime_data = coordinator
+
+    trophy_titles = PlaystationNetworkTrophyTitlesCoordinator(hass, psn, entry)
+
+    entry.runtime_data = PlayStationNetworkCoordinators(coordinator, trophy_titles)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/playstation_network/binary_sensor.py
+++ b/homeassistant/components/playstation_network/binary_sensor.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the binary sensor platform."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data.user_data
     async_add_entities(
         PlaystationNetworkBinarySensorEntity(coordinator, description)
         for description in BINARY_SENSOR_DESCRIPTIONS

--- a/homeassistant/components/playstation_network/binary_sensor.py
+++ b/homeassistant/components/playstation_network/binary_sensor.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the binary sensor platform."""
-    coordinator = config_entry.runtime_data
+    coordinator = config_entry.runtime_data.coordinator
     async_add_entities(
         PlaystationNetworkBinarySensorEntity(coordinator, description)
         for description in BINARY_SENSOR_DESCRIPTIONS

--- a/homeassistant/components/playstation_network/config_flow.py
+++ b/homeassistant/components/playstation_network/config_flow.py
@@ -10,7 +10,6 @@ from psnawp_api.core.psnawp_exceptions import (
     PSNAWPInvalidTokenError,
     PSNAWPNotFoundError,
 )
-from psnawp_api.models.user import User
 from psnawp_api.utils.misc import parse_npsso_token
 import voluptuous as vol
 
@@ -42,7 +41,7 @@ class PlaystationNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 psn = PlaystationNetwork(self.hass, npsso)
                 try:
-                    user: User = await psn.get_user()
+                    user = await psn.get_user()
                 except PSNAWPAuthenticationError:
                     errors["base"] = "invalid_auth"
                 except PSNAWPNotFoundError:
@@ -98,7 +97,7 @@ class PlaystationNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 npsso = parse_npsso_token(user_input[CONF_NPSSO])
                 psn = PlaystationNetwork(self.hass, npsso)
-                user: User = await psn.get_user()
+                user = await psn.get_user()
             except PSNAWPAuthenticationError:
                 errors["base"] = "invalid_auth"
             except (PSNAWPNotFoundError, PSNAWPInvalidTokenError):

--- a/homeassistant/components/playstation_network/const.py
+++ b/homeassistant/components/playstation_network/const.py
@@ -8,9 +8,10 @@ DOMAIN = "playstation_network"
 CONF_NPSSO: Final = "npsso"
 
 SUPPORTED_PLATFORMS = {
-    PlatformType.PS5,
-    PlatformType.PS4,
+    PlatformType.PS_VITA,
     PlatformType.PS3,
+    PlatformType.PS4,
+    PlatformType.PS5,
     PlatformType.PSPC,
 }
 

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -118,4 +118,5 @@ class PlaystationNetworkTrophyTitlesCoordinator(
         self.psn.trophy_titles = await self.hass.async_add_executor_job(
             lambda: list(self.psn.user.trophy_titles())
         )
+        await self.config_entry.runtime_data.user_data.async_request_refresh()
         return self.psn.trophy_titles

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -23,12 +23,12 @@ from .helpers import PlaystationNetwork, PlaystationNetworkData
 
 _LOGGER = logging.getLogger(__name__)
 
-type PlaystationNetworkConfigEntry = ConfigEntry[PlayStationNetworkCoordinators]
+type PlaystationNetworkConfigEntry = ConfigEntry[PlaystationNetworkRuntimeData]
 
 
 @dataclass
-class PlayStationNetworkCoordinators:
-    """Dataclass holding PSN coordinators."""
+class PlaystationNetworkRuntimeData:
+    """Dataclass holding PSN runtime data."""
 
     coordinator: PlaystationNetworkCoordinator
     trophy_titles: PlaystationNetworkTrophyTitlesCoordinator

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -38,13 +38,13 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     """Base coordinator for PSN."""
 
     config_entry: PlaystationNetworkConfigEntry
+    _update_inverval: timedelta
 
     def __init__(
         self,
         hass: HomeAssistant,
         psn: PlaystationNetwork,
         config_entry: PlaystationNetworkConfigEntry,
-        update_interval: timedelta,
     ) -> None:
         """Initialize the Coordinator."""
         super().__init__(
@@ -52,7 +52,7 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
             name=DOMAIN,
             logger=_LOGGER,
             config_entry=config_entry,
-            update_interval=update_interval,
+            update_interval=self._update_interval,
         )
 
         self.psn = psn
@@ -63,14 +63,7 @@ class PlaystationNetworkCoordinator(
 ):
     """Data update coordinator for PSN."""
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        psn: PlaystationNetwork,
-        config_entry: PlaystationNetworkConfigEntry,
-    ) -> None:
-        """Initialize the Coordinator."""
-        super().__init__(hass, psn, config_entry, update_interval=timedelta(seconds=30))
+    _update_interval = timedelta(seconds=30)
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
@@ -109,14 +102,7 @@ class PlaystationNetworkTrophyTitlesCoordinator(
 ):
     """Trophy titles data update coordinator for PSN."""
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        psn: PlaystationNetwork,
-        config_entry: PlaystationNetworkConfigEntry,
-    ) -> None:
-        """Initialize the Coordinator."""
-        super().__init__(hass, psn, config_entry, update_interval=timedelta(minutes=60))
+    _update_interval = timedelta(minutes=60)
 
     async def _async_update_data(self) -> list[TrophyTitle]:
         """Update trophy titles data."""

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -30,7 +30,7 @@ type PlaystationNetworkConfigEntry = ConfigEntry[PlaystationNetworkRuntimeData]
 class PlaystationNetworkRuntimeData:
     """Dataclass holding PSN runtime data."""
 
-    coordinator: PlaystationNetworkCoordinator
+    user_data: PlaystationNetworkUserDataCoordinator
     trophy_titles: PlaystationNetworkTrophyTitlesCoordinator
 
 
@@ -58,7 +58,7 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
         self.psn = psn
 
 
-class PlaystationNetworkCoordinator(
+class PlaystationNetworkUserDataCoordinator(
     PlayStationNetworkBaseCoordinator[PlaystationNetworkData]
 ):
     """Data update coordinator for PSN."""

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -111,7 +111,7 @@ class PlaystationNetworkTrophyTitlesCoordinator(
 ):
     """Trophy titles data update coordinator for PSN."""
 
-    _update_interval = timedelta(minutes=60)
+    _update_interval = timedelta(days=1)
 
     async def update_data(self) -> list[TrophyTitle]:
         """Update trophy titles data."""

--- a/homeassistant/components/playstation_network/diagnostics.py
+++ b/homeassistant/components/playstation_network/diagnostics.py
@@ -10,7 +10,7 @@ from psnawp_api.models.trophies import PlatformType
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
-from .coordinator import PlaystationNetworkConfigEntry, PlaystationNetworkCoordinator
+from .coordinator import PlaystationNetworkConfigEntry
 
 TO_REDACT = {
     "account_id",
@@ -27,7 +27,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: PlaystationNetworkConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: PlaystationNetworkCoordinator = entry.runtime_data.coordinator
+    coordinator = entry.runtime_data.coordinator
 
     return {
         "data": async_redact_data(

--- a/homeassistant/components/playstation_network/diagnostics.py
+++ b/homeassistant/components/playstation_network/diagnostics.py
@@ -27,7 +27,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: PlaystationNetworkConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = entry.runtime_data.coordinator
+    coordinator = entry.runtime_data.user_data
 
     return {
         "data": async_redact_data(

--- a/homeassistant/components/playstation_network/diagnostics.py
+++ b/homeassistant/components/playstation_network/diagnostics.py
@@ -27,12 +27,12 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: PlaystationNetworkConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: PlaystationNetworkCoordinator = entry.runtime_data
+    coordinator: PlaystationNetworkCoordinator = entry.runtime_data.coordinator
 
     return {
         "data": async_redact_data(
             _serialize_platform_types(asdict(coordinator.data)), TO_REDACT
-        ),
+        )
     }
 
 
@@ -46,10 +46,12 @@ def _serialize_platform_types(data: Any) -> Any:
             for platform, record in data.items()
         }
     if isinstance(data, set):
-        return [
-            record.value if isinstance(record, PlatformType) else record
-            for record in data
-        ]
+        return sorted(
+            [
+                record.value if isinstance(record, PlatformType) else record
+                for record in data
+            ]
+        )
     if isinstance(data, PlatformType):
         return data.value
     return data

--- a/homeassistant/components/playstation_network/entity.py
+++ b/homeassistant/components/playstation_network/entity.py
@@ -7,17 +7,19 @@ from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import PlaystationNetworkCoordinator
+from .coordinator import PlaystationNetworkUserDataCoordinator
 
 
-class PlaystationNetworkServiceEntity(CoordinatorEntity[PlaystationNetworkCoordinator]):
+class PlaystationNetworkServiceEntity(
+    CoordinatorEntity[PlaystationNetworkUserDataCoordinator]
+):
     """Common entity class for PlayStationNetwork Service entities."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
-        coordinator: PlaystationNetworkCoordinator,
+        coordinator: PlaystationNetworkUserDataCoordinator,
         entity_description: EntityDescription,
     ) -> None:
         """Initialize PlayStation Network Service Entity."""

--- a/homeassistant/components/playstation_network/helpers.py
+++ b/homeassistant/components/playstation_network/helpers.py
@@ -168,10 +168,14 @@ class PlaystationNetwork:
             return url
 
         url = next(
-            title.title_icon_url
-            for title in self.trophy_titles
-            if game_title_info["titleName"] == normalize_title(title.title_name or "")
-            and next(iter(title.title_platform)) == PlatformType.PS_VITA
+            (
+                title.title_icon_url
+                for title in self.trophy_titles
+                if game_title_info["titleName"]
+                == normalize_title(title.title_name or "")
+                and next(iter(title.title_platform)) == PlatformType.PS_VITA
+            ),
+            None,
         )
         if url is not None:
             self._title_icon_urls[game_title_info["npTitleId"]] = url

--- a/homeassistant/components/playstation_network/media_player.py
+++ b/homeassistant/components/playstation_network/media_player.py
@@ -17,13 +17,18 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import PlaystationNetworkConfigEntry, PlaystationNetworkCoordinator
+from . import (
+    PlaystationNetworkConfigEntry,
+    PlaystationNetworkCoordinator,
+    PlaystationNetworkTrophyTitlesCoordinator,
+)
 from .const import DOMAIN, SUPPORTED_PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
 
 PLATFORM_MAP = {
+    PlatformType.PS_VITA: "PlayStation Vita",
     PlatformType.PS5: "PlayStation 5",
     PlatformType.PS4: "PlayStation 4",
     PlatformType.PS3: "PlayStation 3",
@@ -38,7 +43,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Media Player Entity Setup."""
-    coordinator = config_entry.runtime_data
+    coordinator = config_entry.runtime_data.coordinator
+    trophy_titles = config_entry.runtime_data.trophy_titles
     devices_added: set[PlatformType] = set()
     device_reg = dr.async_get(hass)
     entities = []
@@ -50,10 +56,12 @@ async def async_setup_entry(
         if not SUPPORTED_PLATFORMS - devices_added:
             remove_listener()
 
-        new_platforms = set(coordinator.data.active_sessions.keys()) - devices_added
+        new_platforms = (
+            set(coordinator.data.active_sessions.keys()) & SUPPORTED_PLATFORMS
+        ) - devices_added
         if new_platforms:
             async_add_entities(
-                PsnMediaPlayerEntity(coordinator, platform_type)
+                PsnMediaPlayerEntity(coordinator, platform_type, trophy_titles)
                 for platform_type in new_platforms
             )
             devices_added |= new_platforms
@@ -64,7 +72,7 @@ async def async_setup_entry(
                 (DOMAIN, f"{coordinator.config_entry.unique_id}_{platform.value}")
             }
         ):
-            entities.append(PsnMediaPlayerEntity(coordinator, platform))
+            entities.append(PsnMediaPlayerEntity(coordinator, platform, trophy_titles))
             devices_added.add(platform)
     if entities:
         async_add_entities(entities)
@@ -86,7 +94,10 @@ class PsnMediaPlayerEntity(
     _attr_name = None
 
     def __init__(
-        self, coordinator: PlaystationNetworkCoordinator, platform: PlatformType
+        self,
+        coordinator: PlaystationNetworkCoordinator,
+        platform: PlatformType,
+        trophy_titles: PlaystationNetworkTrophyTitlesCoordinator,
     ) -> None:
         """Initialize PSN MediaPlayer."""
         super().__init__(coordinator)
@@ -101,15 +112,21 @@ class PsnMediaPlayerEntity(
             model=PLATFORM_MAP[platform],
             via_device=(DOMAIN, coordinator.config_entry.unique_id),
         )
+        self.trophy_titles = trophy_titles
 
     @property
     def state(self) -> MediaPlayerState:
         """Media Player state getter."""
         session = self.coordinator.data.active_sessions.get(self.key)
-        if session and session.status == "online":
-            if session.title_id is not None:
-                return MediaPlayerState.PLAYING
-            return MediaPlayerState.ON
+        if session:
+            if session.status == "online":
+                return (
+                    MediaPlayerState.PLAYING
+                    if session.title_id is not None
+                    else MediaPlayerState.ON
+                )
+            if session.status == "standby":
+                return MediaPlayerState.STANDBY
         return MediaPlayerState.OFF
 
     @property
@@ -129,3 +146,12 @@ class PsnMediaPlayerEntity(
         """Media image url getter."""
         session = self.coordinator.data.active_sessions.get(self.key)
         return session.media_image_url if session else None
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+
+        await super().async_added_to_hass()
+        if self.key is PlatformType.PS_VITA:
+            self.async_on_remove(
+                self.trophy_titles.async_add_listener(self._handle_coordinator_update)
+            )

--- a/homeassistant/components/playstation_network/media_player.py
+++ b/homeassistant/components/playstation_network/media_player.py
@@ -19,8 +19,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import (
     PlaystationNetworkConfigEntry,
-    PlaystationNetworkCoordinator,
     PlaystationNetworkTrophyTitlesCoordinator,
+    PlaystationNetworkUserDataCoordinator,
 )
 from .const import DOMAIN, SUPPORTED_PLATFORMS
 
@@ -43,7 +43,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Media Player Entity Setup."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data.user_data
     trophy_titles = config_entry.runtime_data.trophy_titles
     devices_added: set[PlatformType] = set()
     device_reg = dr.async_get(hass)
@@ -82,7 +82,7 @@ async def async_setup_entry(
 
 
 class PsnMediaPlayerEntity(
-    CoordinatorEntity[PlaystationNetworkCoordinator], MediaPlayerEntity
+    CoordinatorEntity[PlaystationNetworkUserDataCoordinator], MediaPlayerEntity
 ):
     """Media player entity representing currently playing game."""
 
@@ -95,7 +95,7 @@ class PsnMediaPlayerEntity(
 
     def __init__(
         self,
-        coordinator: PlaystationNetworkCoordinator,
+        coordinator: PlaystationNetworkUserDataCoordinator,
         platform: PlatformType,
         trophy_titles: PlaystationNetworkTrophyTitlesCoordinator,
     ) -> None:

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -131,7 +131,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    coordinator = config_entry.runtime_data
+    coordinator = config_entry.runtime_data.coordinator
     async_add_entities(
         PlaystationNetworkSensorEntity(coordinator, description)
         for description in SENSOR_DESCRIPTIONS

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -131,7 +131,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data.user_data
     async_add_entities(
         PlaystationNetworkSensorEntity(coordinator, description)
         for description in SENSOR_DESCRIPTIONS

--- a/tests/components/playstation_network/conftest.py
+++ b/tests/components/playstation_network/conftest.py
@@ -1,9 +1,15 @@
 """Common fixtures for the Playstation Network tests."""
 
 from collections.abc import Generator
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from psnawp_api.models.trophies import TrophySet, TrophySummary
+from psnawp_api.models.trophies import (
+    PlatformType,
+    TrophySet,
+    TrophySummary,
+    TrophyTitle,
+)
 import pytest
 
 from homeassistant.components.playstation_network.const import CONF_NPSSO, DOMAIN
@@ -83,13 +89,14 @@ def mock_psnawpapi(mock_user: MagicMock) -> Generator[MagicMock]:
 
         client.user.return_value = mock_user
         client.me.return_value.get_account_devices.return_value = [
+            {"deviceType": "PSVITA"},
             {
                 "deviceId": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234",
                 "deviceType": "PS5",
                 "activationType": "PRIMARY",
                 "activationDate": "2021-01-14T18:00:00.000Z",
                 "accountDeviceVector": "abcdefghijklmnopqrstuv",
-            }
+            },
         ]
         client.me.return_value.trophy_summary.return_value = TrophySummary(
             PSN_ID, 1079, 19, 10, TrophySet(14450, 8722, 11754, 1398)
@@ -118,7 +125,37 @@ def mock_psnawpapi(mock_user: MagicMock) -> Generator[MagicMock]:
             "isOfficiallyVerified": False,
             "isMe": True,
         }
-
+        client.user.return_value.trophy_titles.return_value = [
+            TrophyTitle(
+                np_service_name="trophy",
+                np_communication_id="NPWR03134_00",
+                trophy_set_version="01.03",
+                title_name="Assassin's Creed® III Liberation",
+                title_detail="Assassin's Creed® III Liberation",
+                title_icon_url="https://image.api.playstation.com/trophy/np/NPWR03134_00_0008206095F67FD3BB385E9E00A7C9CFE6F5A4AB96/5F87A6997DD23D1C4D4CC0D1F958ED79CB905331.PNG",
+                title_platform=frozenset({PlatformType.PS_VITA}),
+                has_trophy_groups=False,
+                progress=28,
+                hidden_flag=False,
+                earned_trophies=TrophySet(bronze=4, silver=8, gold=0, platinum=0),
+                defined_trophies=TrophySet(bronze=22, silver=21, gold=1, platinum=1),
+                last_updated_datetime=datetime(2016, 10, 6, 18, 5, 8, tzinfo=UTC),
+                np_title_id=None,
+            )
+        ]
+        client.me.return_value.get_profile_legacy.return_value = {
+            "profile": {
+                "presences": [
+                    {
+                        "onlineStatus": "online",
+                        "platform": "PSVITA",
+                        "npTitleId": "PCSB00074_00",
+                        "titleName": "Assassin's Creed® III Liberation",
+                        "hasBroadcastData": False,
+                    }
+                ]
+            }
+        }
         yield client
 
 

--- a/tests/components/playstation_network/snapshots/test_diagnostics.ambr
+++ b/tests/components/playstation_network/snapshots/test_diagnostics.ambr
@@ -12,6 +12,14 @@
           'title_id': 'PPSA07784_00',
           'title_name': 'STAR WARS Jedi: Survivor™',
         }),
+        'PSVITA': dict({
+          'format': 'PSVITA',
+          'media_image_url': 'https://image.api.playstation.com/trophy/np/NPWR03134_00_0008206095F67FD3BB385E9E00A7C9CFE6F5A4AB96/5F87A6997DD23D1C4D4CC0D1F958ED79CB905331.PNG',
+          'platform': 'PSVITA',
+          'status': 'online',
+          'title_id': 'PCSB00074_00',
+          'title_name': "Assassin's Creed® III Liberation",
+        }),
       }),
       'availability': 'availableToPlay',
       'presence': dict({
@@ -61,6 +69,7 @@
       }),
       'registered_platforms': list([
         'PS5',
+        'PSVITA',
       ]),
       'trophy_summary': dict({
         'account_id': '**REDACTED**',

--- a/tests/components/playstation_network/snapshots/test_media_player.ambr
+++ b/tests/components/playstation_network/snapshots/test_media_player.ambr
@@ -1,4 +1,166 @@
 # serializer version: 1
+# name: test_media_player_psvita[presence_payload0][media_player.playstation_vita-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'media_player',
+    'entity_category': None,
+    'entity_id': 'media_player.playstation_vita',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <MediaPlayerDeviceClass.RECEIVER: 'receiver'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'playstation',
+    'unique_id': 'my-psn-id_PSVITA',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_media_player_psvita[presence_payload0][media_player.playstation_vita-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'receiver',
+      'entity_picture_local': None,
+      'friendly_name': 'PlayStation Vita',
+      'media_content_type': <MediaType.GAME: 'game'>,
+      'supported_features': <MediaPlayerEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.playstation_vita',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'standby',
+  })
+# ---
+# name: test_media_player_psvita[presence_payload1][media_player.playstation_vita-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'media_player',
+    'entity_category': None,
+    'entity_id': 'media_player.playstation_vita',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <MediaPlayerDeviceClass.RECEIVER: 'receiver'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'playstation',
+    'unique_id': 'my-psn-id_PSVITA',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_media_player_psvita[presence_payload1][media_player.playstation_vita-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'receiver',
+      'entity_picture': 'https://image.api.playstation.com/trophy/np/NPWR03134_00_0008206095F67FD3BB385E9E00A7C9CFE6F5A4AB96/5F87A6997DD23D1C4D4CC0D1F958ED79CB905331.PNG',
+      'entity_picture_local': '/api/media_player_proxy/media_player.playstation_vita?token=123456789&cache=c7c916a6e18aec3d',
+      'friendly_name': 'PlayStation Vita',
+      'media_content_id': 'PCSB00074_00',
+      'media_content_type': <MediaType.GAME: 'game'>,
+      'media_title': "Assassin's Creed® III Liberation",
+      'supported_features': <MediaPlayerEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.playstation_vita',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'playing',
+  })
+# ---
+# name: test_media_player_psvita[presence_payload2][media_player.playstation_vita-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'media_player',
+    'entity_category': None,
+    'entity_id': 'media_player.playstation_vita',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <MediaPlayerDeviceClass.RECEIVER: 'receiver'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'playstation',
+    'unique_id': 'my-psn-id_PSVITA',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_media_player_psvita[presence_payload2][media_player.playstation_vita-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'receiver',
+      'entity_picture_local': None,
+      'friendly_name': 'PlayStation Vita',
+      'media_content_type': <MediaType.GAME: 'game'>,
+      'supported_features': <MediaPlayerEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.playstation_vita',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_platform[PS4_idle][media_player.playstation_4-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -227,3 +227,39 @@ async def test_trophy_title_coordinator_doesnt_update(
     await hass.async_block_till_done()
 
     assert len(mock_psnawpapi.user.return_value.trophy_titles.mock_calls) == 1
+
+
+async def test_trophy_title_coordinator_play_new_game(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test we play a new game and get a title image on next trophy titles update."""
+
+    _tmp = mock_psnawpapi.user.return_value.trophy_titles.return_value
+    mock_psnawpapi.user.return_value.trophy_titles.return_value = []
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert (state := hass.states.get("media_player.playstation_vita"))
+    assert state.attributes.get("entity_picture") is None
+
+    mock_psnawpapi.user.return_value.trophy_titles.return_value = _tmp
+
+    freezer.tick(timedelta(days=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert len(mock_psnawpapi.user.return_value.trophy_titles.mock_calls) == 2
+
+    assert (state := hass.states.get("media_player.playstation_vita"))
+    assert (
+        state.attributes["entity_picture"]
+        == "https://image.api.playstation.com/trophy/np/NPWR03134_00_0008206095F67FD3BB385E9E00A7C9CFE6F5A4AB96/5F87A6997DD23D1C4D4CC0D1F958ED79CB905331.PNG"
+    )

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -129,7 +129,7 @@ async def test_trophy_title_coordinator(
     assert config_entry.state is ConfigEntryState.LOADED
     assert len(mock_psnawpapi.user.return_value.trophy_titles.mock_calls) == 1
 
-    freezer.tick(timedelta(minutes=60))
+    freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -154,7 +154,7 @@ async def test_trophy_title_coordinator_auth_failed(
         PSNAWPAuthenticationError
     )
 
-    freezer.tick(timedelta(minutes=60))
+    freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     await hass.async_block_till_done()
@@ -191,7 +191,7 @@ async def test_trophy_title_coordinator_update_data_failed(
 
     mock_psnawpapi.user.return_value.trophy_titles.side_effect = exception
 
-    freezer.tick(timedelta(minutes=60))
+    freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     await hass.async_block_till_done()
@@ -222,7 +222,7 @@ async def test_trophy_title_coordinator_doesnt_update(
     assert config_entry.state is ConfigEntryState.LOADED
     assert len(mock_psnawpapi.user.return_value.trophy_titles.mock_calls) == 1
 
-    freezer.tick(timedelta(minutes=60))
+    freezer.tick(timedelta(days=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -157,9 +157,6 @@ async def test_trophy_title_coordinator_auth_failed(
     freezer.tick(timedelta(minutes=60))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-
-    freezer.tick()
-    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()
@@ -197,9 +194,6 @@ async def test_trophy_title_coordinator_update_data_failed(
     freezer.tick(timedelta(minutes=60))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-
-    freezer.tick()
-    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     runtime_data: PlaystationNetworkRuntimeData = config_entry.runtime_data

--- a/tests/components/playstation_network/test_media_player.py
+++ b/tests/components/playstation_network/test_media_player.py
@@ -114,6 +114,76 @@ async def test_platform(
     """Test setup of the PlayStation Network media_player platform."""
 
     mock_psnawpapi.user().get_presence.return_value = presence_payload
+    mock_psnawpapi.me.return_value.get_profile_legacy.return_value = {
+        "profile": {"presences": []}
+    }
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    "presence_payload",
+    [
+        {
+            "profile": {
+                "presences": [
+                    {
+                        "onlineStatus": "standby",
+                        "platform": "PSVITA",
+                        "hasBroadcastData": False,
+                    }
+                ]
+            }
+        },
+        {
+            "profile": {
+                "presences": [
+                    {
+                        "onlineStatus": "online",
+                        "platform": "PSVITA",
+                        "npTitleId": "PCSB00074_00",
+                        "titleName": "Assassin's Creed® III Liberation",
+                        "hasBroadcastData": False,
+                    }
+                ]
+            }
+        },
+        {
+            "profile": {
+                "presences": [
+                    {
+                        "onlineStatus": "online",
+                        "platform": "PSVITA",
+                        "hasBroadcastData": False,
+                    }
+                ]
+            }
+        },
+    ],
+)
+@pytest.mark.usefixtures("mock_psnawpapi", "mock_token")
+async def test_media_player_psvita(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_psnawpapi: MagicMock,
+    presence_payload: dict[str, Any],
+) -> None:
+    """Test setup of the PlayStation Network media_player for PlayStation Vita."""
+
+    mock_psnawpapi.user().get_presence.return_value = {
+        "basicPresence": {
+            "availability": "unavailable",
+            "primaryPlatformInfo": {"onlineStatus": "offline", "platform": ""},
+        }
+    }
+    mock_psnawpapi.me.return_value.get_profile_legacy.return_value = presence_payload
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Adds support for PS Vita

This adds the PS Vita to supported PlayStation platforms. As there is no endpoint to get the title image for PS Vita via it's  title ID, this uses a workaround by fetching the user's trophy list, which also returns a title image.  The games are then matched by their names, which should work in most cases. For legacy platforms it is not possible to fetch the data only for a specific title, so all trophy data for all titles has to be fetched. As fetching the trophies data is expensive because it requires several successive API requests, it is only fetched once for setting up the integration and then updated hourly only if a PS Vita media player entity has been created. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39895
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
