### PR TITLE
Add assumed optimistic to template number entities

### DIFF
--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -134,6 +134,8 @@ def async_create_preview_number(
 class AbstractTemplateNumber(AbstractTemplateEntity, NumberEntity):
     """Representation of a template number features."""
 
+    _entity_id_format = ENTITY_ID_FORMAT
+
     # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
     # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
     def __init__(self, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
@@ -169,7 +171,6 @@ class StateNumberEntity(TemplateEntity, AbstractTemplateNumber):
     """Representation of a template number."""
 
     _attr_should_poll = False
-    _entity_id_format = ENTITY_ID_FORMAT
 
     def __init__(
         self,
@@ -181,10 +182,11 @@ class StateNumberEntity(TemplateEntity, AbstractTemplateNumber):
         TemplateEntity.__init__(self, hass, config, unique_id)
         AbstractTemplateNumber.__init__(self, config)
 
+        name = self._attr_name
         if TYPE_CHECKING:
-            assert self._attr_name is not None
+            assert name is not None
 
-        self.add_script(CONF_SET_VALUE, config[CONF_SET_VALUE], self._attr_name, DOMAIN)
+        self.add_script(CONF_SET_VALUE, config[CONF_SET_VALUE], name, DOMAIN)
 
     @callback
     def _async_setup_templates(self) -> None:
@@ -223,14 +225,7 @@ class StateNumberEntity(TemplateEntity, AbstractTemplateNumber):
 class TriggerNumberEntity(TriggerEntity, AbstractTemplateNumber):
     """Number entity based on trigger data."""
 
-    _entity_id_format = ENTITY_ID_FORMAT
     domain = NUMBER_DOMAIN
-    extra_template_keys = (
-        CONF_STATE,
-        CONF_STEP,
-        CONF_MIN,
-        CONF_MAX,
-    )
 
     def __init__(
         self,
@@ -242,8 +237,22 @@ class TriggerNumberEntity(TriggerEntity, AbstractTemplateNumber):
         TriggerEntity.__init__(self, hass, coordinator, config)
         AbstractTemplateNumber.__init__(self, config)
 
-        self._attr_name = name = self._rendered.get(CONF_NAME, DEFAULT_NAME)
-        self.add_script(CONF_SET_VALUE, config[CONF_SET_VALUE], name, DOMAIN)
+        for key in (
+            CONF_STATE,
+            CONF_STEP,
+            CONF_MIN,
+            CONF_MAX,
+        ):
+            if isinstance(config.get(key), template.Template):
+                self._to_render_simple.append(key)
+                self._parse_result.add(key)
+
+        self.add_script(
+            CONF_SET_VALUE,
+            config[CONF_SET_VALUE],
+            self._rendered.get(CONF_NAME, DEFAULT_NAME),
+            DOMAIN,
+        )
 
         self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
 
@@ -264,6 +273,7 @@ class TriggerNumberEntity(TriggerEntity, AbstractTemplateNumber):
         ):
             if (rendered := self._rendered.get(key)) is not None:
                 setattr(self, attr, vol.Any(vol.Coerce(float), None)(rendered))
+                write_ha_state = True
 
         if len(self._rendered) > 0:
             # In case any non optimistic template

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -254,8 +254,6 @@ class TriggerNumberEntity(TriggerEntity, AbstractTemplateNumber):
             DOMAIN,
         )
 
-        self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
-
     def _handle_coordinator_update(self):
         """Handle updated data from the coordinator."""
         self._process_data()

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
@@ -99,7 +99,7 @@ async def async_setup_platform(
         hass,
         NUMBER_DOMAIN,
         config,
-        TemplateNumber,
+        StateNumberEntity,
         TriggerNumberEntity,
         async_add_entities,
         discovery_info,

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_ICON,
     CONF_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
 from homeassistant.core import Context, HomeAssistant, ServiceCall
@@ -63,11 +64,11 @@ _VALUE_INPUT_NUMBER_CONFIG = {
 }
 
 TEST_STATE_ENTITY_ID = "number.test_state"
-
+TEST_AVAILABILITY_ENTITY_ID = "binary_sensor.test_availability"
 TEST_STATE_TRIGGER = {
     "trigger": {
         "trigger": "state",
-        "entity_id": [TEST_STATE_ENTITY_ID],
+        "entity_id": [TEST_STATE_ENTITY_ID, TEST_AVAILABILITY_ENTITY_ID],
     },
     "variables": {"triggering_entity": "{{ trigger.entity_id }}"},
     "action": [
@@ -191,19 +192,6 @@ async def test_missing_optional_config(hass: HomeAssistant) -> None:
 
 async def test_missing_required_keys(hass: HomeAssistant) -> None:
     """Test: missing required fields will fail."""
-    with assert_setup_component(0, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "number": {
-                        "set_value": {"service": "script.set_value"},
-                    }
-                }
-            },
-        )
-
     with assert_setup_component(0, "template"):
         assert await setup.async_setup_component(
             hass,
@@ -576,6 +564,91 @@ async def test_device_id(
     template_entity = entity_registry.async_get("number.my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
+
+
+@pytest.mark.parametrize(
+    ("count", "number_config"),
+    [
+        (
+            1,
+            {
+                "set_value": [],
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_number")
+async def test_optimistic(hass: HomeAssistant) -> None:
+    """Test configuration with optimistic state."""
+    await hass.services.async_call(
+        number.DOMAIN,
+        number.SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: _TEST_NUMBER, "value": 4},
+        blocking=True,
+    )
+
+    state = hass.states.get(_TEST_NUMBER)
+    assert float(state.state) == 4
+
+    await hass.services.async_call(
+        number.DOMAIN,
+        number.SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: _TEST_NUMBER, "value": 2},
+        blocking=True,
+    )
+
+    state = hass.states.get(_TEST_NUMBER)
+    assert float(state.state) == 2
+
+
+@pytest.mark.parametrize(
+    ("count", "number_config"),
+    [
+        (
+            1,
+            {
+                "set_value": [],
+                "state": "{{ states('number.test_state') }}",
+                "availability": "{{ is_state('binary_sensor.test_availability', 'on') }}",
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.usefixtures("setup_number")
+async def test_availability(hass: HomeAssistant) -> None:
+    """Test configuration with optimistic state."""
+
+    hass.states.async_set(TEST_AVAILABILITY_ENTITY_ID, "on")
+    hass.states.async_set(TEST_STATE_ENTITY_ID, "4.0")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_NUMBER)
+    assert float(state.state) == 4
+
+    hass.states.async_set(TEST_AVAILABILITY_ENTITY_ID, "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_NUMBER)
+    assert state.state == STATE_UNAVAILABLE
+
+    hass.states.async_set(TEST_STATE_ENTITY_ID, "2.0")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_NUMBER)
+    assert state.state == STATE_UNAVAILABLE
+
+    hass.states.async_set(TEST_AVAILABILITY_ENTITY_ID, "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_NUMBER)
+    assert float(state.state) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add assumed optimistic states to the template number platform.

All other template platforms offer optimistic states by omitting the state template.  Number however required users to add `optimistic: True` to their configuration.  Now the number platform supports both and `state` and `step` are no longer required.

This also adds tests for availability due to changes to account for assumed optimistic states.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39944
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
