### PR TITLE
Add `basic` authentication option for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/services.yaml
+++ b/homeassistant/components/telegram_bot/services.yaml
@@ -82,6 +82,14 @@ send_photo:
       example: "My image"
       selector:
         text:
+    authentication:
+      selector:
+        select:
+          options:
+            - "basic"
+            - "digest"
+            - "bearer_token"
+          translation_key: "authentication"
     username:
       example: myuser
       selector:
@@ -90,13 +98,6 @@ send_photo:
       example: myuser_pwd
       selector:
         text:
-    authentication:
-      default: digest
-      selector:
-        select:
-          options:
-            - "digest"
-            - "bearer_token"
     target:
       example: "[12345, 67890] or 12345"
       selector:
@@ -163,6 +164,14 @@ send_sticker:
       example: CAACAgIAAxkBAAEDDldhZD-hqWclr6krLq-FWSfCrGNmOQAC9gAD9HsZAAFeYY-ltPYnrCEE
       selector:
         text:
+    authentication:
+      selector:
+        select:
+          options:
+            - "basic"
+            - "digest"
+            - "bearer_token"
+          translation_key: "authentication"
     username:
       example: myuser
       selector:
@@ -171,13 +180,6 @@ send_sticker:
       example: myuser_pwd
       selector:
         text:
-    authentication:
-      default: digest
-      selector:
-        select:
-          options:
-            - "digest"
-            - "bearer_token"
     target:
       example: "[12345, 67890] or 12345"
       selector:
@@ -235,6 +237,14 @@ send_animation:
       example: "My animation"
       selector:
         text:
+    authentication:
+      selector:
+        select:
+          options:
+            - "basic"
+            - "digest"
+            - "bearer_token"
+          translation_key: "authentication"
     username:
       example: myuser
       selector:
@@ -243,13 +253,6 @@ send_animation:
       example: myuser_pwd
       selector:
         text:
-    authentication:
-      default: digest
-      selector:
-        select:
-          options:
-            - "digest"
-            - "bearer_token"
     target:
       example: "[12345, 67890] or 12345"
       selector:
@@ -316,6 +319,14 @@ send_video:
       example: "My video"
       selector:
         text:
+    authentication:
+      selector:
+        select:
+          options:
+            - "basic"
+            - "digest"
+            - "bearer_token"
+          translation_key: "authentication"
     username:
       example: myuser
       selector:
@@ -324,13 +335,6 @@ send_video:
       example: myuser_pwd
       selector:
         text:
-    authentication:
-      default: digest
-      selector:
-        select:
-          options:
-            - "digest"
-            - "bearer_token"
     target:
       example: "[12345, 67890] or 12345"
       selector:
@@ -397,6 +401,14 @@ send_voice:
       example: "My microphone recording"
       selector:
         text:
+    authentication:
+      selector:
+        select:
+          options:
+            - "basic"
+            - "digest"
+            - "bearer_token"
+          translation_key: "authentication"
     username:
       example: myuser
       selector:
@@ -405,13 +417,6 @@ send_voice:
       example: myuser_pwd
       selector:
         text:
-    authentication:
-      default: digest
-      selector:
-        select:
-          options:
-            - "digest"
-            - "bearer_token"
     target:
       example: "[12345, 67890] or 12345"
       selector:
@@ -469,6 +474,14 @@ send_document:
       example: Document Title xy
       selector:
         text:
+    authentication:
+      selector:
+        select:
+          options:
+            - "basic"
+            - "digest"
+            - "bearer_token"
+          translation_key: "authentication"
     username:
       example: myuser
       selector:
@@ -477,13 +490,6 @@ send_document:
       example: myuser_pwd
       selector:
         text:
-    authentication:
-      default: digest
-      selector:
-        select:
-          options:
-            - "digest"
-            - "bearer_token"
     target:
       example: "[12345, 67890] or 12345"
       selector:

--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -130,6 +130,13 @@
         "html": "HTML",
         "plain_text": "Plain text"
       }
+    },
+    "authentication": {
+      "options": {
+        "basic": "Basic",
+        "digest": "Digest",
+        "bearer_token": "Bearer token"
+      }
     }
   },
   "services": {

--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -220,15 +220,15 @@
         },
         "username": {
           "name": "[%key:common::config_flow::data::username%]",
-          "description": "Username for a URL which require HTTP authentication."
+          "description": "Username for a URL which requires HTTP `basic` or `digest` authentication."
         },
         "password": {
           "name": "[%key:common::config_flow::data::password%]",
-          "description": "Password (or bearer token) for a URL which require HTTP authentication."
+          "description": "Password (or bearer token) for a URL which require authentication."
         },
         "authentication": {
           "name": "Authentication method",
-          "description": "Define which authentication method to use. Set to `digest` to use HTTP digest authentication, or `bearer_token` for OAuth 2.0 bearer token authentication. Defaults to `basic`."
+          "description": "Define which authentication method to use. Set to `basic` for HTTP basic authentication, `digest` for HTTP digest authentication, or `bearer_token` for OAuth 2.0 bearer token authentication."
         },
         "target": {
           "name": "Target",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds `basic` authentication option which was missing from the UI.
(The basic authentication functionality already exists but can only be specified via yaml.)

The `authentication` field is also moved to the front of the `username` and `password` fields since the sequence makes more sense.

Current:
![image](https://github.com/user-attachments/assets/276f4430-3c65-4a0e-a829-796c8ebb0889)

New:
![image](https://github.com/user-attachments/assets/b0bba30a-569c-4956-a22a-7bcb64f61c64)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148192
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39882
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
