### PR TITLE
Add fault binary sensors to tuya dehumidifer

### DIFF
--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -422,7 +422,6 @@ async def async_setup_entry(
                                     device,
                                     hass_data.manager,
                                     description,
-                                    bitmap_key,
                                     mask,
                                 )
                             )
@@ -446,7 +445,6 @@ class TuyaBinarySensorEntity(TuyaEntity, BinarySensorEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: TuyaBinarySensorEntityDescription,
-        sub_key: str | None = None,
         bit_mask: int | None = None,
     ) -> None:
         """Init Tuya binary sensor."""
@@ -454,8 +452,6 @@ class TuyaBinarySensorEntity(TuyaEntity, BinarySensorEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
         self._bit_mask = bit_mask
-        if sub_key is not None:
-            self._attr_unique_id += f"_{sub_key}"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -15,9 +15,10 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.json import json_loads
 
 from . import TuyaConfigEntry
-from .const import TUYA_DISCOVERY_NEW, DPCode
+from .const import TUYA_DISCOVERY_NEW, DPCode, DPType
 from .entity import TuyaEntity
 
 
@@ -30,6 +31,9 @@ class TuyaBinarySensorEntityDescription(BinarySensorEntityDescription):
 
     # Value or values to consider binary sensor to be "on"
     on_value: bool | float | int | str | set[bool | float | int | str] = True
+
+    # For DPType.BITMAP, the bitmap_key is used to extract the bit mask
+    bitmap_key: str | None = None
 
 
 # Commonly used sensors
@@ -70,6 +74,34 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
             on_value="alarm",
         ),
         TAMPER_BINARY_SENSOR,
+    ),
+    # Dehumidifier
+    # https://developer.tuya.com/en/docs/iot/categorycs?id=Kaiuz1vcz4dha
+    "cs": (
+        TuyaBinarySensorEntityDescription(
+            key="tankfull",
+            dpcode=DPCode.FAULT,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            bitmap_key="tankfull",
+            translation_key="tankfull",
+        ),
+        TuyaBinarySensorEntityDescription(
+            key="defrost",
+            dpcode=DPCode.FAULT,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            bitmap_key="defrost",
+            translation_key="defrost",
+        ),
+        TuyaBinarySensorEntityDescription(
+            key="wet",
+            dpcode=DPCode.FAULT,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            bitmap_key="wet",
+            translation_key="wet",
+        ),
     ),
     # Smart Pet Feeder
     # https://developer.tuya.com/en/docs/iot/categorycwwsq?id=Kaiuz2b6vydld
@@ -343,6 +375,21 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
 }
 
 
+def _get_bitmap_mask(
+    device: CustomerDevice, dpcode: str, bitmap_key: str
+) -> int | None:
+    """Get the bitmap mask for a given description."""
+    if (
+        (status_range := device.status_range.get(dpcode)) is None
+        or status_range.type != DPType.BITMAP
+        or not isinstance(fault_values := json_loads(status_range.values), dict)
+        or not isinstance(fault_labels := fault_values.get("label"), list)
+        or bitmap_key not in fault_labels
+    ):
+        return None
+    return fault_labels.index(bitmap_key)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: TuyaConfigEntry,
@@ -361,11 +408,24 @@ async def async_setup_entry(
                 for description in descriptions:
                     dpcode = description.dpcode or description.key
                     if dpcode in device.status:
-                        entities.append(
-                            TuyaBinarySensorEntity(
-                                device, hass_data.manager, description
+                        if (bitmap_key := description.bitmap_key) is None:
+                            entities.append(
+                                TuyaBinarySensorEntity(
+                                    device, hass_data.manager, description
+                                )
                             )
-                        )
+                        elif (
+                            mask := _get_bitmap_mask(device, dpcode, bitmap_key)
+                        ) is not None:
+                            entities.append(
+                                TuyaBinarySensorEntity(
+                                    device,
+                                    hass_data.manager,
+                                    description,
+                                    bitmap_key,
+                                    mask,
+                                )
+                            )
 
         async_add_entities(entities)
 
@@ -386,11 +446,16 @@ class TuyaBinarySensorEntity(TuyaEntity, BinarySensorEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: TuyaBinarySensorEntityDescription,
+        sub_key: str | None = None,
+        bit_mask: int | None = None,
     ) -> None:
         """Init Tuya binary sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._bit_mask = bit_mask
+        if sub_key is not None:
+            self._attr_unique_id += f"_{sub_key}"
 
     @property
     def is_on(self) -> bool:
@@ -398,6 +463,10 @@ class TuyaBinarySensorEntity(TuyaEntity, BinarySensorEntity):
         dpcode = self.entity_description.dpcode or self.entity_description.key
         if dpcode not in self.device.status:
             return False
+
+        if self._bit_mask is not None:
+            # For bitmap sensors, check the specific bit mask
+            return (self.device.status[dpcode] & (1 << self._bit_mask)) != 0
 
         if isinstance(self.entity_description.on_value, set):
             return self.device.status[dpcode] in self.entity_description.on_value

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -82,6 +82,7 @@ class WorkMode(StrEnum):
 class DPType(StrEnum):
     """Data point types."""
 
+    BITMAP = "Bitmap"
     BOOLEAN = "Boolean"
     ENUM = "Enum"
     INTEGER = "Integer"

--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -18,8 +18,7 @@ from .const import DOMAIN, LOGGER, TUYA_HA_SIGNAL_UPDATE_ENTITY, DPCode, DPType
 from .util import remap_value
 
 _DPTYPE_MAPPING: dict[str, DPType] = {
-    "Bitmap": DPType.RAW,
-    "bitmap": DPType.RAW,
+    "bitmap": DPType.BITMAP,
     "bool": DPType.BOOLEAN,
     "enum": DPType.ENUM,
     "json": DPType.JSON,

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -56,6 +56,15 @@
       },
       "tilt": {
         "name": "Tilt"
+      },
+      "tankfull": {
+        "name": "Tank full"
+      },
+      "defrost": {
+        "name": "Defrost"
+      },
+      "wet": {
+        "name": "Wet"
       }
     },
     "button": {

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -14,6 +14,7 @@ from tests.common import MockConfigEntry
 
 DEVICE_MOCKS = {
     "cs_arete_two_12l_dehumidifier_air_purifier": [
+        Platform.BINARY_SENSOR,
         Platform.FAN,
         Platform.HUMIDIFIER,
         Platform.SELECT,

--- a/tests/components/tuya/fixtures/cs_arete_two_12l_dehumidifier_air_purifier.json
+++ b/tests/components/tuya/fixtures/cs_arete_two_12l_dehumidifier_air_purifier.json
@@ -50,6 +50,6 @@
     "humidity_indoor": 47,
     "countdown_set": "cancel",
     "countdown_left": 0,
-    "fault": 128
+    "fault": 0
   }
 }

--- a/tests/components/tuya/fixtures/cs_arete_two_12l_dehumidifier_air_purifier.json
+++ b/tests/components/tuya/fixtures/cs_arete_two_12l_dehumidifier_air_purifier.json
@@ -50,6 +50,6 @@
     "humidity_indoor": 47,
     "countdown_set": "cancel",
     "countdown_left": 0,
-    "fault": 0
+    "fault": 128
   }
 }

--- a/tests/components/tuya/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_binary_sensor.ambr
@@ -1,4 +1,151 @@
 # serializer version: 1
+# name: test_platform_setup_and_discovery[cs_arete_two_12l_dehumidifier_air_purifier][binary_sensor.dehumidifier_defrost-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.dehumidifier_defrost',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Defrost',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'defrost',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgqdefrost_defrost',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_arete_two_12l_dehumidifier_air_purifier][binary_sensor.dehumidifier_defrost-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Dehumidifier Defrost',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.dehumidifier_defrost',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_arete_two_12l_dehumidifier_air_purifier][binary_sensor.dehumidifier_tank_full-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.dehumidifier_tank_full',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Tank full',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'tankfull',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgqtankfull_tankfull',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_arete_two_12l_dehumidifier_air_purifier][binary_sensor.dehumidifier_tank_full-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Dehumidifier Tank full',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.dehumidifier_tank_full',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_arete_two_12l_dehumidifier_air_purifier][binary_sensor.dehumidifier_wet-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.dehumidifier_wet',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Wet',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wet',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgqwet_wet',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_arete_two_12l_dehumidifier_air_purifier][binary_sensor.dehumidifier_wet-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Dehumidifier Wet',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.dehumidifier_wet',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_platform_setup_and_discovery[mcs_door_sensor][binary_sensor.door_garage_door-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_binary_sensor.ambr
@@ -30,7 +30,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'defrost',
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqdefrost_defrost',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgqdefrost',
     'unit_of_measurement': None,
   })
 # ---
@@ -79,7 +79,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'tankfull',
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqtankfull_tankfull',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgqtankfull',
     'unit_of_measurement': None,
   })
 # ---
@@ -128,7 +128,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'wet',
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqwet_wet',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgqwet',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_binary_sensor.ambr
@@ -143,7 +143,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
 # name: test_platform_setup_and_discovery[mcs_door_sensor][binary_sensor.door_garage_door-entry]

--- a/tests/components/tuya/test_binary_sensor.py
+++ b/tests/components/tuya/test_binary_sensor.py
@@ -56,3 +56,38 @@ async def test_platform_setup_no_discovery(
     assert not er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
     )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["cs_arete_two_12l_dehumidifier_air_purifier"],
+)
+@pytest.mark.parametrize(
+    ("fault_value", "tankfull", "defrost", "wet"),
+    [
+        (0, "off", "off", "off"),
+        (0x1, "on", "off", "off"),
+        (0x2, "off", "on", "off"),
+        (0x80, "off", "off", "on"),
+        (0x83, "on", "on", "on"),
+    ],
+)
+@patch("homeassistant.components.tuya.PLATFORMS", [Platform.BINARY_SENSOR])
+async def test_bitmap(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+    fault_value: int,
+    tankfull: str,
+    defrost: str,
+    wet: str,
+) -> None:
+    """Test BITMAP fault sensor on cs_arete_two_12l_dehumidifier_air_purifier."""
+    mock_device.status["fault"] = fault_value
+
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    assert hass.states.get("binary_sensor.dehumidifier_tank_full").state == tankfull
+    assert hass.states.get("binary_sensor.dehumidifier_defrost").state == defrost
+    assert hass.states.get("binary_sensor.dehumidifier_wet").state == wet


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There have been multiple attempts to add fault code binary sensors to Tuya:
- #125098 by @MrAdam
- #129437 by @frickua
- #137771 by @kevinbackhouse
- #147373 by @BOBAH1248

Each of them had some good ideas - but each also had their own short-comings.

I have taken some ideas from each of the PRs to make it easier to maintain in the long run.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
