### PR TITLE
Re-enable Home Connect updates automatically

### DIFF
--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -38,7 +38,7 @@ from propcache.api import cached_property
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr, issue_registry as ir
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -626,39 +626,34 @@ class HomeConnectCoordinator(
         """Check if the appliance data hasn't been refreshed too often recently."""
 
         now = self.hass.loop.time()
-        if len(self._execution_tracker[appliance_ha_id]) >= MAX_EXECUTIONS:
-            return True
+
+        execution_tracker = self._execution_tracker[appliance_ha_id]
+        initial_len = len(execution_tracker)
 
         execution_tracker = self._execution_tracker[appliance_ha_id] = [
             timestamp
-            for timestamp in self._execution_tracker[appliance_ha_id]
+            for timestamp in execution_tracker
             if now - timestamp < MAX_EXECUTIONS_TIME_WINDOW
         ]
 
         execution_tracker.append(now)
 
         if len(execution_tracker) >= MAX_EXECUTIONS:
-            ir.async_create_issue(
-                self.hass,
-                DOMAIN,
-                f"home_connect_too_many_connected_paired_events_{appliance_ha_id}",
-                is_fixable=True,
-                is_persistent=True,
-                severity=ir.IssueSeverity.ERROR,
-                translation_key="home_connect_too_many_connected_paired_events",
-                data={
-                    "entry_id": self.config_entry.entry_id,
-                    "appliance_ha_id": appliance_ha_id,
-                },
-                translation_placeholders={
-                    "appliance_name": self.data[appliance_ha_id].info.name,
-                    "times": str(MAX_EXECUTIONS),
-                    "time_window": str(MAX_EXECUTIONS_TIME_WINDOW // 60),
-                    "home_connect_resource_url": "https://www.home-connect.com/global/help-support/error-codes#/Togglebox=15362315-13320636-1/",
-                    "home_assistant_core_issue_url": "https://github.com/home-assistant/core/issues/147299",
-                },
-            )
+            if initial_len < MAX_EXECUTIONS:
+                _LOGGER.warning(
+                    'Too many connected/pairing events for appliance "%s" (%s times in less than %s minutes), '
+                    "updates have been disabled and they will be enabled back whenever it stabilizes. "
+                    "Consider trying to unplug the appliance for a while to perform a soft reset",
+                    self.data[appliance_ha_id].info.name,
+                    MAX_EXECUTIONS,
+                    MAX_EXECUTIONS_TIME_WINDOW // 60,
+                )
             return True
+        if initial_len >= MAX_EXECUTIONS:
+            _LOGGER.info(
+                'Connected/paired events from the appliance "%s" have been stabilized, updates have been re-enabled',
+                self.data[appliance_ha_id].info.name,
+            )
 
         return False
 

--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -641,9 +641,9 @@ class HomeConnectCoordinator(
         if len(execution_tracker) >= MAX_EXECUTIONS:
             if initial_len < MAX_EXECUTIONS:
                 _LOGGER.warning(
-                    'Too many connected/pairing events for appliance "%s" '
+                    'Too many connected/paired events for appliance "%s" '
                     "(%s times in less than %s minutes), updates have been disabled "
-                    "and they will be enabled back whenever it stabilizes. "
+                    "and they will be enabled again whenever the connection stabilizes. "
                     "Consider trying to unplug the appliance "
                     "for a while to perform a soft reset",
                     self.data[appliance_ha_id].info.name,
@@ -653,7 +653,7 @@ class HomeConnectCoordinator(
             return True
         if initial_len >= MAX_EXECUTIONS:
             _LOGGER.info(
-                'Connected/paired events from the appliance "%s" have been stabilized,'
+                'Connected/paired events from the appliance "%s" have stabilized,'
                 " updates have been re-enabled",
                 self.data[appliance_ha_id].info.name,
             )

--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -641,9 +641,11 @@ class HomeConnectCoordinator(
         if len(execution_tracker) >= MAX_EXECUTIONS:
             if initial_len < MAX_EXECUTIONS:
                 _LOGGER.warning(
-                    'Too many connected/pairing events for appliance "%s" (%s times in less than %s minutes), '
-                    "updates have been disabled and they will be enabled back whenever it stabilizes. "
-                    "Consider trying to unplug the appliance for a while to perform a soft reset",
+                    'Too many connected/pairing events for appliance "%s" '
+                    "(%s times in less than %s minutes), updates have been disabled "
+                    "and they will be enabled back whenever it stabilizes. "
+                    "Consider trying to unplug the appliance "
+                    "for a while to perform a soft reset",
                     self.data[appliance_ha_id].info.name,
                     MAX_EXECUTIONS,
                     MAX_EXECUTIONS_TIME_WINDOW // 60,
@@ -651,7 +653,8 @@ class HomeConnectCoordinator(
             return True
         if initial_len >= MAX_EXECUTIONS:
             _LOGGER.info(
-                'Connected/paired events from the appliance "%s" have been stabilized, updates have been re-enabled',
+                'Connected/paired events from the appliance "%s" have been stabilized,'
+                " updates have been re-enabled",
                 self.data[appliance_ha_id].info.name,
             )
 

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -124,17 +124,6 @@
     }
   },
   "issues": {
-    "home_connect_too_many_connected_paired_events": {
-      "title": "{appliance_name} sent too many connected or paired events",
-      "fix_flow": {
-        "step": {
-          "confirm": {
-            "title": "[%key:component::home_connect::issues::home_connect_too_many_connected_paired_events::title%]",
-            "description": "The appliance \"{appliance_name}\" has been reported as connected or paired {times} times in less than {time_window} minutes, so refreshes on connected or paired events has been disabled to avoid exceeding the API rate limit.\n\nPlease refer to the [Home Connect Wi-Fi requirements and recommendations]({home_connect_resource_url}). If everything seems right with your network configuration, restart the appliance.\n\nClick \"submit\" to re-enable the updates.\nIf the issue persists, please see the following issue in the [Home Assistant core repository]({home_assistant_core_issue_url})."
-          }
-        }
-      }
-    },
     "deprecated_time_alarm_clock_in_automations_scripts": {
       "title": "Deprecated alarm clock entity detected in some automations or scripts",
       "fix_flow": {

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
-from http import HTTPStatus
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -53,16 +52,11 @@ from homeassistant.core import (
     HomeAssistant,
     callback,
 )
-from homeassistant.helpers import (
-    device_registry as dr,
-    entity_registry as er,
-    issue_registry as ir,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
-from tests.typing import ClientSessionGenerator
 
 INITIAL_FETCH_CLIENT_METHODS = [
     "get_settings",
@@ -580,8 +574,7 @@ async def test_paired_disconnected_devices_not_fetching(
 
 async def test_coordinator_disabling_updates_for_appliance(
     hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
     client: MagicMock,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
@@ -592,7 +585,6 @@ async def test_coordinator_disabling_updates_for_appliance(
     When the user confirms the issue the updates should be enabled again.
     """
     appliance_ha_id = "SIEMENS-HCS02DWH1-6BE58C26DCC1"
-    issue_id = f"home_connect_too_many_connected_paired_events_{appliance_ha_id}"
 
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
@@ -606,13 +598,26 @@ async def test_coordinator_disabling_updates_for_appliance(
                 EventType.CONNECTED,
                 data=ArrayOfEvents([]),
             )
-            for _ in range(8)
+            for _ in range(6)
         ]
     )
     await hass.async_block_till_done()
 
-    issue = issue_registry.async_get_issue(DOMAIN, issue_id)
-    assert issue
+    freezer.tick(timedelta(minutes=10))
+    await client.add_events(
+        [
+            EventMessage(
+                appliance_ha_id,
+                EventType.CONNECTED,
+                data=ArrayOfEvents([]),
+            )
+            for _ in range(2)
+        ]
+    )
+    await hass.async_block_till_done()
+
+    # At this point, the updates have been blocked because
+    # 6 + 2 connected events have been received in less than an hour
 
     get_settings_original_side_effect = client.get_settings.side_effect
 
@@ -644,18 +649,36 @@ async def test_coordinator_disabling_updates_for_appliance(
 
     assert hass.states.is_state("switch.dishwasher_power", STATE_ON)
 
-    _client = await hass_client()
-    resp = await _client.post(
-        "/api/repairs/issues/fix",
-        json={"handler": DOMAIN, "issue_id": issue.issue_id},
+    # After 55 minutes, the updates should be enabled again
+    # because one hour has passed since the first connect events,
+    # so there are 2 connected events in the execution_tracker
+    freezer.tick(timedelta(minutes=55))
+    await client.add_events(
+        [
+            EventMessage(
+                appliance_ha_id,
+                EventType.CONNECTED,
+                data=ArrayOfEvents([]),
+            )
+        ]
     )
-    assert resp.status == HTTPStatus.OK
-    flow_id = (await resp.json())["flow_id"]
-    resp = await _client.post(f"/api/repairs/issues/fix/{flow_id}")
-    assert resp.status == HTTPStatus.OK
+    await hass.async_block_till_done()
 
-    assert not issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert hass.states.is_state("switch.dishwasher_power", STATE_OFF)
 
+    # If more connect events are sent, it should be blocked again
+    await client.add_events(
+        [
+            EventMessage(
+                appliance_ha_id,
+                EventType.CONNECTED,
+                data=ArrayOfEvents([]),
+            )
+            for _ in range(5)  # 2 + 1 + 5 = 8 connect events in less than an hour
+        ]
+    )
+    await hass.async_block_till_done()
+    client.get_settings = get_settings_original_side_effect
     await client.add_events(
         [
             EventMessage(
@@ -672,7 +695,6 @@ async def test_coordinator_disabling_updates_for_appliance(
 
 async def test_coordinator_disabling_updates_for_appliance_is_gone_after_entry_reload(
     hass: HomeAssistant,
-    issue_registry: ir.IssueRegistry,
     client: MagicMock,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
@@ -682,7 +704,6 @@ async def test_coordinator_disabling_updates_for_appliance_is_gone_after_entry_r
     The repair issue should also be deleted.
     """
     appliance_ha_id = "SIEMENS-HCS02DWH1-6BE58C26DCC1"
-    issue_id = f"home_connect_too_many_connected_paired_events_{appliance_ha_id}"
 
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
@@ -701,13 +722,8 @@ async def test_coordinator_disabling_updates_for_appliance_is_gone_after_entry_r
     )
     await hass.async_block_till_done()
 
-    issue = issue_registry.async_get_issue(DOMAIN, issue_id)
-    assert issue
-
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-
-    assert not issue_registry.async_get_issue(DOMAIN, issue_id)
 
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As suggested by @MartinHjelmare at https://github.com/home-assistant/core/pull/148524#issuecomment-3063951233, this PR re-enables automatically the updates that have are disabled because of too many connected or paired events after the number of events stabilizes.

The error dialog has been removed, but I added a warning log informing about this (so the user can get information about this) and an information log indicating that the updates have been re-enabled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #147299
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
