### PR TITLE
Improve Steam Online config flow description text

### DIFF
--- a/homeassistant/components/steam_online/strings.json
+++ b/homeassistant/components/steam_online/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Use {account_id_url} to find your Steam account ID",
+        "description": "You can find your Steam account ID in your Steam account details, profile URL, or use {account_id_url}. See the documentation for more details.",
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "account": "Steam account ID"


### PR DESCRIPTION
## Summary

This PR improves the description text in the Steam Online integration config flow to be more informative and less misleading.

## Changes Made

- Updated the config flow description in `homeassistant/components/steam_online/strings.json`
- Changed from suggesting users must use steamid.io to providing multiple options for finding Steam account IDs
- Added reference to documentation for more details

## Problem Solved

The previous description "Use {account_id_url} to find your Steam account ID" was misleading as it suggested users must use steamid.io to find their account ID. However, there are multiple ways to find Steam account IDs:

1. Through Steam client account details
2. Through Steam profile URLs (for accounts without custom URLs)  
3. Using steamid.io (just one option)

The new description mentions these alternatives and refers users to the documentation for complete details.

## Before/After

**Before:**
```
Use https://steamid.io to find your Steam account ID
```

**After:**
```
You can find your Steam account ID in your Steam account details, profile URL, or use https://steamid.io. See the documentation for more details.
```

## Testing

- Verified that `strings.json` is valid JSON
- Ran translation generation script to ensure proper processing
- Existing tests continue to pass as functionality remains unchanged

Fixes #135876