### PR TITLE
Remove None from device sub config entries when updating with sub con…

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1095,6 +1095,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                     ]
                     | {add_config_subentry_id}
                 }
+                config_entries_subentries[add_config_entry_id].discard(None)
 
         if (
             remove_config_entry_id is not UNDEFINED

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -269,7 +269,7 @@ async def test_multiple_config_subentries(
     assert entry.id == entry_id
     assert entry.config_entries == {config_entry_1.entry_id}
     assert entry.config_entries_subentries == {
-        config_entry_1.entry_id: {None, "mock-subentry-id-1-1"}
+        config_entry_1.entry_id: {"mock-subentry-id-1-1"}
     }
 
     entry = device_registry.async_get_or_create(
@@ -283,7 +283,7 @@ async def test_multiple_config_subentries(
     assert entry.id == entry_id
     assert entry.config_entries == {config_entry_1.entry_id}
     assert entry.config_entries_subentries == {
-        config_entry_1.entry_id: {None, "mock-subentry-id-1-1", "mock-subentry-id-1-2"}
+        config_entry_1.entry_id: {"mock-subentry-id-1-1", "mock-subentry-id-1-2"}
     }
 
     entry = device_registry.async_get_or_create(
@@ -297,7 +297,7 @@ async def test_multiple_config_subentries(
     assert entry.id == entry_id
     assert entry.config_entries == {config_entry_1.entry_id, config_entry_2.entry_id}
     assert entry.config_entries_subentries == {
-        config_entry_1.entry_id: {None, "mock-subentry-id-1-1", "mock-subentry-id-1-2"},
+        config_entry_1.entry_id: {"mock-subentry-id-1-1", "mock-subentry-id-1-2"},
         config_entry_2.entry_id: {"mock-subentry-id-2-1"},
     }
 
@@ -1850,7 +1850,7 @@ async def test_removing_config_subentries(
     assert entry.id == entry4.id
     assert entry4.config_entries == {config_entry_1.entry_id, config_entry_2.entry_id}
     assert entry4.config_entries_subentries == {
-        config_entry_1.entry_id: {None, "mock-subentry-id-1-1", "mock-subentry-id-1-2"},
+        config_entry_1.entry_id: {"mock-subentry-id-1-1", "mock-subentry-id-1-2"},
         config_entry_2.entry_id: {"mock-subentry-id-2-1"},
     }
 
@@ -1887,7 +1887,7 @@ async def test_removing_config_subentries(
 
     await hass.async_block_till_done()
 
-    assert len(update_events) == 8
+    assert len(update_events) == 7
     assert update_events[0].data == {
         "action": "create",
         "device_id": entry.id,
@@ -1904,7 +1904,7 @@ async def test_removing_config_subentries(
         "device_id": entry.id,
         "changes": {
             "config_entries_subentries": {
-                config_entry_1.entry_id: {None, "mock-subentry-id-1-1"}
+                config_entry_1.entry_id: {"mock-subentry-id-1-1"}
             },
         },
     }
@@ -1915,7 +1915,6 @@ async def test_removing_config_subentries(
             "config_entries": {config_entry_1.entry_id},
             "config_entries_subentries": {
                 config_entry_1.entry_id: {
-                    None,
                     "mock-subentry-id-1-1",
                     "mock-subentry-id-1-2",
                 }
@@ -1929,7 +1928,6 @@ async def test_removing_config_subentries(
         "changes": {
             "config_entries_subentries": {
                 config_entry_1.entry_id: {
-                    None,
                     "mock-subentry-id-1-1",
                     "mock-subentry-id-1-2",
                 },
@@ -1940,21 +1938,6 @@ async def test_removing_config_subentries(
         },
     }
     assert update_events[5].data == {
-        "action": "update",
-        "device_id": entry.id,
-        "changes": {
-            "config_entries_subentries": {
-                config_entry_1.entry_id: {
-                    "mock-subentry-id-1-1",
-                    "mock-subentry-id-1-2",
-                },
-                config_entry_2.entry_id: {
-                    "mock-subentry-id-2-1",
-                },
-            },
-        },
-    }
-    assert update_events[6].data == {
         "action": "update",
         "device_id": entry.id,
         "changes": {
@@ -1970,7 +1953,7 @@ async def test_removing_config_subentries(
             "primary_config_entry": config_entry_1.entry_id,
         },
     }
-    assert update_events[7].data == {
+    assert update_events[6].data == {
         "action": "remove",
         "device_id": entry.id,
     }
@@ -2052,7 +2035,7 @@ async def test_deleted_device_removing_config_subentries(
     assert entry.id == entry4.id
     assert entry4.config_entries == {config_entry_1.entry_id, config_entry_2.entry_id}
     assert entry4.config_entries_subentries == {
-        config_entry_1.entry_id: {None, "mock-subentry-id-1-1", "mock-subentry-id-1-2"},
+        config_entry_1.entry_id: {"mock-subentry-id-1-1", "mock-subentry-id-1-2"},
         config_entry_2.entry_id: {"mock-subentry-id-2-1"},
     }
 
@@ -2080,7 +2063,7 @@ async def test_deleted_device_removing_config_subentries(
         "device_id": entry.id,
         "changes": {
             "config_entries_subentries": {
-                config_entry_1.entry_id: {None, "mock-subentry-id-1-1"}
+                config_entry_1.entry_id: {"mock-subentry-id-1-1"}
             },
         },
     }
@@ -2091,7 +2074,6 @@ async def test_deleted_device_removing_config_subentries(
             "config_entries": {config_entry_1.entry_id},
             "config_entries_subentries": {
                 config_entry_1.entry_id: {
-                    None,
                     "mock-subentry-id-1-1",
                     "mock-subentry-id-1-2",
                 }

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -2969,11 +2969,16 @@ async def test_update_remove_config_subentries(
 
     entry = device_registry.async_get_or_create(
         config_entry_id=config_entry_1.entry_id,
-        config_subentry_id="mock-subentry-id-1-1",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
+    )
+    assert entry.config_entries_subentries == {config_entry_1.entry_id: {None}}
+    entry = device_registry.async_update_device(
+        entry.id,
+        add_config_entry_id=config_entry_1.entry_id,
+        add_config_subentry_id="mock-subentry-id-1-1",
     )
     entry_id = entry.id
     assert entry.config_entries == {config_entry_1.entry_id}
@@ -3113,7 +3118,7 @@ async def test_update_remove_config_subentries(
 
     await hass.async_block_till_done()
 
-    assert len(update_events) == 8
+    assert len(update_events) == 9
     assert update_events[0].data == {
         "action": "create",
         "device_id": entry_id,
@@ -3122,12 +3127,19 @@ async def test_update_remove_config_subentries(
         "action": "update",
         "device_id": entry_id,
         "changes": {
+            "config_entries_subentries": {config_entry_1.entry_id: {None}},
+        },
+    }
+    assert update_events[2].data == {
+        "action": "update",
+        "device_id": entry_id,
+        "changes": {
             "config_entries_subentries": {
                 config_entry_1.entry_id: {"mock-subentry-id-1-1"}
             },
         },
     }
-    assert update_events[2].data == {
+    assert update_events[3].data == {
         "action": "update",
         "device_id": entry_id,
         "changes": {
@@ -3140,7 +3152,7 @@ async def test_update_remove_config_subentries(
             },
         },
     }
-    assert update_events[3].data == {
+    assert update_events[4].data == {
         "action": "update",
         "device_id": entry_id,
         "changes": {
@@ -3154,7 +3166,7 @@ async def test_update_remove_config_subentries(
             },
         },
     }
-    assert update_events[4].data == {
+    assert update_events[5].data == {
         "action": "update",
         "device_id": entry_id,
         "changes": {
@@ -3168,7 +3180,7 @@ async def test_update_remove_config_subentries(
             },
         },
     }
-    assert update_events[5].data == {
+    assert update_events[6].data == {
         "action": "update",
         "device_id": entry_id,
         "changes": {
@@ -3187,7 +3199,7 @@ async def test_update_remove_config_subentries(
             "primary_config_entry": config_entry_1.entry_id,
         },
     }
-    assert update_events[6].data == {
+    assert update_events[7].data == {
         "action": "update",
         "device_id": entry_id,
         "changes": {
@@ -3198,7 +3210,7 @@ async def test_update_remove_config_subentries(
             },
         },
     }
-    assert update_events[7].data == {
+    assert update_events[8].data == {
         "action": "remove",
         "device_id": entry_id,
     }

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1719,7 +1719,7 @@ async def test_remove_config_subentry_from_device_removes_entities(
     )
     assert device_entry.config_entries == {config_entry_1.entry_id}
     assert device_entry.config_entries_subentries == {
-        config_entry_1.entry_id: {None, "mock-subentry-id-1", "mock-subentry-id-2"},
+        config_entry_1.entry_id: {"mock-subentry-id-1", "mock-subentry-id-2"},
     }
 
     # Create one entity entry for each config entry or subentry
@@ -1749,7 +1749,6 @@ async def test_remove_config_subentry_from_device_removes_entities(
         config_subentry_id=None,
         device_id=device_entry.id,
     )
-
     assert entity_registry.async_is_registered(entry_1.entity_id)
     assert entity_registry.async_is_registered(entry_2.entity_id)
     assert entity_registry.async_is_registered(entry_3.entity_id)
@@ -1841,7 +1840,7 @@ async def test_remove_config_subentry_from_device_removes_entities_2(
     )
     assert device_entry.config_entries == {config_entry_1.entry_id}
     assert device_entry.config_entries_subentries == {
-        config_entry_1.entry_id: {None, "mock-subentry-id-1", "mock-subentry-id-2"},
+        config_entry_1.entry_id: {"mock-subentry-id-1", "mock-subentry-id-2"},
     }
 
     # Create an entity without config entry or subentry


### PR DESCRIPTION
## Breaking change


## Proposed change
Removes `None` from the sub config entries in device registry when updating a device with a sub config entry and it didn't have one before.

Device `config_entries_subentries` defaults to
`"config_entries_subentries":{"01JZN04ZJ9BQXXGXDS05WS7D6P":[null]}` which after updating becomes `"config_entries_subentries":{"01JZN04ZJ9BQXXGXDS05WS7D6P":[null, "01JZN07D8D23994A49YKS649S7"]}` which makes frontend display the device twice (once without connected to the right sub config entry.

This problem only appears if you are updating a device, creating a new one with a sub config entry doesn't add `None` to the set.

![image](https://github.com/user-attachments/assets/d7573da2-5c18-4700-ad19-1358e063f543)


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 