### PR TITLE
Add Home Connect option to always enable all the commands

### DIFF
--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -10,6 +10,8 @@ from .utils import bsh_key_to_translation_key
 
 DOMAIN = "home_connect"
 
+CONF_ENABLE_ALL_COMMANDS = "enable_all_commands"
+
 API_DEFAULT_RETRY_AFTER = 60
 
 APPLIANCES_WITH_PROGRAMS = (

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -40,6 +40,18 @@
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
+  "options": {
+    "step": {
+      "entry_options": {
+        "data": {
+          "enable_all_commands": "Enable all the possible commands"
+        },
+        "data_description": {
+          "enable_all_commands": "Enabling this will show all the possible buttons related to commands. Requires reloading the integration or use the homeassistant.update_entity service over any entity from the integration."
+        }
+      }
+    }
+  },
   "exceptions": {
     "auth_error": {
       "message": "Authentication error: {error}. Please, re-authenticate your account"

--- a/tests/components/home_connect/conftest.py
+++ b/tests/components/home_connect/conftest.py
@@ -94,6 +94,23 @@ def mock_config_entry(token_entry: dict[str, Any]) -> MockConfigEntry:
     )
 
 
+@pytest.fixture(name="config_entry_with_options")
+def mock_config_entry_with_options(
+    token_entry: dict[str, Any], request: pytest.FixtureRequest
+) -> MockConfigEntry:
+    """Fixture for a config entry with options."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "auth_implementation": FAKE_AUTH_IMPL,
+            "token": token_entry,
+        },
+        minor_version=3,
+        unique_id="1234567890",
+        options=request.param,
+    )
+
+
 @pytest.fixture(name="config_entry_v1_1")
 def mock_config_entry_v1_1(token_entry: dict[str, Any]) -> MockConfigEntry:
     """Fixture for a config entry."""

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -9,7 +9,7 @@ from aiohomeconnect.model import HomeAppliance
 import pytest
 
 from homeassistant import config_entries, setup
-from homeassistant.components.home_connect.const import DOMAIN
+from homeassistant.components.home_connect.const import CONF_ENABLE_ALL_COMMANDS, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -509,3 +509,54 @@ async def test_dhcp_flow_complete_device_information(
     assert device.connections == {
         (dr.CONNECTION_NETWORK_MAC, dr.format_mac(dhcp_discovery.macaddress))
     }
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.parametrize(
+    ("config_entry_with_options", "target_options"),
+    [
+        ({}, {CONF_ENABLE_ALL_COMMANDS: True}),
+        ({CONF_ENABLE_ALL_COMMANDS: False}, {CONF_ENABLE_ALL_COMMANDS: True}),
+        ({CONF_ENABLE_ALL_COMMANDS: True}, {CONF_ENABLE_ALL_COMMANDS: False}),
+    ],
+    indirect=["config_entry_with_options"],
+)
+async def test_options_flow(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry_with_options: MockConfigEntry,
+    platforms: list[str],
+    target_options: dict[str, bool],
+) -> None:
+    """Test the options flow."""
+    assert config_entry_with_options.state is ConfigEntryState.NOT_LOADED
+    config_entry_with_options.add_to_hass(hass)
+    with (
+        patch("homeassistant.components.home_connect.PLATFORMS", platforms),
+        patch("homeassistant.components.home_connect.HomeConnectClient") as client_mock,
+    ):
+        client_mock.return_value = client
+        assert await hass.config_entries.async_setup(config_entry_with_options.entry_id)
+        await hass.async_block_till_done()
+    assert config_entry_with_options.state is ConfigEntryState.LOADED
+
+    assert config_entry_with_options.options != target_options
+
+    result = await hass.config_entries.options.async_init(
+        config_entry_with_options.entry_id,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "entry_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=target_options
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # Get the updated config entry and compare options
+    entry = hass.config_entries.async_get_entry(config_entry_with_options.entry_id)
+    assert entry is not None
+    assert entry.options == target_options


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some appliances doesn't correctly provide the commands that can be used, and some users wants to use them.
To workaround that, I added an option to enable all the commands for all the appliances, so that for users that have this issue can use the commands independently of what does the API report.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #145898
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
