### PR TITLE
Add media browsing to Russound RIO

### DIFF
--- a/homeassistant/components/russound_rio/media_browser.py
+++ b/homeassistant/components/russound_rio/media_browser.py
@@ -1,0 +1,97 @@
+"""Support for Russound media browsing."""
+
+from aiorussound import RussoundClient, Zone
+from aiorussound.const import FeatureFlag
+from aiorussound.util import is_feature_supported
+
+from homeassistant.components.media_player import BrowseMedia, MediaClass
+from homeassistant.core import HomeAssistant
+
+
+async def async_browse_media(
+    hass: HomeAssistant,
+    client: RussoundClient,
+    media_content_id: str | None,
+    media_content_type: str | None,
+    zone: Zone,
+) -> BrowseMedia:
+    """Browse media."""
+    if media_content_type == "presets":
+        return await _presets_payload(_find_presets_by_zone(client, zone))
+
+    return await _root_payload(hass, _find_presets_by_zone(client, zone))
+
+
+async def _root_payload(
+    hass: HomeAssistant, presets_by_zone: dict[int, dict[int, str]]
+) -> BrowseMedia:
+    """Return root payload for Russound RIO."""
+    children: list[BrowseMedia] = []
+
+    if presets_by_zone:
+        children.append(
+            BrowseMedia(
+                title="Presets",
+                media_class=MediaClass.DIRECTORY,
+                media_content_id="",
+                media_content_type="presets",
+                thumbnail="https://brands.home-assistant.io/_/russound_rio/logo.png",
+                can_play=False,
+                can_expand=True,
+            )
+        )
+
+    return BrowseMedia(
+        title="Russound",
+        media_class=MediaClass.DIRECTORY,
+        media_content_id="",
+        media_content_type="root",
+        can_play=False,
+        can_expand=True,
+        children=children,
+    )
+
+
+async def _presets_payload(presets_by_zone: dict[int, dict[int, str]]) -> BrowseMedia:
+    """Create payload to list presets."""
+    children: list[BrowseMedia] = []
+    for source_id, presets in presets_by_zone.items():
+        for preset_id, preset_name in presets.items():
+            children.append(
+                BrowseMedia(
+                    title=preset_name,
+                    media_class=MediaClass.CHANNEL,
+                    media_content_id=f"{source_id},{preset_id}",
+                    media_content_type="preset",
+                    can_play=True,
+                    can_expand=False,
+                )
+            )
+
+    return BrowseMedia(
+        title="Presets",
+        media_class=MediaClass.DIRECTORY,
+        media_content_id="",
+        media_content_type="presets",
+        can_play=False,
+        can_expand=True,
+        children=children,
+    )
+
+
+def _find_presets_by_zone(
+    client: RussoundClient, zone: Zone
+) -> dict[int, dict[int, str]]:
+    """Returns a dict by {source_id: {preset_id: preset_name}}."""
+    assert client.rio_version
+    return {
+        source_id: source.presets
+        for source_id, source in client.sources.items()
+        if source.presets
+        and (
+            not is_feature_supported(
+                client.rio_version, FeatureFlag.SUPPORT_ZONE_SOURCE_EXCLUSION
+            )
+            or source_id in zone.enabled_sources
+        )
+    }

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -13,6 +13,7 @@ from aiorussound.models import PlayStatus, Source
 from aiorussound.util import is_feature_supported
 
 from homeassistant.components.media_player import (
+    BrowseMedia,
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
@@ -23,7 +24,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import RussoundConfigEntry
+from . import RussoundConfigEntry, media_browser
 from .const import DOMAIN, RUSSOUND_MEDIA_TYPE_PRESET, SELECT_SOURCE_DELAY
 from .entity import RussoundBaseEntity, command
 
@@ -65,7 +66,8 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER
     _attr_media_content_type = MediaType.MUSIC
     _attr_supported_features = (
-        MediaPlayerEntityFeature.VOLUME_SET
+        MediaPlayerEntityFeature.BROWSE_MEDIA
+        | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.TURN_ON
@@ -264,3 +266,13 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
                 translation_placeholders={"preset_id": media_id},
             )
         await self._zone.restore_preset(preset_id)
+
+    async def async_browse_media(
+        self,
+        media_content_type: MediaType | str | None = None,
+        media_content_id: str | None = None,
+    ) -> BrowseMedia:
+        """Implement the media browsing helper."""
+        return await media_browser.async_browse_media(
+            self.hass, self._client, media_content_id, media_content_type, self._zone
+        )

--- a/tests/components/russound_rio/fixtures/get_zones.json
+++ b/tests/components/russound_rio/fixtures/get_zones.json
@@ -7,7 +7,8 @@
           "volume": "10",
           "status": "ON",
           "enabled": "True",
-          "current_source": "1"
+          "current_source": "1",
+          "enabled_sources": [1, 2]
         },
         "2": {
           "name": "Kitchen",

--- a/tests/components/russound_rio/snapshots/test_media_browser.ambr
+++ b/tests/components/russound_rio/snapshots/test_media_browser.ambr
@@ -1,0 +1,75 @@
+# serializer version: 1
+# name: test_browse_media_root
+  list([
+    dict({
+      'can_expand': True,
+      'can_play': False,
+      'can_search': False,
+      'children_media_class': None,
+      'media_class': 'directory',
+      'media_content_id': '',
+      'media_content_type': 'presets',
+      'thumbnail': 'https://brands.home-assistant.io/_/russound_rio/logo.png',
+      'title': 'Presets',
+    }),
+  ])
+# ---
+# name: test_browse_presets
+  list([
+    dict({
+      'can_expand': False,
+      'can_play': True,
+      'can_search': False,
+      'children_media_class': None,
+      'media_class': 'channel',
+      'media_content_id': '1,1',
+      'media_content_type': 'preset',
+      'thumbnail': None,
+      'title': 'WOOD',
+    }),
+    dict({
+      'can_expand': False,
+      'can_play': True,
+      'can_search': False,
+      'children_media_class': None,
+      'media_class': 'channel',
+      'media_content_id': '1,2',
+      'media_content_type': 'preset',
+      'thumbnail': None,
+      'title': '89.7 MHz FM',
+    }),
+    dict({
+      'can_expand': False,
+      'can_play': True,
+      'can_search': False,
+      'children_media_class': None,
+      'media_class': 'channel',
+      'media_content_id': '1,7',
+      'media_content_type': 'preset',
+      'thumbnail': None,
+      'title': 'WWKR',
+    }),
+    dict({
+      'can_expand': False,
+      'can_play': True,
+      'can_search': False,
+      'children_media_class': None,
+      'media_class': 'channel',
+      'media_content_id': '1,8',
+      'media_content_type': 'preset',
+      'thumbnail': None,
+      'title': 'WKLA',
+    }),
+    dict({
+      'can_expand': False,
+      'can_play': True,
+      'can_search': False,
+      'children_media_class': None,
+      'media_class': 'channel',
+      'media_content_id': '1,11',
+      'media_content_type': 'preset',
+      'thumbnail': None,
+      'title': 'WGN',
+    }),
+  ])
+# ---

--- a/tests/components/russound_rio/test_media_browser.py
+++ b/tests/components/russound_rio/test_media_browser.py
@@ -1,0 +1,61 @@
+"""Tests for the Russound RIO media browser."""
+
+from unittest.mock import AsyncMock
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+from .const import ENTITY_ID_ZONE_1
+
+from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
+
+
+async def test_browse_media_root(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_russound_client: AsyncMock,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the root browse page."""
+    await setup_integration(hass, mock_config_entry)
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "media_player/browse_media",
+            "entity_id": ENTITY_ID_ZONE_1,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"]["children"] == snapshot
+
+
+async def test_browse_presets(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the presets browse page."""
+    await setup_integration(hass, mock_config_entry)
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "media_player/browse_media",
+            "entity_id": ENTITY_ID_ZONE_1,
+            "media_content_type": "presets",
+            "media_content_id": "",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"]["children"] == snapshot


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds media browsing to Russound RIO.

Requires: https://github.com/home-assistant/core/pull/148240

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39876
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
