### PR TITLE
Support for MOTOR covers and AdvancedConditional

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -80,7 +80,7 @@ async def async_setup_entry(
         for output in area.outputs:
             platform = None
             _LOGGER.debug("Working on output %s", output.type)
-            if output.type == "SYSTEM_SHADE":
+            if output.type in ("SYSTEM_SHADE", "MOTOR"):
                 entry_data.covers.append((area.name, output))
                 platform = Platform.COVER
             elif output.type == "CEILING_FAN_TYPE":
@@ -118,6 +118,7 @@ async def async_setup_entry(
                     "SingleSceneRaiseLower",
                     "MasterRaiseLower",
                     "AdvancedToggle",
+                    "AdvancedConditional",
                 ):
                     # Associate an LED with a button if there is one
                     led = next(

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -80,7 +80,7 @@ async def async_setup_entry(
         for output in area.outputs:
             platform = None
             _LOGGER.debug("Working on output %s", output.type)
-            if output.type in ("SYSTEM_SHADE", "MOTOR"):
+            if output.type in SUPPORTED_COVER_OUTPUT_TYPES:
                 entry_data.covers.append((area.name, output))
                 platform = Platform.COVER
             elif output.type == "CEILING_FAN_TYPE":

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -22,6 +22,8 @@ PLATFORMS = [
     Platform.SWITCH,
 ]
 
+SUPPORTED_COVER_OUTPUT_TYPES = ("SYSTEM_SHADE", "MOTOR")
+
 _LOGGER = logging.getLogger(__name__)
 
 # Attribute on events that indicates what action was taken with the button.

--- a/homeassistant/components/lutron/cover.py
+++ b/homeassistant/components/lutron/cover.py
@@ -48,18 +48,31 @@ class LutronCover(LutronDevice, CoverEntity):
     _attr_supported_features = (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
         | CoverEntityFeature.SET_POSITION
     )
     _lutron_device: Output
     _attr_name = None
 
     def close_cover(self, **kwargs: Any) -> None:
-        """Close the cover."""
-        self._lutron_device.level = 0
+        """Start lowering the shade."""
+        if self._lutron_device._output_type == "MOTOR":
+            # MOTOR outputs don't support setting level directly
+            self._lutron_device.start_lower()
+        else:
+            self._lutron_device.level = 0
 
     def open_cover(self, **kwargs: Any) -> None:
-        """Open the cover."""
-        self._lutron_device.level = 100
+        """Start raising the shade."""
+        if self._lutron_device._output_type == "MOTOR":
+            # MOTOR outputs don't support setting level directly
+            self._lutron_device.start_raise()
+        else:
+            self._lutron_device.level = 100
+
+    def stop_cover(self, **kwargs: Any) -> None:
+        """Stop shade movement."""
+        self._lutron_device.stop()
 
     def set_cover_position(self, **kwargs: Any) -> None:
         """Move the shade to a specific position."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  added support for MOTOR output type used for covers, added back the stop button for covers, added the AdvancedConditional button type for some scenes in keypads.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

For MOTOR output to be supported properly, the latest version of pylutron which includes my fix (commit da6c705
) must be used, so the Shade module is properly activated. However even if pylutron is not yet updated this shouldn't break anything since people with Shades of output type MOTOR currently have their shades recognized as lights anyways, and those who have "SYSTEM_SHADE" shouldn't be affected by this change since the code falls back to the previous behavior if the output type is not MOTOR. It is not yet on pip so I could not update the dependency yet, but as soon as it will be available, the dependency should reflect that.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
