### PR TITLE
Add HTML5 notification service translations

### DIFF
--- a/homeassistant/components/html5/strings.json
+++ b/homeassistant/components/html5/strings.json
@@ -27,6 +27,28 @@
     }
   },
   "services": {
+    "notify": {
+      "name": "Send a notification with html5",
+      "description": "Sends a notification message using the html5 service.",
+      "fields": {
+        "message": {
+          "name": "Message",
+          "description": "The message to be sent."
+        },
+        "title": {
+          "name": "Title",
+          "description": "The title of the message (optional)."
+        },
+        "target": {
+          "name": "Target",
+          "description": "An array of targets to send the notification to."
+        },
+        "data": {
+          "name": "Data",
+          "description": "Extended information for the notification. Supports various HTML5 notification parameters."
+        }
+      }
+    },
     "dismiss": {
       "name": "Dismiss",
       "description": "Dismisses a html5 notification.",


### PR DESCRIPTION
## Summary

This PR adds the missing translation strings for the HTML5 notification service in the Home Assistant UI.

## Changes Made

- Added translation strings for the HTML5 notification service in `homeassistant/components/html5/strings.json`
- Includes service name, description, and field translations for `message`, `title`, `target`, and `data` fields
- All strings follow Home Assistant's translation conventions and style guidelines

## Problem Solved

Previously, when users tried to use the "Send a notification with html5" action in the Home Assistant UI, the service would appear without proper translations, showing raw technical strings instead of user-friendly localized text.

## Testing

- Verified that `strings.json` is valid JSON
- Ran translation generation script to ensure proper processing
- Follows existing patterns used by other Home Assistant integrations

## Screenshots

Before this fix, the HTML5 notification service displayed untranslated strings in the UI automation editor. After this fix, users will see properly localized strings for the service name, description, and all field names.

Fixes #129359