### PR TITLE
Revert "Add tests for Sonos Alarms"

### DIFF
--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -214,24 +214,11 @@ class MockSoCo(MagicMock):
     surround_level = 3
     music_surround_level = 4
     soundbar_audio_input_format = "Dolby 5.1"
-    factory: SoCoMockFactory | None = None
 
     @property
     def visible_zones(self):
         """Return visible zones and allow property to be overridden by device classes."""
         return {self}
-
-    @property
-    def all_zones(self) -> set[MockSoCo]:
-        """Return a set of all mock zones, or just self if no factory or zones."""
-        if self.factory is not None:
-            if zones := self.factory.mock_all_zones:
-                return zones
-        return {self}
-
-    def set_factory(self, factory: SoCoMockFactory) -> None:
-        """Set the factory for this mock."""
-        self.factory = factory
 
 
 class SoCoMockFactory:
@@ -257,19 +244,11 @@ class SoCoMockFactory:
         self.sonos_playlists = sonos_playlists
         self.sonos_queue = sonos_queue
 
-    @property
-    def mock_all_zones(self) -> set[MockSoCo]:
-        """Return a set of all mock zones."""
-        return {
-            mock for mock in self.mock_list.values() if mock.mock_include_in_all_zones
-        }
-
     def cache_mock(
         self, mock_soco: MockSoCo, ip_address: str, name: str = "Zone A"
     ) -> MockSoCo:
         """Put a user created mock into the cache."""
         mock_soco.mock_add_spec(SoCo)
-        mock_soco.set_factory(self)
         mock_soco.ip_address = ip_address
         if ip_address != "192.168.42.2":
             mock_soco.uid += f"_{ip_address}"
@@ -281,11 +260,6 @@ class SoCoMockFactory:
         my_speaker_info = self.speaker_info.copy()
         my_speaker_info["zone_name"] = name
         my_speaker_info["uid"] = mock_soco.uid
-        # Generate a different MAC for the non-default speakers.
-        # otherwise new devices will not be created.
-        if ip_address != "192.168.42.2":
-            last_octet = ip_address.split(".")[-1]
-            my_speaker_info["mac_address"] = f"00-00-00-00-00-{last_octet.zfill(2)}"
         mock_soco.get_speaker_info = Mock(return_value=my_speaker_info)
         mock_soco.add_to_queue = Mock(return_value=10)
         mock_soco.add_uri_to_queue = Mock(return_value=10)
@@ -304,7 +278,7 @@ class SoCoMockFactory:
 
         mock_soco.alarmClock = self.alarm_clock
         mock_soco.get_battery_info.return_value = self.battery_info
-        mock_soco.mock_include_in_all_zones = True
+        mock_soco.all_zones = {mock_soco}
         mock_soco.group.coordinator = mock_soco
         mock_soco.household_id = "test_household_id"
         self.mock_list[ip_address] = mock_soco

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -324,15 +324,10 @@ async def test_async_poll_manual_hosts_5(
     soco_1 = soco_factory.cache_mock(MockSoCo(), "10.10.10.1", "Living Room")
     soco_1.renderingControl = Mock()
     soco_1.renderingControl.GetVolume = Mock()
-    # Unavailable speakers should not be included in all zones
-    soco_1.mock_include_in_all_zones = False
-
     speaker_1_activity = SpeakerActivity(hass, soco_1)
     soco_2 = soco_factory.cache_mock(MockSoCo(), "10.10.10.2", "Bedroom")
     soco_2.renderingControl = Mock()
     soco_2.renderingControl.GetVolume = Mock()
-    soco_2.mock_include_in_all_zones = False
-
     speaker_2_activity = SpeakerActivity(hass, soco_2)
 
     with caplog.at_level(logging.DEBUG):


### PR DESCRIPTION
Reverts home-assistant/core#146308

The addition of these Sonos tests fail on the current `dev` branch and thus break CI.

I've looked at it, but couldn't directly find a fix for it, hence the revert for now.'

CC @PeteRager 