### PR TITLE
Improve translation_key of `EnergyEvseSupplyStateSensor` in `matter`

### DIFF
--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -309,7 +309,7 @@ DISCOVERY_SCHEMAS = [
         platform=Platform.BINARY_SENSOR,
         entity_description=MatterBinarySensorEntityDescription(
             key="EnergyEvseSupplyStateSensor",
-            translation_key="evse_supply_charging_state",
+            translation_key="evse_supply_state",
             device_class=BinarySensorDeviceClass.RUNNING,
             device_to_ha={
                 clusters.EnergyEvse.Enums.SupplyStateEnum.kDisabled: False,

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -83,8 +83,8 @@
       "evse_plug": {
         "name": "Plug state"
       },
-      "evse_supply_charging_state": {
-        "name": "Supply charging state"
+      "evse_supply_state": {
+        "name": "Charger supply state"
       },
       "boost_state": {
         "name": "Boost state"

--- a/tests/components/matter/snapshots/test_binary_sensor.ambr
+++ b/tests/components/matter/snapshots/test_binary_sensor.ambr
@@ -685,7 +685,7 @@
     'state': 'on',
   })
 # ---
-# name: test_binary_sensors[silabs_evse_charging][binary_sensor.evse_supply_charging_state-entry]
+# name: test_binary_sensors[silabs_evse_charging][binary_sensor.evse_charger_supply_state-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -698,7 +698,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.evse_supply_charging_state',
+    'entity_id': 'binary_sensor.evse_charger_supply_state',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -710,24 +710,24 @@
     }),
     'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
     'original_icon': None,
-    'original_name': 'Supply charging state',
+    'original_name': 'Charger supply state',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'evse_supply_charging_state',
+    'translation_key': 'evse_supply_state',
     'unique_id': '00000000000004D2-0000000000000017-MatterNodeDevice-1-EnergyEvseSupplyStateSensor-153-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensors[silabs_evse_charging][binary_sensor.evse_supply_charging_state-state]
+# name: test_binary_sensors[silabs_evse_charging][binary_sensor.evse_charger_supply_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'running',
-      'friendly_name': 'evse Supply charging state',
+      'friendly_name': 'evse Charger supply state',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.evse_supply_charging_state',
+    'entity_id': 'binary_sensor.evse_charger_supply_state',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/test_binary_sensor.py
+++ b/tests/components/matter/test_binary_sensor.py
@@ -184,8 +184,8 @@ async def test_evse_sensor(
     assert state
     assert state.state == "off"
 
-    # Test SupplyStateEnum value with binary_sensor.evse_supply_charging
-    entity_id = "binary_sensor.evse_supply_charging_state"
+    # Test SupplyStateEnum value with binary_sensor.evse_charger_supply_state
+    entity_id = "binary_sensor.evse_charger_supply_state"
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "on"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The current HA translation string of the Matter `EnergyEvseSupplyStateSensor` as "Supply charging state" is misleading and has resulted in (machine) translations into other languages that make no sense.

Fix:
- rename key from `evse_supply_charging_state` to `evse_supply_state`
- rename translation from `Supply charging state` to `Charger supply state`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
