### PR TITLE
Improve entity registry handling of device changes

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -144,11 +144,19 @@ DEVICE_INFO_KEYS = set.union(*(itm for itm in DEVICE_INFO_TYPES.values()))
 LOW_PRIO_CONFIG_ENTRY_DOMAINS = {"homekit_controller", "matter", "mqtt", "upnp"}
 
 
-class _EventDeviceRegistryUpdatedData_CreateRemove(TypedDict):
-    """EventDeviceRegistryUpdated data for action type 'create' and 'remove'."""
+class _EventDeviceRegistryUpdatedData_Create(TypedDict):
+    """EventDeviceRegistryUpdated data for action type 'create'."""
 
-    action: Literal["create", "remove"]
+    action: Literal["create"]
     device_id: str
+
+
+class _EventDeviceRegistryUpdatedData_Remove(TypedDict):
+    """EventDeviceRegistryUpdated data for action type 'remove'."""
+
+    action: Literal["remove"]
+    device_id: str
+    device: DeviceEntry
 
 
 class _EventDeviceRegistryUpdatedData_Update(TypedDict):
@@ -160,7 +168,8 @@ class _EventDeviceRegistryUpdatedData_Update(TypedDict):
 
 
 type EventDeviceRegistryUpdatedData = (
-    _EventDeviceRegistryUpdatedData_CreateRemove
+    _EventDeviceRegistryUpdatedData_Create
+    | _EventDeviceRegistryUpdatedData_Remove
     | _EventDeviceRegistryUpdatedData_Update
 )
 
@@ -1309,8 +1318,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 self.async_update_device(other_device.id, via_device_id=None)
         self.hass.bus.async_fire_internal(
             EVENT_DEVICE_REGISTRY_UPDATED,
-            _EventDeviceRegistryUpdatedData_CreateRemove(
-                action="remove", device_id=device_id
+            _EventDeviceRegistryUpdatedData_Remove(
+                action="remove", device_id=device_id, device=device
             ),
         )
         self.async_schedule_save()

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1112,6 +1112,8 @@ class EntityRegistry(BaseRegistry):
                     in removed_device.config_entries_subentries[config_entry_id]
                 ):
                     self.async_remove(entity.entity_id)
+                else:
+                    self.async_update_entity(entity.entity_id, device_id=None)
             return
 
         if event.data["action"] != "update":

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1103,8 +1103,15 @@ class EntityRegistry(BaseRegistry):
             entities = async_entries_for_device(
                 self, event.data["device_id"], include_disabled_entities=True
             )
+            removed_device = event.data["device"]
             for entity in entities:
-                self.async_remove(entity.entity_id)
+                config_entry_id = entity.config_entry_id
+                if (
+                    config_entry_id in removed_device.config_entries
+                    and entity.config_subentry_id
+                    in removed_device.config_entries_subentries[config_entry_id]
+                ):
+                    self.async_remove(entity.entity_id)
             return
 
         if event.data["action"] != "update":
@@ -1121,29 +1128,38 @@ class EntityRegistry(BaseRegistry):
 
         # Remove entities which belong to config entries no longer associated with the
         # device
-        entities = async_entries_for_device(
-            self, event.data["device_id"], include_disabled_entities=True
-        )
-        for entity in entities:
-            if (
-                entity.config_entry_id is not None
-                and entity.config_entry_id not in device.config_entries
-            ):
-                self.async_remove(entity.entity_id)
+        if old_config_entries := event.data["changes"].get("config_entries"):
+            entities = async_entries_for_device(
+                self, event.data["device_id"], include_disabled_entities=True
+            )
+            for entity in entities:
+                config_entry_id = entity.config_entry_id
+                if (
+                    entity.config_entry_id in old_config_entries
+                    and entity.config_entry_id not in device.config_entries
+                ):
+                    self.async_remove(entity.entity_id)
 
         # Remove entities which belong to config subentries no longer associated with the
         # device
-        entities = async_entries_for_device(
-            self, event.data["device_id"], include_disabled_entities=True
-        )
-        for entity in entities:
-            if (
-                (config_entry_id := entity.config_entry_id) is not None
-                and config_entry_id in device.config_entries
-                and entity.config_subentry_id
-                not in device.config_entries_subentries[config_entry_id]
-            ):
-                self.async_remove(entity.entity_id)
+        if old_config_entries_subentries := event.data["changes"].get(
+            "config_entries_subentries"
+        ):
+            entities = async_entries_for_device(
+                self, event.data["device_id"], include_disabled_entities=True
+            )
+            for entity in entities:
+                config_entry_id = entity.config_entry_id
+                config_subentry_id = entity.config_subentry_id
+                if (
+                    config_entry_id in device.config_entries
+                    and config_entry_id in old_config_entries_subentries
+                    and config_subentry_id
+                    in old_config_entries_subentries[config_entry_id]
+                    and config_subentry_id
+                    not in device.config_entries_subentries[config_entry_id]
+                ):
+                    self.async_remove(entity.entity_id)
 
         # Re-enable disabled entities if the device is no longer disabled
         if not device.disabled:

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1652,6 +1652,7 @@ async def test_removing_config_entries(
     assert update_events[4].data == {
         "action": "remove",
         "device_id": entry3.id,
+        "device": entry3,
     }
 
 
@@ -1724,10 +1725,12 @@ async def test_deleted_device_removing_config_entries(
     assert update_events[3].data == {
         "action": "remove",
         "device_id": entry.id,
+        "device": entry2,
     }
     assert update_events[4].data == {
         "action": "remove",
         "device_id": entry3.id,
+        "device": entry3,
     }
 
     device_registry.async_clear_config_entry(config_entry_1.entry_id)
@@ -1973,6 +1976,7 @@ async def test_removing_config_subentries(
     assert update_events[7].data == {
         "action": "remove",
         "device_id": entry.id,
+        "device": entry,
     }
 
 
@@ -2102,6 +2106,7 @@ async def test_deleted_device_removing_config_subentries(
     assert update_events[4].data == {
         "action": "remove",
         "device_id": entry.id,
+        "device": entry4,
     }
 
     device_registry.async_clear_config_subentry(config_entry_1.entry_id, None)
@@ -2925,6 +2930,7 @@ async def test_update_remove_config_entries(
     assert update_events[6].data == {
         "action": "remove",
         "device_id": entry3.id,
+        "device": entry3,
     }
 
 
@@ -3104,6 +3110,7 @@ async def test_update_remove_config_subentries(
         config_entry_3.entry_id: {None},
     }
 
+    entry_before_remove = entry
     entry = device_registry.async_update_device(
         entry_id,
         remove_config_entry_id=config_entry_3.entry_id,
@@ -3201,6 +3208,7 @@ async def test_update_remove_config_subentries(
     assert update_events[7].data == {
         "action": "remove",
         "device_id": entry_id,
+        "device": entry_before_remove,
     }
 
 
@@ -3422,7 +3430,7 @@ async def test_restore_device(
     )
 
     # Apply user customizations
-    device_registry.async_update_device(
+    entry = device_registry.async_update_device(
         entry.id,
         area_id="12345A",
         disabled_by=dr.DeviceEntryDisabler.USER,
@@ -3543,6 +3551,7 @@ async def test_restore_device(
     assert update_events[2].data == {
         "action": "remove",
         "device_id": entry.id,
+        "device": entry,
     }
     assert update_events[3].data == {
         "action": "create",
@@ -3865,6 +3874,7 @@ async def test_restore_shared_device(
     assert update_events[3].data == {
         "action": "remove",
         "device_id": entry.id,
+        "device": updated_device,
     }
     assert update_events[4].data == {
         "action": "create",
@@ -3873,6 +3883,7 @@ async def test_restore_shared_device(
     assert update_events[5].data == {
         "action": "remove",
         "device_id": entry.id,
+        "device": entry2,
     }
     assert update_events[6].data == {
         "action": "create",

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1698,6 +1698,9 @@ async def test_remove_config_entry_from_device_removes_entities_2(
     # Entities which are not tied to a config entry in the device should not be removed
     assert entity_registry.async_is_registered(entry_1.entity_id)
     assert entity_registry.async_is_registered(entry_2.entity_id)
+    # Check the device link is set to None
+    assert entity_registry.async_get(entry_1.entity_id).device_id is None
+    assert entity_registry.async_get(entry_2.entity_id).device_id is None
 
 
 async def test_remove_config_subentry_from_device_removes_entities(
@@ -1939,6 +1942,10 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
     assert entity_registry.async_is_registered(entry_1.entity_id)
     assert entity_registry.async_is_registered(entry_2.entity_id)
     assert entity_registry.async_is_registered(entry_3.entity_id)
+    # Check the device link is set to None
+    assert entity_registry.async_get(entry_1.entity_id).device_id is None
+    assert entity_registry.async_get(entry_2.entity_id).device_id is None
+    assert entity_registry.async_get(entry_3.entity_id).device_id is None
 
 
 async def test_update_device_race(

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1684,20 +1684,20 @@ async def test_remove_config_entry_from_device_removes_entities_2(
     await hass.async_block_till_done()
 
     assert device_registry.async_get(device_entry.id)
+    # Entities which are not tied to the removed config entry should not be removed
     assert entity_registry.async_is_registered(entry_1.entity_id)
-    # Entities with a config entry not in the device are removed
-    assert not entity_registry.async_is_registered(entry_2.entity_id)
+    assert entity_registry.async_is_registered(entry_2.entity_id)
 
-    # Remove the second config entry from the device
+    # Remove the second config entry from the device (this removes the device)
     device_registry.async_update_device(
         device_entry.id, remove_config_entry_id=config_entry_2.entry_id
     )
     await hass.async_block_till_done()
 
     assert not device_registry.async_get(device_entry.id)
-    # The device is removed, both entities are now removed
-    assert not entity_registry.async_is_registered(entry_1.entity_id)
-    assert not entity_registry.async_is_registered(entry_2.entity_id)
+    # Entities which are not tied to a config entry in the device should not be removed
+    assert entity_registry.async_is_registered(entry_1.entity_id)
+    assert entity_registry.async_is_registered(entry_2.entity_id)
 
 
 async def test_remove_config_subentry_from_device_removes_entities(
@@ -1921,12 +1921,12 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
     await hass.async_block_till_done()
 
     assert device_registry.async_get(device_entry.id)
+    # Entities with a config subentry not in the device are not removed
     assert entity_registry.async_is_registered(entry_1.entity_id)
-    # Entities with a config subentry not in the device are removed
-    assert not entity_registry.async_is_registered(entry_2.entity_id)
-    assert not entity_registry.async_is_registered(entry_3.entity_id)
+    assert entity_registry.async_is_registered(entry_2.entity_id)
+    assert entity_registry.async_is_registered(entry_3.entity_id)
 
-    # Remove the second config subentry from the device
+    # Remove the second config subentry from the device, this removes the device
     device_registry.async_update_device(
         device_entry.id,
         remove_config_entry_id=config_entry_1.entry_id,
@@ -1935,10 +1935,10 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
     await hass.async_block_till_done()
 
     assert not device_registry.async_get(device_entry.id)
-    # All entities are now removed
-    assert not entity_registry.async_is_registered(entry_1.entity_id)
-    assert not entity_registry.async_is_registered(entry_2.entity_id)
-    assert not entity_registry.async_is_registered(entry_3.entity_id)
+    # Entities with a config subentry not in the device are not removed
+    assert entity_registry.async_is_registered(entry_1.entity_id)
+    assert entity_registry.async_is_registered(entry_2.entity_id)
+    assert entity_registry.async_is_registered(entry_3.entity_id)
 
 
 async def test_update_device_race(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve entity registry handling of device changes:
- When a device is removed, only remove entities linked to the device which are owned by config entries and config subentries linked to the device, entities not matching this criteria will not be removed but instead have their device_id set to `None`
- When a config entry is removed from a device, only remove entities linked to the device which are owned by the removed config entry
- When a config subentry is removed from a device, only remove entities linked to the device which are owned by the removed config subentry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
