### PR TITLE
Change config_entry_id to be optional within Mealie actions where only one instance

### DIFF
--- a/homeassistant/components/mealie/services.yaml
+++ b/homeassistant/components/mealie/services.yaml
@@ -1,7 +1,7 @@
 get_mealplan:
   fields:
     config_entry_id:
-      required: true
+      required: false
       selector:
         config_entry:
           integration: mealie
@@ -15,7 +15,7 @@ get_mealplan:
 get_recipe:
   fields:
     config_entry_id:
-      required: true
+      required: false
       selector:
         config_entry:
           integration: mealie
@@ -27,7 +27,7 @@ get_recipe:
 import_recipe:
   fields:
     config_entry_id:
-      required: true
+      required: false
       selector:
         config_entry:
           integration: mealie
@@ -42,7 +42,7 @@ import_recipe:
 set_random_mealplan:
   fields:
     config_entry_id:
-      required: true
+      required: false
       selector:
         config_entry:
           integration: mealie
@@ -62,7 +62,7 @@ set_random_mealplan:
 set_mealplan:
   fields:
     config_entry_id:
-      required: true
+      required: false
       selector:
         config_entry:
           integration: mealie

--- a/homeassistant/components/mealie/strings.json
+++ b/homeassistant/components/mealie/strings.json
@@ -141,6 +141,9 @@
     },
     "setup_failed": {
       "message": "Could not connect to the Mealie instance."
+    },
+    "multiple_config_entries": {
+      "message": "Multiple config entries found. Please specify the Mealie instance to use."
     }
   },
   "services": {

--- a/tests/components/mealie/conftest.py
+++ b/tests/components/mealie/conftest.py
@@ -89,3 +89,15 @@ def mock_config_entry() -> MockConfigEntry:
         entry_id="01J0BC4QM2YBRP6H5G933CETT7",
         unique_id="bf1c62fe-4941-4332-9886-e54e88dbdba0",
     )
+
+
+@pytest.fixture
+def mock_second_config_entry() -> MockConfigEntry:
+    """Mock a config entry, used for checking multiples."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Mealie 2",
+        data={CONF_HOST: "demo2.mealie.io", CONF_API_TOKEN: "token"},
+        entry_id="01J0BC4QM2YBRP6H5G933CETT2",
+        unique_id="bf1c62fe-4941-4332-9886-e54e88dbdba2",
+    )

--- a/tests/components/mealie/test_services.py
+++ b/tests/components/mealie/test_services.py
@@ -97,7 +97,6 @@ async def test_service_mealplan(
         DOMAIN,
         SERVICE_GET_MEALPLAN,
         {
-            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
             ATTR_START_DATE: "2023-10-22",
             ATTR_END_DATE: "2023-10-25",
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change all actions that required a config_entry_id to now be optional and get/validate that there is only one config_entry, if it is not included, otherwise throw a service error if more than one Mealie instance and the config_entry_id is not specified.
It is unlikely that users have more than one Mealie instance so this will make it easier than referencing uid's within automations.
Inspired by the recent Telegram Bot actions which implemented this pattern.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39925
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
