### PR TITLE
Make exceptions translatable in inexogy integration

### DIFF
--- a/homeassistant/components/discovergy/__init__.py
+++ b/homeassistant/components/discovergy/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.httpx_client import create_async_httpx_client
 
+from .const import DOMAIN
 from .coordinator import DiscovergyConfigEntry, DiscovergyUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -30,10 +31,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: DiscovergyConfigEntry) -
         # if no exception is raised everything is fine to go
         meters = await client.meters()
     except discovergyError.InvalidLogin as err:
-        raise ConfigEntryAuthFailed("Invalid email or password") from err
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="invalid_auth",
+        ) from err
     except Exception as err:
         raise ConfigEntryNotReady(
-            "Unexpected error while while getting meters"
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect_meters_setup",
         ) from err
 
     # Init coordinators for meters

--- a/homeassistant/components/discovergy/coordinator.py
+++ b/homeassistant/components/discovergy/coordinator.py
@@ -14,6 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
 
 type DiscovergyConfigEntry = ConfigEntry[list[DiscovergyUpdateCoordinator]]
@@ -51,7 +53,12 @@ class DiscovergyUpdateCoordinator(DataUpdateCoordinator[Reading]):
             )
         except InvalidLogin as err:
             raise ConfigEntryAuthFailed(
-                "Auth expired while fetching last reading"
+                translation_domain=DOMAIN,
+                translation_key="invalid_auth",
             ) from err
         except (HTTPError, DiscovergyClientError) as err:
-            raise UpdateFailed(f"Error while fetching last reading: {err}") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="reading_update_failed",
+                translation_placeholders={"meter_id": self.meter.meter_id},
+            ) from err

--- a/homeassistant/components/discovergy/quality_scale.yaml
+++ b/homeassistant/components/discovergy/quality_scale.yaml
@@ -72,12 +72,16 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations: todo
+  exception-translations: done
   icon-translations:
     status: exempt
     comment: |
       The integration does not provide any additional icons.
-  reconfiguration-flow: todo
+  reconfiguration-flow:
+    status: exempt
+    comment: |
+      No configuration besides credentials.
+      New credentials will create a new config entry.
   repair-issues:
     status: exempt
     comment: |

--- a/homeassistant/components/discovergy/strings.json
+++ b/homeassistant/components/discovergy/strings.json
@@ -23,6 +23,17 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
+  "exceptions": {
+    "invalid_auth": {
+      "message": "Authentication failed. Please check your inexogy email and password."
+    },
+    "cannot_connect_meters_setup": {
+      "message": "Failed to connect and retrieve meters from inexogy during setup. Please ensure the service is reachable and try again."
+    },
+    "reading_update_failed": {
+      "message": "Error fetching the latest reading for meter {meter_id} from inexogy. The service might be temporarily unavailable or there's a connection issue. Check logs for more details."
+    }
+  },
   "system_health": {
     "info": {
       "api_endpoint_reachable": "inexogy API endpoint reachable"


### PR DESCRIPTION
## Proposed change
Make the exceptions in inexogy translatable. Additionally update the `reconfiguration-flow` check as it was missed initially.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
