### PR TITLE
Handle when heat pump rejects same value writes in nibe_heatpump

### DIFF
--- a/homeassistant/components/nibe_heatpump/button.py
+++ b/homeassistant/components/nibe_heatpump/button.py
@@ -52,6 +52,7 @@ class NibeAlarmResetButton(CoordinatorEntity[CoilCoordinator], ButtonEntity):
 
     async def async_press(self) -> None:
         """Execute the command."""
+        await self.coordinator.async_write_coil(self._reset_coil, 0)
         await self.coordinator.async_write_coil(self._reset_coil, 1)
         await self.coordinator.async_read_coil(self._alarm_coil)
 

--- a/homeassistant/components/nibe_heatpump/coordinator.py
+++ b/homeassistant/components/nibe_heatpump/coordinator.py
@@ -143,15 +143,12 @@ class CoilCoordinator(ContextCoordinator[dict[int, CoilData], int]):
         data = CoilData(coil, value)
         try:
             await self.connection.write_coil(data)
-        except WriteDeniedException as e:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="write_denied",
-                translation_placeholders={
-                    "address": str(coil.address),
-                    "value": str(value),
-                },
-            ) from e
+        except WriteDeniedException:
+            LOGGER.debug(
+                "Denied write on address %d with value %s. This is likely already the value the pump has internally",
+                coil.address,
+                value,
+            )
         except WriteTimeoutException as e:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/nibe_heatpump/strings.json
+++ b/homeassistant/components/nibe_heatpump/strings.json
@@ -47,9 +47,6 @@
     }
   },
   "exceptions": {
-    "write_denied": {
-      "message": "Writing of coil {address} with value `{value}` was denied"
-    },
     "write_timeout": {
       "message": "Timeout while writing coil {address}"
     },

--- a/tests/components/nibe_heatpump/snapshots/test_number.ambr
+++ b/tests/components/nibe_heatpump/snapshots/test_number.ambr
@@ -1,4 +1,22 @@
 # serializer version: 1
+# name: test_set_value_same
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'F1155 Room sensor setpoint S1',
+      'max': 30.0,
+      'min': 5.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 0.1,
+      'unit_of_measurement': '°C',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.room_sensor_setpoint_s1_47398',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.0',
+  })
+# ---
 # name: test_update[Model.F1155-47011-number.heat_offset_s1_47011--10]
   StateSnapshot({
     'attributes': ReadOnlyDict({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the heat pump receives a write for a value it already has set
internally, it will reject the write. This however does not indicate the
write failed. Just that we wrote same value as the pump already has.

When reseting alarm this requires some special handling since the
pump will reject the attempt to reset the alarm if the reset register
is already set to 0. So to work around that first set it to 0 before
setting it to 1.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140654
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
