### PR TITLE
Add assumed optimistic state to template select

### DIFF
--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
@@ -32,6 +32,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
 from .const import DOMAIN
+from .entity import AbstractTemplateEntity
 from .template_entity import TemplateEntity, make_template_entity_common_modern_schema
 from .trigger_entity import TriggerEntity
 
@@ -45,7 +46,7 @@ DEFAULT_OPTIMISTIC = False
 
 SELECT_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_STATE): cv.template,
+        vol.Optional(CONF_STATE): cv.template,
         vol.Required(CONF_SELECT_OPTION): cv.SCRIPT_SCHEMA,
         vol.Required(ATTR_OPTIONS): cv.template,
         vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
@@ -116,49 +117,22 @@ async def async_setup_entry(
     async_add_entities([TemplateSelect(hass, validated_config, config_entry.entry_id)])
 
 
-class TemplateSelect(TemplateEntity, SelectEntity):
-    """Representation of a template select."""
+class AbstractTemplateSelect(AbstractTemplateEntity, SelectEntity):
+    """Representation of a template select features."""
 
-    _attr_should_poll = False
+    # The super init is not called because TemplateEntity and TriggerEntity will call AbstractTemplateEntity.__init__.
+    # This ensures that the __init__ on AbstractTemplateEntity is not called twice.
+    def __init__(self, config: dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
+        """Initialize the features."""
+        self._template = config.get(CONF_STATE)
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        config: dict[str, Any],
-        unique_id: str | None,
-    ) -> None:
-        """Initialize the select."""
-        super().__init__(hass, config=config, unique_id=unique_id)
-        assert self._attr_name is not None
-        self._value_template = config[CONF_STATE]
-        # Scripts can be an empty list, therefore we need to check for None
-        if (select_option := config.get(CONF_SELECT_OPTION)) is not None:
-            self.add_script(CONF_SELECT_OPTION, select_option, self._attr_name, DOMAIN)
         self._options_template = config[ATTR_OPTIONS]
-        self._attr_assumed_state = self._optimistic = config.get(CONF_OPTIMISTIC, False)
+
+        self._attr_assumed_state = self._optimistic = (
+            self._template is None or config.get(CONF_OPTIMISTIC, DEFAULT_OPTIMISTIC)
+        )
         self._attr_options = []
         self._attr_current_option = None
-        self._attr_device_info = async_device_info_to_link_from_device_id(
-            hass,
-            config.get(CONF_DEVICE_ID),
-        )
-
-    @callback
-    def _async_setup_templates(self) -> None:
-        """Set up templates."""
-        self.add_template_attribute(
-            "_attr_current_option",
-            self._value_template,
-            validator=cv.string,
-            none_on_template_error=True,
-        )
-        self.add_template_attribute(
-            "_attr_options",
-            self._options_template,
-            validator=vol.All(cv.ensure_list, [cv.string]),
-            none_on_template_error=True,
-        )
-        super()._async_setup_templates()
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -173,11 +147,56 @@ class TemplateSelect(TemplateEntity, SelectEntity):
             )
 
 
-class TriggerSelectEntity(TriggerEntity, SelectEntity):
+class TemplateSelect(TemplateEntity, AbstractTemplateSelect):
+    """Representation of a template select."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config: dict[str, Any],
+        unique_id: str | None,
+    ) -> None:
+        """Initialize the select."""
+        TemplateEntity.__init__(self, hass, config=config, unique_id=unique_id)
+        AbstractTemplateSelect.__init__(self, config)
+
+        name = self._attr_name
+        if TYPE_CHECKING:
+            assert name is not None
+
+        if (select_option := config.get(CONF_SELECT_OPTION)) is not None:
+            self.add_script(CONF_SELECT_OPTION, select_option, name, DOMAIN)
+
+        self._attr_device_info = async_device_info_to_link_from_device_id(
+            hass,
+            config.get(CONF_DEVICE_ID),
+        )
+
+    @callback
+    def _async_setup_templates(self) -> None:
+        """Set up templates."""
+        if self._template is not None:
+            self.add_template_attribute(
+                "_attr_current_option",
+                self._template,
+                validator=cv.string,
+                none_on_template_error=True,
+            )
+        self.add_template_attribute(
+            "_attr_options",
+            self._options_template,
+            validator=vol.All(cv.ensure_list, [cv.string]),
+            none_on_template_error=True,
+        )
+        super()._async_setup_templates()
+
+
+class TriggerSelectEntity(TriggerEntity, AbstractTemplateSelect):
     """Select entity based on trigger data."""
 
     domain = SELECT_DOMAIN
-    extra_template_keys = (CONF_STATE,)
     extra_template_keys_complex = (ATTR_OPTIONS,)
 
     def __init__(
@@ -187,34 +206,38 @@ class TriggerSelectEntity(TriggerEntity, SelectEntity):
         config: dict,
     ) -> None:
         """Initialize the entity."""
-        super().__init__(hass, coordinator, config)
+        TriggerEntity.__init__(self, hass, coordinator, config)
+        AbstractTemplateSelect.__init__(self, config)
+
+        if CONF_STATE in config:
+            self._to_render_simple.append(CONF_STATE)
+
+        self._attr_name = name = self._rendered.get(CONF_NAME, DEFAULT_NAME)
+
         # Scripts can be an empty list, therefore we need to check for None
         if (select_option := config.get(CONF_SELECT_OPTION)) is not None:
-            self.add_script(
-                CONF_SELECT_OPTION,
-                select_option,
-                self._rendered.get(CONF_NAME, DEFAULT_NAME),
-                DOMAIN,
-            )
+            self.add_script(CONF_SELECT_OPTION, select_option, name, DOMAIN)
 
-    @property
-    def current_option(self) -> str | None:
-        """Return the currently selected option."""
-        return self._rendered.get(CONF_STATE)
+    def _handle_coordinator_update(self):
+        """Handle updated data from the coordinator."""
+        self._process_data()
 
-    @property
-    def options(self) -> list[str]:
-        """Return the list of available options."""
-        return self._rendered.get(ATTR_OPTIONS, [])
-
-    async def async_select_option(self, option: str) -> None:
-        """Change the selected option."""
-        if self._config[CONF_OPTIMISTIC]:
-            self._attr_current_option = option
+        if not self.available:
             self.async_write_ha_state()
-        if select_option := self._action_scripts.get(CONF_SELECT_OPTION):
-            await self.async_run_script(
-                select_option,
-                run_variables={ATTR_OPTION: option},
-                context=self._context,
-            )
+            return
+
+        write_ha_state = False
+        for key, attr, validator in (
+            (ATTR_OPTIONS, "_attr_options", vol.All(cv.ensure_list, [cv.string])),
+            (CONF_STATE, "_attr_current_option", cv.string),
+        ):
+            if (rendered := self._rendered.get(key)) is not None:
+                setattr(self, attr, validator(rendered))
+
+        if len(self._rendered) > 0:
+            # In case any non optimistic template
+            write_ha_state = True
+
+        if write_ha_state:
+            self.async_set_context(self.coordinator.data["context"])
+            self.async_write_ha_state()

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -575,6 +575,7 @@ async def test_optimistic(hass: HomeAssistant) -> None:
     state = hass.states.get(_TEST_SELECT)
     assert state.state == STATE_UNKNOWN
 
+    # Ensure Trigger template entities update.
     hass.states.async_set(TEST_STATE_ENTITY_ID, "anything")
     await hass.async_block_till_done()
 

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     ATTR_ICON,
     CONF_ENTITY_ID,
     CONF_ICON,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
 from homeassistant.core import Context, HomeAssistant, ServiceCall
@@ -43,11 +44,15 @@ _TEST_SELECT = f"select.{_TEST_OBJECT_ID}"
 # Represent for select's current_option
 _OPTION_INPUT_SELECT = "input_select.option"
 TEST_STATE_ENTITY_ID = "select.test_state"
-
+TEST_AVAILABILITY_ENTITY_ID = "binary_sensor.test_availability"
 TEST_STATE_TRIGGER = {
     "trigger": {
         "trigger": "state",
-        "entity_id": [_OPTION_INPUT_SELECT, TEST_STATE_ENTITY_ID],
+        "entity_id": [
+            _OPTION_INPUT_SELECT,
+            TEST_STATE_ENTITY_ID,
+            TEST_AVAILABILITY_ENTITY_ID,
+        ],
     },
     "variables": {"triggering_entity": "{{ trigger.entity_id }}"},
     "action": [
@@ -201,20 +206,6 @@ async def test_multiple_configs(hass: HomeAssistant) -> None:
 
 async def test_missing_required_keys(hass: HomeAssistant) -> None:
     """Test: missing required fields will fail."""
-    with assert_setup_component(0, "template"):
-        assert await setup.async_setup_component(
-            hass,
-            "template",
-            {
-                "template": {
-                    "select": {
-                        "select_option": {"service": "script.select_option"},
-                        "options": "{{ ['a', 'b'] }}",
-                    }
-                }
-            },
-        )
-
     with assert_setup_component(0, "select"):
         assert await setup.async_setup_component(
             hass,
@@ -559,3 +550,97 @@ async def test_empty_action_config(hass: HomeAssistant, setup_select) -> None:
 
     state = hass.states.get(_TEST_SELECT)
     assert state.state == "a"
+
+
+@pytest.mark.parametrize(
+    ("count", "select_config"),
+    [
+        (
+            1,
+            {
+                "options": "{{ ['test', 'yes', 'no'] }}",
+                "select_option": [],
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+@pytest.mark.usefixtures("setup_select")
+async def test_optimistic(hass: HomeAssistant) -> None:
+    """Test configuration with optimistic state."""
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == STATE_UNKNOWN
+
+    hass.states.async_set(TEST_STATE_ENTITY_ID, "anything")
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        select.DOMAIN,
+        select.SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: _TEST_SELECT, "option": "test"},
+        blocking=True,
+    )
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == "test"
+
+    await hass.services.async_call(
+        select.DOMAIN,
+        select.SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: _TEST_SELECT, "option": "yes"},
+        blocking=True,
+    )
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == "yes"
+
+
+@pytest.mark.parametrize(
+    ("count", "select_config"),
+    [
+        (
+            1,
+            {
+                "options": "{{ ['test', 'yes', 'no'] }}",
+                "select_option": [],
+                "state": "{{ states('select.test_state') }}",
+                "availability": "{{ is_state('binary_sensor.test_availability', 'on') }}",
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.usefixtures("setup_select")
+async def test_availability(hass: HomeAssistant) -> None:
+    """Test configuration with optimistic state."""
+
+    hass.states.async_set(TEST_AVAILABILITY_ENTITY_ID, "on")
+    hass.states.async_set(TEST_STATE_ENTITY_ID, "test")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == "test"
+
+    hass.states.async_set(TEST_AVAILABILITY_ENTITY_ID, "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == STATE_UNAVAILABLE
+
+    hass.states.async_set(TEST_STATE_ENTITY_ID, "yes")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == STATE_UNAVAILABLE
+
+    hass.states.async_set(TEST_AVAILABILITY_ENTITY_ID, "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == "yes"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add assumed optimistic states to the template select platform.

All other template platforms offer optimistic states by omitting the state template. Select however required users to add `optimistic: True` to their configuration. Now the select platform supports optionally accepts `state` field.

This also adds tests for availability due to changes to account for assumed optimistic states.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39949
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
