### PR TITLE
Fix Tuya support for climate fan modes which use "windspeed" function

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -287,9 +287,9 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
 
         # Determine which DPCode to use for fan mode
         self._fan_dp_code = None
-        if DPCode.WINDSPEED in device.function:
+        if DPCode.WINDSPEED in self.device.function:
             self._fan_dp_code = DPCode.WINDSPEED
-        elif DPCode.FAN_SPEED_ENUM in device.function:
+        elif DPCode.FAN_SPEED_ENUM in self.device.function:
             self._fan_dp_code = DPCode.FAN_SPEED_ENUM
 
         LOGGER.debug(

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -289,10 +289,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         self._fan_dp_code = None
         if DPCode.WINDSPEED in device.function:
             self._fan_dp_code = DPCode.WINDSPEED
-        elif (
-            hasattr(DPCode, "FAN_SPEED_ENUM")
-            and DPCode.FAN_SPEED_ENUM in device.function
-        ):
+        elif DPCode.FAN_SPEED_ENUM in device.function:
             self._fan_dp_code = DPCode.FAN_SPEED_ENUM
 
         LOGGER.debug(

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -250,7 +250,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         )
 
         # Determine fan modes
-        self._fan_dp_code: str | None = None
+        self._fan_mode_dp_code: str | None = None
         if enum_type := self.find_dpcode(
             (DPCode.FAN_SPEED_ENUM, DPCode.WINDSPEED),
             dptype=DPType.ENUM,
@@ -258,7 +258,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         ):
             self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
             self._attr_fan_modes = enum_type.range
-            self._fan_dp_code = enum_type.dpcode
+            self._fan_mode_dp_code = enum_type.dpcode
 
         # Determine swing modes
         if self.find_dpcode(
@@ -306,10 +306,10 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
 
     def set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        if not self._fan_dp_code:
+        if not self._fan_mode_dp_code:
             raise RuntimeError("No valid fan DPCode set for this device.")
 
-        self._send_command([{"code": self._fan_dp_code, "value": fan_mode}])
+        self._send_command([{"code": self._fan_mode_dp_code, "value": fan_mode}])
 
     def set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
@@ -465,7 +465,11 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     @property
     def fan_mode(self) -> str | None:
         """Return fan mode."""
-        return self.device.status.get(self._fan_dp_code) if self._fan_dp_code else None
+        return (
+            self.device.status.get(self._fan_mode_dp_code)
+            if self._fan_mode_dp_code
+            else None
+        )
 
     @property
     def swing_mode(self) -> str:

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -321,7 +321,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
 
     def set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        if not hasattr(self, "_fan_dp_code") or not self._fan_dp_code:
+        if not self._fan_dp_code:
             raise HomeAssistantError("No valid fan DPCode set for this device.")
 
         self._send_command([{"code": self._fan_dp_code, "value": fan_mode}])
@@ -480,7 +480,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     @property
     def fan_mode(self) -> str | None:
         """Return fan mode."""
-        if not hasattr(self, "_fan_dp_code") or not self._fan_dp_code:
+        if not self._fan_dp_code:
             return None
 
         return self.device.status.get(self._fan_dp_code)

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from tuya_sharing import CustomerDevice, Manager
 
@@ -306,8 +306,8 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
 
     def set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        if not self._fan_mode_dp_code:
-            raise RuntimeError("No valid fan DPCode set for this device.")
+        if TYPE_CHECKING:
+            assert self._fan_mode_dp_code is not None
 
         self._send_command([{"code": self._fan_mode_dp_code, "value": fan_mode}])
 

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -250,7 +250,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         )
 
         # Determine fan modes
-        self._fan_dp_code = None
+        self._fan_dp_code: str | None = None
         if enum_type := self.find_dpcode(
             (DPCode.FAN_SPEED_ENUM, DPCode.WINDSPEED),
             dptype=DPType.ENUM,
@@ -465,10 +465,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     @property
     def fan_mode(self) -> str | None:
         """Return fan mode."""
-        if not self._fan_dp_code:
-            return None
-
-        return self.device.status.get(self._fan_dp_code)
+        return self.device.status.get(self._fan_dp_code) if self._fan_dp_code else None
 
     @property
     def swing_mode(self) -> str:

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -287,8 +287,8 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
 
         # Determine which DPCode to use for fan mode
         self._fan_dp_code = None
-        if "windspeed" in device.function:
-            self._fan_dp_code = "windspeed"
+        if DPCode.WINDSPEED in device.function:
+            self._fan_dp_code = DPCode.WINDSPEED
         elif (
             hasattr(DPCode, "FAN_SPEED_ENUM")
             and DPCode.FAN_SPEED_ENUM in device.function

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -20,7 +20,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -308,7 +307,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     def set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         if not self._fan_dp_code:
-            raise HomeAssistantError("No valid fan DPCode set for this device.")
+            raise RuntimeError("No valid fan DPCode set for this device.")
 
         self._send_command([{"code": self._fan_dp_code, "value": fan_mode}])
 

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -307,6 +307,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     def set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         if TYPE_CHECKING:
+            # We can rely on supported_features from __init__
             assert self._fan_mode_dp_code is not None
 
         self._send_command([{"code": self._fan_mode_dp_code, "value": fan_mode}])

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -97,6 +97,10 @@ DEVICE_MOCKS = {
         Platform.SELECT,
         Platform.SWITCH,
     ],
+    "kt_serenelife_slpac905wuk_air_conditioner": [
+        # https://github.com/home-assistant/core/pull/148646
+        Platform.CLIMATE,
+    ],
     "ks_tower_fan": [
         # https://github.com/orgs/home-assistant/discussions/329
         Platform.FAN,

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -97,15 +97,15 @@ DEVICE_MOCKS = {
         Platform.SELECT,
         Platform.SWITCH,
     ],
-    "kt_serenelife_slpac905wuk_air_conditioner": [
-        # https://github.com/home-assistant/core/pull/148646
-        Platform.CLIMATE,
-    ],
     "ks_tower_fan": [
         # https://github.com/orgs/home-assistant/discussions/329
         Platform.FAN,
         Platform.LIGHT,
         Platform.SWITCH,
+    ],
+    "kt_serenelife_slpac905wuk_air_conditioner": [
+        # https://github.com/home-assistant/core/pull/148646
+        Platform.CLIMATE,
     ],
     "mal_alarm_host": [
         # Alarm Host support

--- a/tests/components/tuya/fixtures/kt_serenelife_slpac905wuk_air_conditioner.json
+++ b/tests/components/tuya/fixtures/kt_serenelife_slpac905wuk_air_conditioner.json
@@ -1,0 +1,80 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "terminal_id": "mock_terminal_id",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "id": "mock_device_id",
+  "name": "Air Conditioner",
+  "category": "kt",
+  "product_id": "5wnlzekkstwcdsvm",
+  "product_name": "\u79fb\u52a8\u7a7a\u8c03 YPK--\uff08\u53cc\u6a21+\u84dd\u7259\uff09\u4f4e\u529f\u8017",
+  "online": true,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2025-07-06T10:10:44+00:00",
+  "create_time": "2025-07-06T10:10:44+00:00",
+  "update_time": "2025-07-06T10:10:44+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "\u2103 \u2109",
+        "min": 16,
+        "max": 86,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "windspeed": {
+      "type": "Enum",
+      "value": {
+        "range": ["1", "2"]
+      }
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "temp_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "\u2103 \u2109",
+        "min": 16,
+        "max": 86,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": {
+        "unit": "\u2103 \u2109",
+        "min": -7,
+        "max": 98,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "windspeed": {
+      "type": "Enum",
+      "value": {
+        "range": ["1", "2"]
+      }
+    }
+  },
+  "status": {
+    "switch": false,
+    "temp_set": 23,
+    "temp_current": 22,
+    "windspeed": 1
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_climate.ambr
+++ b/tests/components/tuya/snapshots/test_climate.ambr
@@ -1,4 +1,79 @@
 # serializer version: 1
+# name: test_platform_setup_and_discovery[kt_serenelife_slpac905wuk_air_conditioner][climate.air_conditioner-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'fan_modes': list([
+        '1',
+        '2',
+      ]),
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 86.0,
+      'min_temp': 16.0,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.air_conditioner',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 393>,
+    'translation_key': None,
+    'unique_id': 'tuya.mock_device_id',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[kt_serenelife_slpac905wuk_air_conditioner][climate.air_conditioner-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 22.0,
+      'fan_mode': 1,
+      'fan_modes': list([
+        '1',
+        '2',
+      ]),
+      'friendly_name': 'Air Conditioner',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 86.0,
+      'min_temp': 16.0,
+      'supported_features': <ClimateEntityFeature: 393>,
+      'target_temp_step': 1.0,
+      'temperature': 23.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.air_conditioner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[wk_wifi_smart_gas_boiler_thermostat][climate.wifi_smart_gas_boiler_thermostat-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -86,6 +86,9 @@ async def test_fan_mode_windspeed(
         },
     )
     await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id, [{"code": "windspeed", "value": "2"}]
+    )
 
     # Simulate the device reporting the new windspeed
     mock_device.status["windspeed"] = WINDSPEED_HIGH

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -73,7 +73,7 @@ async def test_fan_mode_windspeed(
 
     state = hass.states.get("climate.air_conditioner")
     assert state is not None, "climate.air_conditioner does not exist"
-    assert state.attributes["fan_mode"] == DEFAULT_FAN_MODE
+    assert state.attributes["fan_mode"] == 1
     await hass.services.async_call(
         Platform.CLIMATE,
         "set_fan_mode",

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -18,6 +18,9 @@ from . import DEVICE_MOCKS, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
+WINDSPEED_LOW = 1
+WINDSPEED_HIGH = 2
+
 
 @pytest.mark.parametrize(
     "mock_device_code",
@@ -73,19 +76,19 @@ async def test_fan_mode_windspeed(
 
     state = hass.states.get("climate.air_conditioner")
     assert state is not None, "climate.air_conditioner does not exist"
-    assert state.attributes["fan_mode"] == DEFAULT_FAN_MODE
+    assert state.attributes["fan_mode"] == WINDSPEED_LOW
     await hass.services.async_call(
         Platform.CLIMATE,
         "set_fan_mode",
         {
             "entity_id": "climate.air_conditioner",
-            "fan_mode": 2,
+            "fan_mode": WINDSPEED_HIGH,
         },
     )
     await hass.async_block_till_done()
 
     # Simulate the device reporting the new windspeed
-    mock_device.status["windspeed"] = 2
+    mock_device.status["windspeed"] = WINDSPEED_HIGH
     await hass.services.async_call(
         "homeassistant",
         "update_entity",
@@ -97,7 +100,7 @@ async def test_fan_mode_windspeed(
     assert state is not None, (
         "climate.air_conditioner does not exist after service call"
     )
-    assert state.attributes["fan_mode"] == 2
+    assert state.attributes["fan_mode"] == WINDSPEED_HIGH
 
 
 @pytest.mark.parametrize(
@@ -127,7 +130,7 @@ async def test_fan_mode_no_valid_code(
             "set_fan_mode",
             {
                 "entity_id": "climate.air_conditioner",
-                "fan_mode": 2,
+                "fan_mode": WINDSPEED_HIGH,
             },
             blocking=True,
         )

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -18,9 +18,6 @@ from . import DEVICE_MOCKS, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
 
-WINDSPEED_LOW = 1
-WINDSPEED_HIGH = 2
-
 
 @pytest.mark.parametrize(
     "mock_device_code",
@@ -76,13 +73,13 @@ async def test_fan_mode_windspeed(
 
     state = hass.states.get("climate.air_conditioner")
     assert state is not None, "climate.air_conditioner does not exist"
-    assert state.attributes["fan_mode"] == WINDSPEED_LOW
+    assert state.attributes["fan_mode"] == DEFAULT_FAN_MODE
     await hass.services.async_call(
         Platform.CLIMATE,
         "set_fan_mode",
         {
             "entity_id": "climate.air_conditioner",
-            "fan_mode": WINDSPEED_HIGH,
+            "fan_mode": 2,
         },
     )
     await hass.async_block_till_done()
@@ -91,7 +88,7 @@ async def test_fan_mode_windspeed(
     )
 
     # Simulate the device reporting the new windspeed
-    mock_device.status["windspeed"] = WINDSPEED_HIGH
+    mock_device.status["windspeed"] = 2
     await hass.services.async_call(
         "homeassistant",
         "update_entity",
@@ -103,7 +100,7 @@ async def test_fan_mode_windspeed(
     assert state is not None, (
         "climate.air_conditioner does not exist after service call"
     )
-    assert state.attributes["fan_mode"] == WINDSPEED_HIGH
+    assert state.attributes["fan_mode"] == 2
 
 
 @pytest.mark.parametrize(
@@ -133,7 +130,7 @@ async def test_fan_mode_no_valid_code(
             "set_fan_mode",
             {
                 "entity_id": "climate.air_conditioner",
-                "fan_mode": WINDSPEED_HIGH,
+                "fan_mode": 2,
             },
             blocking=True,
         )

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -67,34 +67,6 @@ def make_climate_entity(function, status):
     )
 
 
-def test_fan_mode_windspeed() -> None:
-    """Test fan mode with windspeed."""
-    entity = make_climate_entity(
-        {"windspeed": DummyFunction("Enum", '{"range": ["1", "2"]}')},
-        {"windspeed": "2"},
-    )
-    assert entity.fan_mode == "2"
-    entity.set_fan_mode("1")
-
-
-def test_fan_mode_fan_speed_enum() -> None:
-    """Test fan mode with fan speed enum."""
-    entity = make_climate_entity(
-        {DPCode.FAN_SPEED_ENUM: DummyFunction("Enum", '{"range": ["1", "2"]}')},
-        {DPCode.FAN_SPEED_ENUM: "1"},
-    )
-    assert entity.fan_mode == "1"
-    entity.set_fan_mode("2")
-
-
-def test_fan_mode_no_valid_code() -> None:
-    """Test fan mode with no valid code."""
-    entity = make_climate_entity({}, {})
-    assert entity.fan_mode is None
-    with pytest.raises(HomeAssistantError):
-        entity.set_fan_mode("1")
-
-
 @pytest.mark.parametrize(
     "mock_device_code",
     [k for k, v in DEVICE_MOCKS.items() if Platform.CLIMATE in v],
@@ -132,3 +104,31 @@ async def test_platform_setup_no_discovery(
     assert not er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
     )
+
+
+def test_fan_mode_windspeed() -> None:
+    """Test fan mode with windspeed."""
+    entity = make_climate_entity(
+        {"windspeed": DummyFunction("Enum", '{"range": ["1", "2"]}')},
+        {"windspeed": "2"},
+    )
+    assert entity.fan_mode == "2"
+    entity.set_fan_mode("1")
+
+
+def test_fan_mode_fan_speed_enum() -> None:
+    """Test fan mode with fan speed enum."""
+    entity = make_climate_entity(
+        {DPCode.FAN_SPEED_ENUM: DummyFunction("Enum", '{"range": ["1", "2"]}')},
+        {DPCode.FAN_SPEED_ENUM: "1"},
+    )
+    assert entity.fan_mode == "1"
+    entity.set_fan_mode("2")
+
+
+def test_fan_mode_no_valid_code() -> None:
+    """Test fan mode with no valid code."""
+    entity = make_climate_entity({}, {})
+    assert entity.fan_mode is None
+    with pytest.raises(HomeAssistantError):
+        entity.set_fan_mode("1")

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -2,20 +2,97 @@
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
+from homeassistant.components.climate import HVACMode
 from homeassistant.components.tuya import ManagerCompat
-from homeassistant.const import Platform
+from homeassistant.components.tuya.climate import (
+    TuyaClimateEntity,
+    TuyaClimateEntityDescription,
+)
+from homeassistant.components.tuya.const import DPCode
+from homeassistant.const import Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import DEVICE_MOCKS, initialize_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+
+class DummyDevice:
+    """Dummy device for testing."""
+
+    def __init__(self, function, status) -> None:
+        """Initialize the dummy device."""
+        self.function = function
+        self.status = status
+        self.id = "dummy"
+        self.name = "Dummy"
+        self.product_name = "Dummy"
+        self.product_id = "dummy"
+        self.status_range = {}
+        self.online = True
+
+
+class DummyManager:
+    """Dummy manager for testing."""
+
+    def send_commands(self, device_id: str, commands: list) -> None:
+        """Send commands to the device."""
+
+
+class DummyFunction:
+    """Dummy function for testing."""
+
+    def __init__(self, type_: str, values: str) -> None:
+        """Initialize the dummy function."""
+        self.type = type_
+        self.values = values
+
+
+def make_climate_entity(function, status):
+    """Make a dummy climate entity for testing."""
+    return TuyaClimateEntity(
+        cast("CustomerDevice", DummyDevice(function, status)),
+        cast("Manager", DummyManager()),
+        TuyaClimateEntityDescription(key="kt", switch_only_hvac_mode=HVACMode.COOL),
+        UnitOfTemperature.CELSIUS,
+    )
+
+
+def test_fan_mode_windspeed() -> None:
+    """Test fan mode with windspeed."""
+    entity = make_climate_entity(
+        {"windspeed": DummyFunction("Enum", '{"range": ["1", "2"]}')},
+        {"windspeed": "2"},
+    )
+    assert entity.fan_mode == "2"
+    entity.set_fan_mode("1")
+
+
+def test_fan_mode_fan_speed_enum() -> None:
+    """Test fan mode with fan speed enum."""
+    entity = make_climate_entity(
+        {DPCode.FAN_SPEED_ENUM: DummyFunction("Enum", '{"range": ["1", "2"]}')},
+        {DPCode.FAN_SPEED_ENUM: "1"},
+    )
+    assert entity.fan_mode == "1"
+    entity.set_fan_mode("2")
+
+
+def test_fan_mode_no_valid_code() -> None:
+    """Test fan mode with no valid code."""
+    entity = make_climate_entity({}, {})
+    assert entity.fan_mode is None
+    with pytest.raises(HomeAssistantError):
+        entity.set_fan_mode("1")
 
 
 @pytest.mark.parametrize(

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -73,7 +73,7 @@ async def test_fan_mode_windspeed(
 
     state = hass.states.get("climate.air_conditioner")
     assert state is not None, "climate.air_conditioner does not exist"
-    assert state.attributes["fan_mode"] == 1
+    assert state.attributes["fan_mode"] == DEFAULT_FAN_MODE
     await hass.services.async_call(
         Platform.CLIMATE,
         "set_fan_mode",

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -87,21 +87,6 @@ async def test_fan_mode_windspeed(
         mock_device.id, [{"code": "windspeed", "value": "2"}]
     )
 
-    # Simulate the device reporting the new windspeed
-    mock_device.status["windspeed"] = 2
-    await hass.services.async_call(
-        "homeassistant",
-        "update_entity",
-        {"entity_id": "climate.air_conditioner"},
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("climate.air_conditioner")
-    assert state is not None, (
-        "climate.air_conditioner does not exist after service call"
-    )
-    assert state.attributes["fan_mode"] == 2
-
 
 @pytest.mark.parametrize(
     "mock_device_code",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allows devices which use the "windspeed" function to see and control the fan speed (in my case a SereneLife SLPAC905WUK Air Conditioner).

Tested on my device. The labels still show as "1" or "2" for "LOW" and "High", but these labels should probably be from the provider.

Also added fixture and snapshot for my device as requested.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
