### PR TITLE
Fix a bug in state restoration in the statistics integration

### DIFF
--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -47,7 +47,12 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed, get_fixture_path
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    async_mock_restore_state_shutdown_restart,
+    get_fixture_path,
+)
 from tests.components.recorder.common import async_wait_recording_done
 
 VALUES_BINARY = ["on", "off", "on", "off", "on", "off", "on", "off", "on"]
@@ -264,6 +269,7 @@ async def test_sensor_defaults_binary(hass: HomeAssistant) -> None:
 )
 async def test_sensor_state_updated_reported(
     hass: HomeAssistant,
+    hass_storage: dict[str, Any],
     values: list[float],
     attributes: list[dict[str, Any]],
     force_update: bool,
@@ -276,22 +282,29 @@ async def test_sensor_state_updated_reported(
     This fixes problems with time based averages and some other functions that behave
     differently when repeating values are reported.
     """
-    assert await async_setup_component(
-        hass,
-        "sensor",
-        {
-            "sensor": [
-                {
-                    "platform": "statistics",
-                    "name": "test_normal",
-                    "entity_id": "sensor.test_monitored",
-                    "state_characteristic": "mean",
-                    "sampling_size": 20,
-                },
-            ]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            "name": "test_normal",
+            "entity_id": "sensor.test_monitored",
+            "state_characteristic": "mean",
+            "sampling_size": 20.0,
+            "keep_last_sample": False,
+            "percentile": 50.0,
+            "precision": 2.0,
         },
     )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+
+    def verify_state(expected: list[float]) -> None:
+        state = hass.states.get("sensor.test_normal")
+        assert state
+        assert state.state == str(round(sum(expected) / len(expected), 2))
+        assert state.attributes.get("buffer_usage_ratio") == round(
+            len(expected) / 20, 2
+        )
 
     for value, attribute in zip(values, attributes, strict=True):
         hass.states.async_set(
@@ -301,11 +314,27 @@ async def test_sensor_state_updated_reported(
             force_update=force_update,
         )
     await hass.async_block_till_done()
+    verify_state(values)
 
-    state = hass.states.get("sensor.test_normal")
-    assert state
-    assert state.state == str(round(sum(values) / 9, 2))
-    assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
+    # Remove and re-add the sensor to test the restore process.
+    await async_mock_restore_state_shutdown_restart(hass)
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    verify_state(values)
+
+    # Add a new value to verify that the internal state has been restored correctly.
+    NEW_VALUE = 42
+    hass.states.async_set(
+        "sensor.test_monitored",
+        str(NEW_VALUE),
+        {ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS},
+        force_update=force_update,
+    )
+    await hass.async_block_till_done()
+    verify_state([*values, NEW_VALUE])
 
 
 async def test_sampling_boundaries_given(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With #129211 statistics handles repeating input values correctly under normal circumstances, however on HA restart the state buffer is loaded from the recorder DB, which does *not* store such repeating values (unless `force_update` was used on the source sensor), leading to incorrect output values (can be observed by modifying the `test_sensor_state_reported` test in this PR to rely on the recorder which would cause it to fail). 
This PR fixes the discrepancy by utilizing the `RestoreEntity` api to persist the entire state buffer in a dedicated storage, including the repeating values. The recorder DB support stays in place but will now only be used for initial bootstrapping of a newly added statistics sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #147698
- This PR is related to issue: 
- Link to documentation pull request: I don't think there's any documentation updates needed but please let me know if I'm wrong
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
