### PR TITLE
Update aioairzone-cloud to v0.6.14

### DIFF
--- a/homeassistant/components/airzone_cloud/manifest.json
+++ b/homeassistant/components/airzone_cloud/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airzone_cloud",
   "iot_class": "cloud_push",
   "loggers": ["aioairzone_cloud"],
-  "requirements": ["aioairzone-cloud==0.6.13"]
+  "requirements": ["aioairzone-cloud==0.6.14"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,7 +179,7 @@ aioacaia==0.1.14
 aioairq==0.4.6
 
 # homeassistant.components.airzone_cloud
-aioairzone-cloud==0.6.13
+aioairzone-cloud==0.6.14
 
 # homeassistant.components.airzone
 aioairzone==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -167,7 +167,7 @@ aioacaia==0.1.14
 aioairq==0.4.6
 
 # homeassistant.components.airzone_cloud
-aioairzone-cloud==0.6.13
+aioairzone-cloud==0.6.14
 
 # homeassistant.components.airzone
 aioairzone==1.0.0

--- a/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
+++ b/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
@@ -210,10 +210,35 @@
           'ws-connected': True,
         }),
       }),
+      'air-quality': dict({
+        'airqsensor1': dict({
+          'aq-active': False,
+          'aq-index': 1,
+          'aq-pm-1': 3,
+          'aq-pm-10': 3,
+          'aq-pm-2.5': 4,
+          'aq-present': True,
+          'aq-status': 'good',
+          'available': True,
+          'double-set-point': False,
+          'id': 'airqsensor1',
+          'installation': 'installation1',
+          'is-connected': True,
+          'name': 'CapteurQ',
+          'problems': False,
+          'system': 1,
+          'web-server': 'webserver1',
+          'ws-connected': True,
+          'zone': 1,
+        }),
+      }),
       'groups': dict({
         'group1': dict({
           'action': 1,
           'active': True,
+          'air-quality': list([
+            'airqsensor1',
+          ]),
           'available': True,
           'hot-water': list([
             'dhw1',
@@ -332,6 +357,9 @@
             'aidoo1',
             'aidoo_pro',
           ]),
+          'air-quality': list([
+            'airqsensor1',
+          ]),
           'available': True,
           'groups': list([
             'group1',
@@ -377,6 +405,7 @@
       }),
       'systems': dict({
         'system1': dict({
+          'aq-active': False,
           'aq-index': 1,
           'aq-pm-1': 3,
           'aq-pm-10': 3,
@@ -463,6 +492,7 @@
           'action': 1,
           'active': True,
           'air-demand': True,
+          'air-quality-id': 'airqsensor1',
           'aq-active': False,
           'aq-index': 1,
           'aq-mode-conf': 'auto',
@@ -528,19 +558,12 @@
           'action': 6,
           'active': False,
           'air-demand': False,
-          'aq-active': False,
-          'aq-index': 1,
           'aq-mode-conf': 'auto',
           'aq-mode-values': list([
             'off',
             'on',
             'auto',
           ]),
-          'aq-pm-1': 3,
-          'aq-pm-10': 3,
-          'aq-pm-2.5': 4,
-          'aq-present': True,
-          'aq-status': 'good',
           'available': True,
           'double-set-point': False,
           'floor-demand': False,

--- a/tests/components/airzone_cloud/test_binary_sensor.py
+++ b/tests/components/airzone_cloud/test_binary_sensor.py
@@ -45,7 +45,7 @@ async def test_airzone_create_binary_sensors(hass: HomeAssistant) -> None:
     assert state.state == STATE_OFF
 
     state = hass.states.get("binary_sensor.dormitorio_air_quality_active")
-    assert state.state == STATE_OFF
+    assert state is None
 
     state = hass.states.get("binary_sensor.dormitorio_battery")
     assert state.state == STATE_OFF

--- a/tests/components/airzone_cloud/test_sensor.py
+++ b/tests/components/airzone_cloud/test_sensor.py
@@ -59,19 +59,19 @@ async def test_airzone_create_sensors(hass: HomeAssistant) -> None:
 
     # Zones
     state = hass.states.get("sensor.dormitorio_air_quality_index")
-    assert state.state == "1"
+    assert state is None
 
     state = hass.states.get("sensor.dormitorio_battery")
     assert state.state == "54"
 
     state = hass.states.get("sensor.dormitorio_pm1")
-    assert state.state == "3"
+    assert state is None
 
     state = hass.states.get("sensor.dormitorio_pm2_5")
-    assert state.state == "4"
+    assert state is None
 
     state = hass.states.get("sensor.dormitorio_pm10")
-    assert state.state == "3"
+    assert state is None
 
     state = hass.states.get("sensor.dormitorio_signal_percentage")
     assert state.state == "76"
@@ -82,7 +82,7 @@ async def test_airzone_create_sensors(hass: HomeAssistant) -> None:
     state = hass.states.get("sensor.dormitorio_humidity")
     assert state.state == "24"
 
-    state = hass.states.get("sensor.dormitorio_air_quality_index")
+    state = hass.states.get("sensor.salon_air_quality_index")
     assert state.state == "1"
 
     state = hass.states.get("sensor.salon_pm1")

--- a/tests/components/airzone_cloud/util.py
+++ b/tests/components/airzone_cloud/util.py
@@ -19,6 +19,7 @@ from aioairzone_cloud.const import (
     API_AZ_ACS,
     API_AZ_AIDOO,
     API_AZ_AIDOO_PRO,
+    API_AZ_AIRQSENSOR,
     API_AZ_SYSTEM,
     API_AZ_ZONE,
     API_CELSIUS,
@@ -168,6 +169,17 @@ GET_INSTALLATION_MOCK = {
                         API_SYSTEM_NUMBER: 1,
                         API_ZONE_NUMBER: 2,
                     },
+                    API_WS_ID: WS_ID,
+                },
+                {
+                    API_CONFIG: {
+                        API_SYSTEM_NUMBER: 1,
+                        API_ZONE_NUMBER: 1,
+                    },
+                    API_DEVICE_ID: "airqsensor1",
+                    API_NAME: "CapteurQ",
+                    API_TYPE: API_AZ_AIRQSENSOR,
+                    API_META: {},
                     API_WS_ID: WS_ID,
                 },
             ],
@@ -394,11 +406,6 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
     if device.get_id() == "system1":
         return {
             API_AQ_MODE_VALUES: ["off", "on", "auto"],
-            API_AQ_PM_1: 3,
-            API_AQ_PM_2P5: 4,
-            API_AQ_PM_10: 3,
-            API_AQ_PRESENT: True,
-            API_AQ_QUALITY: "good",
             API_ERRORS: [
                 {
                     API_OLD_ID: "error-id",
@@ -419,14 +426,8 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
         return {
             API_ACTIVE: True,
             API_AIR_ACTIVE: True,
-            API_AQ_ACTIVE: False,
             API_AQ_MODE_CONF: "auto",
             API_AQ_MODE_VALUES: ["off", "on", "auto"],
-            API_AQ_PM_1: 3,
-            API_AQ_PM_2P5: 4,
-            API_AQ_PM_10: 3,
-            API_AQ_PRESENT: True,
-            API_AQ_QUALITY: "good",
             API_DOUBLE_SET_POINT: False,
             API_HUMIDITY: 30,
             API_MODE: OperationMode.COOLING.value,
@@ -466,14 +467,8 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
         return {
             API_ACTIVE: False,
             API_AIR_ACTIVE: False,
-            API_AQ_ACTIVE: False,
             API_AQ_MODE_CONF: "auto",
             API_AQ_MODE_VALUES: ["off", "on", "auto"],
-            API_AQ_PM_1: 3,
-            API_AQ_PM_2P5: 4,
-            API_AQ_PM_10: 3,
-            API_AQ_PRESENT: True,
-            API_AQ_QUALITY: "good",
             API_DOUBLE_SET_POINT: False,
             API_HUMIDITY: 24,
             API_MODE: OperationMode.COOLING.value,
@@ -503,6 +498,19 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
             API_WS_CONNECTED: True,
             API_LOCAL_TEMP: {API_FAH: 77, API_CELSIUS: 25},
             API_WARNINGS: [],
+        }
+    if device.get_id() == "airqsensor1":
+        return {
+            API_AQ_ACTIVE: False,
+            API_AQ_MODE_CONF: "auto",
+            API_AQ_MODE_VALUES: ["off", "on", "auto"],
+            API_AQ_PM_1: 3,
+            API_AQ_PM_2P5: 4,
+            API_AQ_PM_10: 3,
+            API_AQ_PRESENT: True,
+            API_AQ_QUALITY: "good",
+            API_IS_CONNECTED: True,
+            API_WS_CONNECTED: True,
         }
     return {}
 


### PR DESCRIPTION
## Proposed change
Update aioairzone-cloud to [v0.6.14](https://github.com/Noltari/aioairzone-cloud/compare/0.6.13...0.6.14).
Fixes Air Quality sensors not being available after an Airzone Cloud API change that moved the Air Quality data to separate (new) entities. The data was duplicated on every zone and now it will only be available in the zone stated by the API.

Releases:
- https://github.com/Noltari/aioairzone-cloud/releases/tag/0.6.14

Git compare: https://github.com/Noltari/aioairzone-cloud/compare/0.6.13...0.6.14

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/146527 https://github.com/home-assistant/core/issues/146157
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
