### PR TITLE
Bump eheimdigital quality scale to platinum

### DIFF
--- a/homeassistant/components/eheimdigital/manifest.json
+++ b/homeassistant/components/eheimdigital/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["eheimdigital"],
-  "quality_scale": "bronze",
+  "quality_scale": "platinum",
   "requirements": ["eheimdigital==1.3.0"],
   "zeroconf": [
     { "type": "_http._tcp.local.", "name": "eheimdigital._http._tcp.local." }

--- a/homeassistant/components/eheimdigital/quality_scale.yaml
+++ b/homeassistant/components/eheimdigital/quality_scale.yaml
@@ -61,7 +61,9 @@ rules:
   exception-translations: done
   icon-translations: done
   reconfiguration-flow: done
-  repair-issues: done
+  repair-issues:
+    status: exempt
+    comment: No repairs.
   stale-devices: done
 
   # Platinum

--- a/homeassistant/components/eheimdigital/quality_scale.yaml
+++ b/homeassistant/components/eheimdigital/quality_scale.yaml
@@ -46,22 +46,22 @@ rules:
   diagnostics: done
   discovery-update-info: done
   discovery: done
-  docs-data-update: todo
-  docs-examples: todo
-  docs-known-limitations: todo
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
   docs-supported-devices: done
   docs-supported-functions: done
-  docs-troubleshooting: todo
-  docs-use-cases: todo
+  docs-troubleshooting: done
+  docs-use-cases: done
   dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
   exception-translations: done
-  icon-translations: todo
+  icon-translations: done
   reconfiguration-flow: done
-  repair-issues: todo
+  repair-issues: done
   stale-devices: done
 
   # Platinum


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump eheimdigital quality scale to platinum.

### Bronze
- [ ] ~`action-setup` - Service actions are registered in async_setup~
  - No service actions
- [X] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [X] `brands` - Has branding assets available for the integration
- [X] `common-modules` - Place common patterns in common modules
- [X] `config-flow-test-coverage` - Full test coverage for the config flow
- [X] `config-flow` - Integration needs to be able to be set up via the UI
    - [X] Uses `data_description` to give context to fields
    - [X] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [X] `dependency-transparency` - Dependency transparency
- [ ]  ~`docs-actions` - The documentation describes the provided service actions that can be used~
  - No service actions
- [X] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [X] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [X] `docs-removal-instructions` - The documentation provides removal instructions
- [X] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods
- [X] `entity-unique-id` - Entities have a unique ID
- [X] `has-entity-name` - Entities use has_entity_name = True
- [X] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [X] `test-before-configure` - Test a connection in the config flow
- [X] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [X] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice

### Silver
- [ ] ~`action-exceptions` - Service actions raise exceptions when encountering failures~
  - No service actions
- [X] `config-entry-unloading` - Support config entry unloading
- [X] `docs-configuration-parameters` - The documentation describes all integration configuration options
- [X] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [X] `entity-unavailable` - Mark entity unavailable if appropriate
- [X] `integration-owner` - Has an integration owner
- [X] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [X] `parallel-updates` - Number of parallel updates is specified
- [ ] ~`reauthentication-flow` - Reauthentication needs to be available via the UI~
  - No authentication
- [X] `test-coverage` - Above 95% test coverage for all integration modules

### Gold
- [X] `devices` - The integration creates devices
- [X] `diagnostics` - Implements diagnostics
- [X] `discovery-update-info` - Integration uses discovery info to update network information
- [X] `discovery` - Devices can be discovered
- [x] https://github.com/home-assistant/home-assistant.io/pull/39878 `docs-data-update` - The documentation describes how data is updated
- [x] https://github.com/home-assistant/home-assistant.io/pull/39878 `docs-examples` - The documentation provides automation examples the user can use.
- [ ] ~`docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)~
  - No known limitations
- [X] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [X] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] ~`docs-troubleshooting` - The documentation provides troubleshooting information~
  - No current troubleshooting
- [x] https://github.com/home-assistant/home-assistant.io/pull/39878 `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [X] `dynamic-devices` - Devices added after integration setup
- [X] `entity-category` - Entities are assigned an appropriate EntityCategory
- [X] `entity-device-class` - Entities use device classes where possible
- [X] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [X] `entity-translations` - Entities have translated names
- [X] `exception-translations` - Exception messages are translatable
- [X] `icon-translations` - Entities implement icon translations
- [X] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] ~`repair-issues` - Repair issues and repair flows are used when user intervention is needed~
  - Nothing to repair
- [X] `stale-devices` - Stale devices are removed

### Platinum
- [X] `async-dependency` - Dependency is async
- [X] `inject-websession` - The integration dependency supports passing in a websession
- [X] `strict-typing` - Strict typing


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
