### PR TITLE
Improve names and descriptions of `rainmachine.push_weather_data`

### DIFF
--- a/homeassistant/components/rainmachine/strings.json
+++ b/homeassistant/components/rainmachine/strings.json
@@ -196,12 +196,12 @@
           "description": "UNIX timestamp for the weather data. If omitted, the RainMachine device's local time at the time of the call is used."
         },
         "mintemp": {
-          "name": "Min temp",
-          "description": "Minimum temperature (°C)."
+          "name": "Min temperature",
+          "description": "Minimum temperature in current period (°C)."
         },
         "maxtemp": {
-          "name": "Max temp",
-          "description": "Maximum temperature (°C)."
+          "name": "Max temperature",
+          "description": "Maximum temperature in current period (°C)."
         },
         "temperature": {
           "name": "Temperature",
@@ -209,11 +209,11 @@
         },
         "wind": {
           "name": "Wind speed",
-          "description": "Wind speed (m/s)."
+          "description": "Current wind speed (m/s)."
         },
         "solarrad": {
           "name": "Solar radiation",
-          "description": "Solar radiation (MJ/m²/h)."
+          "description": "Current solar radiation (MJ/m²/h)."
         },
         "et": {
           "name": "Evapotranspiration",
@@ -229,11 +229,11 @@
         },
         "minrh": {
           "name": "Min relative humidity",
-          "description": "Min relative humidity (%RH)."
+          "description": "Minimum relative humidity in current period (%RH)."
         },
         "maxrh": {
           "name": "Max relative humidity",
-          "description": "Max relative humidity (%RH)."
+          "description": "Maximum relative humidity in current period (%RH)."
         },
         "condition": {
           "name": "Weather condition code",
@@ -241,11 +241,11 @@
         },
         "pressure": {
           "name": "Barametric pressure",
-          "description": "Barametric pressure (kPa)."
+          "description": "Current barametric pressure (kPa)."
         },
         "dewpoint": {
           "name": "Dew point",
-          "description": "Dew point (°C)."
+          "description": "Current dew point (°C)."
         }
       }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

To improve translations this commit does
- remove the unnecessary abbreviation of "temp" for "temperature" as there are no space constraints
(translations followed the English original in abbreviating making them hard to read, too)
- add "current …" to wind speed,  solar radiation, barametric pressure, and dew point in their descriptions
(makes use of the additional space available instead of just repeating the name)
- add "… in current period" to maximum and minimum values for temperature and humidity
(underlines the note that these should reflect the measured values up to the timestamp of the action call)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
