### PR TITLE
Add play media support to Russound RIO

### DIFF
--- a/homeassistant/components/russound_rio/const.py
+++ b/homeassistant/components/russound_rio/const.py
@@ -6,6 +6,10 @@ from aiorussound import CommandError
 
 DOMAIN = "russound_rio"
 
+RUSSOUND_MEDIA_TYPE_PRESET = "preset"
+
+SELECT_SOURCE_DELAY = 0.5
+
 RUSSOUND_RIO_EXCEPTIONS = (
     CommandError,
     ConnectionRefusedError,

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from aiorussound import Controller
 from aiorussound.const import FeatureFlag
@@ -19,9 +20,11 @@ from homeassistant.components.media_player import (
     MediaType,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import RussoundConfigEntry
+from .const import DOMAIN, RUSSOUND_MEDIA_TYPE_PRESET, SELECT_SOURCE_DELAY
 from .entity import RussoundBaseEntity, command
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,6 +61,7 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.SELECT_SOURCE
         | MediaPlayerEntityFeature.SEEK
+        | MediaPlayerEntityFeature.PLAY_MEDIA
     )
     _attr_name = None
 
@@ -215,3 +219,43 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
     async def async_media_seek(self, position: float) -> None:
         """Seek to a position in the current media."""
         await self._zone.set_seek_time(int(position))
+
+    @command
+    async def async_play_media(
+        self, media_type: MediaType | str, media_id: str, **kwargs: Any
+    ) -> None:
+        """Play media on the Russound zone."""
+
+        if media_type not in {RUSSOUND_MEDIA_TYPE_PRESET}:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="unsupported_media_type",
+                translation_placeholders={
+                    "media_type": media_type,
+                },
+            )
+        if media_type == RUSSOUND_MEDIA_TYPE_PRESET:
+            source_id = None
+            try:
+                if "," in media_id:
+                    source_id_str, preset_id_str = media_id.split(",", maxsplit=1)
+                    source_id = int(source_id_str.strip())
+                    preset_id = int(preset_id_str.strip())
+                else:
+                    preset_id = int(media_id)
+            except ValueError as ve:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="preset_non_integer",
+                    translation_placeholders={"preset_id": media_id},
+                ) from ve
+            if source_id:
+                await self._zone.select_source(source_id)
+                await asyncio.sleep(SELECT_SOURCE_DELAY)
+            if not self._source.presets or preset_id not in self._source.presets:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="missing_preset",
+                    translation_placeholders={"preset_id": media_id},
+                )
+            await self._zone.restore_preset(preset_id)

--- a/homeassistant/components/russound_rio/strings.json
+++ b/homeassistant/components/russound_rio/strings.json
@@ -67,6 +67,15 @@
     },
     "command_error": {
       "message": "Error executing {function_name} on entity {entity_id}"
+    },
+    "unsupported_media_type": {
+      "message": "Unsupported media type for Russound zone: {media_type}"
+    },
+    "missing_preset": {
+      "message": "The specified preset is not available for this source: {preset_id}"
+    },
+    "preset_non_integer": {
+      "message": "Preset must be an integer, got: {preset_id}"
     }
   }
 }

--- a/tests/components/russound_rio/conftest.py
+++ b/tests/components/russound_rio/conftest.py
@@ -84,6 +84,7 @@ def mock_russound_client() -> Generator[AsyncMock]:
                 zone.set_treble = AsyncMock()
                 zone.set_turn_on_volume = AsyncMock()
                 zone.set_loudness = AsyncMock()
+                zone.restore_preset = AsyncMock()
 
         client.controllers = {
             1: Controller(

--- a/tests/components/russound_rio/fixtures/get_sources.json
+++ b/tests/components/russound_rio/fixtures/get_sources.json
@@ -1,7 +1,14 @@
 {
   "1": {
     "name": "Aux",
-    "type": "Miscellaneous Audio"
+    "type": "RNET AM/FM Tuner (Internal)",
+    "presets": {
+      "1": "WOOD",
+      "2": "89.7 MHz FM",
+      "7": "WWKR",
+      "8": "WKLA",
+      "11": "WGN"
+    }
   },
   "2": {
     "name": "Spotify",

--- a/tests/components/russound_rio/test_media_player.py
+++ b/tests/components/russound_rio/test_media_player.py
@@ -9,10 +9,13 @@ import pytest
 
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_CONTENT_ID,
+    ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
     DOMAIN as MP_DOMAIN,
+    SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
 )
 from homeassistant.const import (
@@ -32,7 +35,7 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from . import mock_state_update, setup_integration
 from .const import ENTITY_ID_ZONE_1
@@ -253,3 +256,94 @@ async def test_media_seek(
     mock_russound_client.controllers[1].zones[1].set_seek_time.assert_called_once_with(
         100
     )
+
+
+async def test_play_media_preset_item_id(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_russound_client: AsyncMock,
+) -> None:
+    """Test playing media with a preset item id."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_ENTITY_ID: ENTITY_ID_ZONE_1,
+            ATTR_MEDIA_CONTENT_TYPE: "preset",
+            ATTR_MEDIA_CONTENT_ID: "1",
+        },
+        blocking=True,
+    )
+    mock_russound_client.controllers[1].zones[1].restore_preset.assert_called_once_with(
+        1
+    )
+
+    await hass.services.async_call(
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_ENTITY_ID: ENTITY_ID_ZONE_1,
+            ATTR_MEDIA_CONTENT_TYPE: "preset",
+            ATTR_MEDIA_CONTENT_ID: "1,2",
+        },
+        blocking=True,
+    )
+    mock_russound_client.controllers[1].zones[1].select_source.assert_called_once_with(
+        1
+    )
+    mock_russound_client.controllers[1].zones[1].restore_preset.assert_called_with(2)
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="The specified preset is not available for this source: 10",
+    ):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_ENTITY_ID: ENTITY_ID_ZONE_1,
+                ATTR_MEDIA_CONTENT_TYPE: "preset",
+                ATTR_MEDIA_CONTENT_ID: "10",
+            },
+            blocking=True,
+        )
+
+    with pytest.raises(
+        ServiceValidationError, match="Preset must be an integer, got: UNKNOWN_PRESET"
+    ):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_ENTITY_ID: ENTITY_ID_ZONE_1,
+                ATTR_MEDIA_CONTENT_TYPE: "preset",
+                ATTR_MEDIA_CONTENT_ID: "UNKNOWN_PRESET",
+            },
+            blocking=True,
+        )
+
+
+async def test_play_media_unknown_type(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_russound_client: AsyncMock,
+) -> None:
+    """Test playing media with an unsupported content type."""
+    await setup_integration(hass, mock_config_entry)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Unsupported media type for Russound zone: unsupported_content_type",
+    ):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_ENTITY_ID: ENTITY_ID_ZONE_1,
+                ATTR_MEDIA_CONTENT_TYPE: "unsupported_content_type",
+                ATTR_MEDIA_CONTENT_ID: "1",
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for the play media action in Russound RIO. This currently only supports the presets type, but additional types will be added in the future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39873
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
