### PR TITLE
Wallbox Integration - Add repair action for insufficient rights

### DIFF
--- a/homeassistant/components/wallbox/const.py
+++ b/homeassistant/components/wallbox/const.py
@@ -79,8 +79,3 @@ class EcoSmartMode(StrEnum):
     ECO_MODE = "eco_mode"
     FULL_SOLAR = "full_solar"
     DISABLED = "disabled"
-
-
-INSUFFICIENT_RIGHTS_URL = (
-    "https://www.home-assistant.io/integrations/wallbox/#troubleshooting"
-)

--- a/homeassistant/components/wallbox/const.py
+++ b/homeassistant/components/wallbox/const.py
@@ -79,3 +79,8 @@ class EcoSmartMode(StrEnum):
     ECO_MODE = "eco_mode"
     FULL_SOLAR = "full_solar"
     DISABLED = "disabled"
+
+
+INSUFFICIENT_RIGHTS_URL = (
+    "https://www.home-assistant.io/integrations/wallbox/#troubleshooting"
+)

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -233,7 +233,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     learn_more_url="https://www.home-assistant.io/integrations/wallbox/#troubleshooting",
                     translation_key="insufficient_rights",
                 )
-                raise InvalidAuth(
+                raise InsufficientRights(
                     translation_domain=DOMAIN, translation_key="invalid_auth"
                 ) from wallbox_connection_error
             if wallbox_connection_error.response.status_code == 429:
@@ -270,7 +270,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     learn_more_url="https://www.home-assistant.io/integrations/wallbox/#troubleshooting",
                     translation_key="insufficient_rights",
                 )
-                raise InvalidAuth(
+                raise InsufficientRights(
                     translation_domain=DOMAIN, translation_key="invalid_auth"
                 ) from wallbox_connection_error
             if wallbox_connection_error.response.status_code == 429:
@@ -336,7 +336,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     learn_more_url="https://www.home-assistant.io/integrations/wallbox/#troubleshooting",
                     translation_key="insufficient_rights",
                 )
-                raise InvalidAuth(
+                raise InsufficientRights(
                     translation_domain=DOMAIN, translation_key="invalid_auth"
                 ) from wallbox_connection_error
             if wallbox_connection_error.response.status_code == 429:
@@ -402,3 +402,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
 class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+class InsufficientRights(HomeAssistantError):
+    """Error to indicate there are insufficient right for the user."""

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -119,6 +119,19 @@ async def async_validate_input(hass: HomeAssistant, wallbox: Wallbox) -> None:
     await hass.async_add_executor_job(_validate, wallbox)
 
 
+def _create_insufficient_rights_issue(hass: HomeAssistant) -> None:
+    """Creates an issue for insufficient rights."""
+    ir.create_issue(
+        hass,
+        DOMAIN,
+        "insufficient_rights",
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        learn_more_url=INSUFFICIENT_RIGHTS_URL,
+        translation_key="insufficient_rights",
+    )
+
+
 class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Wallbox Coordinator class."""
 
@@ -225,15 +238,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return data  # noqa: TRY300
         except requests.exceptions.HTTPError as wallbox_connection_error:
             if wallbox_connection_error.response.status_code == 403:
-                ir.create_issue(
-                    self.hass,
-                    DOMAIN,
-                    "insufficient_rights",
-                    is_fixable=False,
-                    severity=ir.IssueSeverity.ERROR,
-                    learn_more_url=INSUFFICIENT_RIGHTS_URL,
-                    translation_key="insufficient_rights",
-                )
+                _create_insufficient_rights_issue(self.hass)
                 raise InsufficientRights(
                     translation_domain=DOMAIN, translation_key="insufficient_rights"
                 ) from wallbox_connection_error
@@ -262,15 +267,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return data  # noqa: TRY300
         except requests.exceptions.HTTPError as wallbox_connection_error:
             if wallbox_connection_error.response.status_code == 403:
-                ir.create_issue(
-                    self.hass,
-                    DOMAIN,
-                    "insufficient_rights",
-                    is_fixable=False,
-                    severity=ir.IssueSeverity.ERROR,
-                    learn_more_url=INSUFFICIENT_RIGHTS_URL,
-                    translation_key="insufficient_rights",
-                )
+                _create_insufficient_rights_issue(self.hass)
                 raise InsufficientRights(
                     translation_domain=DOMAIN, translation_key="insufficient_rights"
                 ) from wallbox_connection_error
@@ -328,15 +325,7 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return data  # noqa: TRY300
         except requests.exceptions.HTTPError as wallbox_connection_error:
             if wallbox_connection_error.response.status_code == 403:
-                ir.create_issue(
-                    self.hass,
-                    DOMAIN,
-                    "insufficient_rights",
-                    is_fixable=False,
-                    severity=ir.IssueSeverity.ERROR,
-                    learn_more_url=INSUFFICIENT_RIGHTS_URL,
-                    translation_key="insufficient_rights",
-                )
+                _create_insufficient_rights_issue(self.hass)
                 raise InsufficientRights(
                     translation_domain=DOMAIN, translation_key="insufficient_rights"
                 ) from wallbox_connection_error

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -38,6 +38,7 @@ from .const import (
     CODE_KEY,
     CONF_STATION,
     DOMAIN,
+    INSUFFICIENT_RIGHTS_URL,
     UPDATE_INTERVAL,
     ChargerStatus,
     EcoSmartMode,
@@ -230,11 +231,11 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "insufficient_rights",
                     is_fixable=False,
                     severity=ir.IssueSeverity.ERROR,
-                    learn_more_url="https://www.home-assistant.io/integrations/wallbox/#troubleshooting",
+                    learn_more_url=INSUFFICIENT_RIGHTS_URL,
                     translation_key="insufficient_rights",
                 )
                 raise InsufficientRights(
-                    translation_domain=DOMAIN, translation_key="invalid_auth"
+                    translation_domain=DOMAIN, translation_key="insufficient_rights"
                 ) from wallbox_connection_error
             if wallbox_connection_error.response.status_code == 429:
                 raise HomeAssistantError(
@@ -267,11 +268,11 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "insufficient_rights",
                     is_fixable=False,
                     severity=ir.IssueSeverity.ERROR,
-                    learn_more_url="https://www.home-assistant.io/integrations/wallbox/#troubleshooting",
+                    learn_more_url=INSUFFICIENT_RIGHTS_URL,
                     translation_key="insufficient_rights",
                 )
                 raise InsufficientRights(
-                    translation_domain=DOMAIN, translation_key="invalid_auth"
+                    translation_domain=DOMAIN, translation_key="insufficient_rights"
                 ) from wallbox_connection_error
             if wallbox_connection_error.response.status_code == 429:
                 raise HomeAssistantError(
@@ -333,11 +334,11 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "insufficient_rights",
                     is_fixable=False,
                     severity=ir.IssueSeverity.ERROR,
-                    learn_more_url="https://www.home-assistant.io/integrations/wallbox/#troubleshooting",
+                    learn_more_url=INSUFFICIENT_RIGHTS_URL,
                     translation_key="insufficient_rights",
                 )
                 raise InsufficientRights(
-                    translation_domain=DOMAIN, translation_key="invalid_auth"
+                    translation_domain=DOMAIN, translation_key="insufficient_rights"
                 ) from wallbox_connection_error
             if wallbox_connection_error.response.status_code == 429:
                 raise HomeAssistantError(

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -14,6 +14,7 @@ from wallbox import Wallbox
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -193,7 +194,6 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 data[CHARGER_ECO_SMART_KEY] = EcoSmartMode.ECO_MODE
             elif eco_smart_mode == 1:
                 data[CHARGER_ECO_SMART_KEY] = EcoSmartMode.FULL_SOLAR
-
             return data  # noqa: TRY300
         except requests.exceptions.HTTPError as wallbox_connection_error:
             if wallbox_connection_error.response.status_code == 429:
@@ -224,6 +224,15 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return data  # noqa: TRY300
         except requests.exceptions.HTTPError as wallbox_connection_error:
             if wallbox_connection_error.response.status_code == 403:
+                ir.create_issue(
+                    self.hass,
+                    DOMAIN,
+                    "insufficient_rights",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.ERROR,
+                    learn_more_url="https://www.home-assistant.io/integrations/wallbox/#troubleshooting",
+                    translation_key="insufficient_rights",
+                )
                 raise InvalidAuth(
                     translation_domain=DOMAIN, translation_key="invalid_auth"
                 ) from wallbox_connection_error
@@ -252,6 +261,15 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return data  # noqa: TRY300
         except requests.exceptions.HTTPError as wallbox_connection_error:
             if wallbox_connection_error.response.status_code == 403:
+                ir.create_issue(
+                    self.hass,
+                    DOMAIN,
+                    "insufficient_rights",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.ERROR,
+                    learn_more_url="https://www.home-assistant.io/integrations/wallbox/#troubleshooting",
+                    translation_key="insufficient_rights",
+                )
                 raise InvalidAuth(
                     translation_domain=DOMAIN, translation_key="invalid_auth"
                 ) from wallbox_connection_error
@@ -309,6 +327,15 @@ class WallboxCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return data  # noqa: TRY300
         except requests.exceptions.HTTPError as wallbox_connection_error:
             if wallbox_connection_error.response.status_code == 403:
+                ir.create_issue(
+                    self.hass,
+                    DOMAIN,
+                    "insufficient_rights",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.ERROR,
+                    learn_more_url="https://www.home-assistant.io/integrations/wallbox/#troubleshooting",
+                    translation_key="insufficient_rights",
+                )
                 raise InvalidAuth(
                     translation_domain=DOMAIN, translation_key="invalid_auth"
                 ) from wallbox_connection_error

--- a/homeassistant/components/wallbox/strings.json
+++ b/homeassistant/components/wallbox/strings.json
@@ -117,7 +117,7 @@
   "issues": {
     "insufficient_rights": {
       "title": "The Wallbox account has insufficient rights.",
-      "description": "The Wallbox account has insufficient right to lock/unlock and change the charging power. Please assign the user admin rights in the Wallbox portal."
+      "description": "The Wallbox account has insufficient rights to lock/unlock and change the charging power. Please assign the user admin rights in the Wallbox portal."
     }
   },
   "exceptions": {

--- a/homeassistant/components/wallbox/strings.json
+++ b/homeassistant/components/wallbox/strings.json
@@ -114,6 +114,12 @@
       }
     }
   },
+  "issues": {
+    "insufficient_rights": {
+      "title": "The Wallbox account has insufficient rights.",
+      "description": "The Wallbox account has insufficient right to lock/unlock and change the charging power. Please assign the user admin rights in the Wallbox portal."
+    }
+  },
   "exceptions": {
     "api_failed": {
       "message": "Error communicating with Wallbox API"

--- a/homeassistant/components/wallbox/strings.json
+++ b/homeassistant/components/wallbox/strings.json
@@ -129,6 +129,9 @@
     },
     "invalid_auth": {
       "message": "Invalid authentication"
+    },
+    "insufficient_rights": {
+      "message": "Insufficient rights for Wallbox user"
     }
   }
 }

--- a/tests/components/wallbox/test_lock.py
+++ b/tests/components/wallbox/test_lock.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.lock import SERVICE_LOCK, SERVICE_UNLOCK
-from homeassistant.components.wallbox.coordinator import InvalidAuth
+from homeassistant.components.wallbox.coordinator import InsufficientRights
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -96,7 +96,7 @@ async def test_wallbox_lock_class_error_handling(
     with (
         patch.object(mock_wallbox, "lockCharger", side_effect=http_403_error),
         patch.object(mock_wallbox, "unlockCharger", side_effect=http_403_error),
-        pytest.raises(InvalidAuth),
+        pytest.raises(InsufficientRights),
     ):
         await hass.services.async_call(
             "lock",

--- a/tests/components/wallbox/test_number.py
+++ b/tests/components/wallbox/test_number.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components.input_number import ATTR_VALUE, SERVICE_SET_VALUE
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
-from homeassistant.components.wallbox.coordinator import InvalidAuth
+from homeassistant.components.wallbox.coordinator import InsufficientRights
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -130,7 +130,7 @@ async def test_wallbox_number_power_class_error_handling(
 
     with (
         patch.object(mock_wallbox, "setMaxChargingCurrent", side_effect=http_403_error),
-        pytest.raises(InvalidAuth),
+        pytest.raises(InsufficientRights),
     ):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -202,7 +202,7 @@ async def test_wallbox_number_icp_power_class_error_handling(
 
     with (
         patch.object(mock_wallbox, "setIcpMaxCurrent", side_effect=http_403_error),
-        pytest.raises(InvalidAuth),
+        pytest.raises(InsufficientRights),
     ):
         await hass.services.async_call(
             NUMBER_DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We are adding a repair action for the insufficient rights issue, this occurs when the user used by the integration is not an Admin user and results in the integration not fully working (number and lock component issues).
The user will have to manually change the account permissions, but we have linked to a URL on the Home Assistant documentations which has details about the issue. (this section will be added in a sep PR, see below)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39969
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ X I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
