### PR TITLE
Added config flow support to `signal_messenger`

### DIFF
--- a/homeassistant/components/signal_messenger/__init__.py
+++ b/homeassistant/components/signal_messenger/__init__.py
@@ -1,1 +1,29 @@
 """The signalmessenger component."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+
+from .notify import get_service
+
+
+def _get_service_name(entry: ConfigEntry):
+    return ("notify", f"signal_{entry.data[CONF_NAME]}")
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
+    notify_service = await hass.async_add_executor_job(
+        get_service, hass, dict(entry.data.items()), None
+    )
+    service_domain, service_name = _get_service_name(entry)
+    await notify_service.async_setup(hass, service_name, service_domain)
+    await notify_service.async_register_services()
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    service_domain, service_name = _get_service_name(entry)
+    hass.services.async_remove(service_domain, service_name)
+    return True

--- a/homeassistant/components/signal_messenger/__init__.py
+++ b/homeassistant/components/signal_messenger/__init__.py
@@ -8,7 +8,7 @@ from .notify import get_service
 
 
 def _get_service_name(entry: ConfigEntry):
-    return ("notify", f"signal_{entry.data[CONF_NAME]}")
+    return ("notify", f"signal_{entry.data[CONF_NAME].lower().replace(' ', '_')}")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/signal_messenger/config_flow.py
+++ b/homeassistant/components/signal_messenger/config_flow.py
@@ -1,0 +1,70 @@
+"""Signal Messenger config flow."""
+
+from __future__ import annotations
+
+from pysignalclirestapi import SignalCliRestApi
+import requests
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import selector
+
+from .const import (
+    CONF_RECP_NR,
+    CONF_SENDER_NR,
+    CONF_SIGNAL_CLI_REST_API,
+    DEFAULT_HOST,
+    DOMAIN,
+)
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME, default="signal"): selector.TextSelector(),
+        vol.Required(
+            CONF_SIGNAL_CLI_REST_API, default=DEFAULT_HOST
+        ): selector.TextSelector(),
+        vol.Required(CONF_SENDER_NR): selector.TextSelector(),
+        vol.Required(CONF_RECP_NR): selector.TextSelector(),
+    }
+)
+
+
+class SignalMessengerFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Signal Messenger config flow."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, str] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow initialized by the user."""
+        errors = {}
+        if user_input is not None:
+            try:
+                signal_cli_rest_api = SignalCliRestApi(
+                    user_input[CONF_SIGNAL_CLI_REST_API], user_input[CONF_SENDER_NR]
+                )
+                signal_cli_rest_api_about = await self.hass.async_add_executor_job(
+                    signal_cli_rest_api.about
+                )
+            except requests.ConnectionError:
+                signal_cli_rest_api_about = None
+
+            if signal_cli_rest_api_about is None:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=f"Signal {user_input[CONF_NAME]}",
+                    data={
+                        CONF_NAME: user_input[CONF_NAME],
+                        CONF_SIGNAL_CLI_REST_API: user_input[CONF_SIGNAL_CLI_REST_API],
+                        CONF_SENDER_NR: user_input[CONF_SENDER_NR],
+                        CONF_RECP_NR: user_input[CONF_RECP_NR].split(" "),
+                    },
+                )
+
+        data_schema = self.add_suggested_values_to_schema(DATA_SCHEMA, user_input)
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=errors
+        )

--- a/homeassistant/components/signal_messenger/const.py
+++ b/homeassistant/components/signal_messenger/const.py
@@ -1,0 +1,9 @@
+"""Signal Messenger constants."""
+
+DOMAIN = "signal_messenger"
+
+CONF_SENDER_NR = "number"
+CONF_RECP_NR = "recipients"
+CONF_SIGNAL_CLI_REST_API = "url"
+
+DEFAULT_HOST = "http://1315902c-signal-messenger:8080"

--- a/homeassistant/components/signal_messenger/manifest.json
+++ b/homeassistant/components/signal_messenger/manifest.json
@@ -2,6 +2,7 @@
   "domain": "signal_messenger",
   "name": "Signal Messenger",
   "codeowners": ["@bbernhard"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/signal_messenger",
   "iot_class": "cloud_push",
   "loggers": ["pysignalclirestapi"],

--- a/homeassistant/components/signal_messenger/notify.py
+++ b/homeassistant/components/signal_messenger/notify.py
@@ -18,11 +18,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from .const import CONF_RECP_NR, CONF_SENDER_NR, CONF_SIGNAL_CLI_REST_API
+
 _LOGGER = logging.getLogger(__name__)
 
-CONF_SENDER_NR = "number"
-CONF_RECP_NR = "recipients"
-CONF_SIGNAL_CLI_REST_API = "url"
 CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES = 52428800
 ATTR_FILENAMES = "attachments"
 ATTR_URLS = "urls"

--- a/homeassistant/components/signal_messenger/strings.json
+++ b/homeassistant/components/signal_messenger/strings.json
@@ -13,11 +13,11 @@
         },
         "data_description": {
           "name": "The name for this Signal configuration",
-          "url": "The full URL to signal-cli-rest-api",
+          "url": "The full URL to signal-cli REST API",
           "number": "The phone number used to register the Signal account",
           "recipients": "Space-separated list of phone numbers, usernames or single group to send to"
         },
-        "description": "Setup signal-messenger through signal-cli Rest API."
+        "description": "Set up Signal Messenger through signal-cli REST API."
       }
     }
   }

--- a/homeassistant/components/signal_messenger/strings.json
+++ b/homeassistant/components/signal_messenger/strings.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "url": "[%key:common::config_flow::data::url%]",
+          "number": "Phone number",
+          "recipients": "Recipient(s)"
+        },
+        "data_description": {
+          "name": "The name for this Signal configuration",
+          "url": "The full URL to signal-cli-rest-api",
+          "number": "The phone number used to register the Signal account",
+          "recipients": "Space-separated list of phone numbers, usernames or single group to send to"
+        },
+        "description": "Setup signal-messenger through signal-cli Rest API."
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -568,6 +568,7 @@ FLOWS = {
         "shelly",
         "shopping_list",
         "sia",
+        "signal_messenger",
         "simplefin",
         "simplepush",
         "simplisafe",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5910,7 +5910,7 @@
     "signal_messenger": {
       "name": "Signal Messenger",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "cloud_push"
     },
     "simplefin": {

--- a/tests/components/signal_messenger/test_config_flow.py
+++ b/tests/components/signal_messenger/test_config_flow.py
@@ -1,0 +1,65 @@
+"""Test the signal_messenger config flow."""
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.signal_messenger.const import (
+    CONF_RECP_NR,
+    CONF_SENDER_NR,
+    CONF_SIGNAL_CLI_REST_API,
+    DOMAIN,
+)
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+async def test_form_user(hass: HomeAssistant) -> None:
+    """Test we get the user form."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    def request_get_mock(*args, **kwargs):
+        """Mock the requests.get method."""
+
+        class MockResponse:
+            def __init__(self, status_code) -> None:
+                self.status_code = status_code
+
+            def json(self):
+                return {"status": "ok"}
+
+        return MockResponse(200)
+
+    with (
+        patch(
+            "requests.get",
+        ) as mock_request_get,
+    ):
+        mock_request_get.return_value.status_code = 200
+        mock_request_get.return_value.content = "{}"
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "My Signal",
+                CONF_SIGNAL_CLI_REST_API: "http://127.0.0.1:8123/",
+                CONF_SENDER_NR: "+1234567890",
+                CONF_RECP_NR: "+0987654321 +1122334455",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Signal My Signal"
+    assert result2["data"] == {
+        CONF_NAME: "My Signal",
+        CONF_SIGNAL_CLI_REST_API: "http://127.0.0.1:8123/",
+        CONF_SENDER_NR: "+1234567890",
+        CONF_RECP_NR: ["+0987654321", "+1122334455"],
+    }
+    assert len(hass.services.async_services()) == 1
+    assert hass.services.has_service("notify", "signal_my_signal")

--- a/tests/components/signal_messenger/test_config_flow.py
+++ b/tests/components/signal_messenger/test_config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 
-async def test_form_user(hass: HomeAssistant) -> None:
+async def test_form_user_success(hass: HomeAssistant) -> None:
     """Test we get the user form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -22,18 +22,6 @@ async def test_form_user(hass: HomeAssistant) -> None:
     )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
-
-    def request_get_mock(*args, **kwargs):
-        """Mock the requests.get method."""
-
-        class MockResponse:
-            def __init__(self, status_code) -> None:
-                self.status_code = status_code
-
-            def json(self):
-                return {"status": "ok"}
-
-        return MockResponse(200)
 
     with (
         patch(

--- a/tests/components/signal_messenger/test_config_flow.py
+++ b/tests/components/signal_messenger/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import requests
+
 from homeassistant import config_entries
 from homeassistant.components.signal_messenger.const import (
     CONF_RECP_NR,
@@ -51,3 +53,33 @@ async def test_form_user_success(hass: HomeAssistant) -> None:
     }
     assert len(hass.services.async_services()) == 1
     assert hass.services.has_service("notify", "signal_my_signal")
+
+
+async def test_form_user_can_not_connect(hass: HomeAssistant) -> None:
+    """Test we get the user form."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "requests.get",
+        ) as mock_request_get,
+    ):
+        mock_request_get.exc = requests.exceptions.ConnectionError
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "My Signal",
+                CONF_SIGNAL_CLI_REST_API: "http://127.0.0.1:8123/",
+                CONF_SENDER_NR: "+1234567890",
+                CONF_RECP_NR: "+0987654321 +1122334455",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2.get("step_id") == "user"
+    assert result2.get("errors") == {"base": "cannot_connect"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config flow to setup Signal:
![image](https://github.com/user-attachments/assets/9890e557-3a9f-4fbf-a08e-70f19acf3968)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39902
- Link to developer documentation pull request: n/a
- Link to frontend pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
