### PR TITLE
Keep entities of dead Z-Wave devices available

### DIFF
--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from zwave_js_server.const import NodeStatus
 from zwave_js_server.exceptions import BaseZwaveJSServerError
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.value import (
@@ -27,8 +26,6 @@ from .discovery import ZwaveDiscoveryInfo
 from .helpers import get_device_id, get_unique_id, get_valueless_base_unique_id
 
 EVENT_VALUE_REMOVED = "value removed"
-EVENT_DEAD = "dead"
-EVENT_ALIVE = "alive"
 
 
 class ZWaveBaseEntity(Entity):
@@ -141,11 +138,6 @@ class ZWaveBaseEntity(Entity):
             )
         )
 
-        for status_event in (EVENT_ALIVE, EVENT_DEAD):
-            self.async_on_remove(
-                self.info.node.on(status_event, self._node_status_alive_or_dead)
-            )
-
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
@@ -211,19 +203,7 @@ class ZWaveBaseEntity(Entity):
     @property
     def available(self) -> bool:
         """Return entity availability."""
-        return (
-            self.driver.client.connected
-            and bool(self.info.node.ready)
-            and self.info.node.status != NodeStatus.DEAD
-        )
-
-    @callback
-    def _node_status_alive_or_dead(self, event_data: dict) -> None:
-        """Call when node status changes to alive or dead.
-
-        Should not be overridden by subclasses.
-        """
-        self.async_write_ha_state()
+        return self.driver.client.connected and bool(self.info.node.ready)
 
     @callback
     def _value_changed(self, event_data: dict) -> None:

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -199,18 +199,13 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             )
             return
 
-        # If device is asleep/dead, wait for it to wake up/become alive before
-        # attempting an update
-        for status, event_name in (
-            (NodeStatus.ASLEEP, "wake up"),
-            (NodeStatus.DEAD, "alive"),
-        ):
-            if self.node.status == status:
-                if not self._status_unsub:
-                    self._status_unsub = self.node.once(
-                        event_name, self._update_on_status_change
-                    )
-                return
+        # If device is asleep, wait for it to wake up before attempting an update
+        if self.node.status == NodeStatus.ASLEEP:
+            if not self._status_unsub:
+                self._status_unsub = self.node.once(
+                    "wake up", self._update_on_status_change
+                )
+            return
 
         try:
             # Retrieve all firmware updates including non-stable ones but filter

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -20,13 +20,10 @@ from homeassistant.components.zwave_js.helpers import (
     get_device_id,
     get_zwave_value_from_config,
 )
-from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
-
-from .common import BULB_6_MULTI_COLOR_LIGHT_ENTITY
 
 from tests.common import async_get_device_automations
 
@@ -697,39 +694,3 @@ async def test_get_value_from_config_failure(
                 "endpoint": 10,
             },
         )
-
-
-async def test_entity_available_when_node_dead(
-    hass: HomeAssistant, client, bulb_6_multi_color, integration
-) -> None:
-    """Test that entities remain available even when the node is dead."""
-
-    node = bulb_6_multi_color
-    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
-
-    assert state
-    assert state.state != STATE_UNAVAILABLE
-
-    # Send dead event to the node
-    event = Event(
-        "dead", data={"source": "node", "event": "dead", "nodeId": node.node_id}
-    )
-    node.receive_event(event)
-    await hass.async_block_till_done()
-
-    # Entity should remain available even though the node is dead
-    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
-    assert state
-    assert state.state != STATE_UNAVAILABLE
-
-    # Send alive event to bring the node back
-    event = Event(
-        "alive", data={"source": "node", "event": "alive", "nodeId": node.node_id}
-    )
-    node.receive_event(event)
-    await hass.async_block_till_done()
-
-    # Entity should still be available
-    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
-    assert state
-    assert state.state != STATE_UNAVAILABLE

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -20,10 +20,13 @@ from homeassistant.components.zwave_js.helpers import (
     get_device_id,
     get_zwave_value_from_config,
 )
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
+
+from .common import BULB_6_MULTI_COLOR_LIGHT_ENTITY
 
 from tests.common import async_get_device_automations
 
@@ -694,3 +697,39 @@ async def test_get_value_from_config_failure(
                 "endpoint": 10,
             },
         )
+
+
+async def test_entity_available_when_node_dead(
+    hass: HomeAssistant, client, bulb_6_multi_color, integration
+) -> None:
+    """Test that entities remain available even when the node is dead."""
+
+    node = bulb_6_multi_color
+    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
+
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    # Send dead event to the node
+    event = Event(
+        "dead", data={"source": "node", "event": "dead", "nodeId": node.node_id}
+    )
+    node.receive_event(event)
+    await hass.async_block_till_done()
+
+    # Entity should remain available even though the node is dead
+    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    # Send alive event to bring the node back
+    event = Event(
+        "alive", data={"source": "node", "event": "alive", "nodeId": node.node_id}
+    )
+    node.receive_event(event)
+    await hass.async_block_till_done()
+
+    # Entity should still be available
+    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
+    assert state
+    assert state.state != STATE_UNAVAILABLE

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -28,7 +28,7 @@ from homeassistant.components.zwave_js.lock import (
     SERVICE_SET_LOCK_CONFIGURATION,
     SERVICE_SET_LOCK_USERCODE,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -295,7 +295,8 @@ async def test_door_lock(
     assert node.status == NodeStatus.DEAD
     state = hass.states.get(SCHLAGE_BE469_LOCK_ENTITY)
     assert state
-    assert state.state == STATE_UNAVAILABLE
+    # The state should still be locked, even if the node is dead
+    assert state.state == LockState.LOCKED
 
 
 async def test_only_one_lock(

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -277,7 +277,7 @@ async def test_update_entity_dead(
     zen_31,
     integration,
 ) -> None:
-    """Test update occurs when device is dead after it becomes alive."""
+    """Test update occurs even when device is dead."""
     event = Event(
         "dead",
         data={"source": "node", "event": "dead", "nodeId": zen_31.node_id},
@@ -290,17 +290,7 @@ async def test_update_entity_dead(
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
-    # Because node is asleep we shouldn't attempt to check for firmware updates
-    assert len(client.async_send_command.call_args_list) == 0
-
-    event = Event(
-        "alive",
-        data={"source": "node", "event": "alive", "nodeId": zen_31.node_id},
-    )
-    zen_31.receive_event(event)
-    await hass.async_block_till_done()
-
-    # Now that the node is up we can check for updates
+    # Checking for firmware updates should proceed even for dead nodes
     assert len(client.async_send_command.call_args_list) > 0
 
     args = client.async_send_command.call_args_list[0][0][0]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

For a long time, entities for devices that the Z-Wave JS driver considers "dead" have been marked unavailable by the Z-Wave integration. As a result, users are no longer able to control their Z-Wave devices, or read the sensor status, until those devices become "alive" again. The cause for the "dead" status may simply have been a short hiccup in communication several hours ago.

The problem with this behavior is that Z-Wave does not have persistent connections. The device status is simply the last known status, and is only updated when communication happens, which may be very infrequently. But because all entities are unavailable, users cannot even perform communication attempts, aside from pinging. Which is why these (in my opinion totally unnecessary workarounds fill entire forum threads):
- https://community.home-assistant.io/t/automate-zwavejs-ping-dead-nodes/374307
- https://community.home-assistant.io/t/wth-automate-zwavejs-ping-dead-nodes/470031
- https://community.home-assistant.io/t/help-writing-script-to-ping-z-wave-nodes-every-night/698362
- https://community.smarthome-for-dummies.de/viewtopic.php?t=1169
- https://community.home-assistant.io/t/is-it-possible-to-automate-detecting-z-wave-devices-dropping-off-the-network-and-healing-them/476630
- ... and many more

Simply put, for each communication attempt with a device, we hope that it is responsive. The current behavior only adds an additional command to this: Users ping, hope that that works, and then when they want to communicate with a device, hope that that works too.
In retrospect, I should have called the status something other than "dead", for example "maybe dead", but it's about 7 years too later for that.

The underlying problem in all those cases can be diverse: bad antennas in the Z-Wave adapter or end device, too much background noise, bad locations of the devices, too much traffic in the network, bugs in the firmware of a device, someone turned on the microwave, .... These issues should be fixed, but we cannot do it for the user, and especially not with the existing behavior of blocking interaction.

This PR removes the functionality that marks devices and entities unavailable when a device is considered "dead" by Z-Wave JS.

In addition it removes the requirement for a device to be alive before checking for firmware updates, which itself is completely independent of the current device status.

In the long term we should consider adding heuristics to determine whether a device is actually dead (also for battery powered devices), and mark a device as unavailable only when that is the case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/55
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
