### PR TITLE
Fix erroneous zero water usage readings

### DIFF
--- a/tests/components/drop_connect/test_sensor.py
+++ b/tests/components/drop_connect/test_sensor.py
@@ -1,14 +1,25 @@
 """Test DROP sensor entities."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
+from dataclasses import dataclass
 from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.drop_connect.const import (
+    CONF_DEVICE_DESC,
+    CONF_DEVICE_NAME,
+    CONF_DEVICE_TYPE,
+    CONF_HUB_ID,
+)
+from homeassistant.components.drop_connect.sensor import WATER_USED_TODAY, DROPSensor
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import EntityDescription
 
 from .common import (
     TEST_DATA_ALERT,
@@ -139,3 +150,75 @@ async def test_sensors(
     async_fire_mqtt_message(hass, topic, data)
     await hass.async_block_till_done()
     help_assert_entries(hass, entity_registry, snapshot, config_entry, "data")
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Create a mock config entry for testing."""
+    return MockConfigEntry(
+        domain="drop_connect",
+        unique_id="test_device_id",
+        data={
+            CONF_DEVICE_DESC: "Hub",
+            CONF_DEVICE_TYPE: "hub",
+            CONF_HUB_ID: "test_hub_id",
+            CONF_DEVICE_NAME: "Test Hub",
+        },
+    )
+
+
+@pytest.fixture
+def mock_coordinator(mock_config_entry):
+    """Mock a coordinator for sensor tests."""
+
+    class MockCoordinator:
+        def __init__(self) -> None:
+            self.data = {}
+            self.config_entry = mock_config_entry
+
+    return MockCoordinator()
+
+
+@dataclass
+class DummySensorEntityDescription(EntityDescription):
+    """A minimal sensor entity description for testing."""
+
+    state_class: SensorStateClass | None = None
+    value_fn: Callable | None = None
+
+
+@pytest.fixture
+def mock_description():
+    """Mock a sensor description for water_used_today tests."""
+    return DummySensorEntityDescription(
+        key=WATER_USED_TODAY,
+        device_class=SensorDeviceClass.WATER,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coordinator: coordinator.data.get("usedToday", 0),
+    )
+
+
+def test_water_used_today(mock_coordinator, mock_description) -> None:
+    """Test handling of water_used_today sensor values."""
+
+    sensor = DROPSensor(mock_coordinator, mock_description)
+
+    # Simulate a normal reading at 9 AM
+    mock_coordinator.data = {"usedToday": 1100}
+    with freeze_time("2025-07-15 09:00:00"):
+        assert sensor.native_value == 1100
+
+    # Simulate a glitch: drop to 0 at 9:01 AM
+    mock_coordinator.data = {"usedToday": 0}
+    with freeze_time("2025-07-15 09:01:00"):
+        assert sensor.native_value == 1100  # should return previous value
+
+    # Simulate legitimate reset at 12:03 AM (within 10-min window)
+    mock_coordinator.data = {"usedToday": 0}
+    with freeze_time("2025-07-16 00:03:00"):
+        assert sensor.native_value == 0  # allow legitimate reset
+
+    # After reset, new usage comes in
+    mock_coordinator.data = {"usedToday": 5}
+    with freeze_time("2025-07-16 00:10:00"):
+        assert sensor.native_value == 5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`total_increasing` sensors should never erroneously return decreasing values [docs](https://developers.home-assistant.io/blog/2021/08/16/state_class_total/#state_class_total_increasing). I occasionally see the `water_used_today` sensor returning zero values mid-day when it should only be resetting at midnight. This affects how water usage is displayed on the energy dashboard. It reports a large usage from the value going to zero then back to the current value. Integrations are responsible for ensuring this shouldn't happen. This change adds logic to the drop_connect integration to drop mid-day zeros and only allow resets in the first 10 minutes of the day, local time. 

<img width="964" height="440" alt="Screenshot 2025-07-15 at 8 01 04 PM" src="https://github.com/user-attachments/assets/ea11392c-86ea-4e9e-a27f-996609861d78" />

<img width="1240" height="580" alt="Screenshot 2025-07-15 at 7 59 34 PM" src="https://github.com/user-attachments/assets/d0383887-2dc6-46cb-8a62-d288fa5ac335" />



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
