### PR TITLE
Add Fan platform to Switchbot cloud

### DIFF
--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -29,6 +29,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CLIMATE,
+    Platform.FAN,
     Platform.LOCK,
     Platform.SENSOR,
     Platform.SWITCH,
@@ -51,6 +52,7 @@ class SwitchbotDevices:
     sensors: list[tuple[Device, SwitchBotCoordinator]] = field(default_factory=list)
     vacuums: list[tuple[Device, SwitchBotCoordinator]] = field(default_factory=list)
     locks: list[tuple[Device, SwitchBotCoordinator]] = field(default_factory=list)
+    fans: list[tuple[Device, SwitchBotCoordinator]] = field(default_factory=list)
 
 
 @dataclass

--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -98,7 +98,6 @@ async def make_switchbot_devices(
             for device in devices
         ]
     )
-
     return devices_data
 
 
@@ -155,12 +154,7 @@ async def make_device_data(
         )
         devices_data.vacuums.append((device, coordinator))
 
-    if isinstance(device, Device) and device.device_type in [
-        "Smart Lock",
-        "Smart Lock Lite",
-        "Smart Lock Pro",
-        "Smart Lock Ultra",
-    ]:
+    if isinstance(device, Device) and device.device_type.startswith("Smart Lock"):
         coordinator = await coordinator_for_device(
             hass, entry, api, device, coordinators_by_id
         )
@@ -178,6 +172,16 @@ async def make_device_data(
                 devices_data.buttons.append((device, coordinator))
             else:
                 devices_data.switches.append((device, coordinator))
+
+    if isinstance(device, Device) and device.device_type in [
+        "Battery Circulator Fan",
+        "Circulator Fan",
+    ]:
+        coordinator = await coordinator_for_device(
+            hass, entry, api, device, coordinators_by_id
+        )
+        devices_data.fans.append((device, coordinator))
+        devices_data.sensors.append((device, coordinator))
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -154,7 +154,12 @@ async def make_device_data(
         )
         devices_data.vacuums.append((device, coordinator))
 
-    if isinstance(device, Device) and device.device_type.startswith("Smart Lock"):
+    if isinstance(device, Device) and device.device_type in [
+        "Smart Lock",
+        "Smart Lock Lite",
+        "Smart Lock Pro",
+        "Smart Lock Ultra",
+    ]:
         coordinator = await coordinator_for_device(
             hass, entry, api, device, coordinators_by_id
         )

--- a/homeassistant/components/switchbot_cloud/fan.py
+++ b/homeassistant/components/switchbot_cloud/fan.py
@@ -55,25 +55,16 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
         """Set attributes from coordinator data."""
         if self.coordinator.data is None:
             return
-        if (
-            self._attr_is_on is None
-            and self.percentage == 0
-            and self.preset_mode is None
-        ):
-            response: dict | None = self.coordinator.data
-            assert response is not None
-            power: str | None = response.get("power")
-            mode: str | None = response.get("mode")
-            fan_speed: str | None = response.get("fanSpeed")
-            assert fan_speed is not None
-            self.preset_mode = mode if mode else BatteryCirculatorFanMode.DIRECT.value
-            self.percentage = (
-                int(fan_speed)
-                if self.preset_mode in BatteryCirculatorFanMode.DIRECT.value
-                else 0
-            )
-            assert power is not None
-            self._attr_is_on = "on" in power
+
+        power: str | None = self.coordinator.data.get("power")
+        mode: str | None = self.coordinator.data.get("mode")
+        fan_speed: str | None = self.coordinator.data.get("fanSpeed")
+        assert power is not None
+        self._attr_is_on = "on" in power
+        assert mode is not None
+        self.preset_mode = mode
+        assert fan_speed is not None
+        self.percentage = int(fan_speed)
 
     async def async_turn_on(
         self,
@@ -82,116 +73,42 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn on the fan."""
-        response: dict | None = await self._api.get_status(self.unique_id)
-        assert response is not None
-
-        power: str | None = response.get("power")
-        fan_speed: int | None = response.get("fanSpeed")
-        mode: str | None = response.get("mode")
-        if self._attr_is_on is False and (power and "off" in power):
-            await self.send_api_command(CommonCommands.ON)
-            self._attr_is_on = True
-        elif self._attr_is_on is False and (power and "on" in power):
-            self._attr_is_on = True
-        else:
-            pass
-        if self.preset_mode is None:
-            self.preset_mode = BatteryCirculatorFanMode.DIRECT.value
-        # if mode exist, do something
-        if mode is not None:
-            # if current mode != preset_mode, send set mode command again
-            if mode != self.preset_mode:
-                await self.send_api_command(
-                    command=BatteryCirculatorFanCommands.SET_WIND_MODE,
-                    parameters=self.preset_mode,
-                )
-        # if mode is None, set as default
-        else:
-            self.preset_mode = BatteryCirculatorFanMode.DIRECT.value
-            await self.send_api_command(
-                command=BatteryCirculatorFanCommands.SET_WIND_MODE,
-                parameters=self.preset_mode,
-            )
-
-        # if fanspeed exist, do something
-        if (
-            fan_speed is not None
-            and fan_speed != self.percentage
-            and self.preset_mode in BatteryCirculatorFanMode.DIRECT.value
-        ):
-            await self.send_api_command(
-                command=BatteryCirculatorFanCommands.SET_WIND_SPEED,
-                parameters=str(percentage),
-            )
-        else:
-            self.percentage = 0
+        await self.coordinator.async_refresh()
+        await self.send_api_command(CommonCommands.ON)
+        self._attr_is_on = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
-
-        response: dict | None = await self._api.get_status(self.unique_id)
-        assert response is not None
-        power: str | None = response.get("power")
-        fan_speed: int | None = response.get("fanSpeed")
-        mode: str | None = response.get("mode")
-
-        # update self.percentage and self.preset_mode
-        if fan_speed is not None:
-            self.percentage = fan_speed
-        if mode is not None:
-            self.preset_mode = mode
-            if mode not in BatteryCirculatorFanMode.DIRECT.value:
-                self.percentage = 0
-
-        if self._attr_is_on is True and (power and "on" in power):
-            await self.send_api_command(CommonCommands.OFF)
-            self._attr_is_on = False
-        elif self._attr_is_on is True and (power and "off" in power):
-            self._attr_is_on = False
-        else:
-            pass
+        await self.coordinator.async_refresh()
+        await self.send_api_command(CommonCommands.OFF)
+        self.percentage = 0
+        self._attr_is_on = False
         self.async_write_ha_state()
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
-        assert 0 <= percentage <= 100
-        response: dict | None = await self._api.get_status(self.unique_id)
-        assert response is not None
-        mode: str | None = response.get("mode")
-        if self._attr_is_on is False:
+        await self.coordinator.async_refresh()
+        if self.is_on and self.preset_mode == BatteryCirculatorFanMode.DIRECT.value:
+            await self.send_api_command(
+                command=BatteryCirculatorFanCommands.SET_WIND_SPEED,
+                parameters=str(percentage),
+            )
+            self.percentage = percentage
+        else:
             self.percentage = 0
-            self.async_write_ha_state()
-            return
 
-        if mode is not None:
-            if mode in BatteryCirculatorFanMode.DIRECT.value:
-                await self.send_api_command(
-                    command=BatteryCirculatorFanCommands.SET_WIND_SPEED,
-                    parameters=str(percentage),
-                )
-                self.percentage = percentage
-                self.preset_mode = mode
-            else:
-                self.percentage = 0
-                self.preset_mode = mode
         self.async_write_ha_state()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-        assert preset_mode in [item.value for item in list(BatteryCirculatorFanMode)]
-        if preset_mode != self.preset_mode:
-            await self.send_api_command(
-                command=BatteryCirculatorFanCommands.SET_WIND_MODE,
-                parameters=preset_mode,
-            )
+        await self.coordinator.async_refresh()
+        await self.send_api_command(
+            command=BatteryCirculatorFanCommands.SET_WIND_MODE,
+            parameters=preset_mode,
+        )
         self.preset_mode = preset_mode
 
-        response: dict | None = await self._api.get_status(self.unique_id)
-        assert response is not None
-        fan_speed: int | None = response.get("fanSpeed")
-        if preset_mode in BatteryCirculatorFanMode.DIRECT.value:
-            self.percentage = int(fan_speed) if fan_speed else 0
-        else:
+        if self.preset_mode != BatteryCirculatorFanMode.DIRECT.value:
             self.percentage = 0
         self.async_write_ha_state()

--- a/homeassistant/components/switchbot_cloud/fan.py
+++ b/homeassistant/components/switchbot_cloud/fan.py
@@ -63,18 +63,14 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
         self._attr_is_on = power == "on"
         self.preset_mode = mode
         self.percentage = int(fan_speed)
+        self._attr_supported_features = (
+            FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.TURN_ON
+        )
         if self.is_on and mode == BatteryCirculatorFanMode.DIRECT.value:
-            self._attr_supported_features = (
+            self._attr_supported_features |= (
                 FanEntityFeature.SET_SPEED
-                | FanEntityFeature.PRESET_MODE
-                | FanEntityFeature.TURN_OFF
-                | FanEntityFeature.TURN_ON
-            )
-        else:
-            self._attr_supported_features = (
-                FanEntityFeature.PRESET_MODE
-                | FanEntityFeature.TURN_OFF
-                | FanEntityFeature.TURN_ON
             )
 
     async def async_turn_on(

--- a/homeassistant/components/switchbot_cloud/fan.py
+++ b/homeassistant/components/switchbot_cloud/fan.py
@@ -1,0 +1,197 @@
+"""Support for the Switchbot Battery Circulator fan."""
+
+from typing import Any
+
+from switchbot_api import (
+    BatteryCirculatorFanCommands,
+    BatteryCirculatorFanMode,
+    CommonCommands,
+)
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import SwitchbotCloudData
+from .const import DOMAIN
+from .entity import SwitchBotCloudEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up SwitchBot Cloud entry."""
+    data: SwitchbotCloudData = hass.data[DOMAIN][config.entry_id]
+    async_add_entities(
+        SwitchBotCloudFan(data.api, device, coordinator)
+        for device, coordinator in data.devices.fans
+    )
+
+
+class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
+    """Representation of a SwitchBot Battery Circulator Fan."""
+
+    _attr_name = None
+
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.PRESET_MODE
+        | FanEntityFeature.TURN_OFF
+        | FanEntityFeature.TURN_ON
+    )
+    _attr_preset_modes = list(BatteryCirculatorFanMode)
+
+    _attr_is_on: bool | None = None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the entity is on."""
+        return self._attr_is_on
+
+    def _set_attributes(self) -> None:
+        """Set attributes from coordinator data."""
+        if self.coordinator.data is None:
+            return
+        if (
+            self._attr_is_on is None
+            and self.percentage == 0
+            and self.preset_mode is None
+        ):
+            response: dict | None = self.coordinator.data
+            assert response is not None
+            power: str | None = response.get("power")
+            mode: str | None = response.get("mode")
+            fan_speed: str | None = response.get("fanSpeed")
+            assert fan_speed is not None
+            self.preset_mode = mode if mode else BatteryCirculatorFanMode.DIRECT.value
+            self.percentage = (
+                int(fan_speed)
+                if self.preset_mode in BatteryCirculatorFanMode.DIRECT.value
+                else 0
+            )
+            assert power is not None
+            self._attr_is_on = "on" in power
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan."""
+        response: dict | None = await self._api.get_status(self.unique_id)
+        assert response is not None
+
+        power: str | None = response.get("power")
+        fan_speed: int | None = response.get("fanSpeed")
+        mode: str | None = response.get("mode")
+        if self._attr_is_on is False and (power and "off" in power):
+            await self.send_api_command(CommonCommands.ON)
+            self._attr_is_on = True
+        elif self._attr_is_on is False and (power and "on" in power):
+            self._attr_is_on = True
+        else:
+            pass
+        if self.preset_mode is None:
+            self.preset_mode = BatteryCirculatorFanMode.DIRECT.value
+        # if mode exist, do something
+        if mode is not None:
+            # if current mode != preset_mode, send set mode command again
+            if mode != self.preset_mode:
+                await self.send_api_command(
+                    command=BatteryCirculatorFanCommands.SET_WIND_MODE,
+                    parameters=self.preset_mode,
+                )
+        # if mode is None, set as default
+        else:
+            self.preset_mode = BatteryCirculatorFanMode.DIRECT.value
+            await self.send_api_command(
+                command=BatteryCirculatorFanCommands.SET_WIND_MODE,
+                parameters=self.preset_mode,
+            )
+
+        # if fanspeed exist, do something
+        if (
+            fan_speed is not None
+            and fan_speed != self.percentage
+            and self.preset_mode in BatteryCirculatorFanMode.DIRECT.value
+        ):
+            await self.send_api_command(
+                command=BatteryCirculatorFanCommands.SET_WIND_SPEED,
+                parameters=str(percentage),
+            )
+        else:
+            self.percentage = 0
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the fan."""
+
+        response: dict | None = await self._api.get_status(self.unique_id)
+        assert response is not None
+        power: str | None = response.get("power")
+        fan_speed: int | None = response.get("fanSpeed")
+        mode: str | None = response.get("mode")
+
+        # update self.percentage and self.preset_mode
+        if fan_speed is not None:
+            self.percentage = fan_speed
+        if mode is not None:
+            self.preset_mode = mode
+            if mode not in BatteryCirculatorFanMode.DIRECT.value:
+                self.percentage = 0
+
+        if self._attr_is_on is True and (power and "on" in power):
+            await self.send_api_command(CommonCommands.OFF)
+            self._attr_is_on = False
+        elif self._attr_is_on is True and (power and "off" in power):
+            self._attr_is_on = False
+        else:
+            pass
+        self.async_write_ha_state()
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed of the fan, as a percentage."""
+        assert 0 <= percentage <= 100
+        response: dict | None = await self._api.get_status(self.unique_id)
+        assert response is not None
+        mode: str | None = response.get("mode")
+        if self._attr_is_on is False:
+            self.percentage = 0
+            self.async_write_ha_state()
+            return
+
+        if mode is not None:
+            if mode in BatteryCirculatorFanMode.DIRECT.value:
+                await self.send_api_command(
+                    command=BatteryCirculatorFanCommands.SET_WIND_SPEED,
+                    parameters=str(percentage),
+                )
+                self.percentage = percentage
+                self.preset_mode = mode
+            else:
+                self.percentage = 0
+                self.preset_mode = mode
+        self.async_write_ha_state()
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        assert preset_mode in [item.value for item in list(BatteryCirculatorFanMode)]
+        if preset_mode != self.preset_mode:
+            await self.send_api_command(
+                command=BatteryCirculatorFanCommands.SET_WIND_MODE,
+                parameters=preset_mode,
+            )
+        self.preset_mode = preset_mode
+
+        response: dict | None = await self._api.get_status(self.unique_id)
+        assert response is not None
+        fan_speed: int | None = response.get("fanSpeed")
+        if preset_mode in BatteryCirculatorFanMode.DIRECT.value:
+            self.percentage = int(fan_speed) if fan_speed else 0
+        else:
+            self.percentage = 0
+        self.async_write_ha_state()

--- a/homeassistant/components/switchbot_cloud/fan.py
+++ b/homeassistant/components/switchbot_cloud/fan.py
@@ -89,13 +89,13 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
                 parameters=str(self.percentage),
             )
         await asyncio.sleep(5)
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         await self.send_api_command(CommonCommands.OFF)
         await asyncio.sleep(5)
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
@@ -108,7 +108,7 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
             parameters=str(percentage),
         )
         await asyncio.sleep(5)
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
@@ -117,4 +117,4 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
             parameters=preset_mode,
         )
         await asyncio.sleep(5)
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/switchbot_cloud/fan.py
+++ b/homeassistant/components/switchbot_cloud/fan.py
@@ -63,6 +63,19 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
         self._attr_is_on = power == "on"
         self.preset_mode = mode
         self.percentage = int(fan_speed)
+        if self.is_on and mode == BatteryCirculatorFanMode.DIRECT.value:
+            self._attr_supported_features = (
+                FanEntityFeature.SET_SPEED
+                | FanEntityFeature.PRESET_MODE
+                | FanEntityFeature.TURN_OFF
+                | FanEntityFeature.TURN_ON
+            )
+        else:
+            self._attr_supported_features = (
+                FanEntityFeature.PRESET_MODE
+                | FanEntityFeature.TURN_OFF
+                | FanEntityFeature.TURN_ON
+            )
 
     async def async_turn_on(
         self,
@@ -83,34 +96,34 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
             )
         await self.coordinator.async_refresh()
         await asyncio.sleep(2)
-        self._attr_is_on = True
         self.async_write_ha_state()
+        await asyncio.sleep(2)
+        await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         await self.send_api_command(CommonCommands.OFF)
         await self.coordinator.async_refresh()
         await asyncio.sleep(2)
-        self._attr_is_on = False
         self.async_write_ha_state()
+        await asyncio.sleep(2)
+        await self.coordinator.async_refresh()
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
-        if self.is_on:
-            await self.send_api_command(
-                command=BatteryCirculatorFanCommands.SET_WIND_MODE,
-                parameters=str(BatteryCirculatorFanMode.DIRECT.value),
-            )
-            await self.send_api_command(
-                command=BatteryCirculatorFanCommands.SET_WIND_SPEED,
-                parameters=str(percentage),
-            )
-            self.percentage = percentage
+        await self.send_api_command(
+            command=BatteryCirculatorFanCommands.SET_WIND_MODE,
+            parameters=str(BatteryCirculatorFanMode.DIRECT.value),
+        )
+        await self.send_api_command(
+            command=BatteryCirculatorFanCommands.SET_WIND_SPEED,
+            parameters=str(percentage),
+        )
         await self.coordinator.async_refresh()
         await asyncio.sleep(2)
-        self.percentage = percentage
-        self.preset_mode = BatteryCirculatorFanMode.DIRECT.value
         self.async_write_ha_state()
+        await asyncio.sleep(2)
+        await self.coordinator.async_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
@@ -120,5 +133,6 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
         )
         await self.coordinator.async_refresh()
         await asyncio.sleep(2)
-        self.preset_mode = preset_mode
         self.async_write_ha_state()
+        await asyncio.sleep(2)
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/switchbot_cloud/fan.py
+++ b/homeassistant/components/switchbot_cloud/fan.py
@@ -61,17 +61,15 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
         mode: str = self.coordinator.data["mode"]
         fan_speed: str = self.coordinator.data["fanSpeed"]
         self._attr_is_on = power == "on"
-        self.preset_mode = mode
-        self.percentage = int(fan_speed)
+        self._attr_preset_mode = mode
+        self._attr_percentage = int(fan_speed)
         self._attr_supported_features = (
             FanEntityFeature.PRESET_MODE
             | FanEntityFeature.TURN_OFF
             | FanEntityFeature.TURN_ON
         )
-        if self.is_on and mode == BatteryCirculatorFanMode.DIRECT.value:
-            self._attr_supported_features |= (
-                FanEntityFeature.SET_SPEED
-            )
+        if self.is_on and self.preset_mode == BatteryCirculatorFanMode.DIRECT.value:
+            self._attr_supported_features |= FanEntityFeature.SET_SPEED
 
     async def async_turn_on(
         self,
@@ -90,19 +88,13 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
                 command=BatteryCirculatorFanCommands.SET_WIND_SPEED,
                 parameters=str(self.percentage),
             )
-        await self.coordinator.async_refresh()
-        await asyncio.sleep(2)
-        self.async_write_ha_state()
-        await asyncio.sleep(2)
+        await asyncio.sleep(5)
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         await self.send_api_command(CommonCommands.OFF)
-        await self.coordinator.async_refresh()
-        await asyncio.sleep(2)
-        self.async_write_ha_state()
-        await asyncio.sleep(2)
+        await asyncio.sleep(5)
         await self.coordinator.async_refresh()
 
     async def async_set_percentage(self, percentage: int) -> None:
@@ -115,10 +107,7 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
             command=BatteryCirculatorFanCommands.SET_WIND_SPEED,
             parameters=str(percentage),
         )
-        await self.coordinator.async_refresh()
-        await asyncio.sleep(2)
-        self.async_write_ha_state()
-        await asyncio.sleep(2)
+        await asyncio.sleep(5)
         await self.coordinator.async_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -127,8 +116,5 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
             command=BatteryCirculatorFanCommands.SET_WIND_MODE,
             parameters=preset_mode,
         )
-        await self.coordinator.async_refresh()
-        await asyncio.sleep(2)
-        self.async_write_ha_state()
-        await asyncio.sleep(2)
+        await asyncio.sleep(5)
         await self.coordinator.async_refresh()

--- a/homeassistant/components/switchbot_cloud/sensor.py
+++ b/homeassistant/components/switchbot_cloud/sensor.py
@@ -91,6 +91,7 @@ CO2_DESCRIPTION = SensorEntityDescription(
 
 SENSOR_DESCRIPTIONS_BY_DEVICE_TYPES = {
     "Bot": (BATTERY_DESCRIPTION,),
+    "Battery Circulator Fan": (BATTERY_DESCRIPTION,),
     "Meter": (
         TEMPERATURE_DESCRIPTION,
         HUMIDITY_DESCRIPTION,

--- a/tests/components/switchbot_cloud/test_fan.py
+++ b/tests/components/switchbot_cloud/test_fan.py
@@ -28,7 +28,7 @@ from . import configure_integration
 async def test_coordinator_data_is_none(
     hass: HomeAssistant, mock_list_devices, mock_get_status
 ) -> None:
-    """Test turning on the fan."""
+    """Test coordinator data is none."""
     mock_list_devices.return_value = [
         Device(
             version="V1.0",
@@ -62,7 +62,8 @@ async def test_turn_on(hass: HomeAssistant, mock_list_devices, mock_get_status) 
     ]
     mock_get_status.side_effect = [
         {"power": "off", "mode": "direct", "fanSpeed": "0"},
-        {"power": "off", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
     ]
     entry = await configure_integration(hass)
     assert entry.state is ConfigEntryState.LOADED
@@ -84,7 +85,7 @@ async def test_turn_on(hass: HomeAssistant, mock_list_devices, mock_get_status) 
 async def test_turn_off(
     hass: HomeAssistant, mock_list_devices, mock_get_status
 ) -> None:
-    """Test turning on the fan."""
+    """Test turning off the fan."""
     mock_list_devices.return_value = [
         Device(
             version="V1.0",
@@ -97,6 +98,7 @@ async def test_turn_off(
     mock_get_status.side_effect = [
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "off", "mode": "direct", "fanSpeed": "0"},
     ]
     entry = await configure_integration(hass)
     assert entry.state is ConfigEntryState.LOADED
@@ -118,7 +120,7 @@ async def test_turn_off(
 async def test_set_percentage(
     hass: HomeAssistant, mock_list_devices, mock_get_status
 ) -> None:
-    """Test turning on the fan."""
+    """Test set percentage."""
     mock_list_devices.return_value = [
         Device(
             version="V1.0",
@@ -130,7 +132,7 @@ async def test_set_percentage(
     ]
     mock_get_status.side_effect = [
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
-        {"power": "on", "mode": "baby", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
         {"power": "off", "mode": "direct", "fanSpeed": "5"},
     ]
     entry = await configure_integration(hass)
@@ -149,20 +151,11 @@ async def test_set_percentage(
         )
     mock_send_command.assert_called()
 
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN,
-            SERVICE_SET_PERCENTAGE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
-            blocking=True,
-        )
-    mock_send_command.assert_called()
-
 
 async def test_set_preset_mode(
     hass: HomeAssistant, mock_list_devices, mock_get_status
 ) -> None:
-    """Test turning on the fan."""
+    """Test set preset mode."""
     mock_list_devices.return_value = [
         Device(
             version="V1.0",
@@ -175,6 +168,7 @@ async def test_set_preset_mode(
     mock_get_status.side_effect = [
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "baby", "fanSpeed": "0"},
     ]
     entry = await configure_integration(hass)
     assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/switchbot_cloud/test_fan.py
+++ b/tests/components/switchbot_cloud/test_fan.py
@@ -131,7 +131,7 @@ async def test_set_percentage(
     mock_get_status.side_effect = [
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
         {"power": "on", "mode": "baby", "fanSpeed": "0"},
-        {"power": "on", "mode": "direct", "fanSpeed": "5"},
+        {"power": "off", "mode": "direct", "fanSpeed": "5"},
     ]
     entry = await configure_integration(hass)
     assert entry.state is ConfigEntryState.LOADED
@@ -147,7 +147,7 @@ async def test_set_percentage(
             {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
             blocking=True,
         )
-    mock_send_command.assert_not_called()
+    mock_send_command.assert_called()
 
     with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
         await hass.services.async_call(
@@ -156,7 +156,7 @@ async def test_set_percentage(
             {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
             blocking=True,
         )
-    mock_send_command.assert_called_once()
+    mock_send_command.assert_called()
 
 
 async def test_set_preset_mode(

--- a/tests/components/switchbot_cloud/test_fan.py
+++ b/tests/components/switchbot_cloud/test_fan.py
@@ -97,7 +97,7 @@ async def test_turn_off(
     ]
     mock_get_status.side_effect = [
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "off", "mode": "direct", "fanSpeed": "0"},
         {"power": "off", "mode": "direct", "fanSpeed": "0"},
     ]
     entry = await configure_integration(hass)

--- a/tests/components/switchbot_cloud/test_fan.py
+++ b/tests/components/switchbot_cloud/test_fan.py
@@ -2,13 +2,7 @@
 
 from unittest.mock import patch
 
-from switchbot_api import (
-    BatteryCirculatorFanCommands,
-    BatteryCirculatorFanMode,
-    CommonCommands,
-    Device,
-    SwitchBotAPI,
-)
+from switchbot_api import Device, SwitchBotAPI
 
 from homeassistant.components.fan import (
     ATTR_PERCENTAGE,
@@ -19,13 +13,19 @@ from homeassistant.components.fan import (
     SERVICE_TURN_ON,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant
 
 from . import configure_integration
 
 
-async def test_fan_turn_on_1(
+async def test_coordinator_data_is_none(
     hass: HomeAssistant, mock_list_devices, mock_get_status
 ) -> None:
     """Test turning on the fan."""
@@ -39,9 +39,30 @@ async def test_fan_turn_on_1(
         ),
     ]
     mock_get_status.side_effect = [
+        None,
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_turn_on(hass: HomeAssistant, mock_list_devices, mock_get_status) -> None:
+    """Test turning on the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
         {"power": "off", "mode": "direct", "fanSpeed": "0"},
         {"power": "off", "mode": "direct", "fanSpeed": "0"},
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
     ]
     entry = await configure_integration(hass)
     assert entry.state is ConfigEntryState.LOADED
@@ -60,7 +81,7 @@ async def test_fan_turn_on_1(
     assert state.state == STATE_ON
 
 
-async def test_fan_turn_on_2(
+async def test_turn_off(
     hass: HomeAssistant, mock_list_devices, mock_get_status
 ) -> None:
     """Test turning on the fan."""
@@ -74,7 +95,6 @@ async def test_fan_turn_on_2(
         ),
     ]
     mock_get_status.side_effect = [
-        {"power": "off", "mode": "direct", "fanSpeed": "0"},
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
     ]
@@ -83,52 +103,19 @@ async def test_fan_turn_on_2(
     entity_id = "fan.battery_fan_1"
     state = hass.states.get(entity_id)
 
+    assert state.state == STATE_ON
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+    mock_send_command.assert_called()
+
+    state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
 
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-    mock_send_command.assert_called()
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
 
-
-async def test_fan_turn_on_3(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test turning on the fan."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        ),
-    ]
-    mock_get_status.side_effect = [
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-    ]
-    entry = await configure_integration(hass)
-    assert entry.state is ConfigEntryState.LOADED
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-
-    assert state.state == STATE_ON
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-    mock_send_command.assert_called()
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-
-
-async def test_fan_turn_on_4(
+async def test_set_percentage(
     hass: HomeAssistant, mock_list_devices, mock_get_status
 ) -> None:
     """Test turning on the fan."""
@@ -144,7 +131,7 @@ async def test_fan_turn_on_4(
     mock_get_status.side_effect = [
         {"power": "on", "mode": "direct", "fanSpeed": "0"},
         {"power": "on", "mode": "baby", "fanSpeed": "0"},
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "5"},
     ]
     entry = await configure_integration(hass)
     assert entry.state is ConfigEntryState.LOADED
@@ -155,299 +142,12 @@ async def test_fan_turn_on_4(
 
     with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
         await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-    mock_send_command.assert_called()
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-
-
-async def test_fan_turn_on_5(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test turning on the fan."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        ),
-    ]
-    mock_get_status.side_effect = [
-        {"power": "off", "mode": "direct", "fanSpeed": "0"},
-        {"power": "on", "fanSpeed": "0"},
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-    ]
-    entry = await configure_integration(hass)
-    assert entry.state is ConfigEntryState.LOADED
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-
-    assert state.state == STATE_OFF
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-
-    mock_send_command.assert_called()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-
-
-async def test_fan_turn_on_6(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test turning on the fan."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        ),
-    ]
-    mock_get_status.side_effect = [
-        {"power": "off", "mode": "direct", "fanSpeed": "50"},
-        {"power": "on", "mode": "direct", "fanSpeed": "30"},
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-    ]
-    entry = await configure_integration(hass)
-    assert entry.state is ConfigEntryState.LOADED
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-
-    assert state.state == STATE_OFF
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-    mock_send_command.assert_called()
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-
-
-async def test_fan_turn_on_7(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test turning on the fan."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        ),
-    ]
-    mock_get_status.side_effect = [
-        {"power": "off", "mode": "direct", "fanSpeed": "50"},
-        {"power": "on", "mode": "direct"},
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-    ]
-    entry = await configure_integration(hass)
-    assert entry.state is ConfigEntryState.LOADED
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-
-    assert state.state == STATE_OFF
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+            FAN_DOMAIN,
+            SERVICE_SET_PERCENTAGE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
+            blocking=True,
         )
     mock_send_command.assert_not_called()
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-
-
-async def test_fan_turn_off_1(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test turning off the fan."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        ),
-    ]
-    mock_get_status.side_effect = [
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-    ]
-
-    entry = await configure_integration(hass)
-
-    assert entry.state is ConfigEntryState.LOADED
-
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-
-    assert state.state == STATE_ON
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-
-        mock_send_command.assert_called_once_with(
-            "battery-fan-id-1", CommonCommands.OFF, "command", "default"
-        )
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-
-async def test_fan_turn_off_2(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test turning off the fan."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        ),
-    ]
-    mock_get_status.side_effect = [
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-        {"power": "on", "mode": "baby", "fanSpeed": "0"},
-    ]
-
-    entry = await configure_integration(hass)
-
-    assert entry.state is ConfigEntryState.LOADED
-
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-
-    assert state.state == STATE_ON
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-
-        mock_send_command.assert_called_once_with(
-            "battery-fan-id-1", CommonCommands.OFF, "command", "default"
-        )
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-
-async def test_fan_turn_off_3(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test turning off the fan."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        ),
-    ]
-    mock_get_status.side_effect = [
-        {"power": "on", "mode": "direct", "fanSpeed": "0"},
-        {"power": "off", "mode": "baby", "fanSpeed": "0"},
-    ]
-
-    entry = await configure_integration(hass)
-
-    assert entry.state is ConfigEntryState.LOADED
-
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-
-    assert state.state == STATE_ON
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-
-        mock_send_command.assert_not_called()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-
-async def test_fan_turn_off_4(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test turning off the fan."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        ),
-    ]
-    mock_get_status.side_effect = [
-        {"power": "off", "mode": "direct", "fanSpeed": "0"},
-        {"power": "off", "mode": "baby", "fanSpeed": "0"},
-    ]
-
-    entry = await configure_integration(hass)
-
-    assert entry.state is ConfigEntryState.LOADED
-
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-
-    assert state.state == STATE_OFF
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-
-        mock_send_command.assert_not_called()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-
-async def test_fan_set_percentage_1(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test setting fan speed percentage."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        )
-    ]
-
-    mock_get_status.side_effect = [
-        {"power": "off", "mode": "direct", "fanSpeed": "3"},
-        {"power": "off", "mode": "direct", "fanSpeed": "5"},
-        {"power": "on", "mode": "baby", "fanSpeed": "3"},
-    ]
-
-    entry = await configure_integration(hass)
-    assert entry.state is ConfigEntryState.LOADED
-
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-    assert state.attributes.get(ATTR_PERCENTAGE) == 3
 
     with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
         await hass.services.async_call(
@@ -456,22 +156,13 @@ async def test_fan_set_percentage_1(
             {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
             blocking=True,
         )
-        mock_send_command.assert_not_called()
-        # mock_send_command.assert_called_once_with(
-        #     "battery-fan-id-1",
-        #     BatteryCirculatorFanCommands.SET_WIND_SPEED,
-        #     "command",
-        #     "5",
-        # )
-    state = hass.states.get(entity_id)
-    assert state.attributes.get("percentage") == 0
-    assert state.attributes.get("preset_mode") == BatteryCirculatorFanMode.DIRECT.value
+    mock_send_command.assert_called_once()
 
 
-async def test_fan_set_percentage_2(
+async def test_set_preset_mode(
     hass: HomeAssistant, mock_list_devices, mock_get_status
 ) -> None:
-    """Test setting fan speed percentage."""
+    """Test turning on the fan."""
     mock_list_devices.return_value = [
         Device(
             version="V1.0",
@@ -479,169 +170,24 @@ async def test_fan_set_percentage_2(
             deviceName="battery-fan-1",
             deviceType="Battery Circulator Fan",
             hubDeviceId="test-hub-id",
-        )
+        ),
     ]
-
     mock_get_status.side_effect = [
-        {"power": "on", "mode": "direct", "fanSpeed": "3"},
-        {"power": "on", "mode": "direct", "fanSpeed": "5"},
-        {"power": "on", "mode": "direct", "fanSpeed": "3"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
     ]
-
     entry = await configure_integration(hass)
     assert entry.state is ConfigEntryState.LOADED
-
     entity_id = "fan.battery_fan_1"
     state = hass.states.get(entity_id)
-    assert state.attributes.get(ATTR_PERCENTAGE) == 3
 
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN,
-            SERVICE_SET_PERCENTAGE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
-            blocking=True,
-        )
-        mock_send_command.assert_called_once_with(
-            "battery-fan-id-1",
-            BatteryCirculatorFanCommands.SET_WIND_SPEED,
-            "command",
-            "5",
-        )
-    state = hass.states.get(entity_id)
-    assert state.attributes.get("percentage") == 5
-    assert state.attributes.get("preset_mode") == BatteryCirculatorFanMode.DIRECT.value
-
-
-async def test_fan_set_percentage_3(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test setting fan speed percentage."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        )
-    ]
-
-    mock_get_status.side_effect = [
-        {"power": "on", "mode": "direct", "fanSpeed": "3"},
-        {"power": "on", "mode": "baby", "fanSpeed": "5"},
-        {"power": "on", "mode": "baby", "fanSpeed": "3"},
-    ]
-
-    entry = await configure_integration(hass)
-    assert entry.state is ConfigEntryState.LOADED
-
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-    assert state.attributes.get(ATTR_PERCENTAGE) == 3
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN,
-            SERVICE_SET_PERCENTAGE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
-            blocking=True,
-        )
-        mock_send_command.assert_not_called()
-    state = hass.states.get(entity_id)
-    assert state.attributes.get("percentage") == 0
-    assert state.attributes.get("preset_mode") == BatteryCirculatorFanMode.BABY.value
-
-
-async def test_fan_set_preset_mode_1(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test setting fan preset mode."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        )
-    ]
-
-    mock_get_status.side_effect = [
-        {"power": "on", "mode": "direct", "fanSpeed": "3"},
-        {"power": "on", "mode": "natural", "fanSpeed": "0"},
-        # {"power": "on", "mode": "direct", "fanSpeed": "10"},
-    ]
-
-    entry = await configure_integration(hass)
-    assert entry.state is ConfigEntryState.LOADED
-
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-    assert (
-        state.attributes.get(ATTR_PRESET_MODE) == BatteryCirculatorFanMode.DIRECT.value
-    )
+    assert state.state == STATE_ON
 
     with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
         await hass.services.async_call(
             FAN_DOMAIN,
             SERVICE_SET_PRESET_MODE,
-            {
-                ATTR_ENTITY_ID: entity_id,
-                ATTR_PRESET_MODE: BatteryCirculatorFanMode.NATURAL.value,
-            },
+            {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: "baby"},
             blocking=True,
         )
-        mock_send_command.assert_awaited_once()
-    state = hass.states.get(entity_id)
-    assert (
-        state.attributes.get(ATTR_PRESET_MODE) == BatteryCirculatorFanMode.NATURAL.value
-    )
-    assert state.attributes.get(ATTR_PERCENTAGE) == 0
-
-
-async def test_fan_set_preset_mode_2(
-    hass: HomeAssistant, mock_list_devices, mock_get_status
-) -> None:
-    """Test setting fan preset mode."""
-    mock_list_devices.return_value = [
-        Device(
-            version="V1.0",
-            deviceId="battery-fan-id-1",
-            deviceName="battery-fan-1",
-            deviceType="Battery Circulator Fan",
-            hubDeviceId="test-hub-id",
-        )
-    ]
-
-    mock_get_status.side_effect = [
-        {"power": "on", "mode": "direct", "fanSpeed": "3"},
-        {"power": "on", "mode": "direct", "fanSpeed": "10"},
-        # {"power": "on", "mode": "direct", "fanSpeed": "10"},
-    ]
-
-    entry = await configure_integration(hass)
-    assert entry.state is ConfigEntryState.LOADED
-
-    entity_id = "fan.battery_fan_1"
-    state = hass.states.get(entity_id)
-    assert (
-        state.attributes.get(ATTR_PRESET_MODE) == BatteryCirculatorFanMode.DIRECT.value
-    )
-
-    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
-        await hass.services.async_call(
-            FAN_DOMAIN,
-            SERVICE_SET_PRESET_MODE,
-            {
-                ATTR_ENTITY_ID: entity_id,
-                ATTR_PRESET_MODE: BatteryCirculatorFanMode.DIRECT.value,
-            },
-            blocking=True,
-        )
-        mock_send_command.assert_not_called()
-    state = hass.states.get(entity_id)
-    assert (
-        state.attributes.get(ATTR_PRESET_MODE) == BatteryCirculatorFanMode.DIRECT.value
-    )
-    assert state.attributes.get(ATTR_PERCENTAGE) == 10
+    mock_send_command.assert_called_once()

--- a/tests/components/switchbot_cloud/test_fan.py
+++ b/tests/components/switchbot_cloud/test_fan.py
@@ -1,0 +1,647 @@
+"""Test for the Switchbot Battery Circulator Fan."""
+
+from unittest.mock import patch
+
+from switchbot_api import (
+    BatteryCirculatorFanCommands,
+    BatteryCirculatorFanMode,
+    CommonCommands,
+    Device,
+    SwitchBotAPI,
+)
+
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    ATTR_PRESET_MODE,
+    DOMAIN as FAN_DOMAIN,
+    SERVICE_SET_PERCENTAGE,
+    SERVICE_SET_PRESET_MODE,
+    SERVICE_TURN_ON,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+
+from . import configure_integration
+
+
+async def test_fan_turn_on_1(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning on the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "off", "mode": "direct", "fanSpeed": "0"},
+        {"power": "off", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_OFF
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+    mock_send_command.assert_called()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_fan_turn_on_2(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning on the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "off", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_OFF
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+    mock_send_command.assert_called()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_fan_turn_on_3(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning on the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_ON
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+    mock_send_command.assert_called()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_fan_turn_on_4(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning on the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "baby", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_ON
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+    mock_send_command.assert_called()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_fan_turn_on_5(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning on the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "off", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_OFF
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+
+    mock_send_command.assert_called()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_fan_turn_on_6(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning on the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "off", "mode": "direct", "fanSpeed": "50"},
+        {"power": "on", "mode": "direct", "fanSpeed": "30"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_OFF
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+    mock_send_command.assert_called()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_fan_turn_on_7(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning on the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "off", "mode": "direct", "fanSpeed": "50"},
+        {"power": "on", "mode": "direct"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_OFF
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+    mock_send_command.assert_not_called()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_fan_turn_off_1(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning off the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+    ]
+
+    entry = await configure_integration(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_ON
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+
+        mock_send_command.assert_called_once_with(
+            "battery-fan-id-1", CommonCommands.OFF, "command", "default"
+        )
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+
+async def test_fan_turn_off_2(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning off the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "on", "mode": "baby", "fanSpeed": "0"},
+    ]
+
+    entry = await configure_integration(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_ON
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+
+        mock_send_command.assert_called_once_with(
+            "battery-fan-id-1", CommonCommands.OFF, "command", "default"
+        )
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+
+async def test_fan_turn_off_3(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning off the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "on", "mode": "direct", "fanSpeed": "0"},
+        {"power": "off", "mode": "baby", "fanSpeed": "0"},
+    ]
+
+    entry = await configure_integration(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_ON
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+
+        mock_send_command.assert_not_called()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+
+async def test_fan_turn_off_4(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test turning off the fan."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.side_effect = [
+        {"power": "off", "mode": "direct", "fanSpeed": "0"},
+        {"power": "off", "mode": "baby", "fanSpeed": "0"},
+    ]
+
+    entry = await configure_integration(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_OFF
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+
+        mock_send_command.assert_not_called()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+
+async def test_fan_set_percentage_1(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test setting fan speed percentage."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        )
+    ]
+
+    mock_get_status.side_effect = [
+        {"power": "off", "mode": "direct", "fanSpeed": "3"},
+        {"power": "off", "mode": "direct", "fanSpeed": "5"},
+        {"power": "on", "mode": "baby", "fanSpeed": "3"},
+    ]
+
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+    assert state.attributes.get(ATTR_PERCENTAGE) == 3
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PERCENTAGE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
+            blocking=True,
+        )
+        mock_send_command.assert_not_called()
+        # mock_send_command.assert_called_once_with(
+        #     "battery-fan-id-1",
+        #     BatteryCirculatorFanCommands.SET_WIND_SPEED,
+        #     "command",
+        #     "5",
+        # )
+    state = hass.states.get(entity_id)
+    assert state.attributes.get("percentage") == 0
+    assert state.attributes.get("preset_mode") == BatteryCirculatorFanMode.DIRECT.value
+
+
+async def test_fan_set_percentage_2(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test setting fan speed percentage."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        )
+    ]
+
+    mock_get_status.side_effect = [
+        {"power": "on", "mode": "direct", "fanSpeed": "3"},
+        {"power": "on", "mode": "direct", "fanSpeed": "5"},
+        {"power": "on", "mode": "direct", "fanSpeed": "3"},
+    ]
+
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+    assert state.attributes.get(ATTR_PERCENTAGE) == 3
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PERCENTAGE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
+            blocking=True,
+        )
+        mock_send_command.assert_called_once_with(
+            "battery-fan-id-1",
+            BatteryCirculatorFanCommands.SET_WIND_SPEED,
+            "command",
+            "5",
+        )
+    state = hass.states.get(entity_id)
+    assert state.attributes.get("percentage") == 5
+    assert state.attributes.get("preset_mode") == BatteryCirculatorFanMode.DIRECT.value
+
+
+async def test_fan_set_percentage_3(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test setting fan speed percentage."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        )
+    ]
+
+    mock_get_status.side_effect = [
+        {"power": "on", "mode": "direct", "fanSpeed": "3"},
+        {"power": "on", "mode": "baby", "fanSpeed": "5"},
+        {"power": "on", "mode": "baby", "fanSpeed": "3"},
+    ]
+
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+    assert state.attributes.get(ATTR_PERCENTAGE) == 3
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PERCENTAGE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 5},
+            blocking=True,
+        )
+        mock_send_command.assert_not_called()
+    state = hass.states.get(entity_id)
+    assert state.attributes.get("percentage") == 0
+    assert state.attributes.get("preset_mode") == BatteryCirculatorFanMode.BABY.value
+
+
+async def test_fan_set_preset_mode_1(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test setting fan preset mode."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        )
+    ]
+
+    mock_get_status.side_effect = [
+        {"power": "on", "mode": "direct", "fanSpeed": "3"},
+        {"power": "on", "mode": "natural", "fanSpeed": "0"},
+        # {"power": "on", "mode": "direct", "fanSpeed": "10"},
+    ]
+
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+    assert (
+        state.attributes.get(ATTR_PRESET_MODE) == BatteryCirculatorFanMode.DIRECT.value
+    )
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PRESET_MODE,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_PRESET_MODE: BatteryCirculatorFanMode.NATURAL.value,
+            },
+            blocking=True,
+        )
+        mock_send_command.assert_awaited_once()
+    state = hass.states.get(entity_id)
+    assert (
+        state.attributes.get(ATTR_PRESET_MODE) == BatteryCirculatorFanMode.NATURAL.value
+    )
+    assert state.attributes.get(ATTR_PERCENTAGE) == 0
+
+
+async def test_fan_set_preset_mode_2(
+    hass: HomeAssistant, mock_list_devices, mock_get_status
+) -> None:
+    """Test setting fan preset mode."""
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="battery-fan-id-1",
+            deviceName="battery-fan-1",
+            deviceType="Battery Circulator Fan",
+            hubDeviceId="test-hub-id",
+        )
+    ]
+
+    mock_get_status.side_effect = [
+        {"power": "on", "mode": "direct", "fanSpeed": "3"},
+        {"power": "on", "mode": "direct", "fanSpeed": "10"},
+        # {"power": "on", "mode": "direct", "fanSpeed": "10"},
+    ]
+
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_id = "fan.battery_fan_1"
+    state = hass.states.get(entity_id)
+    assert (
+        state.attributes.get(ATTR_PRESET_MODE) == BatteryCirculatorFanMode.DIRECT.value
+    )
+
+    with patch.object(SwitchBotAPI, "send_command") as mock_send_command:
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PRESET_MODE,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_PRESET_MODE: BatteryCirculatorFanMode.DIRECT.value,
+            },
+            blocking=True,
+        )
+        mock_send_command.assert_not_called()
+    state = hass.states.get(entity_id)
+    assert (
+        state.attributes.get(ATTR_PRESET_MODE) == BatteryCirculatorFanMode.DIRECT.value
+    )
+    assert state.attributes.get(ATTR_PERCENTAGE) == 10


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add Fan platform to Switchbot cloud

- Battery Circulator Fan
- Circulator Fan

Supports the following functions:
Turn on/off
Wind speed adjustment（direct mode）
Mode switching
Battery level display（Battery Circulator Fan）



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39892
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
