### PR TITLE
Add last_reported to state reported event data

### DIFF
--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -320,7 +320,12 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
                 # changed state, then we know it will still be zero.
                 return
             schedule_max_sub_interval_exceeded(new_state)
-            calc_derivative(new_state, new_state.state, event.data["old_last_reported"])
+            calc_derivative(
+                new_state,
+                new_state.state,
+                event.data["last_reported"],
+                event.data["old_last_reported"],
+            )
 
         @callback
         def on_state_changed(event: Event[EventStateChangedData]) -> None:
@@ -334,19 +339,27 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
             schedule_max_sub_interval_exceeded(new_state)
             old_state = event.data["old_state"]
             if old_state is not None:
-                calc_derivative(new_state, old_state.state, old_state.last_reported)
+                calc_derivative(
+                    new_state,
+                    old_state.state,
+                    new_state.last_updated,
+                    old_state.last_reported,
+                )
             else:
                 # On first state change from none, update availability
                 self.async_write_ha_state()
 
         def calc_derivative(
-            new_state: State, old_value: str, old_last_reported: datetime
+            new_state: State,
+            old_value: str,
+            new_timestamp: datetime,
+            old_timestamp: datetime,
         ) -> None:
             """Handle the sensor state changes."""
             if not _is_decimal_state(old_value):
                 if self._last_valid_state_time:
                     old_value = self._last_valid_state_time[0]
-                    old_last_reported = self._last_valid_state_time[1]
+                    old_timestamp = self._last_valid_state_time[1]
                 else:
                     # Sensor becomes valid for the first time, just keep the restored value
                     self.async_write_ha_state()
@@ -358,12 +371,10 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
                     "" if unit is None else unit
                 )
 
-            self._prune_state_list(new_state.last_reported)
+            self._prune_state_list(new_timestamp)
 
             try:
-                elapsed_time = (
-                    new_state.last_reported - old_last_reported
-                ).total_seconds()
+                elapsed_time = (new_timestamp - old_timestamp).total_seconds()
                 delta_value = Decimal(new_state.state) - Decimal(old_value)
                 new_derivative = (
                     delta_value
@@ -392,12 +403,10 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
                 return
 
             # add latest derivative to the window list
-            self._state_list.append(
-                (old_last_reported, new_state.last_reported, new_derivative)
-            )
+            self._state_list.append((old_timestamp, new_timestamp, new_derivative))
             self._last_valid_state_time = (
                 new_state.state,
-                new_state.last_reported,
+                new_timestamp,
             )
 
             # If outside of time window just report derivative (is the same as modeling it in the window),
@@ -405,9 +414,7 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
             if elapsed_time > self._time_window:
                 derivative = new_derivative
             else:
-                derivative = self._calc_derivative_from_state_list(
-                    new_state.last_reported
-                )
+                derivative = self._calc_derivative_from_state_list(new_timestamp)
             self._write_native_value(derivative)
 
         source_state = self.hass.states.get(self._sensor_source_id)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -157,7 +157,6 @@ class EventStateEventData(TypedDict):
     """Base class for EVENT_STATE_CHANGED and EVENT_STATE_REPORTED data."""
 
     entity_id: str
-    new_state: State | None
 
 
 class EventStateChangedData(EventStateEventData):
@@ -166,6 +165,7 @@ class EventStateChangedData(EventStateEventData):
     A state changed event is fired when on state write the state is changed.
     """
 
+    new_state: State | None
     old_state: State | None
 
 
@@ -175,6 +175,8 @@ class EventStateReportedData(EventStateEventData):
     A state reported event is fired when on state write the state is unchanged.
     """
 
+    last_reported: datetime.datetime
+    new_state: State
     old_last_reported: datetime.datetime
 
 
@@ -2340,6 +2342,7 @@ class StateMachine:
                 EVENT_STATE_REPORTED,
                 {
                     "entity_id": entity_id,
+                    "last_reported": now,
                     "old_last_reported": old_last_reported,
                     "new_state": old_state,
                 },

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1751,18 +1751,38 @@ class CompressedState(TypedDict):
 
 
 class State:
-    """Object to represent a state within the state machine.
+    """Object to represent a state within the state machine."""
 
-    entity_id: the entity that is represented.
-    state: the state of the entity
-    attributes: extra information on entity and state
-    last_changed: last time the state was changed.
-    last_reported: last time the state was reported.
-    last_updated: last time the state or attributes were changed.
-    context: Context in which it was created
-    domain: Domain of this state.
-    object_id: Object id of this state.
+    entity_id: str
+    """The entity that is represented by the state."""
+    domain: str
+    """Domain of the entity that is represented by the state."""
+    object_id: str
+    """object_id: Object id of this state."""
+    state: str
+    """The state of the entity."""
+    attributes: ReadOnlyDict[str, Any]
+    """Extra information on entity and state"""
+    last_changed: datetime.datetime
+    """Last time the state was changed."""
+    last_reported: datetime.datetime
+    """Last time the state was reported.
+
+    Note: When the state is set and neither the state nor attributes are
+    changed, the existing state will be mutated with an updated last_reported.
+
+    When handling a state change event, the last_reported attribute of the old
+    state will not be modified and can safely be used. The last_reported attribute
+    of the new state may be modified and the last_updated attribute should be used
+    instead.
+
+    When handling a state report event, the last_reported attribute may be
+    modified and last_reported from the event data should be used instead.
     """
+    last_updated: datetime.datetime
+    """Last time the state or attributes were changed."""
+    context: Context
+    """Context in which the state was created."""
 
     __slots__ = (
         "_cache",
@@ -1843,7 +1863,20 @@ class State:
 
     @under_cached_property
     def last_reported_timestamp(self) -> float:
-        """Timestamp of last report."""
+        """Timestamp of last report.
+
+        Note: When the state is set and neither the state nor attributes are
+        changed, the existing state will be mutated with an updated last_reported.
+
+        When handling a state change event, the last_reported_timestamp attribute
+        of the old state will not be modified and can safely be used. The
+        last_reported_timestamp attribute of the new state may be modified and the
+        last_updated_timestamp attribute should be used instead.
+
+        When handling a state report event, the last_reported_timestamp attribute may
+        be modified and last_reported from the event data should be used instead.
+        """
+
         return self.last_reported.timestamp()
 
     @under_cached_property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `last_reported` to state reported event data and update the `derivative`, `integration` and `statistics` integration

#### Background

When integrations write an unchanged state, we don't create a new `State` object, instead, the existing `State` object is mutated with a new `last_reported` timestamp and an `EVENT_STATE_REPORTED` is fired. This means it's not reliable for integrations which consume `EVENT_STATE_REPORTED` to read the `last_reported` from the `State` object as it might be overwritten when the event is consumed.
This issue was revealed when working on https://github.com/home-assistant/core/pull/148766

#### Planned future work
- Migrate other core integrations which consume `EVENT_STATE_REPORTED`
- Deprecate `State.last_reported` and `State.last_reported_timestamp`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
