### PR TITLE
Clean up ModuleWrapper from loader

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -10,7 +10,6 @@ import asyncio
 from collections.abc import Callable, Iterable
 from contextlib import suppress
 from dataclasses import dataclass
-import functools as ft
 import importlib
 import logging
 import os
@@ -1650,77 +1649,6 @@ class CircularDependency(LoaderError):
         self.args[1].insert(0, domain)
 
 
-def _load_file(
-    hass: HomeAssistant, comp_or_platform: str, base_paths: list[str]
-) -> ComponentProtocol | None:
-    """Try to load specified file.
-
-    Looks in config dir first, then built-in components.
-    Only returns it if also found to be valid.
-    Async friendly.
-    """
-    cache = hass.data[DATA_COMPONENTS]
-    if module := cache.get(comp_or_platform):
-        return cast(ComponentProtocol, module)
-
-    for path in (f"{base}.{comp_or_platform}" for base in base_paths):
-        try:
-            module = importlib.import_module(path)
-
-            # In Python 3 you can import files from directories that do not
-            # contain the file __init__.py. A directory is a valid module if
-            # it contains a file with the .py extension. In this case Python
-            # will succeed in importing the directory as a module and call it
-            # a namespace. We do not care about namespaces.
-            # This prevents that when only
-            # custom_components/switch/some_platform.py exists,
-            # the import custom_components.switch would succeed.
-            # __file__ was unset for namespaces before Python 3.7
-            if getattr(module, "__file__", None) is None:
-                continue
-
-            cache[comp_or_platform] = module
-
-            return cast(ComponentProtocol, module)
-
-        except ImportError as err:
-            # This error happens if for example custom_components/switch
-            # exists and we try to load switch.demo.
-            # Ignore errors for custom_components, custom_components.switch
-            # and custom_components.switch.demo.
-            white_listed_errors = []
-            parts = []
-            for part in path.split("."):
-                parts.append(part)
-                white_listed_errors.append(f"No module named '{'.'.join(parts)}'")
-
-            if str(err) not in white_listed_errors:
-                _LOGGER.exception(
-                    "Error loading %s. Make sure all dependencies are installed", path
-                )
-
-    return None
-
-
-class ModuleWrapper:
-    """Class to wrap a Python module and auto fill in hass argument."""
-
-    def __init__(self, hass: HomeAssistant, module: ComponentProtocol) -> None:
-        """Initialize the module wrapper."""
-        self._hass = hass
-        self._module = module
-
-    def __getattr__(self, attr: str) -> Any:
-        """Fetch an attribute."""
-        value = getattr(self._module, attr)
-
-        if hasattr(value, "__bind_hass"):
-            value = ft.partial(value, self._hass)
-
-        setattr(self, attr, value)
-        return value
-
-
 def bind_hass[_CallableT: Callable[..., Any]](func: _CallableT) -> _CallableT:
     """Decorate function to indicate that first argument is hass.
 
@@ -1742,13 +1670,6 @@ def _async_mount_config_dir(hass: HomeAssistant) -> None:
         import custom_components  # noqa: F401, PLC0415
     sys.path.remove(hass.config.config_dir)
     sys.path_importer_cache.pop(hass.config.config_dir, None)
-
-
-def _lookup_path(hass: HomeAssistant) -> list[str]:
-    """Return the lookup paths for legacy lookups."""
-    if hass.config.recovery_mode or hass.config.safe_mode:
-        return [PACKAGE_BUILTIN]
-    return [PACKAGE_CUSTOM_COMPONENTS, PACKAGE_BUILTIN]
 
 
 def is_component_module_loaded(hass: HomeAssistant, module: str) -> bool:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean up `ModuleWrapper` (and some other helper functions) from loader.
We no longer need any of this after #141947 and #143514. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
