### PR TITLE
Support all Energy units in Energy integration

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -41,13 +41,8 @@ SUPPORTED_STATE_CLASSES = {
     SensorStateClass.TOTAL,
     SensorStateClass.TOTAL_INCREASING,
 }
-VALID_ENERGY_UNITS: set[str] = {
-    UnitOfEnergy.GIGA_JOULE,
-    UnitOfEnergy.KILO_WATT_HOUR,
-    UnitOfEnergy.MEGA_JOULE,
-    UnitOfEnergy.MEGA_WATT_HOUR,
-    UnitOfEnergy.WATT_HOUR,
-}
+VALID_ENERGY_UNITS: set[str] = set(UnitOfEnergy)
+
 VALID_ENERGY_UNITS_GAS = {
     UnitOfVolume.CENTUM_CUBIC_FEET,
     UnitOfVolume.CUBIC_FEET,

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -21,14 +21,9 @@ from .const import DOMAIN
 
 ENERGY_USAGE_DEVICE_CLASSES = (sensor.SensorDeviceClass.ENERGY,)
 ENERGY_USAGE_UNITS: dict[str, tuple[UnitOfEnergy, ...]] = {
-    sensor.SensorDeviceClass.ENERGY: (
-        UnitOfEnergy.GIGA_JOULE,
-        UnitOfEnergy.KILO_WATT_HOUR,
-        UnitOfEnergy.MEGA_JOULE,
-        UnitOfEnergy.MEGA_WATT_HOUR,
-        UnitOfEnergy.WATT_HOUR,
-    )
+    sensor.SensorDeviceClass.ENERGY: tuple(UnitOfEnergy)
 }
+
 ENERGY_PRICE_UNITS = tuple(
     f"/{unit}" for units in ENERGY_USAGE_UNITS.values() for unit in units
 )
@@ -39,13 +34,9 @@ GAS_USAGE_DEVICE_CLASSES = (
     sensor.SensorDeviceClass.GAS,
 )
 GAS_USAGE_UNITS: dict[str, tuple[UnitOfEnergy | UnitOfVolume, ...]] = {
-    sensor.SensorDeviceClass.ENERGY: (
-        UnitOfEnergy.GIGA_JOULE,
-        UnitOfEnergy.KILO_WATT_HOUR,
-        UnitOfEnergy.MEGA_JOULE,
-        UnitOfEnergy.MEGA_WATT_HOUR,
-        UnitOfEnergy.WATT_HOUR,
-    ),
+    sensor.SensorDeviceClass.ENERGY: ENERGY_USAGE_UNITS[
+        sensor.SensorDeviceClass.ENERGY
+    ],
     sensor.SensorDeviceClass.GAS: (
         UnitOfVolume.CENTUM_CUBIC_FEET,
         UnitOfVolume.CUBIC_FEET,

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -29,6 +29,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import _WH_TO_CAL, _WH_TO_J
 from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from tests.components.recorder.common import async_wait_recording_done
@@ -748,10 +749,12 @@ async def test_cost_sensor_price_entity_total_no_reset(
 @pytest.mark.parametrize(
     ("energy_unit", "factor"),
     [
+        (UnitOfEnergy.MILLIWATT_HOUR, 1e6),
         (UnitOfEnergy.WATT_HOUR, 1000),
         (UnitOfEnergy.KILO_WATT_HOUR, 1),
         (UnitOfEnergy.MEGA_WATT_HOUR, 0.001),
-        (UnitOfEnergy.GIGA_JOULE, 0.001 * 3.6),
+        (UnitOfEnergy.GIGA_JOULE, _WH_TO_J / 1e6),
+        (UnitOfEnergy.CALORIE, _WH_TO_CAL * 1e3),
     ],
 )
 async def test_cost_sensor_handle_energy_units(
@@ -815,6 +818,7 @@ async def test_cost_sensor_handle_energy_units(
 @pytest.mark.parametrize(
     ("price_unit", "factor"),
     [
+        (f"EUR/{UnitOfEnergy.MILLIWATT_HOUR}", 1e-6),
         (f"EUR/{UnitOfEnergy.WATT_HOUR}", 0.001),
         (f"EUR/{UnitOfEnergy.KILO_WATT_HOUR}", 1),
         (f"EUR/{UnitOfEnergy.MEGA_WATT_HOUR}", 1000),

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -7,16 +7,14 @@ import pytest
 from homeassistant.components.energy import async_get_manager, validate
 from homeassistant.components.energy.data import EnergyManager
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.sensor import DEVICE_CLASS_UNITS, SensorDeviceClass
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import JSON_DUMP
 from homeassistant.setup import async_setup_component
 
-ENERGY_UNITS_STRING = ", ".join(DEVICE_CLASS_UNITS[SensorDeviceClass.ENERGY])
-ENERGY_PRICE_UNITS_STRING = ", ".join(
-    f"EUR/{unit}" for unit in DEVICE_CLASS_UNITS[SensorDeviceClass.ENERGY]
-)
+ENERGY_UNITS_STRING = ", ".join(tuple(UnitOfEnergy))
+
+ENERGY_PRICE_UNITS_STRING = ", ".join(f"EUR/{unit}" for unit in tuple(UnitOfEnergy))
 
 
 @pytest.fixture

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -7,10 +7,16 @@ import pytest
 from homeassistant.components.energy import async_get_manager, validate
 from homeassistant.components.energy.data import EnergyManager
 from homeassistant.components.recorder import Recorder
+from homeassistant.components.sensor import DEVICE_CLASS_UNITS, SensorDeviceClass
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import JSON_DUMP
 from homeassistant.setup import async_setup_component
+
+ENERGY_UNITS_STRING = ", ".join(DEVICE_CLASS_UNITS[SensorDeviceClass.ENERGY])
+ENERGY_PRICE_UNITS_STRING = ", ".join(
+    f"EUR/{unit}" for unit in DEVICE_CLASS_UNITS[SensorDeviceClass.ENERGY]
+)
 
 
 @pytest.fixture
@@ -69,6 +75,7 @@ async def test_validation_empty_config(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("state_class", "energy_unit", "extra"),
     [
+        ("total_increasing", UnitOfEnergy.MILLIWATT_HOUR, {}),
         ("total_increasing", UnitOfEnergy.KILO_WATT_HOUR, {}),
         ("total_increasing", UnitOfEnergy.MEGA_WATT_HOUR, {}),
         ("total_increasing", UnitOfEnergy.WATT_HOUR, {}),
@@ -76,6 +83,7 @@ async def test_validation_empty_config(hass: HomeAssistant) -> None:
         ("total", UnitOfEnergy.KILO_WATT_HOUR, {"last_reset": "abc"}),
         ("measurement", UnitOfEnergy.KILO_WATT_HOUR, {"last_reset": "abc"}),
         ("total_increasing", UnitOfEnergy.GIGA_JOULE, {}),
+        ("total_increasing", UnitOfEnergy.CALORIE, {}),
     ],
 )
 async def test_validation(
@@ -235,9 +243,7 @@ async def test_validation_device_consumption_entity_unexpected_unit(
                 {
                     "type": "entity_unexpected_unit_energy",
                     "affected_entities": {("sensor.unexpected_unit", "beers")},
-                    "translation_placeholders": {
-                        "energy_units": "GJ, kWh, MJ, MWh, Wh"
-                    },
+                    "translation_placeholders": {"energy_units": ENERGY_UNITS_STRING},
                 }
             ]
         ],
@@ -325,9 +331,7 @@ async def test_validation_solar(
                 {
                     "type": "entity_unexpected_unit_energy",
                     "affected_entities": {("sensor.solar_production", "beers")},
-                    "translation_placeholders": {
-                        "energy_units": "GJ, kWh, MJ, MWh, Wh"
-                    },
+                    "translation_placeholders": {"energy_units": ENERGY_UNITS_STRING},
                 }
             ]
         ],
@@ -378,9 +382,7 @@ async def test_validation_battery(
                         ("sensor.battery_import", "beers"),
                         ("sensor.battery_export", "beers"),
                     },
-                    "translation_placeholders": {
-                        "energy_units": "GJ, kWh, MJ, MWh, Wh"
-                    },
+                    "translation_placeholders": {"energy_units": ENERGY_UNITS_STRING},
                 },
             ]
         ],
@@ -449,9 +451,7 @@ async def test_validation_grid(
                         ("sensor.grid_consumption_1", "beers"),
                         ("sensor.grid_production_1", "beers"),
                     },
-                    "translation_placeholders": {
-                        "energy_units": "GJ, kWh, MJ, MWh, Wh"
-                    },
+                    "translation_placeholders": {"energy_units": ENERGY_UNITS_STRING},
                 },
                 {
                     "type": "statistics_not_defined",
@@ -538,9 +538,7 @@ async def test_validation_grid_external_cost_compensation(
                         ("sensor.grid_consumption_1", "beers"),
                         ("sensor.grid_production_1", "beers"),
                     },
-                    "translation_placeholders": {
-                        "energy_units": "GJ, kWh, MJ, MWh, Wh"
-                    },
+                    "translation_placeholders": {"energy_units": ENERGY_UNITS_STRING},
                 },
                 {
                     "type": "statistics_not_defined",
@@ -710,9 +708,7 @@ async def test_validation_grid_auto_cost_entity_errors(
             {
                 "type": "entity_unexpected_unit_energy_price",
                 "affected_entities": {("sensor.grid_price_1", "$/Ws")},
-                "translation_placeholders": {
-                    "price_units": "EUR/GJ, EUR/kWh, EUR/MJ, EUR/MWh, EUR/Wh"
-                },
+                "translation_placeholders": {"price_units": ENERGY_PRICE_UNITS_STRING},
             },
         ),
     ],
@@ -855,7 +851,7 @@ async def test_validation_gas(
                     "type": "entity_unexpected_unit_gas",
                     "affected_entities": {("sensor.gas_consumption_1", "beers")},
                     "translation_placeholders": {
-                        "energy_units": "GJ, kWh, MJ, MWh, Wh",
+                        "energy_units": ENERGY_UNITS_STRING,
                         "gas_units": "CCF, ft³, m³, L",
                     },
                 },
@@ -885,7 +881,7 @@ async def test_validation_gas(
                     "affected_entities": {("sensor.gas_price_2", "EUR/invalid")},
                     "translation_placeholders": {
                         "price_units": (
-                            "EUR/GJ, EUR/kWh, EUR/MJ, EUR/MWh, EUR/Wh, EUR/CCF, EUR/ft³, EUR/m³, EUR/L"
+                            f"{ENERGY_PRICE_UNITS_STRING}, EUR/CCF, EUR/ft³, EUR/m³, EUR/L"
                         )
                     },
                 },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
The frontend and backend are not in sync in describing what units are supported for energy dashboard energy sensors.

Frontend uses the sensor websocket api `device_class_convertible_units` to populate it's list of valid units for energy, and the list of what entities it allows to pick from the statistics selector, which is a set of 13 various SI units of type joules, watthours, and calories.

Backend currently has a hardcoded list of only 5 units that it will accept for validation. 

So this leads to the UI telling users they can pick one unit, and then as soon as it is picked, the validation immediately telling users that unit they just picked is invalid. 

I believe that even though backend throws a validation error if one of its 5 types is not picked, energy integration seems to still work correctly, so it might just be a spurious warning. 

To harmonize the UI with the implementation, this PR makes any of the converible energy units valid for energy validation. 

I think that is preferrable to making the change the other way, and hardcode the same list of 5 units in the frontend. 

Haven't checked yet if gas/water could use a similar change, but lets just try this first. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/25629
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
