### PR TITLE
Revert "Deprecate hddtemp"

### DIFF
--- a/homeassistant/components/hddtemp/__init__.py
+++ b/homeassistant/components/hddtemp/__init__.py
@@ -1,3 +1,1 @@
 """The hddtemp component."""
-
-DOMAIN = "hddtemp"

--- a/homeassistant/components/hddtemp/sensor.py
+++ b/homeassistant/components/hddtemp/sensor.py
@@ -22,13 +22,10 @@ from homeassistant.const import (
     CONF_PORT,
     UnitOfTemperature,
 )
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-
-from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,21 +56,6 @@ def setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the HDDTemp sensor."""
-    create_issue(
-        hass,
-        HOMEASSISTANT_DOMAIN,
-        f"deprecated_system_packages_yaml_integration_{DOMAIN}",
-        breaks_in_ha_version="2025.12.0",
-        is_fixable=False,
-        issue_domain=DOMAIN,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_system_packages_yaml_integration",
-        translation_placeholders={
-            "domain": DOMAIN,
-            "integration_title": "hddtemp",
-        },
-    )
-
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)

--- a/tests/components/hddtemp/test_sensor.py
+++ b/tests/components/hddtemp/test_sensor.py
@@ -1,15 +1,12 @@
 """The tests for the hddtemp platform."""
 
 import socket
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.hddtemp import DOMAIN
-from homeassistant.components.sensor import DOMAIN as PLATFORM_DOMAIN
 from homeassistant.const import UnitOfTemperature
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 VALID_CONFIG_MINIMAL = {"sensor": {"platform": "hddtemp"}}
@@ -195,17 +192,3 @@ async def test_hddtemp_host_unreachable(hass: HomeAssistant, telnetmock) -> None
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_HOST_UNREACHABLE)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
-
-
-@patch.dict("sys.modules", gsp=Mock())
-async def test_repair_issue_is_created(
-    hass: HomeAssistant,
-    issue_registry: ir.IssueRegistry,
-) -> None:
-    """Test repair issue is created."""
-    assert await async_setup_component(hass, PLATFORM_DOMAIN, VALID_CONFIG_MINIMAL)
-    await hass.async_block_till_done()
-    assert (
-        HOMEASSISTANT_DOMAIN,
-        f"deprecated_system_packages_yaml_integration_{DOMAIN}",
-    ) in issue_registry.issues


### PR DESCRIPTION
This reverts home-assistant/core#145850, as the HA docs were wrong. The integration connects via telnet to the hddtemp service. Therefore, you can use it in our containers.

Fixes https://github.com/home-assistant/core/issues/146578

Docs PR: https://github.com/home-assistant/home-assistant.io/pull/39941