### PR TITLE
Add repairs from issue registry to integration diagnostics

### DIFF
--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -279,17 +279,18 @@ class DownloadDiagnosticsView(http.HomeAssistantView):
 
         filename = f"{config_entry.domain}-{config_entry.entry_id}"
 
+        issue_registry = ir.async_get(hass)
+        issues = issue_registry.issues
+        data_issues = []
+        for issue_id, issue_reg in issues.items():
+            if issue_id[0] == config_entry.domain:
+                data_issues.append(issue_reg.to_json())
+
         if not device_diagnostics:
             # Config entry diagnostics
             if info.config_entry_diagnostics is None:
                 return web.Response(status=HTTPStatus.NOT_FOUND)
             data = await info.config_entry_diagnostics(hass, config_entry)
-            issue_registry = ir.async_get(hass)
-            issues = issue_registry.issues
-            data_issues = []
-            for issue_id, issue_reg in issues.items():
-                if issue_id[0] == config_entry.domain:
-                    data_issues.append(issue_reg.to_json())
             filename = f"{DiagnosticsType.CONFIG_ENTRY}-{filename}"
             return await _async_get_json_file_response(
                 hass, data, data_issues, filename, config_entry.domain, d_id
@@ -310,5 +311,5 @@ class DownloadDiagnosticsView(http.HomeAssistantView):
 
         data = await info.device_diagnostics(hass, config_entry, device)
         return await _async_get_json_file_response(
-            hass, data, None, filename, config_entry.domain, d_id, sub_id
+            hass, data, data_issues, filename, config_entry.domain, d_id, sub_id
         )

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -281,10 +281,11 @@ class DownloadDiagnosticsView(http.HomeAssistantView):
 
         issue_registry = ir.async_get(hass)
         issues = issue_registry.issues
-        data_issues = []
-        for issue_id, issue_reg in issues.items():
-            if issue_id[0] == config_entry.domain:
-                data_issues.append(issue_reg.to_json())
+        data_issues = [
+            issue_reg.to_json()
+            for issue_id, issue_reg in issues.items()
+            if issue_id[0] == config_entry.domain
+        ]
 
         if not device_diagnostics:
             # Config entry diagnostics

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -1,13 +1,15 @@
 """Test the Diagnostics integration."""
 
+from datetime import datetime
 from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock, patch
 
+from freezegun import freeze_time
 import pytest
 
 from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.system_info import async_get_system_info
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
@@ -81,10 +83,20 @@ async def test_websocket(
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.parametrize(
+    "ignore_missing_translations",
+    [
+        [
+            "component.fake_integration.issues.test_issue.title",
+            "component.fake_integration.issues.test_issue.description",
+        ]
+    ],
+)
 async def test_download_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     device_registry: dr.DeviceRegistry,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test download diagnostics."""
     config_entry = MockConfigEntry(domain="fake_integration")
@@ -95,6 +107,18 @@ async def test_download_diagnostics(
     integration = await async_get_integration(hass, "fake_integration")
     original_manifest = integration.manifest.copy()
     original_manifest["codeowners"] = ["@test"]
+
+    with freeze_time(datetime(2025, 7, 9, 14, 00, 00)):
+        issue_registry.async_get_or_create(
+            domain="fake_integration",
+            issue_id="test_issue",
+            breaks_in_ha_version="2023.10.0",
+            severity=ir.IssueSeverity.WARNING,
+            is_fixable=False,
+            is_persistent=False,
+            translation_key="test_issue",
+        )
+
     with patch.object(integration, "manifest", original_manifest):
         response = await _get_diagnostics_for_config_entry(
             hass, hass_client, config_entry
@@ -179,6 +203,15 @@ async def test_download_diagnostics(
             "requirements": [],
         },
         "data": {"config_entry": "info"},
+        "issues": [
+            {
+                "created": "2025-07-09T14:00:00+00:00",
+                "dismissed_version": None,
+                "domain": "fake_integration",
+                "is_persistent": False,
+                "issue_id": "test_issue",
+            },
+        ],
     }
 
     device = device_registry.async_get_or_create(

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -299,6 +299,15 @@ async def test_download_diagnostics(
             "requirements": [],
         },
         "data": {"device": "info"},
+        "issues": [
+            {
+                "created": "2025-07-09T14:00:00+00:00",
+                "dismissed_version": None,
+                "domain": "fake_integration",
+                "is_persistent": False,
+                "issue_id": "test_issue",
+            },
+        ],
         "setup_times": {},
     }
 

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -115,7 +115,7 @@ async def test_download_diagnostics(
             breaks_in_ha_version="2023.10.0",
             severity=ir.IssueSeverity.WARNING,
             is_fixable=False,
-            is_persistent=False,
+            is_persistent=True,
             translation_key="test_issue",
         )
 
@@ -205,11 +205,19 @@ async def test_download_diagnostics(
         "data": {"config_entry": "info"},
         "issues": [
             {
+                "breaks_in_ha_version": "2023.10.0",
                 "created": "2025-07-09T14:00:00+00:00",
+                "data": None,
                 "dismissed_version": None,
                 "domain": "fake_integration",
-                "is_persistent": False,
+                "is_fixable": False,
+                "is_persistent": True,
+                "issue_domain": None,
                 "issue_id": "test_issue",
+                "learn_more_url": None,
+                "severity": "warning",
+                "translation_key": "test_issue",
+                "translation_placeholders": None,
             },
         ],
     }
@@ -301,11 +309,19 @@ async def test_download_diagnostics(
         "data": {"device": "info"},
         "issues": [
             {
+                "breaks_in_ha_version": "2023.10.0",
                 "created": "2025-07-09T14:00:00+00:00",
+                "data": None,
                 "dismissed_version": None,
                 "domain": "fake_integration",
-                "is_persistent": False,
+                "is_fixable": False,
+                "is_persistent": True,
+                "issue_domain": None,
                 "issue_id": "test_issue",
+                "learn_more_url": None,
+                "severity": "warning",
+                "translation_key": "test_issue",
+                "translation_placeholders": None,
             },
         ],
         "setup_times": {},


### PR DESCRIPTION
## Breaking change


## Proposed change
Adds integration repairs to the diagnostics output for config entry (all issues for domain).
As per decision in https://github.com/home-assistant/architecture/discussions/807

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 