### PR TITLE
Do not add switch_as_x config entry to source device

### DIFF
--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -92,13 +92,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             options.setdefault(CONF_INVERT, False)
         if config_entry.version < 3:
             # Remove the switch_as_x config entry from the source device
-            async_remove_helper_config_entry_from_source_device(
-                hass,
-                helper_config_entry_id=config_entry.entry_id,
-                source_device_id=async_get_parent_device_id(
-                    hass, options[CONF_ENTITY_ID]
-                ),
-            )
+            if source_device_id := async_get_parent_device_id(
+                hass, options[CONF_ENTITY_ID]
+            ):
+                async_remove_helper_config_entry_from_source_device(
+                    hass,
+                    helper_config_entry_id=config_entry.entry_id,
+                    source_device_id=source_device_id,
+                )
         hass.config_entries.async_update_entry(
             config_entry, options=options, minor_version=3
         )

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -58,6 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
+            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_get_parent_device_id(hass, entity_id),

--- a/homeassistant/components/switch_as_x/config_flow.py
+++ b/homeassistant/components/switch_as_x/config_flow.py
@@ -58,7 +58,7 @@ class SwitchAsXConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     options_flow = OPTIONS_FLOW
 
     VERSION = 1
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title and hide the wrapped entity if registered."""

--- a/homeassistant/components/switch_as_x/entity.py
+++ b/homeassistant/components/switch_as_x/entity.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, ToggleEntity
 from homeassistant.helpers.event import async_track_state_change_event
 
@@ -48,12 +47,8 @@ class BaseEntity(Entity):
         if wrapped_switch:
             name = wrapped_switch.original_name
 
-        self._device_id = device_id
         if device_id and (device := device_registry.async_get(device_id)):
-            self._attr_device_info = DeviceInfo(
-                connections=device.connections,
-                identifiers=device.identifiers,
-            )
+            self.device_entry = device
         self._attr_entity_category = entity_category
         self._attr_has_entity_name = has_entity_name
         self._attr_name = name

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -825,21 +825,25 @@ class EntityPlatform:
                     entity.add_to_platform_abort()
                     return
 
-            if self.config_entry and (device_info := entity.device_info):
-                try:
-                    device = dev_reg.async_get(self.hass).async_get_or_create(
-                        config_entry_id=self.config_entry.entry_id,
-                        config_subentry_id=config_subentry_id,
-                        **device_info,
-                    )
-                except dev_reg.DeviceInfoError as exc:
-                    self.logger.error(
-                        "%s: Not adding entity with invalid device info: %s",
-                        self.platform_name,
-                        str(exc),
-                    )
-                    entity.add_to_platform_abort()
-                    return
+            device: dev_reg.DeviceEntry | None
+            if self.config_entry:
+                if device_info := entity.device_info:
+                    try:
+                        device = dev_reg.async_get(self.hass).async_get_or_create(
+                            config_entry_id=self.config_entry.entry_id,
+                            config_subentry_id=config_subentry_id,
+                            **device_info,
+                        )
+                    except dev_reg.DeviceInfoError as exc:
+                        self.logger.error(
+                            "%s: Not adding entity with invalid device info: %s",
+                            self.platform_name,
+                            str(exc),
+                        )
+                        entity.add_to_platform_abort()
+                        return
+                else:
+                    device = entity.device_entry
             else:
                 device = None
 

--- a/homeassistant/helpers/helper_integration.py
+++ b/homeassistant/helpers/helper_integration.py
@@ -120,7 +120,7 @@ def async_remove_helper_config_entry_from_source_device(
     hass: HomeAssistant,
     *,
     helper_config_entry_id: str,
-    source_device_id: str | None,
+    source_device_id: str,
 ) -> None:
     """Remove helper config entry from source device.
 
@@ -130,20 +130,20 @@ def async_remove_helper_config_entry_from_source_device(
     device_registry = dr.async_get(hass)
 
     if (
-        not source_device_id
-        or not (source_device := device_registry.async_get(source_device_id))
+        not (source_device := device_registry.async_get(source_device_id))
         or helper_config_entry_id not in source_device.config_entries
     ):
         return
 
     entity_registry = er.async_get(hass)
-    helper_entities = er.async_entries_for_config_entry(
+    helper_entity_entries = er.async_entries_for_config_entry(
         entity_registry, helper_config_entry_id
     )
 
-    # Disconnect helper entities from the device
+    # Disconnect helper entities from the device to prevent them from
+    # being removed when the config entry link to the device is removed.
     modified_helpers: list[er.RegistryEntry] = []
-    for helper in helper_entities:
+    for helper in helper_entity_entries:
         if helper.device_id != source_device_id:
             continue
         modified_helpers.append(helper)
@@ -152,7 +152,7 @@ def async_remove_helper_config_entry_from_source_device(
     device_registry.async_update_device(
         source_device_id, remove_config_entry_id=helper_config_entry_id
     )
-    # Connect the helper entity from the device
+    # Connect the helper entity to the device
     for helper in modified_helpers:
         entity_registry.async_update_entity(
             helper.entity_id, device_id=source_device_id

--- a/homeassistant/helpers/helper_integration.py
+++ b/homeassistant/helpers/helper_integration.py
@@ -14,6 +14,7 @@ from .event import async_track_entity_registry_updated_event
 def async_handle_source_entity_changes(
     hass: HomeAssistant,
     *,
+    add_helper_config_entry_to_device: bool = True,
     helper_config_entry_id: str,
     set_source_entity_id_or_uuid: Callable[[str], None],
     source_device_id: str | None,
@@ -88,15 +89,17 @@ def async_handle_source_entity_changes(
                 helper_entity.entity_id, device_id=source_entity_entry.device_id
             )
 
-        if source_entity_entry.device_id is not None:
+        if add_helper_config_entry_to_device:
+            if source_entity_entry.device_id is not None:
+                device_registry.async_update_device(
+                    source_entity_entry.device_id,
+                    add_config_entry_id=helper_config_entry_id,
+                )
+
             device_registry.async_update_device(
-                source_entity_entry.device_id,
-                add_config_entry_id=helper_config_entry_id,
+                source_device_id, remove_config_entry_id=helper_config_entry_id
             )
 
-        device_registry.async_update_device(
-            source_device_id, remove_config_entry_id=helper_config_entry_id
-        )
         source_device_id = source_entity_entry.device_id
 
         # Reload the config entry so the helper entity is recreated with

--- a/tests/components/switch_as_x/__init__.py
+++ b/tests/components/switch_as_x/__init__.py
@@ -1,6 +1,11 @@
 """The tests for Switch as X platforms."""
 
+from homeassistant.components.cover import CoverEntityFeature
+from homeassistant.components.fan import FanEntityFeature
+from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode
 from homeassistant.components.lock import LockState
+from homeassistant.components.siren import SirenEntityFeature
+from homeassistant.components.valve import ValveEntityFeature
 from homeassistant.const import STATE_CLOSED, STATE_OFF, STATE_ON, STATE_OPEN, Platform
 
 PLATFORMS_TO_TEST = (
@@ -11,6 +16,15 @@ PLATFORMS_TO_TEST = (
     Platform.SIREN,
     Platform.VALVE,
 )
+
+CAPABILITY_MAP = {
+    Platform.COVER: None,
+    Platform.FAN: {},
+    Platform.LIGHT: {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.ONOFF]},
+    Platform.LOCK: None,
+    Platform.SIREN: None,
+    Platform.VALVE: None,
+}
 
 STATE_MAP = {
     False: {
@@ -29,4 +43,13 @@ STATE_MAP = {
         Platform.SIREN: {STATE_ON: STATE_ON, STATE_OFF: STATE_OFF},
         Platform.VALVE: {STATE_ON: STATE_CLOSED, STATE_OFF: STATE_OPEN},
     },
+}
+
+SUPPORTED_FEATURE_MAP = {
+    Platform.COVER: CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE,
+    Platform.FAN: FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF,
+    Platform.LIGHT: 0,
+    Platform.LOCK: 0,
+    Platform.SIREN: SirenEntityFeature.TURN_ON | SirenEntityFeature.TURN_OFF,
+    Platform.VALVE: ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE,
 }

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -25,12 +25,12 @@ from homeassistant.const import (
     EntityCategory,
     Platform,
 )
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 from homeassistant.setup import async_setup_component
 
-from . import PLATFORMS_TO_TEST
+from . import CAPABILITY_MAP, PLATFORMS_TO_TEST, SUPPORTED_FEATURE_MAP
 
 from tests.common import MockConfigEntry
 
@@ -77,6 +77,22 @@ def switch_as_x_config_entry(
     config_entry.add_to_hass(hass)
 
     return config_entry
+
+
+def track_entity_registry_actions(
+    hass: HomeAssistant, entity_id: str
+) -> list[er.EventEntityRegistryUpdatedData]:
+    """Track entity registry actions for an entity."""
+    events = []
+
+    @callback
+    def add_event(event: Event[er.EventEntityRegistryUpdatedData]) -> None:
+        """Add entity registry updated event to the list."""
+        events.append(event.data)
+
+    async_track_entity_registry_updated_event(hass, entity_id, add_event)
+
+    return events
 
 
 @pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
@@ -1083,11 +1099,31 @@ async def test_restore_expose_settings(
 @pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
 async def test_migrate(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     target_domain: Platform,
 ) -> None:
     """Test migration."""
-    # Setup the config entry
+    # Switch config entry, device and entity
+    switch_config_entry = MockConfigEntry()
+    switch_config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=switch_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch",
+        "test",
+        "unique",
+        config_entry=switch_config_entry,
+        device_id=device_entry.id,
+        original_name="ABC",
+        suggested_object_id="test",
+    )
+    assert switch_entity_entry.entity_id == "switch.test"
+
+    # Switch_as_x config entry, device and entity
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
@@ -1100,8 +1136,36 @@ async def test_migrate(
         minor_version=1,
     )
     config_entry.add_to_hass(hass)
+    device_registry.async_update_device(
+        device_entry.id, add_config_entry_id=config_entry.entry_id
+    )
+    switch_as_x_entity_entry = entity_registry.async_get_or_create(
+        target_domain,
+        "switch_as_x",
+        config_entry.entry_id,
+        capabilities=CAPABILITY_MAP[target_domain],
+        config_entry=config_entry,
+        device_id=device_entry.id,
+        original_name="ABC",
+        suggested_object_id="abc",
+        supported_features=SUPPORTED_FEATURE_MAP[target_domain],
+    )
+    entity_registry.async_update_entity_options(
+        switch_as_x_entity_entry.entity_id,
+        DOMAIN,
+        {"entity_id": "switch.test", "invert": False},
+    )
+
+    events = track_entity_registry_actions(hass, switch_as_x_entity_entry.entity_id)
+
+    # Setup the switch_as_x config entry
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+
+    assert set(entity_registry.entities) == {
+        switch_entity_entry.entity_id,
+        switch_as_x_entity_entry.entity_id,
+    }
 
     # Check migration was successful and added invert option
     assert config_entry.state is ConfigEntryState.LOADED
@@ -1116,6 +1180,20 @@ async def test_migrate(
     # Check the state and entity registry entry are present
     assert hass.states.get(f"{target_domain}.abc") is not None
     assert entity_registry.async_get(f"{target_domain}.abc") is not None
+
+    # Entity removed from device to prevent deletion, then added back to device
+    assert events == [
+        {
+            "action": "update",
+            "changes": {"device_id": device_entry.id},
+            "entity_id": switch_as_x_entity_entry.entity_id,
+        },
+        {
+            "action": "update",
+            "changes": {"device_id": None},
+            "entity_id": switch_as_x_entity_entry.entity_id,
+        },
+    ]
 
 
 @pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -413,7 +413,7 @@ async def test_device_registry_config_entry_3(
     device_entry = device_registry.async_get(device_entry.id)
     assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
     device_entry_2 = device_registry.async_get(device_entry_2.id)
-    assert switch_as_x_config_entry.entry_id in device_entry_2.config_entries
+    assert switch_as_x_config_entry.entry_id not in device_entry_2.config_entries
 
     # Check that the switch_as_x config entry is not removed
     assert switch_as_x_config_entry.entry_id in hass.config_entries.async_entry_ids()

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -222,7 +222,7 @@ async def test_device_registry_config_entry_1(
     assert entity_entry.device_id == switch_entity_entry.device_id
 
     device_entry = device_registry.async_get(device_entry.id)
-    assert switch_as_x_config_entry.entry_id in device_entry.config_entries
+    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
 
     events = []
 
@@ -304,7 +304,7 @@ async def test_device_registry_config_entry_2(
     assert entity_entry.device_id == switch_entity_entry.device_id
 
     device_entry = device_registry.async_get(device_entry.id)
-    assert switch_as_x_config_entry.entry_id in device_entry.config_entries
+    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
 
     events = []
 
@@ -386,7 +386,7 @@ async def test_device_registry_config_entry_3(
     assert entity_entry.device_id == switch_entity_entry.device_id
 
     device_entry = device_registry.async_get(device_entry.id)
-    assert switch_as_x_config_entry.entry_id in device_entry.config_entries
+    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
     device_entry_2 = device_registry.async_get(device_entry_2.id)
     assert switch_as_x_config_entry.entry_id not in device_entry_2.config_entries
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do not add `switch_as_x` config entry to source device, instead, set the device entry to that of the source device in the switch_as_x entity constructor and update `EntityPlatform` to respect this

#### Background
The `switch_as_x` config entry was not initially added to the source device, it was added as a bug fix after `has_entity_name` was introduced. The architecture proposal https://github.com/home-assistant/architecture/discussions/1226 limits devices to a single config entry, which means we need a better solution for `switch_as_x` and other helpers which currently add their config entry to the source device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
