### PR TITLE
Cleanup bleak warnings

### DIFF
--- a/tests/components/bluemaestro/__init__.py
+++ b/tests/components/bluemaestro/__init__.py
@@ -32,7 +32,6 @@ def make_bluetooth_service_info(
             name=name,
             address=address,
             details={},
-            rssi=rssi,
         ),
         time=monotonic_time_coarse(),
         advertisement=None,

--- a/tests/components/eq3btsmart/conftest.py
+++ b/tests/components/eq3btsmart/conftest.py
@@ -28,7 +28,7 @@ def fake_service_info():
         source="local",
         connectable=False,
         time=0,
-        device=generate_ble_device(address=MAC, name="CC-RT-BLE", rssi=0),
+        device=generate_ble_device(address=MAC, name="CC-RT-BLE"),
         advertisement=AdvertisementData(
             local_name="CC-RT-BLE",
             manufacturer_data={},

--- a/tests/components/homekit_controller/conftest.py
+++ b/tests/components/homekit_controller/conftest.py
@@ -66,9 +66,7 @@ def fake_ble_discovery() -> Generator[None]:
     """Fake BLE discovery."""
 
     class FakeBLEDiscovery(FakeDiscovery):
-        device = BLEDevice(
-            address="AA:BB:CC:DD:EE:FF", name="TestDevice", rssi=-50, details=()
-        )
+        device = BLEDevice(address="AA:BB:CC:DD:EE:FF", name="TestDevice", details=())
 
     with patch("aiohomekit.testing.FakeDiscovery", FakeBLEDiscovery):
         yield

--- a/tests/components/inkbird/__init__.py
+++ b/tests/components/inkbird/__init__.py
@@ -29,7 +29,6 @@ def _make_bluetooth_service_info(
             name=name,
             address=address,
             details={},
-            rssi=rssi,
         ),
         time=MONOTONIC_TIME(),
         advertisement=None,

--- a/tests/components/iron_os/conftest.py
+++ b/tests/components/iron_os/conftest.py
@@ -131,7 +131,7 @@ def mock_ble_device() -> Generator[MagicMock]:
     with patch(
         "homeassistant.components.bluetooth.async_ble_device_from_address",
         return_value=BLEDevice(
-            address="c0:ff:ee:c0:ff:ee", name=DEFAULT_NAME, rssi=-50, details={}
+            address="c0:ff:ee:c0:ff:ee", name=DEFAULT_NAME, details={}
         ),
     ) as ble_device:
         yield ble_device

--- a/tests/components/kulersky/test_light.py
+++ b/tests/components/kulersky/test_light.py
@@ -40,9 +40,7 @@ def mock_ble_device() -> Generator[MagicMock]:
     """Mock BLEDevice."""
     with patch(
         "homeassistant.components.kulersky.async_ble_device_from_address",
-        return_value=BLEDevice(
-            address="AA:BB:CC:11:22:33", name="Bedroom", rssi=-50, details={}
-        ),
+        return_value=BLEDevice(address="AA:BB:CC:11:22:33", name="Bedroom", details={}),
     ) as ble_device:
         yield ble_device
 

--- a/tests/components/leaone/__init__.py
+++ b/tests/components/leaone/__init__.py
@@ -32,7 +32,6 @@ def make_bluetooth_service_info(
             name=name,
             address=address,
             details={},
-            rssi=rssi,
         ),
         time=monotonic_time_coarse(),
         advertisement=None,

--- a/tests/components/sensorpro/__init__.py
+++ b/tests/components/sensorpro/__init__.py
@@ -32,7 +32,6 @@ def make_bluetooth_service_info(
             name=name,
             address=address,
             details={},
-            rssi=rssi,
         ),
         time=monotonic_time_coarse(),
         advertisement=None,

--- a/tests/components/sensorpush/__init__.py
+++ b/tests/components/sensorpush/__init__.py
@@ -32,7 +32,6 @@ def make_bluetooth_service_info(
             name=name,
             address=address,
             details={},
-            rssi=rssi,
         ),
         time=monotonic_time_coarse(),
         advertisement=None,

--- a/tests/components/thermobeacon/__init__.py
+++ b/tests/components/thermobeacon/__init__.py
@@ -32,7 +32,6 @@ def make_bluetooth_service_info(
             name=name,
             address=address,
             details={},
-            rssi=rssi,
         ),
         time=monotonic_time_coarse(),
         advertisement=None,

--- a/tests/components/thermopro/__init__.py
+++ b/tests/components/thermopro/__init__.py
@@ -32,7 +32,6 @@ def make_bluetooth_service_info(
             name=name,
             address=address,
             details={},
-            rssi=rssi,
         ),
         time=monotonic_time_coarse(),
         advertisement=None,


### PR DESCRIPTION
## Proposed change
Followup after https://github.com/home-assistant/core/pull/147742

Fixes
```
DeprecationWarning: Passing additional arguments for BLEDevice is deprecated and has no effect.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
