### PR TITLE
Increase open file descriptor limit on startup

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -111,6 +111,7 @@ from .util.async_ import create_eager_task
 from .util.hass_dict import HassKey
 from .util.logging import async_activate_log_queue_handler
 from .util.package import async_get_user_site, is_docker_env, is_virtual_env
+from .util.resource import set_open_file_descriptor_limit
 from .util.system_info import is_official_image
 
 with contextlib.suppress(ImportError):
@@ -301,6 +302,8 @@ async def async_setup_hass(
         return hass
 
     hass = await create_hass()
+
+    set_open_file_descriptor_limit()
 
     if runtime_config.skip_pip or runtime_config.skip_pip_packages:
         _LOGGER.warning(

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -111,7 +111,6 @@ from .util.async_ import create_eager_task
 from .util.hass_dict import HassKey
 from .util.logging import async_activate_log_queue_handler
 from .util.package import async_get_user_site, is_docker_env, is_virtual_env
-from .util.resource import set_open_file_descriptor_limit
 from .util.system_info import is_official_image
 
 with contextlib.suppress(ImportError):
@@ -302,8 +301,6 @@ async def async_setup_hass(
         return hass
 
     hass = await create_hass()
-
-    set_open_file_descriptor_limit()
 
     if runtime_config.skip_pip or runtime_config.skip_pip_packages:
         _LOGGER.warning(

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -17,6 +17,7 @@ from . import bootstrap
 from .core import callback
 from .helpers.frame import warn_use
 from .util.executor import InterruptibleThreadPoolExecutor
+from .util.resource import set_open_file_descriptor_limit
 from .util.thread import deadlock_safe_shutdown
 
 #
@@ -146,6 +147,7 @@ def _enable_posix_spawn() -> None:
 def run(runtime_config: RuntimeConfig) -> int:
     """Run Home Assistant."""
     _enable_posix_spawn()
+    set_open_file_descriptor_limit()
     asyncio.set_event_loop_policy(HassEventLoopPolicy(runtime_config.debug))
     # Backport of cpython 3.9 asyncio.run with a _cancel_all_tasks that times out
     loop = asyncio.new_event_loop()

--- a/homeassistant/util/resource.py
+++ b/homeassistant/util/resource.py
@@ -1,0 +1,63 @@
+"""Resource management utilities for Home Assistant."""
+
+from __future__ import annotations
+
+import logging
+import os
+import resource
+from typing import Final
+
+_LOGGER = logging.getLogger(__name__)
+
+# Default soft file descriptor limit to set
+DEFAULT_SOFT_FILE_LIMIT: Final = 2048
+
+
+def set_open_file_descriptor_limit() -> None:
+    """Set the maximum open file descriptor soft limit."""
+    # Check environment variable first, then use default
+    soft_limit = int(os.environ.get("SOFT_FILE_LIMIT", DEFAULT_SOFT_FILE_LIMIT))
+
+    try:
+        # Get current limits
+        current_soft, current_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+
+        _LOGGER.debug(
+            "Current file descriptor limits: soft=%d, hard=%d",
+            current_soft,
+            current_hard,
+        )
+
+        # Don't increase if already at or above the desired limit
+        if current_soft >= soft_limit:
+            _LOGGER.debug(
+                "Current soft limit (%d) is already >= desired limit (%d), skipping",
+                current_soft,
+                soft_limit,
+            )
+            return
+
+        # Don't set soft limit higher than hard limit
+        if soft_limit > current_hard:
+            _LOGGER.warning(
+                "Requested soft limit (%d) exceeds hard limit (%d), "
+                "setting to hard limit",
+                soft_limit,
+                current_hard,
+            )
+            soft_limit = current_hard
+
+        # Set the new soft limit
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, current_hard))
+
+        # Verify the change
+        new_soft, new_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        _LOGGER.info(
+            "File descriptor limits updated: soft=%d->%d, hard=%d",
+            current_soft,
+            new_soft,
+            new_hard,
+        )
+
+    except OSError as err:
+        _LOGGER.error("Failed to set file descriptor limit: %s", err)

--- a/homeassistant/util/resource.py
+++ b/homeassistant/util/resource.py
@@ -15,10 +15,10 @@ DEFAULT_SOFT_FILE_LIMIT: Final = 2048
 
 def set_open_file_descriptor_limit() -> None:
     """Set the maximum open file descriptor soft limit."""
-    # Check environment variable first, then use default
-    soft_limit = int(os.environ.get("SOFT_FILE_LIMIT", DEFAULT_SOFT_FILE_LIMIT))
-
     try:
+        # Check environment variable first, then use default
+        soft_limit = int(os.environ.get("SOFT_FILE_LIMIT", DEFAULT_SOFT_FILE_LIMIT))
+
         # Get current limits
         current_soft, current_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
 
@@ -61,3 +61,5 @@ def set_open_file_descriptor_limit() -> None:
 
     except OSError as err:
         _LOGGER.error("Failed to set file descriptor limit: %s", err)
+    except ValueError as err:
+        _LOGGER.error("Invalid file descriptor limit value: %s", err)

--- a/tests/util/test_resource.py
+++ b/tests/util/test_resource.py
@@ -90,3 +90,18 @@ def test_set_open_file_descriptor_limit_os_error() -> None:
         assert (
             "Failed to set file descriptor limit" in mock_logger.error.call_args[0][0]
         )
+
+
+def test_set_open_file_descriptor_limit_value_error() -> None:
+    """Test handling ValueError when setting file limit."""
+
+    with (
+        patch.dict(os.environ, {"SOFT_FILE_LIMIT": "invalid_value"}),
+        patch("homeassistant.util.resource._LOGGER") as mock_logger,
+    ):
+        set_open_file_descriptor_limit()
+
+        mock_logger.error.assert_called_once()
+        assert (
+            "Invalid file descriptor limit value" in mock_logger.error.call_args[0][0]
+        )

--- a/tests/util/test_resource.py
+++ b/tests/util/test_resource.py
@@ -1,0 +1,92 @@
+"""Test the resource utility module."""
+
+import os
+import resource
+from unittest.mock import patch
+
+from homeassistant.util.resource import (
+    DEFAULT_SOFT_FILE_LIMIT,
+    set_open_file_descriptor_limit,
+)
+
+
+def test_set_open_file_descriptor_limit_default() -> None:
+    """Test setting file limit with default value."""
+    original_soft, original_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+
+    with patch("homeassistant.util.resource._LOGGER") as mock_logger:
+        set_open_file_descriptor_limit()
+
+        # Check that we attempted to set the limit
+        new_soft, new_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+
+        # If the original soft limit was already >= DEFAULT_SOFT_FILE_LIMIT,
+        # it should remain unchanged
+        if original_soft >= DEFAULT_SOFT_FILE_LIMIT:
+            assert new_soft == original_soft
+            mock_logger.debug.assert_called()
+        else:
+            # Should have been increased to DEFAULT_SOFT_FILE_LIMIT or hard limit
+            expected_soft = min(DEFAULT_SOFT_FILE_LIMIT, original_hard)
+            assert new_soft == expected_soft
+            mock_logger.info.assert_called()
+
+
+def test_set_open_file_descriptor_limit_environment_variable() -> None:
+    """Test setting file limit from environment variable."""
+    custom_limit = 1500
+
+    with (
+        patch.dict(os.environ, {"SOFT_FILE_LIMIT": str(custom_limit)}),
+        patch("homeassistant.util.resource._LOGGER") as mock_logger,
+    ):
+        original_soft, original_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+
+        set_open_file_descriptor_limit()
+
+        new_soft, new_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+
+        if original_soft >= custom_limit:
+            assert new_soft == original_soft
+            mock_logger.debug.assert_called()
+        else:
+            expected_soft = min(custom_limit, original_hard)
+            assert new_soft == expected_soft
+
+
+def test_set_open_file_descriptor_limit_exceeds_hard_limit() -> None:
+    """Test setting file limit that exceeds hard limit."""
+    original_soft, original_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    excessive_limit = original_hard + 1000
+
+    with (
+        patch.dict(os.environ, {"SOFT_FILE_LIMIT": str(excessive_limit)}),
+        patch("homeassistant.util.resource._LOGGER") as mock_logger,
+    ):
+        set_open_file_descriptor_limit()
+
+        new_soft, new_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+
+        # Should be capped at hard limit
+        assert new_soft == original_hard
+        mock_logger.warning.assert_called_once()
+
+
+def test_set_open_file_descriptor_limit_os_error() -> None:
+    """Test handling OSError when setting file limit."""
+    with (
+        patch(
+            "homeassistant.util.resource.resource.getrlimit", return_value=(1000, 4096)
+        ),
+        patch(
+            "homeassistant.util.resource.resource.setrlimit",
+            side_effect=OSError("Permission denied"),
+        ),
+        patch("homeassistant.util.resource._LOGGER") as mock_logger,
+    ):
+        set_open_file_descriptor_limit()
+
+        mock_logger.error.assert_called_once()
+        assert (
+            "Failed to set file descriptor limit" in mock_logger.error.call_args[0][0]
+        )

--- a/tests/util/test_resource.py
+++ b/tests/util/test_resource.py
@@ -47,8 +47,7 @@ def test_set_open_file_descriptor_limit_default(
         set_open_file_descriptor_limit()
 
     assert mock_setrlimit.call_args_list == expected_calls
-    if should_log_already_sufficient:
-        assert f"Current soft limit ({original_soft}) is already" in caplog.text
+    assert f"Current soft limit ({original_soft}) is already" in caplog.text is should_log_already_sufficient
 
 
 @pytest.mark.parametrize(
@@ -84,8 +83,7 @@ def test_set_open_file_descriptor_limit_environment_variable(
         set_open_file_descriptor_limit()
 
     assert mock_setrlimit.call_args_list == expected_calls
-    if should_log_already_sufficient:
-        assert f"Current soft limit ({original_soft}) is already" in caplog.text
+    assert f"Current soft limit ({original_soft}) is already" in caplog.text is should_log_already_sufficient
 
 
 def test_set_open_file_descriptor_limit_exceeds_hard_limit(

--- a/tests/util/test_resource.py
+++ b/tests/util/test_resource.py
@@ -47,7 +47,9 @@ def test_set_open_file_descriptor_limit_default(
         set_open_file_descriptor_limit()
 
     assert mock_setrlimit.call_args_list == expected_calls
-    assert f"Current soft limit ({original_soft}) is already" in caplog.text is should_log_already_sufficient
+    assert (
+        f"Current soft limit ({original_soft}) is already" in caplog.text
+    ) is should_log_already_sufficient
 
 
 @pytest.mark.parametrize(
@@ -83,7 +85,9 @@ def test_set_open_file_descriptor_limit_environment_variable(
         set_open_file_descriptor_limit()
 
     assert mock_setrlimit.call_args_list == expected_calls
-    assert f"Current soft limit ({original_soft}) is already" in caplog.text is should_log_already_sufficient
+    assert (
+        f"Current soft limit ({original_soft}) is already" in caplog.text
+    ) is should_log_already_sufficient
 
 
 def test_set_open_file_descriptor_limit_exceeds_hard_limit(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Increase the open file descriptor soft limit to 2048 on startup. This is necessary to prevent issues with file descriptor exhaustion in environments where the soft limit is low (e.g. the defaul of 1024 on Linux and since Home Assistant OS 16.0 in its container environment).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148806
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
