### PR TITLE
Bump holidays to 0.76

### DIFF
--- a/homeassistant/components/holiday/manifest.json
+++ b/homeassistant/components/holiday/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/holiday",
   "iot_class": "local_polling",
-  "requirements": ["holidays==0.75", "babel==2.15.0"]
+  "requirements": ["holidays==0.76", "babel==2.15.0"]
 }

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["holidays"],
   "quality_scale": "internal",
-  "requirements": ["holidays==0.75"]
+  "requirements": ["holidays==0.76"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1165,7 +1165,7 @@ hole==0.9.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.75
+holidays==0.76
 
 # homeassistant.components.frontend
 home-assistant-frontend==20250702.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1014,7 +1014,7 @@ hole==0.9.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.75
+holidays==0.76
 
 # homeassistant.components.frontend
 home-assistant-frontend==20250702.1

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -108,6 +108,7 @@ async def test_form_province_no_alias(hass: HomeAssistant) -> None:
         "name": "Workday Sensor",
         "country": "US",
         "excludes": ["sat", "sun", "holiday"],
+        "language": "en_US",
         "days_offset": 0,
         "workdays": ["mon", "tue", "wed", "thu", "fri"],
         "add_holidays": [],

--- a/tests/components/workday/test_init.py
+++ b/tests/components/workday/test_init.py
@@ -61,8 +61,4 @@ async def test_workday_subdiv_aliases() -> None:
         years=2025,
     )
     subdiv_aliases = country.get_subdivision_aliases()
-    assert subdiv_aliases["GES"] == [  # codespell:ignore
-        "Alsace",
-        "Champagne-Ardenne",
-        "Lorraine",
-    ]
+    assert subdiv_aliases["6AE"] == ["Alsace"]


### PR DESCRIPTION
## Breaking change


## Proposed change
Bump holidays lib to 0.76
https://github.com/vacanza/holidays/releases/tag/v0.76
https://github.com/vacanza/holidays/compare/v0.75...v0.76

This refactors France provinces so not adding the milestone for this one (even though the repair flow should trigger for the user)

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 