### PR TITLE
Improve entity registry tests related to config entries in devices

### DIFF
--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1930,12 +1930,13 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
     device_registry.async_update_device(
         device_entry.id,
         remove_config_entry_id=config_entry_1.entry_id,
-        remove_config_subentry_id=subentries_in_device[0],
+        remove_config_subentry_id=subentries_in_device[1],
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get(device_entry.id)
-    assert entity_registry.async_is_registered(entry_1.entity_id)
+    assert not device_registry.async_get(device_entry.id)
+    # All entities are now removed
+    assert not entity_registry.async_is_registered(entry_1.entity_id)
     assert not entity_registry.async_is_registered(entry_2.entity_id)
     assert not entity_registry.async_is_registered(entry_3.entity_id)
 

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1822,10 +1822,19 @@ async def test_remove_config_subentry_from_device_removes_entities(
     assert not entity_registry.async_is_registered(entry_3.entity_id)
 
 
+@pytest.mark.parametrize(
+    ("subentries_in_device", "subentry_in_entity"),
+    [
+        (["mock-subentry-id-1", "mock-subentry-id-2"], None),
+        ([None, "mock-subentry-id-2"], "mock-subentry-id-1"),
+    ],
+)
 async def test_remove_config_subentry_from_device_removes_entities_2(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    subentries_in_device: list[str | None],
+    subentry_in_entity: str | None,
 ) -> None:
     """Test that we don't remove entities with no config entry when device is modified."""
     config_entry_1 = MockConfigEntry(
@@ -1856,24 +1865,20 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
     )
     config_entry_1.add_to_hass(hass)
 
-    # Create device with three config subentries
+    # Create device with two config subentries
     device_registry.async_get_or_create(
         config_entry_id=config_entry_1.entry_id,
-        config_subentry_id="mock-subentry-id-1",
-        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
-    )
-    device_registry.async_get_or_create(
-        config_entry_id=config_entry_1.entry_id,
-        config_subentry_id="mock-subentry-id-2",
+        config_subentry_id=subentries_in_device[0],
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry_1.entry_id,
+        config_subentry_id=subentries_in_device[1],
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     assert device_entry.config_entries == {config_entry_1.entry_id}
     assert device_entry.config_entries_subentries == {
-        config_entry_1.entry_id: {None, "mock-subentry-id-1", "mock-subentry-id-2"},
+        config_entry_1.entry_id: set(subentries_in_device),
     }
 
     # Create an entity without config entry or subentry
@@ -1883,15 +1888,16 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
         "5678",
         device_id=device_entry.id,
     )
-    # Create an entity same config entry but no subentry
+    # Create an entity for same config entry but no subentry not in device
     entry_2 = entity_registry.async_get_or_create(
         "light",
         "some_helper",
         "5678",
         config_entry=config_entry_1,
+        config_subentry_id=subentry_in_entity,
         device_id=device_entry.id,
     )
-    # Create an entity same config entry but subentry not in device
+    # Create an entity for same config entry but subentry not in device
     entry_3 = entity_registry.async_get_or_create(
         "light",
         "some_helper",
@@ -1910,7 +1916,7 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
     device_registry.async_update_device(
         device_entry.id,
         remove_config_entry_id=config_entry_1.entry_id,
-        remove_config_subentry_id=None,
+        remove_config_subentry_id=subentries_in_device[0],
     )
     await hass.async_block_till_done()
 
@@ -1924,7 +1930,7 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
     device_registry.async_update_device(
         device_entry.id,
         remove_config_entry_id=config_entry_1.entry_id,
-        remove_config_subentry_id="mock-subentry-id-1",
+        remove_config_subentry_id=subentries_in_device[0],
     )
     await hass.async_block_till_done()
 

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1640,6 +1640,8 @@ async def test_remove_config_entry_from_device_removes_entities_2(
     config_entry_1.add_to_hass(hass)
     config_entry_2 = MockConfigEntry(domain="device_tracker")
     config_entry_2.add_to_hass(hass)
+    config_entry_3 = MockConfigEntry(domain="some_helper")
+    config_entry_3.add_to_hass(hass)
 
     # Create device with two config entries
     device_registry.async_get_or_create(
@@ -1662,8 +1664,18 @@ async def test_remove_config_entry_from_device_removes_entities_2(
         "5678",
         device_id=device_entry.id,
     )
+    # Create an entity with a config entry not in the device
+    entry_2 = entity_registry.async_get_or_create(
+        "light",
+        "some_helper",
+        "5678",
+        config_entry=config_entry_3,
+        device_id=device_entry.id,
+    )
 
+    assert entry_1.entity_id != entry_2.entity_id
     assert entity_registry.async_is_registered(entry_1.entity_id)
+    assert entity_registry.async_is_registered(entry_2.entity_id)
 
     # Remove the first config entry from the device
     device_registry.async_update_device(
@@ -1673,6 +1685,19 @@ async def test_remove_config_entry_from_device_removes_entities_2(
 
     assert device_registry.async_get(device_entry.id)
     assert entity_registry.async_is_registered(entry_1.entity_id)
+    # Entities with a config entry not in the device are removed
+    assert not entity_registry.async_is_registered(entry_2.entity_id)
+
+    # Remove the second config entry from the device
+    device_registry.async_update_device(
+        device_entry.id, remove_config_entry_id=config_entry_2.entry_id
+    )
+    await hass.async_block_till_done()
+
+    assert not device_registry.async_get(device_entry.id)
+    # The device is removed, both entities are now removed
+    assert not entity_registry.async_is_registered(entry_1.entity_id)
+    assert not entity_registry.async_is_registered(entry_2.entity_id)
 
 
 async def test_remove_config_subentry_from_device_removes_entities(
@@ -1820,6 +1845,13 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
                 title="Mock title",
                 unique_id="test",
             ),
+            config_entries.ConfigSubentryData(
+                data={},
+                subentry_id="mock-subentry-id-3",
+                subentry_type="test",
+                title="Mock title",
+                unique_id="test",
+            ),
         ],
     )
     config_entry_1.add_to_hass(hass)
@@ -1851,8 +1883,28 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
         "5678",
         device_id=device_entry.id,
     )
+    # Create an entity same config entry but no subentry
+    entry_2 = entity_registry.async_get_or_create(
+        "light",
+        "some_helper",
+        "5678",
+        config_entry=config_entry_1,
+        device_id=device_entry.id,
+    )
+    # Create an entity same config entry but subentry not in device
+    entry_3 = entity_registry.async_get_or_create(
+        "light",
+        "some_helper",
+        "abcd",
+        config_entry=config_entry_1,
+        config_subentry_id="mock-subentry-id-3",
+        device_id=device_entry.id,
+    )
 
+    assert len({entry_1.entity_id, entry_2.entity_id, entry_3.entity_id}) == 3
     assert entity_registry.async_is_registered(entry_1.entity_id)
+    assert entity_registry.async_is_registered(entry_2.entity_id)
+    assert entity_registry.async_is_registered(entry_3.entity_id)
 
     # Remove the first config subentry from the device
     device_registry.async_update_device(
@@ -1864,6 +1916,9 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
 
     assert device_registry.async_get(device_entry.id)
     assert entity_registry.async_is_registered(entry_1.entity_id)
+    # Entities with a config subentry not in the device are removed
+    assert not entity_registry.async_is_registered(entry_2.entity_id)
+    assert not entity_registry.async_is_registered(entry_3.entity_id)
 
     # Remove the second config subentry from the device
     device_registry.async_update_device(
@@ -1875,6 +1930,8 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
 
     assert device_registry.async_get(device_entry.id)
     assert entity_registry.async_is_registered(entry_1.entity_id)
+    assert not entity_registry.async_is_registered(entry_2.entity_id)
+    assert not entity_registry.async_is_registered(entry_3.entity_id)
 
 
 async def test_update_device_race(

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1888,7 +1888,7 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
         "5678",
         device_id=device_entry.id,
     )
-    # Create an entity for same config entry but no subentry not in device
+    # Create an entity for same config entry but subentry not in device
     entry_2 = entity_registry.async_get_or_create(
         "light",
         "some_helper",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve entity registry tests related to some edge cases for config entry and config subentry removal from devices

The current behavior is not logical, the intention is to change the behavior (and the tests added by this PR) in a follow-up

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
