### PR TITLE
Use Tuya device listener in binary sensor tests

### DIFF
--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 from tuya_sharing import CustomerDevice
 
-from homeassistant.components.tuya import ManagerCompat
+from homeassistant.components.tuya import DeviceListener, ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
@@ -160,6 +161,29 @@ DEVICE_MOCKS = {
         Platform.SENSOR,
     ],
 }
+
+
+class MockDeviceListener(DeviceListener):
+    """Mocked DeviceListener for testing."""
+
+    async def async_send_device_update(
+        self,
+        hass: HomeAssistant,
+        device: CustomerDevice,
+        updated_status_properties: dict[str, Any] | None = None,
+    ) -> None:
+        """Mock update device method."""
+        property_list: list[str] = []
+        if updated_status_properties:
+            for key, value in updated_status_properties.items():
+                if key not in device.status:
+                    raise ValueError(
+                        f"Property {key} not found in device status: {device.status}"
+                    )
+                device.status[key] = value
+                property_list.append(key)
+        self.update_device(device, property_list)
+        await hass.async_block_till_done()
 
 
 async def initialize_entry(

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -21,6 +21,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import json_dumps
 from homeassistant.util import dt as dt_util
 
+from . import MockDeviceListener
+
 from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
@@ -181,3 +183,13 @@ async def mock_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDev
     }
     device.status = details["status"]
     return device
+
+
+@pytest.fixture
+def mock_listener(
+    hass: HomeAssistant, mock_manager: ManagerCompat
+) -> MockDeviceListener:
+    """Create a DeviceListener for testing."""
+    listener = MockDeviceListener(hass, mock_manager)
+    mock_manager.add_device_listener(listener)
+    return listener


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Makes it easier to test cloud updates rather than relying on initial status

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
