### PR TITLE
Do not add generic_hygrostat config entry to source device

### DIFF
--- a/homeassistant/components/generic_hygrostat/__init__.py
+++ b/homeassistant/components/generic_hygrostat/__init__.py
@@ -1,5 +1,7 @@
 """The generic_hygrostat component."""
 
+import logging
+
 import voluptuous as vol
 
 from homeassistant.components.humidifier import HumidifierDeviceClass
@@ -16,7 +18,10 @@ from homeassistant.helpers.device import (
     async_remove_stale_devices_links_keep_entity_device,
 )
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
-from homeassistant.helpers.helper_integration import async_handle_source_entity_changes
+from homeassistant.helpers.helper_integration import (
+    async_handle_source_entity_changes,
+    async_remove_helper_config_entry_from_source_device,
+)
 from homeassistant.helpers.typing import ConfigType
 
 DOMAIN = "generic_hygrostat"
@@ -70,6 +75,8 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Generic Hygrostat component."""
@@ -89,6 +96,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
 
+    # This can be removed in HA Core 2026.2
     async_remove_stale_devices_links_keep_entity_device(
         hass,
         entry.entry_id,
@@ -101,23 +109,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             options={**entry.options, CONF_HUMIDIFIER: source_entity_id},
         )
 
-    async def source_entity_removed() -> None:
-        # The source entity has been removed, we need to clean the device links.
-        async_remove_stale_devices_links_keep_entity_device(hass, entry.entry_id, None)
-
     entry.async_on_unload(
         # We use async_handle_source_entity_changes to track changes to the humidifer,
         # but not the humidity sensor because the generic_hygrostat adds itself to the
         # humidifier's device.
         async_handle_source_entity_changes(
             hass,
+            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_humidifier_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(
                 hass, entry.options[CONF_HUMIDIFIER]
             ),
             source_entity_id_or_uuid=entry.options[CONF_HUMIDIFIER],
-            source_entity_removed=source_entity_removed,
         )
     )
 
@@ -145,6 +149,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, (Platform.HUMIDIFIER,))
     entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug(
+        "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
+    )
+
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+    if config_entry.version == 1:
+        options = {**config_entry.options}
+        if config_entry.minor_version < 2:
+            # Remove the derivative config entry from the source device
+            if source_device_id := async_entity_id_to_device_id(
+                hass, options[CONF_HUMIDIFIER]
+            ):
+                async_remove_helper_config_entry_from_source_device(
+                    hass,
+                    helper_config_entry_id=config_entry.entry_id,
+                    source_device_id=source_device_id,
+                )
+        hass.config_entries.async_update_entry(
+            config_entry, options=options, minor_version=2
+        )
+
+    _LOGGER.debug(
+        "Migration to version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
     return True
 
 

--- a/homeassistant/components/generic_hygrostat/__init__.py
+++ b/homeassistant/components/generic_hygrostat/__init__.py
@@ -164,7 +164,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:
-            # Remove the derivative config entry from the source device
+            # Remove the generic_hygrostat config entry from the source device
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_HUMIDIFIER]
             ):

--- a/homeassistant/components/generic_hygrostat/config_flow.py
+++ b/homeassistant/components/generic_hygrostat/config_flow.py
@@ -92,6 +92,8 @@ OPTIONS_FLOW = {
 class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     """Handle a config or options flow."""
 
+    MINOR_VERSION = 2
+
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW
 

--- a/homeassistant/components/generic_hygrostat/humidifier.py
+++ b/homeassistant/components/generic_hygrostat/humidifier.py
@@ -42,7 +42,7 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.helpers import condition, config_validation as cv
-from homeassistant.helpers.device import async_device_info_to_link_from_entity
+from homeassistant.helpers.device import async_entity_id_to_device
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
@@ -145,22 +145,22 @@ async def _async_setup_config(
         [
             GenericHygrostat(
                 hass,
-                name,
-                switch_entity_id,
-                sensor_entity_id,
-                min_humidity,
-                max_humidity,
-                target_humidity,
-                device_class,
-                min_cycle_duration,
-                dry_tolerance,
-                wet_tolerance,
-                keep_alive,
-                initial_state,
-                away_humidity,
-                away_fixed,
-                sensor_stale_duration,
-                unique_id,
+                name=name,
+                switch_entity_id=switch_entity_id,
+                sensor_entity_id=sensor_entity_id,
+                min_humidity=min_humidity,
+                max_humidity=max_humidity,
+                target_humidity=target_humidity,
+                device_class=device_class,
+                min_cycle_duration=min_cycle_duration,
+                dry_tolerance=dry_tolerance,
+                wet_tolerance=wet_tolerance,
+                keep_alive=keep_alive,
+                initial_state=initial_state,
+                away_humidity=away_humidity,
+                away_fixed=away_fixed,
+                sensor_stale_duration=sensor_stale_duration,
+                unique_id=unique_id,
             )
         ]
     )
@@ -174,6 +174,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
     def __init__(
         self,
         hass: HomeAssistant,
+        *,
         name: str,
         switch_entity_id: str,
         sensor_entity_id: str,
@@ -195,7 +196,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         self._name = name
         self._switch_entity_id = switch_entity_id
         self._sensor_entity_id = sensor_entity_id
-        self._attr_device_info = async_device_info_to_link_from_entity(
+        self.device_entry = async_entity_id_to_device(
             hass,
             switch_entity_id,
         )

--- a/tests/components/generic_hygrostat/test_init.py
+++ b/tests/components/generic_hygrostat/test_init.py
@@ -9,8 +9,8 @@ import pytest
 from homeassistant.components import generic_hygrostat
 from homeassistant.components.generic_hygrostat import DOMAIN
 from homeassistant.components.generic_hygrostat.config_flow import ConfigFlowHandler
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 
@@ -119,10 +119,20 @@ def generic_hygrostat_config_entry(
     return config_entry
 
 
+@pytest.fixture
+def expected_helper_device_id(
+    request: pytest.FixtureRequest,
+    switch_device: dr.DeviceEntry,
+) -> str | None:
+    """Fixture to provide the expected helper device ID."""
+    return switch_device.id if request.param == "switch_device_id" else None
+
+
 def track_entity_registry_actions(hass: HomeAssistant, entity_id: str) -> list[str]:
     """Track entity registry actions for an entity."""
     events = []
 
+    @callback
     def add_event(event: Event[er.EventEntityRegistryUpdatedData]) -> None:
         """Add entity registry updated event to the list."""
         events.append(event.data["action"])
@@ -201,7 +211,7 @@ async def test_device_cleaning(
     devices_before_reload = device_registry.devices.get_devices_for_config_entry_id(
         helper_config_entry.entry_id
     )
-    assert len(devices_before_reload) == 3
+    assert len(devices_before_reload) == 2
 
     # Config entry reload
     await hass.config_entries.async_reload(helper_config_entry.entry_id)
@@ -216,9 +226,7 @@ async def test_device_cleaning(
     devices_after_reload = device_registry.devices.get_devices_for_config_entry_id(
         helper_config_entry.entry_id
     )
-    assert len(devices_after_reload) == 1
-
-    assert devices_after_reload[0].id == source_device1_entry.id
+    assert len(devices_after_reload) == 0
 
 
 @pytest.mark.usefixtures(
@@ -229,8 +237,12 @@ async def test_device_cleaning(
     "switch_device",
 )
 @pytest.mark.parametrize(
-    ("source_entity_id", "helper_in_device", "expected_events"),
-    [("switch.test_unique", True, ["update"]), ("sensor.test_unique", False, [])],
+    ("source_entity_id", "expected_helper_device_id", "expected_events"),
+    [
+        ("switch.test_unique", None, ["update"]),
+        ("sensor.test_unique", "switch_device_id", []),
+    ],
+    indirect=["expected_helper_device_id"],
 )
 async def test_async_handle_source_entity_changes_source_entity_removed(
     hass: HomeAssistant,
@@ -239,7 +251,83 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     generic_hygrostat_config_entry: MockConfigEntry,
     switch_entity_entry: er.RegistryEntry,
     source_entity_id: str,
-    helper_in_device: bool,
+    expected_helper_device_id: str | None,
+    expected_events: list[str],
+) -> None:
+    """Test the generic_hygrostat config entry is removed when the source entity is removed."""
+    source_entity_entry = entity_registry.async_get(source_entity_id)
+
+    assert await hass.config_entries.async_setup(
+        generic_hygrostat_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    generic_hygrostat_entity_entry = entity_registry.async_get(
+        "humidifier.my_generic_hygrostat"
+    )
+    assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
+
+    source_device = device_registry.async_get(source_entity_entry.device_id)
+    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+
+    events = track_entity_registry_actions(
+        hass, generic_hygrostat_entity_entry.entity_id
+    )
+
+    # Remove the source entity's config entry from the device, this removes the
+    # source entity
+    with patch(
+        "homeassistant.components.generic_hygrostat.async_unload_entry",
+        wraps=generic_hygrostat.async_unload_entry,
+    ) as mock_unload_entry:
+        device_registry.async_update_device(
+            source_device.id, remove_config_entry_id=source_entity_entry.config_entry_id
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+    mock_unload_entry.assert_not_called()
+
+    # Check that the helper entity is linked to the expected source device
+    generic_hygrostat_entity_entry = entity_registry.async_get(
+        "humidifier.my_generic_hygrostat"
+    )
+    assert generic_hygrostat_entity_entry.device_id == expected_helper_device_id
+
+    # Check that the device is removed
+    assert not device_registry.async_get(source_device.id)
+
+    # Check that the generic_hygrostat config entry is not removed
+    assert (
+        generic_hygrostat_config_entry.entry_id in hass.config_entries.async_entry_ids()
+    )
+
+    # Check we got the expected events
+    assert events == expected_events
+
+
+@pytest.mark.usefixtures(
+    "sensor_config_entry",
+    "sensor_device",
+    "sensor_entity_entry",
+    "switch_config_entry",
+    "switch_device",
+)
+@pytest.mark.parametrize(
+    ("source_entity_id", "expected_helper_device_id", "expected_events"),
+    [
+        ("switch.test_unique", None, ["update"]),
+        ("sensor.test_unique", "switch_device_id", []),
+    ],
+    indirect=["expected_helper_device_id"],
+)
+async def test_async_handle_source_entity_changes_source_entity_removed_shared_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    generic_hygrostat_config_entry: MockConfigEntry,
+    switch_entity_entry: er.RegistryEntry,
+    source_entity_id: str,
+    expected_helper_device_id: str | None,
     expected_events: list[str],
 ) -> None:
     """Test the generic_hygrostat config entry is removed when the source entity is removed."""
@@ -263,9 +351,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert (
-        generic_hygrostat_config_entry.entry_id in source_device.config_entries
-    ) == helper_in_device
+    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
 
     events = track_entity_registry_actions(
         hass, generic_hygrostat_entity_entry.entity_id
@@ -283,6 +369,13 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     mock_unload_entry.assert_not_called()
+
+    # Check that the helper entity is linked to the expected source device
+    switch_entity_entry = entity_registry.async_get("switch.test_unique")
+    generic_hygrostat_entity_entry = entity_registry.async_get(
+        "humidifier.my_generic_hygrostat"
+    )
+    assert generic_hygrostat_entity_entry.device_id == expected_helper_device_id
 
     # Check if the generic_hygrostat config entry is not in the device
     source_device = device_registry.async_get(source_device.id)
@@ -305,8 +398,17 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     "switch_device",
 )
 @pytest.mark.parametrize(
-    ("source_entity_id", "helper_in_device", "unload_entry_calls", "expected_events"),
-    [("switch.test_unique", True, 1, ["update"]), ("sensor.test_unique", False, 0, [])],
+    (
+        "source_entity_id",
+        "unload_entry_calls",
+        "expected_helper_device_id",
+        "expected_events",
+    ),
+    [
+        ("switch.test_unique", 1, None, ["update"]),
+        ("sensor.test_unique", 0, "switch_device_id", []),
+    ],
+    indirect=["expected_helper_device_id"],
 )
 async def test_async_handle_source_entity_changes_source_entity_removed_from_device(
     hass: HomeAssistant,
@@ -315,8 +417,8 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     generic_hygrostat_config_entry: MockConfigEntry,
     switch_entity_entry: er.RegistryEntry,
     source_entity_id: str,
-    helper_in_device: bool,
     unload_entry_calls: int,
+    expected_helper_device_id: str | None,
     expected_events: list[str],
 ) -> None:
     """Test the source entity removed from the source device."""
@@ -333,9 +435,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert (
-        generic_hygrostat_config_entry.entry_id in source_device.config_entries
-    ) == helper_in_device
+    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
 
     events = track_entity_registry_actions(
         hass, generic_hygrostat_entity_entry.entity_id
@@ -352,7 +452,13 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
         await hass.async_block_till_done()
     assert len(mock_unload_entry.mock_calls) == unload_entry_calls
 
-    # Check that the generic_hygrostat config entry is removed from the device
+    # Check that the helper entity is linked to the expected source device
+    generic_hygrostat_entity_entry = entity_registry.async_get(
+        "humidifier.my_generic_hygrostat"
+    )
+    assert generic_hygrostat_entity_entry.device_id == expected_helper_device_id
+
+    # Check that the generic_hygrostat config entry is not in the device
     source_device = device_registry.async_get(source_device.id)
     assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
 
@@ -373,8 +479,8 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     "switch_device",
 )
 @pytest.mark.parametrize(
-    ("source_entity_id", "helper_in_device", "unload_entry_calls", "expected_events"),
-    [("switch.test_unique", True, 1, ["update"]), ("sensor.test_unique", False, 0, [])],
+    ("source_entity_id", "unload_entry_calls", "expected_events"),
+    [("switch.test_unique", 1, ["update"]), ("sensor.test_unique", 0, [])],
 )
 async def test_async_handle_source_entity_changes_source_entity_moved_other_device(
     hass: HomeAssistant,
@@ -383,7 +489,6 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     generic_hygrostat_config_entry: MockConfigEntry,
     switch_entity_entry: er.RegistryEntry,
     source_entity_id: str,
-    helper_in_device: bool,
     unload_entry_calls: int,
     expected_events: list[str],
 ) -> None:
@@ -406,9 +511,7 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert (
-        generic_hygrostat_config_entry.entry_id in source_device.config_entries
-    ) == helper_in_device
+    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
     source_device_2 = device_registry.async_get(source_device_2.id)
     assert generic_hygrostat_config_entry.entry_id not in source_device_2.config_entries
 
@@ -427,13 +530,18 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
         await hass.async_block_till_done()
     assert len(mock_unload_entry.mock_calls) == unload_entry_calls
 
-    # Check that the generic_hygrostat config entry is moved to the other device
+    # Check that the helper entity is linked to the expected source device
+    switch_entity_entry = entity_registry.async_get(switch_entity_entry.entity_id)
+    generic_hygrostat_entity_entry = entity_registry.async_get(
+        "humidifier.my_generic_hygrostat"
+    )
+    assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
+
+    # Check that the generic_hygrostat config entry is not in any of the devices
     source_device = device_registry.async_get(source_device.id)
     assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
     source_device_2 = device_registry.async_get(source_device_2.id)
-    assert (
-        generic_hygrostat_config_entry.entry_id in source_device_2.config_entries
-    ) == helper_in_device
+    assert generic_hygrostat_config_entry.entry_id not in source_device_2.config_entries
 
     # Check that the generic_hygrostat config entry is not removed
     assert (
@@ -452,10 +560,10 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     "switch_device",
 )
 @pytest.mark.parametrize(
-    ("source_entity_id", "new_entity_id", "helper_in_device", "config_key"),
+    ("source_entity_id", "new_entity_id", "config_key"),
     [
-        ("switch.test_unique", "switch.new_entity_id", True, "humidifier"),
-        ("sensor.test_unique", "sensor.new_entity_id", False, "target_sensor"),
+        ("switch.test_unique", "switch.new_entity_id", "humidifier"),
+        ("sensor.test_unique", "sensor.new_entity_id", "target_sensor"),
     ],
 )
 async def test_async_handle_source_entity_new_entity_id(
@@ -466,7 +574,6 @@ async def test_async_handle_source_entity_new_entity_id(
     switch_entity_entry: er.RegistryEntry,
     source_entity_id: str,
     new_entity_id: str,
-    helper_in_device: bool,
     config_key: str,
 ) -> None:
     """Test the source entity's entity ID is changed."""
@@ -483,9 +590,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert (
-        generic_hygrostat_config_entry.entry_id in source_device.config_entries
-    ) == helper_in_device
+    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
 
     events = track_entity_registry_actions(
         hass, generic_hygrostat_entity_entry.entity_id
@@ -505,11 +610,9 @@ async def test_async_handle_source_entity_new_entity_id(
     # Check that the generic_hygrostat config entry is updated with the new entity ID
     assert generic_hygrostat_config_entry.options[config_key] == new_entity_id
 
-    # Check that the helper config is still in the device
+    # Check that the helper config is not in the device
     source_device = device_registry.async_get(source_device.id)
-    assert (
-        generic_hygrostat_config_entry.entry_id in source_device.config_entries
-    ) == helper_in_device
+    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
 
     # Check that the generic_hygrostat config entry is not removed
     assert (
@@ -518,3 +621,84 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check we got the expected events
     assert events == []
+
+
+@pytest.mark.usefixtures("sensor_device")
+async def test_migration_1_1(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    sensor_entity_entry: er.RegistryEntry,
+    switch_device: dr.DeviceEntry,
+    switch_entity_entry: er.RegistryEntry,
+) -> None:
+    """Test migration from v1.1 removes generic_hygrostat config entry from device."""
+
+    generic_hygrostat_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "device_class": "humidifier",
+            "dry_tolerance": 2.0,
+            "humidifier": switch_entity_entry.entity_id,
+            "name": "My generic hygrostat",
+            "target_sensor": sensor_entity_entry.entity_id,
+            "wet_tolerance": 4.0,
+        },
+        title="My generic hygrostat",
+        version=1,
+        minor_version=1,
+    )
+    generic_hygrostat_config_entry.add_to_hass(hass)
+
+    # Add the helper config entry to the device
+    device_registry.async_update_device(
+        switch_device.id, add_config_entry_id=generic_hygrostat_config_entry.entry_id
+    )
+
+    # Check preconditions
+    switch_device = device_registry.async_get(switch_device.id)
+    assert generic_hygrostat_config_entry.entry_id in switch_device.config_entries
+
+    await hass.config_entries.async_setup(generic_hygrostat_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert generic_hygrostat_config_entry.state is ConfigEntryState.LOADED
+
+    # Check that the helper config entry is removed from the device and the helper
+    # entity is linked to the source device
+    switch_device = device_registry.async_get(switch_device.id)
+    assert generic_hygrostat_config_entry.entry_id not in switch_device.config_entries
+    generic_hygrostat_entity_entry = entity_registry.async_get(
+        "humidifier.my_generic_hygrostat"
+    )
+    assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
+
+    assert generic_hygrostat_config_entry.version == 1
+    assert generic_hygrostat_config_entry.minor_version == 2
+
+
+async def test_migration_from_future_version(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration from future version."""
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "device_class": "humidifier",
+            "dry_tolerance": 2.0,
+            "humidifier": "switch.test",
+            "name": "My generic hygrostat",
+            "target_sensor": "sensor.test",
+            "wet_tolerance": 4.0,
+        },
+        title="My generic hygrostat",
+        version=2,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do not add generic_hygrostat config entry to source device, instead, set the device entry to that of the source device

Background in PR https://github.com/home-assistant/core/pull/148346


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
