### PR TITLE
Fix - only enable AlexaModeController if at least one mode is offered

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -505,8 +505,13 @@ class ClimateCapabilities(AlexaEntity):
         ):
             yield AlexaThermostatController(self.hass, self.entity)
             yield AlexaTemperatureSensor(self.hass, self.entity)
-        if self.entity.domain == water_heater.DOMAIN and (
-            supported_features & water_heater.WaterHeaterEntityFeature.OPERATION_MODE
+        if (
+            self.entity.domain == water_heater.DOMAIN
+            and (
+                supported_features
+                & water_heater.WaterHeaterEntityFeature.OPERATION_MODE
+            )
+            and self.entity.attributes.get(water_heater.ATTR_OPERATION_LIST)
         ):
             yield AlexaModeController(
                 self.entity,
@@ -634,7 +639,9 @@ class FanCapabilities(AlexaEntity):
                 self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_OSCILLATING}"
             )
             force_range_controller = False
-        if supported & fan.FanEntityFeature.PRESET_MODE:
+        if supported & fan.FanEntityFeature.PRESET_MODE and self.entity.attributes.get(
+            fan.ATTR_PRESET_MODES
+        ):
             yield AlexaModeController(
                 self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}"
             )
@@ -672,7 +679,11 @@ class RemoteCapabilities(AlexaEntity):
         yield AlexaPowerController(self.entity)
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         activities = self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST) or []
-        if activities and supported & remote.RemoteEntityFeature.ACTIVITY:
+        if (
+            activities
+            and (supported & remote.RemoteEntityFeature.ACTIVITY)
+            and self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST)
+        ):
             yield AlexaModeController(
                 self.entity, instance=f"{remote.DOMAIN}.{remote.ATTR_ACTIVITY}"
             )
@@ -692,7 +703,9 @@ class HumidifierCapabilities(AlexaEntity):
         """Yield the supported interfaces."""
         yield AlexaPowerController(self.entity)
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-        if supported & humidifier.HumidifierEntityFeature.MODES:
+        if (
+            supported & humidifier.HumidifierEntityFeature.MODES
+        ) and self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES):
             yield AlexaModeController(
                 self.entity, instance=f"{humidifier.DOMAIN}.{humidifier.ATTR_MODE}"
             )

--- a/tests/components/alexa/test_entities.py
+++ b/tests/components/alexa/test_entities.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components import fan, humidifier, remote, water_heater
 from homeassistant.components.alexa import smart_home
 from homeassistant.const import EntityCategory, UnitOfTemperature, __version__
 from homeassistant.core import HomeAssistant
@@ -200,3 +201,167 @@ async def test_serialize_discovery_recovers(
         "Error serializing Alexa.PowerController discovery"
         f" for {hass.states.get('switch.bla')}"
     ) in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("domain", "state", "state_attributes", "mode_controller_exists"),
+    [
+        ("switch", "on", {}, False),
+        (
+            "fan",
+            "on",
+            {
+                "preset_modes": ["eco", "auto"],
+                "preset_mode": "eco",
+                "supported_features": fan.FanEntityFeature.PRESET_MODE.value,
+            },
+            True,
+        ),
+        (
+            "fan",
+            "on",
+            {
+                "preset_modes": ["eco", "auto"],
+                "preset_mode": None,
+                "supported_features": fan.FanEntityFeature.PRESET_MODE.value,
+            },
+            True,
+        ),
+        (
+            "fan",
+            "on",
+            {
+                "preset_modes": ["eco"],
+                "preset_mode": None,
+                "supported_features": fan.FanEntityFeature.PRESET_MODE.value,
+            },
+            True,
+        ),
+        (
+            "fan",
+            "on",
+            {
+                "preset_modes": [],
+                "preset_mode": None,
+                "supported_features": fan.FanEntityFeature.PRESET_MODE.value,
+            },
+            False,
+        ),
+        (
+            "humidifier",
+            "on",
+            {
+                "available_modes": ["auto", "manual"],
+                "mode": "auto",
+                "supported_features": humidifier.HumidifierEntityFeature.MODES.value,
+            },
+            True,
+        ),
+        (
+            "humidifier",
+            "on",
+            {
+                "available_modes": ["auto"],
+                "mode": None,
+                "supported_features": humidifier.HumidifierEntityFeature.MODES.value,
+            },
+            True,
+        ),
+        (
+            "humidifier",
+            "on",
+            {
+                "available_modes": [],
+                "mode": None,
+                "supported_features": humidifier.HumidifierEntityFeature.MODES.value,
+            },
+            False,
+        ),
+        (
+            "remote",
+            "on",
+            {
+                "activity_list": ["tv", "dvd"],
+                "current_activity": "tv",
+                "supported_features": remote.RemoteEntityFeature.ACTIVITY.value,
+            },
+            True,
+        ),
+        (
+            "remote",
+            "on",
+            {
+                "activity_list": ["tv"],
+                "current_activity": None,
+                "supported_features": remote.RemoteEntityFeature.ACTIVITY.value,
+            },
+            True,
+        ),
+        (
+            "remote",
+            "on",
+            {
+                "activity_list": [],
+                "current_activity": None,
+                "supported_features": remote.RemoteEntityFeature.ACTIVITY.value,
+            },
+            False,
+        ),
+        (
+            "water_heater",
+            "on",
+            {
+                "operation_list": ["on", "auto"],
+                "operation_mode": "auto",
+                "supported_features": water_heater.WaterHeaterEntityFeature.OPERATION_MODE.value,
+            },
+            True,
+        ),
+        (
+            "water_heater",
+            "on",
+            {
+                "operation_list": ["on"],
+                "operation_mode": None,
+                "supported_features": water_heater.WaterHeaterEntityFeature.OPERATION_MODE.value,
+            },
+            True,
+        ),
+        (
+            "water_heater",
+            "on",
+            {
+                "operation_list": [],
+                "operation_mode": None,
+                "supported_features": water_heater.WaterHeaterEntityFeature.OPERATION_MODE.value,
+            },
+            False,
+        ),
+    ],
+)
+async def test_mode_controller_is_omitted_if_no_modes_are_set(
+    hass: HomeAssistant,
+    domain: str,
+    state: str,
+    state_attributes: dict[str, Any],
+    mode_controller_exists: bool,
+) -> None:
+    """Test we do not generate an invalid discovery with AlexaModeController during serialize discovery.
+
+    AlexModeControllers need at least 2 modes. If one mode is set, an extra mode will be added for compatibility.
+    If no modes are offered, the mode controller should be omitted to prevent schema validations.
+    """
+    request = get_new_request("Alexa.Discovery", "Discover")
+
+    hass.states.async_set(
+        f"{domain}.bla", state, {"friendly_name": "Boop Woz"} | state_attributes
+    )
+
+    msg = await smart_home.async_handle_message(hass, get_default_config(hass), request)
+    msg = msg["event"]
+
+    interfaces = {
+        ifc["interface"] for ifc in msg["payload"]["endpoints"][0]["capabilities"]
+    }
+
+    assert ("Alexa.ModeController" in interfaces) is mode_controller_exists


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
AlexaModeControllers [must have at least 2 mode objects](https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-modecontroller.html#mode-object). In case no modes are added, this will break Alexa dicovery. In case 1 mode is added, a phantom mode was already supplied.

This PR will disable the mode controller if no modes are available, even if the feature is set. This effects:
- fans with preset mode capability, but no preset mode set
- remotes with no activity
- humidifiers with no modes
- water heaters with no operation modes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #144894
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
