### PR TITLE
Add `hydrological alert` sensor to IMGW-PIB integration

### DIFF
--- a/homeassistant/components/imgw_pib/icons.json
+++ b/homeassistant/components/imgw_pib/icons.json
@@ -2,7 +2,7 @@
   "entity": {
     "sensor": {
       "hydrological_alert": {
-        "default": "mdi:alert-outline"
+        "default": "mdi:alert-octagon"
       },
       "water_flow": {
         "default": "mdi:waves-arrow-right"

--- a/homeassistant/components/imgw_pib/icons.json
+++ b/homeassistant/components/imgw_pib/icons.json
@@ -1,6 +1,9 @@
 {
   "entity": {
     "sensor": {
+      "hydrological_alert": {
+        "default": "mdi:alert-outline"
+      },
       "water_flow": {
         "default": "mdi:waves-arrow-right"
       },

--- a/homeassistant/components/imgw_pib/icons.json
+++ b/homeassistant/components/imgw_pib/icons.json
@@ -2,7 +2,7 @@
   "entity": {
     "sensor": {
       "hydrological_alert": {
-        "default": "mdi:alert-octagon"
+        "default": "mdi:alert-octagon-outline"
       },
       "water_flow": {
         "default": "mdi:waves-arrow-right"

--- a/homeassistant/components/imgw_pib/sensor.py
+++ b/homeassistant/components/imgw_pib/sensor.py
@@ -32,14 +32,14 @@ PARALLEL_UPDATES = 0
 
 def gen_alert_attributes(data: HydrologicalData) -> dict[str, Any] | None:
     """Generate attributes for the alert entity."""
-    if data.alert.value == NO_ALERT:
+    if data.hydrological_alert.value == NO_ALERT:
         return None
 
     return {
-        "level": data.alert.level,
-        "probability": data.alert.probability,
-        "valid_from": data.alert.valid_from,
-        "valid_to": data.alert.valid_to,
+        "level": data.hydrological_alert.level,
+        "probability": data.hydrological_alert.probability,
+        "valid_from": data.hydrological_alert.valid_from,
+        "valid_to": data.hydrological_alert.valid_to,
     }
 
 
@@ -53,11 +53,11 @@ class ImgwPibSensorEntityDescription(SensorEntityDescription):
 
 SENSOR_TYPES: tuple[ImgwPibSensorEntityDescription, ...] = (
     ImgwPibSensorEntityDescription(
-        key="alert",
+        key="hydrological_alert",
         translation_key="hydrological_alert",
         device_class=SensorDeviceClass.ENUM,
         options=list(HYDROLOGICAL_ALERTS_MAP.values()),
-        value=lambda data: data.alert.value,
+        value=lambda data: data.hydrological_alert.value,
         attrs=gen_alert_attributes,
     ),
     ImgwPibSensorEntityDescription(

--- a/homeassistant/components/imgw_pib/sensor.py
+++ b/homeassistant/components/imgw_pib/sensor.py
@@ -30,7 +30,7 @@ from .entity import ImgwPibEntity
 PARALLEL_UPDATES = 0
 
 
-def gen_attributes(data: HydrologicalData) -> dict[str, Any] | None:
+def gen_alert_attributes(data: HydrologicalData) -> dict[str, Any] | None:
     """Generate attributes for the alert entity."""
     if data.alert.value == NO_ALERT:
         return None
@@ -58,7 +58,7 @@ SENSOR_TYPES: tuple[ImgwPibSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENUM,
         options=list(HYDROLOGICAL_ALERTS_MAP.values()),
         value=lambda data: data.alert.value,
-        attrs=gen_attributes,
+        attrs=gen_alert_attributes,
     ),
     ImgwPibSensorEntityDescription(
         key="water_flow",

--- a/homeassistant/components/imgw_pib/sensor.py
+++ b/homeassistant/components/imgw_pib/sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from imgw_pib.const import HYDROLOGICAL_ALERTS_MAP
 from imgw_pib.model import HydrologicalData
 
 from homeassistant.components.sensor import (
@@ -36,6 +37,13 @@ class ImgwPibSensorEntityDescription(SensorEntityDescription):
 
 
 SENSOR_TYPES: tuple[ImgwPibSensorEntityDescription, ...] = (
+    ImgwPibSensorEntityDescription(
+        key="alert",
+        translation_key="hydrological_alert",
+        device_class=SensorDeviceClass.ENUM,
+        options=list(HYDROLOGICAL_ALERTS_MAP.values()),
+        value=lambda data: data.alert.value,
+    ),
     ImgwPibSensorEntityDescription(
         key="water_flow",
         translation_key="water_flow",

--- a/homeassistant/components/imgw_pib/strings.json
+++ b/homeassistant/components/imgw_pib/strings.json
@@ -29,12 +29,30 @@
           "rapid_water_level_rise": "Rapid water level rise"
         },
         "state_attributes": {
+          "level": {
+            "name": "Level",
+            "state": {
+              "none": "None",
+              "orange": "Orange",
+              "red": "Red",
+              "yellow": "Yellow"
+            }
+          },
           "options": {
             "state": {
               "no_alert": "[%key:component::imgw_pib::entity::sensor::hydrological_alert::state::no_alert%]",
               "hydrological_drought": "[%key:component::imgw_pib::entity::sensor::hydrological_alert::state::hydrological_drought%]",
               "rapid_water_level_rise": "[%key:component::imgw_pib::entity::sensor::hydrological_alert::state::rapid_water_level_rise%]"
             }
+          },
+          "probability": {
+            "name": "Probability"
+          },
+          "valid_from": {
+            "name": "Valid from"
+          },
+          "valid_to": {
+            "name": "Valid to"
           }
         }
       },

--- a/homeassistant/components/imgw_pib/strings.json
+++ b/homeassistant/components/imgw_pib/strings.json
@@ -21,6 +21,23 @@
   },
   "entity": {
     "sensor": {
+      "hydrological_alert": {
+        "name": "Hydrological alert",
+        "state": {
+          "no_alert": "No alert",
+          "hydrological_drought": "Hydrological drought",
+          "rapid_water_level_rise": "Rapid water level rise"
+        },
+        "state_attributes": {
+          "options": {
+            "state": {
+              "no_alert": "[%key:component::imgw_pib::entity::sensor::hydrological_alert::state::no_alert%]",
+              "hydrological_drought": "[%key:component::imgw_pib::entity::sensor::hydrological_alert::state::hydrological_drought%]",
+              "rapid_water_level_rise": "[%key:component::imgw_pib::entity::sensor::hydrological_alert::state::rapid_water_level_rise%]"
+            }
+          }
+        }
+      },
       "water_flow": {
         "name": "Water flow"
       },

--- a/tests/components/imgw_pib/conftest.py
+++ b/tests/components/imgw_pib/conftest.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
-from imgw_pib import NO_ALERT, Alert, HydrologicalData, SensorData
+from imgw_pib import Alert, HydrologicalData, SensorData
 import pytest
 
 from homeassistant.components.imgw_pib.const import DOMAIN
@@ -25,7 +25,13 @@ HYDROLOGICAL_DATA = HydrologicalData(
     water_temperature_measurement_date=datetime(2024, 4, 27, 10, 10, tzinfo=UTC),
     water_flow=SensorData(name="Water Flow", value=123.45),
     water_flow_measurement_date=datetime(2024, 4, 27, 10, 5, tzinfo=UTC),
-    hydrological_alert=Alert(value=NO_ALERT),
+    hydrological_alert=Alert(
+        value="rapid_water_level_rise",
+        valid_from=datetime(2024, 4, 27, 7, 0, tzinfo=UTC),
+        valid_to=datetime(2024, 4, 28, 11, 0, tzinfo=UTC),
+        level="yellow",
+        probability=80,
+    ),
 )
 
 

--- a/tests/components/imgw_pib/snapshots/test_diagnostics.ambr
+++ b/tests/components/imgw_pib/snapshots/test_diagnostics.ambr
@@ -22,13 +22,6 @@
       'version': 1,
     }),
     'hydrological_data': dict({
-      'hydrological_alert': dict({
-        'level': 'yellow',
-        'probability': 80,
-        'valid_from': '2024-04-27T07:00:00+00:00',
-        'valid_to': '2024-04-28T11:00:00+00:00',
-        'value': 'rapid_water_level_rise',
-      }),
       'flood_alarm': None,
       'flood_alarm_level': dict({
         'name': 'Flood Alarm Level',
@@ -42,11 +35,11 @@
         'value': None,
       }),
       'hydrological_alert': dict({
-        'level': None,
-        'probability': None,
-        'valid_from': None,
-        'valid_to': None,
-        'value': 'no_alert',
+        'level': 'yellow',
+        'probability': 80,
+        'valid_from': '2024-04-27T07:00:00+00:00',
+        'valid_to': '2024-04-28T11:00:00+00:00',
+        'value': 'rapid_water_level_rise',
       }),
       'latitude': None,
       'longitude': None,

--- a/tests/components/imgw_pib/snapshots/test_diagnostics.ambr
+++ b/tests/components/imgw_pib/snapshots/test_diagnostics.ambr
@@ -22,6 +22,13 @@
       'version': 1,
     }),
     'hydrological_data': dict({
+      'hydrological_alert': dict({
+        'level': 'yellow',
+        'probability': 80,
+        'valid_from': '2024-04-27T07:00:00+00:00',
+        'valid_to': '2024-04-28T11:00:00+00:00',
+        'value': 'rapid_water_level_rise',
+      }),
       'flood_alarm': None,
       'flood_alarm_level': dict({
         'name': 'Flood Alarm Level',

--- a/tests/components/imgw_pib/snapshots/test_sensor.ambr
+++ b/tests/components/imgw_pib/snapshots/test_sensor.ambr
@@ -1,4 +1,69 @@
 # serializer version: 1
+# name: test_sensor[sensor.river_name_station_name_hydrological_alert-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'no_alert',
+        'hydrological_drought',
+        'rapid_water_level_rise',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.river_name_station_name_hydrological_alert',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Hydrological alert',
+    'platform': 'imgw_pib',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'hydrological_alert',
+    'unique_id': '123_alert',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[sensor.river_name_station_name_hydrological_alert-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by IMGW-PIB',
+      'device_class': 'enum',
+      'friendly_name': 'River Name (Station Name) Hydrological alert',
+      'level': 'yellow',
+      'options': list([
+        'no_alert',
+        'hydrological_drought',
+        'rapid_water_level_rise',
+      ]),
+      'probability': 80,
+      'valid_from': datetime.datetime(2024, 4, 27, 7, 0, tzinfo=datetime.timezone.utc),
+      'valid_to': datetime.datetime(2024, 4, 28, 11, 0, tzinfo=datetime.timezone.utc),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.river_name_station_name_hydrological_alert',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'rapid_water_level_rise',
+  })
+# ---
 # name: test_sensor[sensor.river_name_station_name_water_flow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/imgw_pib/snapshots/test_sensor.ambr
+++ b/tests/components/imgw_pib/snapshots/test_sensor.ambr
@@ -36,7 +36,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'hydrological_alert',
-    'unique_id': '123_alert',
+    'unique_id': '123_hydrological_alert',
     'unit_of_measurement': None,
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a `hydrological alert` sensor that provides information about the alert type, its level, validity dates and probability of occurrence.

<strike>Changing the key name from `alert` to `hydrological alert` required a change in the backend library.</strike>
<strike>Changelog: https://github.com/bieniu/imgw-pib/compare/1.4.0...1.4.1</strike>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40025
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
