### PR TITLE
Bump letpot to 0.5.0

### DIFF
--- a/homeassistant/components/letpot/__init__.py
+++ b/homeassistant/components/letpot/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 
 from letpot.client import LetPotClient
 from letpot.converters import CONVERTERS
+from letpot.deviceclient import LetPotDeviceClient
 from letpot.exceptions import LetPotAuthenticationException, LetPotException
 from letpot.models import AuthenticationInfo
 
@@ -68,8 +69,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> bo
     except LetPotException as exc:
         raise ConfigEntryNotReady from exc
 
+    device_client = LetPotDeviceClient(auth)
+
     coordinators: list[LetPotDeviceCoordinator] = [
-        LetPotDeviceCoordinator(hass, entry, auth, device)
+        LetPotDeviceCoordinator(hass, entry, device, device_client)
         for device in devices
         if any(converter.supports_type(device.device_type) for converter in CONVERTERS)
     ]
@@ -92,5 +95,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> b
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         for coordinator in entry.runtime_data:
-            coordinator.device_client.disconnect()
+            await coordinator.device_client.unsubscribe(
+                coordinator.device.serial_number
+            )
     return unload_ok

--- a/homeassistant/components/letpot/binary_sensor.py
+++ b/homeassistant/components/letpot/binary_sensor.py
@@ -58,7 +58,9 @@ BINARY_SENSORS: tuple[LetPotBinarySensorEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.RUNNING,
         supported_fn=(
             lambda coordinator: DeviceFeature.PUMP_STATUS
-            in coordinator.device_client.device_features
+            in coordinator.device_client.device_info(
+                coordinator.device.serial_number
+            ).features
         ),
     ),
     LetPotBinarySensorEntityDescription(

--- a/homeassistant/components/letpot/coordinator.py
+++ b/homeassistant/components/letpot/coordinator.py
@@ -8,7 +8,7 @@ import logging
 
 from letpot.deviceclient import LetPotDeviceClient
 from letpot.exceptions import LetPotAuthenticationException, LetPotException
-from letpot.models import AuthenticationInfo, LetPotDevice, LetPotDeviceStatus
+from letpot.models import LetPotDevice, LetPotDeviceStatus
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -34,8 +34,8 @@ class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
         self,
         hass: HomeAssistant,
         config_entry: LetPotConfigEntry,
-        info: AuthenticationInfo,
         device: LetPotDevice,
+        device_client: LetPotDeviceClient,
     ) -> None:
         """Initialize coordinator."""
         super().__init__(
@@ -45,9 +45,8 @@ class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
             name=f"LetPot {device.serial_number}",
             update_interval=timedelta(minutes=10),
         )
-        self._info = info
         self.device = device
-        self.device_client = LetPotDeviceClient(info, device.serial_number)
+        self.device_client = device_client
 
     def _handle_status_update(self, status: LetPotDeviceStatus) -> None:
         """Distribute status update to entities."""
@@ -56,7 +55,9 @@ class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
     async def _async_setup(self) -> None:
         """Set up subscription for coordinator."""
         try:
-            await self.device_client.subscribe(self._handle_status_update)
+            await self.device_client.subscribe(
+                self.device.serial_number, self._handle_status_update
+            )
         except LetPotAuthenticationException as exc:
             raise ConfigEntryAuthFailed from exc
 
@@ -64,7 +65,7 @@ class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
         """Request an update from the device and wait for a status update or timeout."""
         try:
             async with asyncio.timeout(REQUEST_UPDATE_TIMEOUT):
-                await self.device_client.get_current_status()
+                await self.device_client.get_current_status(self.device.serial_number)
         except LetPotException as exc:
             raise UpdateFailed(exc) from exc
 

--- a/homeassistant/components/letpot/entity.py
+++ b/homeassistant/components/letpot/entity.py
@@ -30,12 +30,13 @@ class LetPotEntity(CoordinatorEntity[LetPotDeviceCoordinator]):
     def __init__(self, coordinator: LetPotDeviceCoordinator) -> None:
         """Initialize a LetPot entity."""
         super().__init__(coordinator)
+        info = coordinator.device_client.device_info(coordinator.device.serial_number)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.device.serial_number)},
             name=coordinator.device.name,
             manufacturer="LetPot",
-            model=coordinator.device_client.device_model_name,
-            model_id=coordinator.device_client.device_model_code,
+            model=info.model_name,
+            model_id=info.model_code,
             serial_number=coordinator.device.serial_number,
         )
 

--- a/homeassistant/components/letpot/manifest.json
+++ b/homeassistant/components/letpot/manifest.json
@@ -6,6 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/letpot",
   "integration_type": "hub",
   "iot_class": "cloud_push",
+  "loggers": ["letpot"],
   "quality_scale": "bronze",
-  "requirements": ["letpot==0.4.0"]
+  "requirements": ["letpot==0.5.0"]
 }

--- a/homeassistant/components/letpot/sensor.py
+++ b/homeassistant/components/letpot/sensor.py
@@ -50,7 +50,9 @@ SENSORS: tuple[LetPotSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         supported_fn=(
             lambda coordinator: DeviceFeature.TEMPERATURE
-            in coordinator.device_client.device_features
+            in coordinator.device_client.device_info(
+                coordinator.device.serial_number
+            ).features
         ),
     ),
     LetPotSensorEntityDescription(
@@ -61,7 +63,9 @@ SENSORS: tuple[LetPotSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         supported_fn=(
             lambda coordinator: DeviceFeature.WATER_LEVEL
-            in coordinator.device_client.device_features
+            in coordinator.device_client.device_info(
+                coordinator.device.serial_number
+            ).features
         ),
     ),
 )

--- a/homeassistant/components/letpot/time.py
+++ b/homeassistant/components/letpot/time.py
@@ -26,7 +26,7 @@ class LetPotTimeEntityDescription(TimeEntityDescription):
     """Describes a LetPot time entity."""
 
     value_fn: Callable[[LetPotDeviceStatus], time | None]
-    set_value_fn: Callable[[LetPotDeviceClient, time], Coroutine[Any, Any, None]]
+    set_value_fn: Callable[[LetPotDeviceClient, str, time], Coroutine[Any, Any, None]]
 
 
 TIME_SENSORS: tuple[LetPotTimeEntityDescription, ...] = (
@@ -34,8 +34,10 @@ TIME_SENSORS: tuple[LetPotTimeEntityDescription, ...] = (
         key="light_schedule_end",
         translation_key="light_schedule_end",
         value_fn=lambda status: None if status is None else status.light_schedule_end,
-        set_value_fn=lambda deviceclient, value: deviceclient.set_light_schedule(
-            start=None, end=value
+        set_value_fn=(
+            lambda device_client, serial, value: device_client.set_light_schedule(
+                serial=serial, start=None, end=value
+            )
         ),
         entity_category=EntityCategory.CONFIG,
     ),
@@ -43,8 +45,10 @@ TIME_SENSORS: tuple[LetPotTimeEntityDescription, ...] = (
         key="light_schedule_start",
         translation_key="light_schedule_start",
         value_fn=lambda status: None if status is None else status.light_schedule_start,
-        set_value_fn=lambda deviceclient, value: deviceclient.set_light_schedule(
-            start=value, end=None
+        set_value_fn=(
+            lambda device_client, serial, value: device_client.set_light_schedule(
+                serial=serial, start=value, end=None
+            )
         ),
         entity_category=EntityCategory.CONFIG,
     ),
@@ -89,5 +93,5 @@ class LetPotTimeEntity(LetPotEntity, TimeEntity):
     async def async_set_value(self, value: time) -> None:
         """Set the time."""
         await self.entity_description.set_value_fn(
-            self.coordinator.device_client, value
+            self.coordinator.device_client, self.coordinator.device.serial_number, value
         )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1334,7 +1334,7 @@ led-ble==1.1.7
 lektricowifi==0.1
 
 # homeassistant.components.letpot
-letpot==0.4.0
+letpot==0.5.0
 
 # homeassistant.components.foscam
 libpyfoscamcgi==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1153,7 +1153,7 @@ led-ble==1.1.7
 lektricowifi==0.1
 
 # homeassistant.components.letpot
-letpot==0.4.0
+letpot==0.5.0
 
 # homeassistant.components.foscam
 libpyfoscamcgi==0.0.6

--- a/tests/components/letpot/conftest.py
+++ b/tests/components/letpot/conftest.py
@@ -3,7 +3,12 @@
 from collections.abc import Callable, Generator
 from unittest.mock import AsyncMock, patch
 
-from letpot.models import DeviceFeature, LetPotDevice, LetPotDeviceStatus
+from letpot.models import (
+    DeviceFeature,
+    LetPotDevice,
+    LetPotDeviceInfo,
+    LetPotDeviceStatus,
+)
 import pytest
 
 from homeassistant.components.letpot.const import (
@@ -24,6 +29,16 @@ from tests.common import MockConfigEntry
 def device_type() -> str:
     """Return the device type to use for mock data."""
     return "LPH63"
+
+
+def _mock_device_info(device_type: str) -> LetPotDeviceInfo:
+    """Return mock device info for the given type."""
+    return LetPotDeviceInfo(
+        model=device_type,
+        model_name=f"LetPot {device_type}",
+        model_code=device_type,
+        features=_mock_device_features(device_type),
+    )
 
 
 def _mock_device_features(device_type: str) -> DeviceFeature:
@@ -89,32 +104,33 @@ def mock_client(device_type: str) -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_device_client(device_type: str) -> Generator[AsyncMock]:
+def mock_device_client() -> Generator[AsyncMock]:
     """Mock a LetPotDeviceClient."""
     with patch(
-        "homeassistant.components.letpot.coordinator.LetPotDeviceClient",
+        "homeassistant.components.letpot.LetPotDeviceClient",
         autospec=True,
     ) as mock_device_client:
         device_client = mock_device_client.return_value
-        device_client.device_features = _mock_device_features(device_type)
-        device_client.device_model_code = device_type
-        device_client.device_model_name = f"LetPot {device_type}"
-        device_status = _mock_device_status(device_type)
 
-        subscribe_callbacks: list[Callable] = []
+        subscribe_callbacks: dict[str, Callable] = {}
 
-        def subscribe_side_effect(callback: Callable) -> None:
-            subscribe_callbacks.append(callback)
+        def subscribe_side_effect(serial: str, callback: Callable) -> None:
+            subscribe_callbacks[serial] = callback
 
-        def status_side_effect() -> None:
-            # Deliver a status update to any subscribers, like the real client
-            for callback in subscribe_callbacks:
-                callback(device_status)
+        def request_status_side_effect(serial: str) -> None:
+            # Deliver a status update to the subscriber, like the real client
+            if (callback := subscribe_callbacks.get(serial)) is not None:
+                callback(_mock_device_status(serial[:5]))
 
-        device_client.get_current_status.side_effect = status_side_effect
-        device_client.get_current_status.return_value = device_status
-        device_client.last_status.return_value = device_status
-        device_client.request_status_update.side_effect = status_side_effect
+        def get_current_status_side_effect(serial: str) -> LetPotDeviceStatus:
+            request_status_side_effect(serial)
+            return _mock_device_status(serial[:5])
+
+        device_client.device_info.side_effect = lambda serial: _mock_device_info(
+            serial[:5]
+        )
+        device_client.get_current_status.side_effect = get_current_status_side_effect
+        device_client.request_status_update.side_effect = request_status_side_effect
         device_client.subscribe.side_effect = subscribe_side_effect
 
         yield device_client

--- a/tests/components/letpot/test_init.py
+++ b/tests/components/letpot/test_init.py
@@ -37,7 +37,7 @@ async def test_load_unload_config_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
-    mock_device_client.disconnect.assert_called_once()
+    mock_device_client.unsubscribe.assert_called_once()
 
 
 @pytest.mark.freeze_time("2025-02-15 00:00:00")

--- a/tests/components/letpot/test_switch.py
+++ b/tests/components/letpot/test_switch.py
@@ -58,6 +58,7 @@ async def test_set_switch(
     mock_config_entry: MockConfigEntry,
     mock_client: MagicMock,
     mock_device_client: MagicMock,
+    device_type: str,
     service: str,
     parameter_value: bool,
 ) -> None:
@@ -71,7 +72,9 @@ async def test_set_switch(
         target={"entity_id": "switch.garden_power"},
     )
 
-    mock_device_client.set_power.assert_awaited_once_with(parameter_value)
+    mock_device_client.set_power.assert_awaited_once_with(
+        f"{device_type}ABCD", parameter_value
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/letpot/test_time.py
+++ b/tests/components/letpot/test_time.py
@@ -38,6 +38,7 @@ async def test_set_time(
     mock_config_entry: MockConfigEntry,
     mock_client: MagicMock,
     mock_device_client: MagicMock,
+    device_type: str,
 ) -> None:
     """Test setting the time entity."""
     await setup_integration(hass, mock_config_entry)
@@ -50,7 +51,9 @@ async def test_set_time(
         target={"entity_id": "time.garden_light_on"},
     )
 
-    mock_device_client.set_light_schedule.assert_awaited_once_with(time(7, 0), None)
+    mock_device_client.set_light_schedule.assert_awaited_once_with(
+        f"{device_type}ABCD", time(7, 0), None
+    )
 
 
 @pytest.mark.parametrize(
@@ -71,6 +74,7 @@ async def test_time_error(
     mock_config_entry: MockConfigEntry,
     mock_client: MagicMock,
     mock_device_client: MagicMock,
+    device_type: str,
     exception: Exception,
     user_error: str,
 ) -> None:

--- a/tests/components/letpot/test_time.py
+++ b/tests/components/letpot/test_time.py
@@ -74,7 +74,6 @@ async def test_time_error(
     mock_config_entry: MockConfigEntry,
     mock_client: MagicMock,
     mock_device_client: MagicMock,
-    device_type: str,
     exception: Exception,
     user_error: str,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump letpot to 0.5.0.

 - Changelog https://github.com/jpelgrom/python-letpot/releases/tag/v0.5.0
 - Diff https://github.com/jpelgrom/python-letpot/compare/v0.4.0...v0.5.0

This release changes the device client setup so you're using one client for all devices (sharing the underlying connection), instead of a client per device (each maintaining a separate connection). That requires changes in most places to pass the device serial when interacting with the client.

The device client changes also include more debug logger calls so I'm setting `loggers` in the integration manifest for that as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
