### PR TITLE
Add tuya snapshots for more humidifiers (cs category)

### DIFF
--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -31,6 +31,20 @@ DEVICE_MOCKS = {
         Platform.SENSOR,
         Platform.SWITCH,
     ],
+    "cs_emma_dehumidifier": [
+        # https://github.com/home-assistant/core/issues/119865
+        Platform.BINARY_SENSOR,
+        Platform.FAN,
+        Platform.HUMIDIFIER,
+        Platform.SELECT,
+        Platform.SENSOR,
+        Platform.SWITCH,
+    ],
+    "cs_smart_dry_plus": [
+        # https://github.com/home-assistant/core/issues/119865
+        Platform.FAN,
+        Platform.HUMIDIFIER,
+    ],
     "cwwsq_cleverio_pf100": [
         # https://github.com/home-assistant/core/issues/144745
         Platform.NUMBER,

--- a/tests/components/tuya/fixtures/cs_emma_dehumidifier.json
+++ b/tests/components/tuya/fixtures/cs_emma_dehumidifier.json
@@ -1,0 +1,129 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "terminal_id": "mock_terminal_id",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "id": "mock_device_id",
+  "name": "Dehumidifer",
+  "category": "cs",
+  "product_id": "ka2wfrdoogpvgzfi",
+  "product_name": "Emma Dehumidifier - eeese air care",
+  "online": false,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2024-11-06T18:25:00+00:00",
+  "create_time": "2024-11-06T18:25:00+00:00",
+  "update_time": "2024-11-06T18:25:00+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "dehumidify_set_value": {
+      "type": "Integer",
+      "value": {
+        "unit": "%",
+        "min": 25,
+        "max": 80,
+        "scale": 0,
+        "step": 5
+      }
+    },
+    "fan_speed_enum": {
+      "type": "Enum",
+      "value": {
+        "range": ["low", "high"]
+      }
+    },
+    "anion": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "countdown_set": {
+      "type": "Enum",
+      "value": {
+        "range": ["cancel", "1h", "2h", "3h"]
+      }
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "dehumidify_set_value": {
+      "type": "Integer",
+      "value": {
+        "unit": "%",
+        "min": 25,
+        "max": 80,
+        "scale": 0,
+        "step": 5
+      }
+    },
+    "fan_speed_enum": {
+      "type": "Enum",
+      "value": {
+        "range": ["low", "high"]
+      }
+    },
+    "anion": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "humidity_indoor": {
+      "type": "Integer",
+      "value": {
+        "unit": "%",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "countdown_set": {
+      "type": "Enum",
+      "value": {
+        "range": ["cancel", "1h", "2h", "3h"]
+      }
+    },
+    "countdown_left": {
+      "type": "Integer",
+      "value": {
+        "unit": "h",
+        "min": 0,
+        "max": 24,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "fault": {
+      "type": "Bitmap",
+      "value": {
+        "label": ["tankfull", "defrost", "E1", "E2", "L3", "L4", "L2"]
+      }
+    }
+  },
+  "status": {
+    "switch": false,
+    "dehumidify_set_value": 25,
+    "fan_speed_enum": "low",
+    "anion": false,
+    "child_lock": false,
+    "humidity_indoor": 48,
+    "countdown_set": "cancel",
+    "countdown_left": 0,
+    "fault": 0
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/fixtures/cs_smart_dry_plus.json
+++ b/tests/components/tuya/fixtures/cs_smart_dry_plus.json
@@ -1,0 +1,32 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "terminal_id": "mock_terminal_id",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "id": "mock_device_id",
+  "name": "Dehumidifier ",
+  "category": "cs",
+  "product_id": "vmxuxszzjwp5smli",
+  "product_name": "the Smart Dry Plus\u2122 Connect Dehumidifier ",
+  "online": true,
+  "sub": false,
+  "time_zone": "+10:00",
+  "active_time": "2024-05-28T01:57:58+00:00",
+  "create_time": "2024-05-28T01:57:58+00:00",
+  "update_time": "2024-05-28T01:57:58+00:00",
+  "function": {},
+  "status_range": {
+    "fault": {
+      "type": "Bitmap",
+      "value": {
+        "label": ["E1", "E2"]
+      }
+    }
+  },
+  "status": {
+    "fault": 0
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_binary_sensor.ambr
@@ -146,6 +146,104 @@
     'state': 'off',
   })
 # ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][binary_sensor.dehumidifer_defrost-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.dehumidifer_defrost',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Defrost',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'defrost',
+    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9defrost',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][binary_sensor.dehumidifer_defrost-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Dehumidifer Defrost',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.dehumidifer_defrost',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][binary_sensor.dehumidifer_tank_full-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.dehumidifer_tank_full',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Tank full',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'tankfull',
+    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9tankfull',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][binary_sensor.dehumidifer_tank_full-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Dehumidifer Tank full',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.dehumidifer_tank_full',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_platform_setup_and_discovery[mcs_door_sensor][binary_sensor.door_garage_door-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_binary_sensor.ambr
@@ -177,7 +177,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'defrost',
-    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9defrost',
+    'unique_id': 'tuya.mock_device_iddefrost',
     'unit_of_measurement': None,
   })
 # ---
@@ -226,7 +226,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'tankfull',
-    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9tankfull',
+    'unique_id': 'tuya.mock_device_idtankfull',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_fan.ambr
+++ b/tests/components/tuya/snapshots/test_fan.ambr
@@ -49,6 +49,110 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][fan.dehumidifer-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'preset_modes': list([
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.dehumidifer',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <FanEntityFeature: 49>,
+    'translation_key': None,
+    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][fan.dehumidifer-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dehumidifer',
+      'preset_modes': list([
+      ]),
+      'supported_features': <FanEntityFeature: 49>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.dehumidifer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_smart_dry_plus][fan.dehumidifier-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.dehumidifier',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.mock_device_id',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_smart_dry_plus][fan.dehumidifier-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dehumidifier ',
+      'supported_features': <FanEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.dehumidifier',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_platform_setup_and_discovery[kj_bladeless_tower_fan][fan.bree-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_fan.ambr
+++ b/tests/components/tuya/snapshots/test_fan.ambr
@@ -83,7 +83,7 @@
     'suggested_object_id': None,
     'supported_features': <FanEntityFeature: 49>,
     'translation_key': None,
-    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9',
+    'unique_id': 'tuya.mock_device_id',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_humidifier.ambr
+++ b/tests/components/tuya/snapshots/test_humidifier.ambr
@@ -90,7 +90,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9switch',
+    'unique_id': 'tuya.mock_device_idswitch',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_humidifier.ambr
+++ b/tests/components/tuya/snapshots/test_humidifier.ambr
@@ -56,3 +56,113 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][humidifier.dehumidifer-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max_humidity': 80,
+      'min_humidity': 25,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'humidifier',
+    'entity_category': None,
+    'entity_id': 'humidifier.dehumidifer',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <HumidifierDeviceClass.DEHUMIDIFIER: 'dehumidifier'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9switch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][humidifier.dehumidifer-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'dehumidifier',
+      'friendly_name': 'Dehumidifer',
+      'max_humidity': 80,
+      'min_humidity': 25,
+      'supported_features': <HumidifierEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'humidifier.dehumidifer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_smart_dry_plus][humidifier.dehumidifier-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max_humidity': 100,
+      'min_humidity': 0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'humidifier',
+    'entity_category': None,
+    'entity_id': 'humidifier.dehumidifier',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <HumidifierDeviceClass.DEHUMIDIFIER: 'dehumidifier'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.mock_device_idswitch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_smart_dry_plus][humidifier.dehumidifier-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'dehumidifier',
+      'friendly_name': 'Dehumidifier ',
+      'max_humidity': 100,
+      'min_humidity': 0,
+      'supported_features': <HumidifierEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'humidifier.dehumidifier',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/tuya/snapshots/test_select.ambr
+++ b/tests/components/tuya/snapshots/test_select.ambr
@@ -155,7 +155,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'countdown',
-    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9countdown_set',
+    'unique_id': 'tuya.mock_device_idcountdown_set',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_select.ambr
+++ b/tests/components/tuya/snapshots/test_select.ambr
@@ -117,6 +117,67 @@
     'state': 'cancel',
   })
 # ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][select.dehumidifer_countdown-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'cancel',
+        '1h',
+        '2h',
+        '3h',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.dehumidifer_countdown',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Countdown',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'countdown',
+    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9countdown_set',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][select.dehumidifer_countdown-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dehumidifer Countdown',
+      'options': list([
+        'cancel',
+        '1h',
+        '2h',
+        '3h',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.dehumidifer_countdown',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_platform_setup_and_discovery[kj_bladeless_tower_fan][select.bree_countdown-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -85,7 +85,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'humidity',
-    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9humidity_indoor',
+    'unique_id': 'tuya.mock_device_idhumidity_indoor',
     'unit_of_measurement': '%',
   })
 # ---

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -52,6 +52,59 @@
     'state': '47.0',
   })
 # ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][sensor.dehumidifer_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.dehumidifer_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity',
+    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9humidity_indoor',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][sensor.dehumidifer_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'friendly_name': 'Dehumidifer Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.dehumidifer_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_platform_setup_and_discovery[cwwsq_cleverio_pf100][sensor.cleverio_pf100_last_amount-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -48,6 +48,104 @@
     'state': 'off',
   })
 # ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][switch.dehumidifer_child_lock-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.dehumidifer_child_lock',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:account-lock',
+    'original_name': 'Child lock',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'child_lock',
+    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9child_lock',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][switch.dehumidifer_child_lock-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dehumidifer Child lock',
+      'icon': 'mdi:account-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.dehumidifer_child_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][switch.dehumidifer_ionizer-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.dehumidifer_ionizer',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:atom',
+    'original_name': 'Ionizer',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ionizer',
+    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9anion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[cs_emma_dehumidifier][switch.dehumidifer_ionizer-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dehumidifer Ionizer',
+      'icon': 'mdi:atom',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.dehumidifer_ionizer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_platform_setup_and_discovery[cwysj_pixi_smart_drinking_fountain][switch.pixi_smart_drinking_fountain_filter_reset-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -579,7 +677,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_arm_beep-entry]
+# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_none-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -592,7 +690,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.multifunction_alarm_arm_beep',
+    'entity_id': 'switch.multifunction_alarm_none',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -604,7 +702,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Arm beep',
+    'original_name': None,
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -614,20 +712,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_arm_beep-state]
+# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_none-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Multifunction alarm Arm beep',
+      'friendly_name': 'Multifunction alarm None',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.multifunction_alarm_arm_beep',
+    'entity_id': 'switch.multifunction_alarm_none',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_siren-entry]
+# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_none_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -640,7 +738,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.multifunction_alarm_siren',
+    'entity_id': 'switch.multifunction_alarm_none_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -652,7 +750,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Siren',
+    'original_name': None,
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -662,13 +760,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_siren-state]
+# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_none_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Multifunction alarm Siren',
+      'friendly_name': 'Multifunction alarm None',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.multifunction_alarm_siren',
+    'entity_id': 'switch.multifunction_alarm_none_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -79,7 +79,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'child_lock',
-    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9child_lock',
+    'unique_id': 'tuya.mock_device_idchild_lock',
     'unit_of_measurement': None,
   })
 # ---
@@ -128,7 +128,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'ionizer',
-    'unique_id': 'tuya.bf183ee21e5b3f58a3yhz9anion',
+    'unique_id': 'tuya.mock_device_idanion',
     'unit_of_measurement': None,
   })
 # ---
@@ -677,7 +677,7 @@
     'state': 'off',
   })
 # ---
-# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_none-entry]
+# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_arm_beep-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -690,7 +690,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.multifunction_alarm_none',
+    'entity_id': 'switch.multifunction_alarm_arm_beep',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -702,7 +702,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Arm beep',
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -712,20 +712,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_none-state]
+# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_arm_beep-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Multifunction alarm None',
+      'friendly_name': 'Multifunction alarm Arm beep',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.multifunction_alarm_none',
+    'entity_id': 'switch.multifunction_alarm_arm_beep',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_none_2-entry]
+# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_siren-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -738,7 +738,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.multifunction_alarm_none_2',
+    'entity_id': 'switch.multifunction_alarm_siren',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -750,7 +750,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Siren',
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -760,13 +760,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_none_2-state]
+# name: test_platform_setup_and_discovery[mal_alarm_host][switch.multifunction_alarm_siren-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Multifunction alarm None',
+      'friendly_name': 'Multifunction alarm Siren',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.multifunction_alarm_none_2',
+    'entity_id': 'switch.multifunction_alarm_siren',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, from https://github.com/home-assistant/core/issues/119865

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
