### PR TITLE
Add initial support for tuya qccdz

### DIFF
--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -545,6 +545,14 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
             device_class=SwitchDeviceClass.OUTLET,
         ),
     ),
+    # AC charging
+    # Not documented
+    "qccdz": (
+        SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            translation_key="switch",
+        ),
+    ),
     # Unknown product with switch capabilities
     # Fond in some diffusers, plugs and PIR flood lights
     # Not documented

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -113,6 +113,10 @@ DEVICE_MOCKS = {
         Platform.BINARY_SENSOR,
         Platform.SENSOR,
     ],
+    "qccdz_ac_charging_control": [
+        # https://github.com/home-assistant/core/issues/136207
+        Platform.SWITCH,
+    ],
     "qxj_temp_humidity_external_probe": [
         # https://github.com/home-assistant/core/issues/136472
         Platform.SENSOR,

--- a/tests/components/tuya/fixtures/qccdz_ac_charging_control.json
+++ b/tests/components/tuya/fixtures/qccdz_ac_charging_control.json
@@ -1,0 +1,105 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "terminal_id": "1737479380414pasuj4",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "id": "bf83514d9c14b426f0fz5y",
+  "name": "AC charging control box",
+  "category": "qccdz",
+  "product_id": "7bvgooyjhiua1yyq",
+  "product_name": "AC charging control box",
+  "online": true,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2025-01-21T17:00:03+00:00",
+  "create_time": "2025-01-21T17:00:03+00:00",
+  "update_time": "2025-01-21T17:00:03+00:00",
+  "function": {
+    "work_mode": {
+      "type": "Enum",
+      "value": {
+        "range": [
+          "charge_now",
+          "charge_pct",
+          "charge_energy",
+          "charge_schedule"
+        ]
+      }
+    },
+    "clear_energy": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    }
+  },
+  "status_range": {
+    "work_state": {
+      "type": "Enum",
+      "value": {
+        "range": [
+          "charger_free",
+          "charger_insert",
+          "charger_free_fault",
+          "charger_wait",
+          "charger_charging",
+          "charger_pause",
+          "charger_end",
+          "charger_fault"
+        ]
+      }
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": {
+        "range": [
+          "charge_now",
+          "charge_pct",
+          "charge_energy",
+          "charge_schedule"
+        ]
+      }
+    },
+    "balance_energy": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW\u00b7h",
+        "min": 0,
+        "max": 99999999,
+        "scale": 3,
+        "step": 1
+      }
+    },
+    "clear_energy": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "charge_energy_once": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW\u00b7h",
+        "min": 1,
+        "max": 999999,
+        "scale": 2,
+        "step": 1
+      }
+    }
+  },
+  "status": {
+    "work_state": "charger_free",
+    "work_mode": "charge_now",
+    "balance_energy": 0,
+    "clear_energy": false,
+    "switch": false,
+    "charge_energy_once": 1
+  },
+  "set_up": false,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -869,6 +869,54 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[qccdz_ac_charging_control][switch.ac_charging_control_box_switch-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.ac_charging_control_box_switch',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch',
+    'unique_id': 'tuya.bf83514d9c14b426f0fz5yswitch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[qccdz_ac_charging_control][switch.ac_charging_control_box_switch-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AC charging control box Switch',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ac_charging_control_box_switch',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sfkzq_valve_controller][switch.sprinkler_cesare_switch-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
AC charging system

Based on https://github.com/home-assistant/core/issues/136207

Replaces #136603

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
