### PR TITLE
Fix warning about failure to get action during setup phase

### DIFF
--- a/homeassistant/components/wmspro/button.py
+++ b/homeassistant/components/wmspro/button.py
@@ -23,7 +23,9 @@ async def async_setup_entry(
     entities: list[WebControlProGenericEntity] = [
         WebControlProIdentifyButton(config_entry.entry_id, dest)
         for dest in hub.dests.values()
-        if dest.action(WMS_WebControl_pro_API_actionDescription.Identify)
+        if dest.action(
+            WMS_WebControl_pro_API_actionDescription.Identify, warnMissing=False
+        )
     ]
 
     async_add_entities(entities)

--- a/homeassistant/components/wmspro/button.py
+++ b/homeassistant/components/wmspro/button.py
@@ -23,9 +23,7 @@ async def async_setup_entry(
     entities: list[WebControlProGenericEntity] = [
         WebControlProIdentifyButton(config_entry.entry_id, dest)
         for dest in hub.dests.values()
-        if dest.action(
-            WMS_WebControl_pro_API_actionDescription.Identify, warnMissing=False
-        )
+        if dest.hasAction(WMS_WebControl_pro_API_actionDescription.Identify)
     ]
 
     async_add_entities(entities)

--- a/homeassistant/components/wmspro/cover.py
+++ b/homeassistant/components/wmspro/cover.py
@@ -32,10 +32,13 @@ async def async_setup_entry(
 
     entities: list[WebControlProGenericEntity] = []
     for dest in hub.dests.values():
-        if dest.action(WMS_WebControl_pro_API_actionDescription.AwningDrive):
+        if dest.action(
+            WMS_WebControl_pro_API_actionDescription.AwningDrive, warnMissing=False
+        ):
             entities.append(WebControlProAwning(config_entry.entry_id, dest))
         elif dest.action(
-            WMS_WebControl_pro_API_actionDescription.RollerShutterBlindDrive
+            WMS_WebControl_pro_API_actionDescription.RollerShutterBlindDrive,
+            warnMissing=False,
         ):
             entities.append(WebControlProRollerShutter(config_entry.entry_id, dest))
 

--- a/homeassistant/components/wmspro/cover.py
+++ b/homeassistant/components/wmspro/cover.py
@@ -32,13 +32,10 @@ async def async_setup_entry(
 
     entities: list[WebControlProGenericEntity] = []
     for dest in hub.dests.values():
-        if dest.action(
-            WMS_WebControl_pro_API_actionDescription.AwningDrive, warnMissing=False
-        ):
+        if dest.hasAction(WMS_WebControl_pro_API_actionDescription.AwningDrive):
             entities.append(WebControlProAwning(config_entry.entry_id, dest))
-        elif dest.action(
-            WMS_WebControl_pro_API_actionDescription.RollerShutterBlindDrive,
-            warnMissing=False,
+        elif dest.hasAction(
+            WMS_WebControl_pro_API_actionDescription.RollerShutterBlindDrive
         ):
             entities.append(WebControlProRollerShutter(config_entry.entry_id, dest))
 

--- a/homeassistant/components/wmspro/light.py
+++ b/homeassistant/components/wmspro/light.py
@@ -33,13 +33,9 @@ async def async_setup_entry(
 
     entities: list[WebControlProGenericEntity] = []
     for dest in hub.dests.values():
-        if dest.action(
-            WMS_WebControl_pro_API_actionDescription.LightDimming, warnMissing=False
-        ):
+        if dest.hasAction(WMS_WebControl_pro_API_actionDescription.LightDimming):
             entities.append(WebControlProDimmer(config_entry.entry_id, dest))
-        elif dest.action(
-            WMS_WebControl_pro_API_actionDescription.LightSwitch, warnMissing=False
-        ):
+        elif dest.hasAction(WMS_WebControl_pro_API_actionDescription.LightSwitch):
             entities.append(WebControlProLight(config_entry.entry_id, dest))
 
     async_add_entities(entities)

--- a/homeassistant/components/wmspro/light.py
+++ b/homeassistant/components/wmspro/light.py
@@ -33,9 +33,13 @@ async def async_setup_entry(
 
     entities: list[WebControlProGenericEntity] = []
     for dest in hub.dests.values():
-        if dest.action(WMS_WebControl_pro_API_actionDescription.LightDimming):
+        if dest.action(
+            WMS_WebControl_pro_API_actionDescription.LightDimming, warnMissing=False
+        ):
             entities.append(WebControlProDimmer(config_entry.entry_id, dest))
-        elif dest.action(WMS_WebControl_pro_API_actionDescription.LightSwitch):
+        elif dest.action(
+            WMS_WebControl_pro_API_actionDescription.LightSwitch, warnMissing=False
+        ):
             entities.append(WebControlProLight(config_entry.entry_id, dest))
 
     async_add_entities(entities)

--- a/homeassistant/components/wmspro/manifest.json
+++ b/homeassistant/components/wmspro/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://www.home-assistant.io/integrations/wmspro",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "requirements": ["pywmspro==0.3.0"]
+  "requirements": ["pywmspro==0.3.1"]
 }

--- a/homeassistant/components/wmspro/manifest.json
+++ b/homeassistant/components/wmspro/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://www.home-assistant.io/integrations/wmspro",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "requirements": ["pywmspro==0.3.1"]
+  "requirements": ["pywmspro==0.3.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2603,7 +2603,7 @@ pywilight==0.0.74
 pywizlight==0.6.3
 
 # homeassistant.components.wmspro
-pywmspro==0.3.1
+pywmspro==0.3.2
 
 # homeassistant.components.ws66i
 pyws66i==1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2603,7 +2603,7 @@ pywilight==0.0.74
 pywizlight==0.6.3
 
 # homeassistant.components.wmspro
-pywmspro==0.3.0
+pywmspro==0.3.1
 
 # homeassistant.components.ws66i
 pyws66i==1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2161,7 +2161,7 @@ pywilight==0.0.74
 pywizlight==0.6.3
 
 # homeassistant.components.wmspro
-pywmspro==0.3.0
+pywmspro==0.3.1
 
 # homeassistant.components.ws66i
 pyws66i==1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2161,7 +2161,7 @@ pywilight==0.0.74
 pywizlight==0.6.3
 
 # homeassistant.components.wmspro
-pywmspro==0.3.1
+pywmspro==0.3.2
 
 # homeassistant.components.ws66i
 pyws66i==1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix/hide the following type of warnings during platform setup, because missing actions are expected during capability testing:

```
Failed to get action with description 6 and type None in Markise
(components/wmspro/light.py:37)
``` 
```
Failed to get action with description 8 and type None in Markise
(components/wmspro/light.py:35)
``` 
```
Failed to get action with description 0 and type None in LED 
(components/wmspro/cover.py:36)
```
```
Failed to get action with description 4 and type None in LED 
(components/wmspro/cover.py:38)
```

Requires a slight dependency bump to hide the warning:
Changelog/diff: https://github.com/mback2k/pywmspro/compare/0.3.0...0.3.2
Only relevant commits:
- 1st attempt: https://github.com/mback2k/pywmspro/commit/70babd4f48658df3ab677a33da1dc9d8eff27844
- 2nd improvement: https://github.com/mback2k/pywmspro/commit/23688d8bb5e240edf8ae64b81a5e6e5407f48de2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade (*required for bugfix!*)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/145539
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
