### PR TITLE
Fix flaky nuki tests by preventing teardown race condition

### DIFF
--- a/tests/components/nuki/__init__.py
+++ b/tests/components/nuki/__init__.py
@@ -14,28 +14,33 @@ from tests.common import (
 )
 
 
-async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
+async def init_integration(
+    hass: HomeAssistant, mock_nuki_requests: requests_mock.Mocker
+) -> MockConfigEntry:
     """Mock integration setup."""
-    with requests_mock.Mocker() as mock:
-        # Mocking authentication endpoint
-        mock.get("http://1.1.1.1:8080/info", json=MOCK_INFO)
-        mock.get(
-            "http://1.1.1.1:8080/list",
-            json=await async_load_json_array_fixture(hass, "list.json", DOMAIN),
-        )
-        mock.get(
-            "http://1.1.1.1:8080/callback/list",
-            json=await async_load_json_object_fixture(
-                hass, "callback_list.json", DOMAIN
-            ),
-        )
-        mock.get(
-            "http://1.1.1.1:8080/callback/add",
-            json=await async_load_json_object_fixture(
-                hass, "callback_add.json", DOMAIN
-            ),
-        )
-        entry = await setup_nuki_integration(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    # Mocking authentication endpoint
+    mock_nuki_requests.get("http://1.1.1.1:8080/info", json=MOCK_INFO)
+    mock_nuki_requests.get(
+        "http://1.1.1.1:8080/list",
+        json=await async_load_json_array_fixture(hass, "list.json", DOMAIN),
+    )
+    callback_list_data = await async_load_json_object_fixture(
+        hass, "callback_list.json", DOMAIN
+    )
+    mock_nuki_requests.get(
+        "http://1.1.1.1:8080/callback/list",
+        json=callback_list_data,
+    )
+    mock_nuki_requests.get(
+        "http://1.1.1.1:8080/callback/add",
+        json=await async_load_json_object_fixture(hass, "callback_add.json", DOMAIN),
+    )
+    # Mock the callback remove endpoint for teardown
+    mock_nuki_requests.delete(
+        requests_mock.ANY,
+        json={"success": True},
+    )
+    entry = await setup_nuki_integration(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
     return entry

--- a/tests/components/nuki/conftest.py
+++ b/tests/components/nuki/conftest.py
@@ -1,0 +1,13 @@
+"""Fixtures for nuki tests."""
+
+from collections.abc import Generator
+
+import pytest
+import requests_mock
+
+
+@pytest.fixture
+def mock_nuki_requests() -> Generator[requests_mock.Mocker]:
+    """Mock nuki HTTP requests."""
+    with requests_mock.Mocker() as mock:
+        yield mock

--- a/tests/components/nuki/test_binary_sensor.py
+++ b/tests/components/nuki/test_binary_sensor.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
@@ -19,9 +20,10 @@ async def test_binary_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
+    mock_nuki_requests: requests_mock.Mocker,
 ) -> None:
     """Test binary sensors."""
     with patch("homeassistant.components.nuki.PLATFORMS", [Platform.BINARY_SENSOR]):
-        entry = await init_integration(hass)
+        entry = await init_integration(hass, mock_nuki_requests)
 
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)

--- a/tests/components/nuki/test_lock.py
+++ b/tests/components/nuki/test_lock.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import requests_mock
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
@@ -17,9 +18,10 @@ async def test_locks(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
+    mock_nuki_requests: requests_mock.Mocker,
 ) -> None:
     """Test locks."""
     with patch("homeassistant.components.nuki.PLATFORMS", [Platform.LOCK]):
-        entry = await init_integration(hass)
+        entry = await init_integration(hass, mock_nuki_requests)
 
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)

--- a/tests/components/nuki/test_sensor.py
+++ b/tests/components/nuki/test_sensor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import requests_mock
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
@@ -17,9 +18,10 @@ async def test_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
+    mock_nuki_requests: requests_mock.Mocker,
 ) -> None:
     """Test sensors."""
     with patch("homeassistant.components.nuki.PLATFORMS", [Platform.SENSOR]):
-        entry = await init_integration(hass)
+        entry = await init_integration(hass, mock_nuki_requests)
 
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)


### PR DESCRIPTION
## Proposed change
This PR fixes flaky test failures in the nuki integration tests that were occurring in CI. The tests (`test_binary_sensors`, `test_locks`, `test_sensors`) were intermittently failing with thread cleanup errors and async generator errors during teardown.

The root cause was that the `requests_mock` context was exiting before test teardown completed, causing the nuki integration's HTTP requests during unload to hit real network endpoints. This created a race condition where executor threads were still running when the test's async generator tried to close.

Example of the unmocked requests causing issues:
```
ERROR:homeassistant.config_entries:Error unloading entry Mock Title for nuki
  Traceback (most recent call last):
    File "/Users/bdraco/home-assistant/homeassistant/components/nuki/__init__.py", line 248, in async_unload_entry
      await hass.async_add_executor_job(
      ...<3 lines>...
      )
    File "/opt/homebrew/Cellar/python@3.13/3.13.3/Frameworks/Python.framework/Versions/3.13/lib/python3.13/concurrent/futures/thread.py", line 59, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/Users/bdraco/home-assistant/homeassistant/components/nuki/__init__.py", line 152, in _remove_webhook
      callbacks = bridge.callback_list()
    File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/pynuki/bridge.py", line 173, in callback_list
      return self.__rq("callback/list")
             ~~~~~~~~~^^^^^^^^^^^^^^^^^
    File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/pynuki/bridge.py", line 110, in __rq
      result.raise_for_status()
      ~~~~~~~~~~~~~~~~~~~~~~~^^
    File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/requests/models.py", line 1026, in raise_for_status
      raise HTTPError(http_error_msg, response=self)
  requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://one.one.one.one/callback/list?ctoken=c01f7d147f51a8429679850a40ddbdf57a87bf9c1f7bac8250e95832786c0d49
  a7061fb5e47446e83311&nonce=5cf28d89a1182b8f0d415d3c767e69721f02368bd06c78b6
```

The fix introduces a pytest fixture that keeps the `requests_mock` active throughout the entire test lifecycle, including teardown, preventing the race condition.

## Type of change
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: Flaky CI failures in nuki tests - [Failed CI run](https://github.com/home-assistant/core/actions/runs/16278621479/job/45964824189)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
- Not applicable

If the code communicates with devices, web services, or third-party tools:
- Not applicable (test-only changes)

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr