### PR TITLE
Track ESPHome entities by (device_id, key) to support sub-devices with overlaping names

### DIFF
--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -150,8 +150,8 @@ def async_static_info_updated(
         # We must remove the old entity and re-add it to ensure:
         # 1. The entity appears under the correct device in the UI
         # 2. The entity's state subscription is updated to use the new device_id
-        _LOGGER.info(
-            "Entity %s moving from device_id %s to %s, signaling entity removal",
+        _LOGGER.debug(
+            "Entity %s moving from device_id %s to %s",
             info.key,
             old_info.device_id,
             info.device_id,

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -82,7 +82,7 @@ def async_static_info_updated(
         # If not found, search for entity with same key but different device_id
         # This handles the case where entity moved between devices
         if not old_info:
-            for existing_device_id, existing_key in list(current_infos.keys()):
+            for existing_device_id, existing_key in list(current_infos):
                 if existing_key == info.key:
                     # Found entity with same key but different device_id
                     old_info = current_infos.pop((existing_device_id, existing_key))

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -82,10 +82,8 @@ def async_static_info_updated(
         # If not found, search for entity with same key but different device_id
         # This handles the case where entity moved between devices
         if not old_info:
-            for (existing_device_id, existing_key), existing_info in list(
-                current_infos.items()
-            ):
-                if existing_key == info.key and existing_info.key == info.key:
+            for existing_device_id, existing_key in list(current_infos.keys()):
+                if existing_key == info.key:
                     # Found entity with same key but different device_id
                     old_info = current_infos.pop((existing_device_id, existing_key))
                     break

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -34,7 +34,7 @@ from .const import DOMAIN
 
 # Import config flow so that it's added to the registry
 from .entry_data import (
-    DeviceEntityHashType,
+    DeviceEntityKey,
     ESPHomeConfigEntry,
     RuntimeEntryData,
     build_device_unique_id,
@@ -64,7 +64,7 @@ def async_static_info_updated(
     device_info = entry_data.device_info
     if TYPE_CHECKING:
         assert device_info is not None
-    new_infos: dict[DeviceEntityHashType, EntityInfo] = {}
+    new_infos: dict[DeviceEntityKey, EntityInfo] = {}
     add_entities: list[_EntityT] = []
 
     ent_reg = er.async_get(hass)

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -148,10 +148,16 @@ def async_static_info_updated(
         # Signal the existing entity to remove itself
         # The entity is registered with the old device_id, so we signal with that
         entry_data.async_signal_entity_removal(info_type, old_info.device_id, info.key)
+        # Make sure to remove the old info from current_infos
+        # since the entity is going to remove itself so it
+        # can be re-added with the new device_id, otherwise
+        # if it stays in current_infos, it will be deleted
+        # from all the registries and we will loose the
+        # entity_id.
+        del current_infos[info_key]
 
         # Create new entity with the new device_id
-        entity = entity_type(entry_data, platform.domain, info, state_type)
-        add_entities.append(entity)
+        add_entities.append(entity_type(entry_data, platform.domain, info, state_type))
 
     # Anything still in current_infos is now gone
     if current_infos:

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -60,9 +60,9 @@ from .const import DOMAIN
 from .dashboard import async_get_dashboard
 
 type ESPHomeConfigEntry = ConfigEntry[RuntimeEntryData]
-type PlatformDeviceEntityHashType = tuple[type[EntityState], int, int]
-type PlatformDeviceInfoHashType = tuple[type[EntityInfo], int, int]
-type DeviceEntityHashType = tuple[int, int]
+type EntityStateKey = tuple[type[EntityState], int, int]  # (state_type, device_id, key)
+type EntityInfoKey = tuple[type[EntityInfo], int, int]  # (info_type, device_id, key)
+type DeviceEntityKey = tuple[int, int]  # (device_id, key)
 
 INFO_TO_COMPONENT_TYPE: Final = {v: k for k, v in COMPONENT_TYPE_TO_INFO.items()}
 
@@ -139,8 +139,8 @@ class RuntimeEntryData:
     # When the disconnect callback is called, we mark all states
     # as stale so we will always dispatch a state update when the
     # device reconnects. This is the same format as state_subscriptions.
-    stale_state: set[PlatformDeviceEntityHashType] = field(default_factory=set)
-    info: dict[type[EntityInfo], dict[DeviceEntityHashType, EntityInfo]] = field(
+    stale_state: set[EntityStateKey] = field(default_factory=set)
+    info: dict[type[EntityInfo], dict[DeviceEntityKey, EntityInfo]] = field(
         default_factory=dict
     )
     services: dict[int, UserService] = field(default_factory=dict)
@@ -151,7 +151,7 @@ class RuntimeEntryData:
     api_version: APIVersion = field(default_factory=APIVersion)
     cleanup_callbacks: list[CALLBACK_TYPE] = field(default_factory=list)
     disconnect_callbacks: set[CALLBACK_TYPE] = field(default_factory=set)
-    state_subscriptions: dict[PlatformDeviceEntityHashType, CALLBACK_TYPE] = field(
+    state_subscriptions: dict[EntityStateKey, CALLBACK_TYPE] = field(
         default_factory=dict
     )
     device_update_subscriptions: set[CALLBACK_TYPE] = field(default_factory=set)
@@ -168,7 +168,7 @@ class RuntimeEntryData:
         type[EntityInfo], list[Callable[[list[EntityInfo]], None]]
     ] = field(default_factory=dict)
     entity_info_key_updated_callbacks: dict[
-        PlatformDeviceInfoHashType, list[Callable[[EntityInfo], None]]
+        EntityInfoKey, list[Callable[[EntityInfo], None]]
     ] = field(default_factory=dict)
     original_options: dict[str, Any] = field(default_factory=dict)
     media_player_formats: dict[str, list[MediaPlayerSupportedFormat]] = field(

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -588,7 +588,7 @@ class ESPHomeManager:
         # Mark state as stale so that we will always dispatch
         # the next state update of that type when the device reconnects
         entry_data.stale_state = {
-            (type(entity_state), key)
+            (type(entity_state), entity_state.device_id, key)
             for state_dict in entry_data.state.values()
             for key, entity_state in state_dict.items()
         }

--- a/tests/components/esphome/test_binary_sensor.py
+++ b/tests/components/esphome/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Test ESPHome binary sensors."""
 
-from aioesphomeapi import APIClient, BinarySensorInfo, BinarySensorState
+from aioesphomeapi import APIClient, BinarySensorInfo, BinarySensorState, SubDeviceInfo
 import pytest
 
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
@@ -127,3 +127,157 @@ async def test_binary_sensor_has_state_false(
     state = hass.states.get("binary_sensor.test_my_binary_sensor")
     assert state is not None
     assert state.state == STATE_ON
+
+
+async def test_binary_sensors_same_key_different_device_id(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test binary sensors with same key but different device_id."""
+    # Create sub-devices
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="Sub Device 1", area_id=0),
+        SubDeviceInfo(device_id=22222222, name="Sub Device 2", area_id=0),
+    ]
+
+    device_info = {
+        "name": "test",
+        "devices": sub_devices,
+    }
+
+    # Both sub-devices have a binary sensor with key=1
+    entity_info = [
+        BinarySensorInfo(
+            object_id="sensor",
+            key=1,
+            name="Motion",
+            unique_id="motion_1",
+            device_id=11111111,
+        ),
+        BinarySensorInfo(
+            object_id="sensor",
+            key=1,
+            name="Motion",
+            unique_id="motion_2",
+            device_id=22222222,
+        ),
+    ]
+
+    # States for both sensors with same key but different device_id
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=11111111),
+        BinarySensorState(key=1, state=False, missing_state=False, device_id=22222222),
+    ]
+
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    # Verify both entities exist and have correct states
+    state1 = hass.states.get("binary_sensor.sub_device_1_motion")
+    assert state1 is not None
+    assert state1.state == STATE_ON
+
+    state2 = hass.states.get("binary_sensor.sub_device_2_motion")
+    assert state2 is not None
+    assert state2.state == STATE_OFF
+
+    # Update states to verify they update independently
+    mock_device.set_state(
+        BinarySensorState(key=1, state=False, missing_state=False, device_id=11111111)
+    )
+    await hass.async_block_till_done()
+
+    state1 = hass.states.get("binary_sensor.sub_device_1_motion")
+    assert state1.state == STATE_OFF
+
+    # Sub device 2 should remain unchanged
+    state2 = hass.states.get("binary_sensor.sub_device_2_motion")
+    assert state2.state == STATE_OFF
+
+    # Update sub device 2
+    mock_device.set_state(
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=22222222)
+    )
+    await hass.async_block_till_done()
+
+    state2 = hass.states.get("binary_sensor.sub_device_2_motion")
+    assert state2.state == STATE_ON
+
+    # Sub device 1 should remain unchanged
+    state1 = hass.states.get("binary_sensor.sub_device_1_motion")
+    assert state1.state == STATE_OFF
+
+
+async def test_binary_sensor_main_and_sub_device_same_key(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test binary sensor on main device and sub-device with same key."""
+    # Create sub-device
+    sub_devices = [
+        SubDeviceInfo(device_id=11111111, name="Sub Device", area_id=0),
+    ]
+
+    device_info = {
+        "name": "test",
+        "devices": sub_devices,
+    }
+
+    # Main device and sub-device both have a binary sensor with key=1
+    entity_info = [
+        BinarySensorInfo(
+            object_id="main_sensor",
+            key=1,
+            name="Main Sensor",
+            unique_id="main_1",
+            device_id=0,  # Main device
+        ),
+        BinarySensorInfo(
+            object_id="sub_sensor",
+            key=1,
+            name="Sub Sensor",
+            unique_id="sub_1",
+            device_id=11111111,
+        ),
+    ]
+
+    # States for both sensors
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=0),
+        BinarySensorState(key=1, state=False, missing_state=False, device_id=11111111),
+    ]
+
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info=device_info,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    # Verify both entities exist
+    main_state = hass.states.get("binary_sensor.test_main_sensor")
+    assert main_state is not None
+    assert main_state.state == STATE_ON
+
+    sub_state = hass.states.get("binary_sensor.sub_device_sub_sensor")
+    assert sub_state is not None
+    assert sub_state.state == STATE_OFF
+
+    # Update main device sensor
+    mock_device.set_state(
+        BinarySensorState(key=1, state=False, missing_state=False, device_id=0)
+    )
+    await hass.async_block_till_done()
+
+    main_state = hass.states.get("binary_sensor.test_main_sensor")
+    assert main_state.state == STATE_OFF
+
+    # Sub device sensor should remain unchanged
+    sub_state = hass.states.get("binary_sensor.sub_device_sub_sensor")
+    assert sub_state.state == STATE_OFF

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -1507,7 +1507,7 @@ async def test_entity_device_id_rename_in_yaml(
     ]
 
     states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=11111111),
     ]
 
     device = await mock_esphome_device(

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -754,9 +754,9 @@ async def test_entity_assignment_to_sub_device(
     ]
 
     states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
-        BinarySensorState(key=2, state=False, missing_state=False),
-        BinarySensorState(key=3, state=True, missing_state=False),
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=0),
+        BinarySensorState(key=2, state=False, missing_state=False, device_id=11111111),
+        BinarySensorState(key=3, state=True, missing_state=False, device_id=22222222),
     ]
 
     device = await mock_esphome_device(

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -938,7 +938,7 @@ async def test_entity_switches_between_devices(
     ]
 
     states = [
-        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=1, state=True, missing_state=False, device_id=0),
     ]
 
     device = await mock_esphome_device(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR redesigns how the ESPHome integration tracks entities to properly support sub-devices that may have entities with overlapping names. Previously, entities were tracked only by their `key` field (which is a hash of the entity name), which prevented multiple sub-devices from having entities with the same name (e.g., multiple thermostats each with a "temperature" sensor would have the same key/hash).

The key changes:
- Entity tracking now uses `(device_id, key)` tuples instead of just `key`
- State subscriptions are properly scoped to specific device_id values
- Entity migration between devices is handled correctly with proper cleanup
- Added comprehensive tests for entities with same key on different devices

This enables "natural naming" of sensors across sub-devices without requiring artificial name prefixes, improving the user experience for ESPHome devices with multiple sub-devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/esphome/backlog/issues/35
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

### Implementation Details

The changes include:
1. **Type aliases for clarity**: Added `EntityStateKey`, `EntityInfoKey`, and `DeviceEntityKey` type aliases
2. **Updated data structures**: All entity tracking dictionaries now use `(device_id, key)` tuples
3. **Entity migration handling**: When entities move between devices, they are properly removed and re-added
4. **Entity removal signaling**: Implemented a callback mechanism for entities to be notified when they should remove themselves due to device_id changes
5. **Comprehensive test coverage**: Added tests for scenarios with overlapping keys across devices

### Testing

Added new tests in `test_binary_sensor.py`:
- `test_binary_sensors_same_key_different_device_id`: Tests multiple sub-devices with entities having the same key (same name hash)
- `test_binary_sensor_main_and_sub_device_same_key`: Tests main device and sub-device with entities having the same key (same name hash)

All existing tests continue to pass, ensuring backward compatibility.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr