### PR TITLE
Replace asyncio.iscoroutinefunction

### DIFF
--- a/homeassistant/components/knx/websocket.py
+++ b/homeassistant/components/knx/websocket.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Awaitable, Callable
 from functools import wraps
+import inspect
 from typing import TYPE_CHECKING, Any, Final, overload
 
 import knx_frontend as knx_panel
@@ -116,7 +116,7 @@ def provide_knx(
             "KNX integration not loaded.",
         )
 
-    if asyncio.iscoroutinefunction(func):
+    if inspect.iscoroutinefunction(func):
 
         @wraps(func)
         async def with_knx(

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -384,7 +384,7 @@ def get_hassjob_callable_job_type(target: Callable[..., Any]) -> HassJobType:
     while isinstance(check_target, functools.partial):
         check_target = check_target.func
 
-    if asyncio.iscoroutinefunction(check_target):
+    if inspect.iscoroutinefunction(check_target):
         return HassJobType.Coroutinefunction
     if is_callback(check_target):
         return HassJobType.Callback

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import abc
-import asyncio
 from collections import deque
 from collections.abc import Callable, Container, Coroutine, Generator, Iterable
 from contextlib import contextmanager
 from datetime import datetime, time as dt_time, timedelta
 import functools as ft
+import inspect
 import logging
 import re
 import sys
@@ -359,7 +359,7 @@ async def async_from_config(
     while isinstance(check_factory, ft.partial):
         check_factory = check_factory.func
 
-    if asyncio.iscoroutinefunction(check_factory):
+    if inspect.iscoroutinefunction(check_factory):
         return cast(ConditionCheckerType, await factory(hass, config))
     return cast(ConditionCheckerType, factory(config))
 

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 import enum
 import functools
+import inspect
 import linecache
 import logging
 import sys
@@ -397,7 +397,7 @@ def _report_usage_no_integration(
 
 def warn_use[_CallableT: Callable](func: _CallableT, what: str) -> _CallableT:
     """Mock a function to warn when it was about to be used."""
-    if asyncio.iscoroutinefunction(func):
+    if inspect.iscoroutinefunction(func):
 
         @functools.wraps(func)
         async def report_use(*args: Any, **kwargs: Any) -> None:

--- a/homeassistant/helpers/http.py
+++ b/homeassistant/helpers/http.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from http import HTTPStatus
+import inspect
 import logging
 from typing import Any, Final
 
@@ -45,7 +45,7 @@ def request_handler_factory(
     hass: HomeAssistant, view: HomeAssistantView, handler: Callable
 ) -> Callable[[web.Request], Awaitable[web.StreamResponse]]:
     """Wrap the handler classes."""
-    is_coroutinefunction = asyncio.iscoroutinefunction(handler)
+    is_coroutinefunction = inspect.iscoroutinefunction(handler)
     assert is_coroutinefunction or is_callback(handler), (
         "Handler should be a coroutine or a callback."
     )

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Coroutine, Iterable
 import dataclasses
 from enum import Enum
 from functools import cache, partial
+import inspect
 import logging
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, TypedDict, cast, override
@@ -997,7 +998,7 @@ def verify_domain_control(
         service_handler: Callable[[ServiceCall], Any],
     ) -> Callable[[ServiceCall], Any]:
         """Decorate."""
-        if not asyncio.iscoroutinefunction(service_handler):
+        if not inspect.iscoroutinefunction(service_handler):
             raise HomeAssistantError("Can only decorate async functions.")
 
         async def check_permissions(call: ServiceCall) -> Any:

--- a/homeassistant/helpers/singleton.py
+++ b/homeassistant/helpers/singleton.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Coroutine
 import functools
+import inspect
 from typing import Any, Literal, assert_type, cast, overload
 
 from homeassistant.core import HomeAssistant
@@ -47,7 +48,7 @@ def singleton[_S, _T, _U](
 
     def wrapper(func: _FuncType[_Coro[_T] | _U]) -> _FuncType[_Coro[_T] | _U]:
         """Wrap a function with caching logic."""
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
 
             @functools.lru_cache(maxsize=1)
             @bind_hass

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass, field
 import functools
+import inspect
 import logging
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, cast
 
@@ -407,7 +408,7 @@ def _trigger_action_wrapper(
         check_func = check_func.func
 
     wrapper_func: Callable[..., Any] | Callable[..., Coroutine[Any, Any, Any]]
-    if asyncio.iscoroutinefunction(check_func):
+    if inspect.iscoroutinefunction(check_func):
         async_action = cast(Callable[..., Coroutine[Any, Any, Any]], action)
 
         @functools.wraps(async_action)

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable, Coroutine, Iterable, KeysView, Mapping
 from datetime import datetime, timedelta
 from functools import wraps
+import inspect
 import random
 import re
 import string
@@ -125,7 +125,7 @@ class Throttle:
     def __call__(self, method: Callable) -> Callable:
         """Caller for the throttle."""
         # Make sure we return a coroutine if the method is async.
-        if asyncio.iscoroutinefunction(method):
+        if inspect.iscoroutinefunction(method):
 
             async def throttled_value() -> None:
                 """Stand-in function for when real func is being throttled."""

--- a/tests/components/music_assistant/common.py
+++ b/tests/components/music_assistant/common.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -191,7 +191,7 @@ async def trigger_subscription_callback(
             object_id=object_id,
             data=data,
         )
-        if asyncio.iscoroutinefunction(cb_func):
+        if inspect.iscoroutinefunction(cb_func):
             await cb_func(event)
         else:
             cb_func(event)

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from functools import partial
+import inspect
 import logging
 import queue
 from unittest.mock import patch
@@ -102,7 +103,7 @@ def test_catch_log_exception() -> None:
     async def async_meth():
         pass
 
-    assert asyncio.iscoroutinefunction(
+    assert inspect.iscoroutinefunction(
         logging_util.catch_log_exception(partial(async_meth), lambda: None)
     )
 
@@ -120,7 +121,7 @@ def test_catch_log_exception() -> None:
     wrapped = logging_util.catch_log_exception(partial(sync_meth), lambda: None)
 
     assert not is_callback(wrapped)
-    assert not asyncio.iscoroutinefunction(wrapped)
+    assert not inspect.iscoroutinefunction(wrapped)
 
 
 @pytest.mark.no_fail_on_log_exception


### PR DESCRIPTION
## Proposed change
`asyncio.iscoroutinefunction` has been deprecated and is scheduled for removal in Python 3.16. It's recommended to use `inspect.iscoroutinefunction` instead.
https://docs.python.org/3.13/deprecations/pending-removal-in-3.16.html

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
