### PR TITLE
Fix Homee tests (fix CI)

### DIFF
--- a/tests/components/homee/test_init.py
+++ b/tests/components/homee/test_init.py
@@ -18,10 +18,16 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    "side_eff",
+    ("side_eff", "expected_state"),
     [
-        HomeeConnectionFailedException("connection timed out"),
-        HomeeAuthFailedException("wrong username or password"),
+        (
+            HomeeConnectionFailedException("connection timed out"),
+            ConfigEntryState.SETUP_RETRY,
+        ),
+        (
+            HomeeAuthFailedException("wrong username or password"),
+            ConfigEntryState.SETUP_ERROR,
+        ),
     ],
 )
 async def test_connection_errors(
@@ -29,6 +35,7 @@ async def test_connection_errors(
     mock_homee: MagicMock,
     mock_config_entry: MockConfigEntry,
     side_eff: Exception,
+    expected_state: ConfigEntryState,
 ) -> None:
     """Test if connection errors on startup are handled correctly."""
     mock_homee.get_access_token.side_effect = side_eff
@@ -36,7 +43,7 @@ async def test_connection_errors(
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is expected_state
 
 
 async def test_connection_listener(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes the current Homee tests, as spotted in 

https://github.com/home-assistant/core/actions/runs/16111360701/job/45456072348?pr=148273

```
FAILED tests/components/homee/test_init.py::test_connection_errors[side_eff1] - AssertionError: assert <ConfigEntryState.SETUP_ERROR: 'setup_error'> is <ConfigEntryState.SETUP_RETRY: 'setup_retry'>
 +  where <ConfigEntryState.SETUP_ERROR: 'setup_error'> = <ConfigEntry entry_id=test_entry_id version=1 domain=homee title=TestHomee (192.168.1.11) state=ConfigEntryState.SETUP_ERROR unique_id=00055511EECC>.state
 +  and   <ConfigEntryState.SETUP_RETRY: 'setup_retry'> = ConfigEntryState.SETUP_RETRY
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
