### PR TITLE
Fix UTF-8 encoding for REST basic authentication

### DIFF
--- a/homeassistant/components/rest/data.py
+++ b/homeassistant/components/rest/data.py
@@ -49,7 +49,7 @@ class RestData:
         # Convert auth tuple to aiohttp.BasicAuth if needed
         if isinstance(auth, tuple) and len(auth) == 2:
             self._auth: aiohttp.BasicAuth | aiohttp.DigestAuthMiddleware | None = (
-                aiohttp.BasicAuth(auth[0], auth[1])
+                aiohttp.BasicAuth(auth[0], auth[1], encoding="utf-8")
             )
         else:
             self._auth = auth

--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -703,17 +703,11 @@ async def test_utf8_basic_auth(
     )
     await hass.async_block_till_done()
 
-    # Verify the request was made with correct auth header
+    # Verify the request was made
     assert len(aioclient_mock.mock_calls) == 1
 
-    # Check the auth header was included
-    call = aioclient_mock.mock_calls[0]
-    assert "auth" in call[2]
-    auth = call[2]["auth"]
-    assert isinstance(auth, aiohttp.BasicAuth)
-    assert auth.login == username
-    assert auth.password == password
-    assert auth.encoding == "utf-8"
+    # The test verifies that the component sets up correctly with UTF-8 chars in password
+    # The actual auth encoding verification happens at the aiohttp level
 
     # Verify the sensor state
     state = hass.states.get("binary_sensor.test_utf8_auth")

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -156,6 +156,9 @@ class AiohttpClientMocker:
 
         for response in self._mocks:
             if response.match_request(method, url, params):
+                # If auth is provided, try to encode it to trigger any encoding errors
+                if auth is not None:
+                    auth.encode()
                 self.mock_calls.append((method, url, data, headers))
                 if response.side_effect:
                     response = await response.side_effect(method, url, data)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes an issue where the REST integration fails to authenticate when passwords contain non-Latin1 Unicode characters (like `'`, `"`, or other Unicode symbols). 

The issue occurs because `aiohttp.BasicAuth` defaults to Latin-1 encoding, which cannot handle many Unicode characters. This change explicitly sets the encoding to UTF-8 when creating BasicAuth instances, aligning with modern standards and fixing authentication failures.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148194
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

## Details

The change is minimal - adding `encoding="utf-8"` parameter when creating `aiohttp.BasicAuth` instances:

```python
aiohttp.BasicAuth(auth[0], auth[1], encoding="utf-8")
```

This ensures passwords containing Unicode characters are properly encoded. A test has been added to verify this functionality using the Unicode character `\u2018` (left single quotation mark) in a password.