### PR TITLE
Use non-autospec mock for Reolink's util and view tests

### DIFF
--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -84,6 +84,8 @@ def _init_host_mock(host_mock: MagicMock) -> None:
     host_mock.set_whiteled = AsyncMock()
     host_mock.set_state_light = AsyncMock()
     host_mock.renew = AsyncMock()
+    host_mock.get_vod_source = AsyncMock()
+    host_mock.expire_session = AsyncMock()
     host_mock.is_nvr = True
     host_mock.is_hub = False
     host_mock.mac_address = TEST_MAC

--- a/tests/components/reolink/test_util.py
+++ b/tests/components/reolink/test_util.py
@@ -103,12 +103,12 @@ DEV_ID_STANDALONE_CAM = f"{TEST_UID_CAM}"
 async def test_try_function(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     side_effect: ReolinkError,
     expected: HomeAssistantError,
 ) -> None:
     """Test try_function error translations using number entity."""
-    reolink_connect.volume.return_value = 80
+    reolink_host.volume.return_value = 80
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.NUMBER]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -117,7 +117,7 @@ async def test_try_function(
 
     entity_id = f"{Platform.NUMBER}.{TEST_NVR_NAME}_volume"
 
-    reolink_connect.set_volume.side_effect = side_effect
+    reolink_host.set_volume.side_effect = side_effect
     with pytest.raises(expected.__class__) as err:
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -127,8 +127,6 @@ async def test_try_function(
         )
 
     assert err.value.translation_key == expected.translation_key
-
-    reolink_connect.set_volume.reset_mock(side_effect=True)
 
 
 @pytest.mark.parametrize(
@@ -141,12 +139,12 @@ async def test_try_function(
 async def test_get_device_uid_and_ch(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     device_registry: dr.DeviceRegistry,
     identifiers: set[tuple[str, str]],
 ) -> None:
     """Test get_device_uid_and_ch with multiple identifiers."""
-    reolink_connect.channels = [0]
+    reolink_host.channels = [0]
 
     dev_entry = device_registry.async_get_or_create(
         identifiers=identifiers,

--- a/tests/components/reolink/test_views.py
+++ b/tests/components/reolink/test_views.py
@@ -64,14 +64,14 @@ def get_mock_session(
 )
 async def test_playback_proxy(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
     caplog: pytest.LogCaptureFixture,
     content_type: str,
 ) -> None:
     """Test successful playback proxy URL."""
-    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
 
     mock_session = get_mock_session(content_type=content_type)
 
@@ -100,12 +100,12 @@ async def test_playback_proxy(
 
 async def test_proxy_get_source_error(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test error while getting source for playback proxy URL."""
-    reolink_connect.get_vod_source.side_effect = ReolinkError(TEST_ERROR)
+    reolink_host.get_vod_source.side_effect = ReolinkError(TEST_ERROR)
 
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -123,12 +123,11 @@ async def test_proxy_get_source_error(
 
     assert await response.content.read() == bytes(TEST_ERROR, "utf-8")
     assert response.status == HTTPStatus.BAD_REQUEST
-    reolink_connect.get_vod_source.side_effect = None
 
 
 async def test_proxy_invalid_config_entry_id(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
 ) -> None:
@@ -156,12 +155,12 @@ async def test_proxy_invalid_config_entry_id(
 
 async def test_playback_proxy_timeout(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test playback proxy URL with a timeout in the second chunk."""
-    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
 
     mock_session = get_mock_session([b"test", TimeoutError()], 4)
 
@@ -190,13 +189,13 @@ async def test_playback_proxy_timeout(
 @pytest.mark.parametrize(("content_type"), [("video/x-flv"), ("text/html")])
 async def test_playback_wrong_content(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
     content_type: str,
 ) -> None:
     """Test playback proxy URL with a wrong content type in the response."""
-    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
 
     mock_session = get_mock_session(content_type=content_type)
 
@@ -223,12 +222,12 @@ async def test_playback_wrong_content(
 
 async def test_playback_connect_error(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Test playback proxy URL with a connection error."""
-    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
 
     mock_session = Mock()
     mock_session.get = AsyncMock(side_effect=ClientConnectionError(TEST_ERROR))


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to #146969

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
