### PR TITLE
Bump nyt_games to 0.5.0

### DIFF
--- a/homeassistant/components/nyt_games/manifest.json
+++ b/homeassistant/components/nyt_games/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/nyt_games",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["nyt_games==0.4.4"]
+  "requirements": ["nyt_games==0.5.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1555,7 +1555,7 @@ numato-gpio==0.13.0
 numpy==2.3.0
 
 # homeassistant.components.nyt_games
-nyt_games==0.4.4
+nyt_games==0.5.0
 
 # homeassistant.components.oasa_telematics
 oasatelematics==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1329,7 +1329,7 @@ numato-gpio==0.13.0
 numpy==2.3.0
 
 # homeassistant.components.nyt_games
-nyt_games==0.4.4
+nyt_games==0.5.0
 
 # homeassistant.components.google
 oauth2client==4.1.3

--- a/tests/components/nyt_games/fixtures/latest.json
+++ b/tests/components/nyt_games/fixtures/latest.json
@@ -46,7 +46,7 @@
         },
         "calculatedStats": {
           "currentStreak": 237,
-          "maxStreak": 237,
+          "maxStreak": 241,
           "lastWonPrintDate": "2025-07-08",
           "lastCompletedPrintDate": "2025-07-08",
           "hasPlayed": true

--- a/tests/components/nyt_games/fixtures/latest.json
+++ b/tests/components/nyt_games/fixtures/latest.json
@@ -25,43 +25,46 @@
       },
       "wordle": {
         "legacyStats": {
-          "gamesPlayed": 70,
-          "gamesWon": 51,
+          "gamesPlayed": 1111,
+          "gamesWon": 1069,
           "guesses": {
             "1": 0,
-            "2": 1,
-            "3": 7,
-            "4": 11,
-            "5": 20,
-            "6": 12,
-            "fail": 19
+            "2": 8,
+            "3": 83,
+            "4": 440,
+            "5": 372,
+            "6": 166,
+            "fail": 42
           },
-          "currentStreak": 1,
-          "maxStreak": 5,
-          "lastWonDayOffset": 1189,
+          "currentStreak": 229,
+          "maxStreak": 229,
+          "lastWonDayOffset": 1472,
           "hasPlayed": true,
-          "autoOptInTimestamp": 1708273168957,
-          "hasMadeStatsChoice": false,
-          "timestamp": 1726831978
+          "autoOptInTimestamp": 1712205417018,
+          "hasMadeStatsChoice": true,
+          "timestamp": 1751255756
         },
         "calculatedStats": {
-          "gamesPlayed": 33,
-          "gamesWon": 26,
+          "currentStreak": 237,
+          "maxStreak": 237,
+          "lastWonPrintDate": "2025-07-08",
+          "lastCompletedPrintDate": "2025-07-08",
+          "hasPlayed": true
+        },
+        "totalStats": {
+          "gamesWon": 1077,
+          "gamesPlayed": 1119,
           "guesses": {
             "1": 0,
-            "2": 1,
-            "3": 4,
-            "4": 7,
-            "5": 10,
-            "6": 4,
-            "fail": 7
+            "2": 8,
+            "3": 83,
+            "4": 444,
+            "5": 376,
+            "6": 166,
+            "fail": 42
           },
-          "currentStreak": 1,
-          "maxStreak": 5,
-          "lastWonPrintDate": "2024-09-20",
-          "lastCompletedPrintDate": "2024-09-20",
           "hasPlayed": true,
-          "generation": 1
+          "hasPlayedArchive": false
         }
       }
     }

--- a/tests/components/nyt_games/fixtures/new_account.json
+++ b/tests/components/nyt_games/fixtures/new_account.json
@@ -7,26 +7,6 @@
     "stats": {
       "wordle": {
         "legacyStats": {
-          "gamesPlayed": 1,
-          "gamesWon": 1,
-          "guesses": {
-            "1": 0,
-            "2": 0,
-            "3": 0,
-            "4": 0,
-            "5": 1,
-            "6": 0,
-            "fail": 0
-          },
-          "currentStreak": 0,
-          "maxStreak": 1,
-          "lastWonDayOffset": 1118,
-          "hasPlayed": true,
-          "autoOptInTimestamp": 1727357874700,
-          "hasMadeStatsChoice": false,
-          "timestamp": 1727358123
-        },
-        "calculatedStats": {
           "gamesPlayed": 0,
           "gamesWon": 0,
           "guesses": {
@@ -40,10 +20,33 @@
           },
           "currentStreak": 0,
           "maxStreak": 1,
+          "lastWonDayOffset": 1118,
+          "hasPlayed": true,
+          "autoOptInTimestamp": 1727357874700,
+          "hasMadeStatsChoice": false,
+          "timestamp": 1727358123
+        },
+        "calculatedStats": {
+          "currentStreak": 0,
+          "maxStreak": 1,
           "lastWonPrintDate": "",
           "lastCompletedPrintDate": "",
+          "hasPlayed": false
+        },
+        "totalStats": {
+          "gamesPlayed": 1,
+          "gamesWon": 1,
+          "guesses": {
+            "1": 0,
+            "2": 0,
+            "3": 0,
+            "4": 0,
+            "5": 1,
+            "6": 0,
+            "fail": 0
+          },
           "hasPlayed": false,
-          "generation": 1
+          "hasPlayedArchive": false
         }
       }
     }

--- a/tests/components/nyt_games/snapshots/test_sensor.ambr
+++ b/tests/components/nyt_games/snapshots/test_sensor.ambr
@@ -473,7 +473,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1',
+    'state': '237',
   })
 # ---
 # name: test_all_entities[sensor.wordle_highest_streak-entry]
@@ -529,7 +529,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '5',
+    'state': '237',
   })
 # ---
 # name: test_all_entities[sensor.wordle_played-entry]
@@ -581,7 +581,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '33',
+    'state': '1119',
   })
 # ---
 # name: test_all_entities[sensor.wordle_won-entry]
@@ -633,6 +633,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '26',
+    'state': '1077',
   })
 # ---

--- a/tests/components/nyt_games/snapshots/test_sensor.ambr
+++ b/tests/components/nyt_games/snapshots/test_sensor.ambr
@@ -581,7 +581,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '70',
+    'state': '33',
   })
 # ---
 # name: test_all_entities[sensor.wordle_won-entry]
@@ -633,6 +633,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '51',
+    'state': '26',
   })
 # ---

--- a/tests/components/nyt_games/snapshots/test_sensor.ambr
+++ b/tests/components/nyt_games/snapshots/test_sensor.ambr
@@ -529,7 +529,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '237',
+    'state': '241',
   })
 # ---
 # name: test_all_entities[sensor.wordle_played-entry]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump nyt_games to 0.5.0. 

This makes Wordle stats update again in Home Assistant.

See: https://github.com/joostlek/python-nyt-games/releases/tag/v0.5.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
