### PR TITLE
Refactor unique ID to use separator between for keys

### DIFF
--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -118,7 +118,9 @@ class TuyaAlarmEntity(TuyaEntity, AlarmControlPanelEntity):
         """Init Tuya Alarm."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
 
         # Determine supported  modes
         if supported_modes := self.find_dpcode(

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -118,9 +118,7 @@ class TuyaAlarmEntity(TuyaEntity, AlarmControlPanelEntity):
         """Init Tuya Alarm."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
 
         # Determine supported  modes
         if supported_modes := self.find_dpcode(

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -450,7 +450,9 @@ class TuyaBinarySensorEntity(TuyaEntity, BinarySensorEntity):
         """Init Tuya binary sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
         self._bit_mask = bit_mask
 
     @property

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -450,9 +450,7 @@ class TuyaBinarySensorEntity(TuyaEntity, BinarySensorEntity):
         """Init Tuya binary sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
         self._bit_mask = bit_mask
 
     @property

--- a/homeassistant/components/tuya/button.py
+++ b/homeassistant/components/tuya/button.py
@@ -99,9 +99,7 @@ class TuyaButtonEntity(TuyaEntity, ButtonEntity):
         """Init Tuya button."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
 
     def press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/tuya/button.py
+++ b/homeassistant/components/tuya/button.py
@@ -99,7 +99,9 @@ class TuyaButtonEntity(TuyaEntity, ButtonEntity):
         """Init Tuya button."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
 
     def press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -192,7 +192,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         """Init Tuya Cover."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
         self._attr_supported_features = CoverEntityFeature(0)
 
         # Check if this cover is based on a switch or has controls

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -192,9 +192,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         """Init Tuya Cover."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
         self._attr_supported_features = CoverEntityFeature(0)
 
         # Check if this cover is based on a switch or has controls

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -128,7 +128,9 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         """Init Tuya event entity."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
 
         if dpcode := self.find_dpcode(description.key, dptype=DPType.ENUM):
             self._attr_event_types: list[str] = dpcode.range

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -128,9 +128,7 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         """Init Tuya event entity."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
 
         if dpcode := self.find_dpcode(description.key, dptype=DPType.ENUM):
             self._attr_event_types: list[str] = dpcode.range

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -101,7 +101,9 @@ class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
         """Init Tuya (de)humidifier."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
 
         # Determine main switch DPCode
         self._switch_dpcode = self.find_dpcode(

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -101,9 +101,7 @@ class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
         """Init Tuya (de)humidifier."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
 
         # Determine main switch DPCode
         self._switch_dpcode = self.find_dpcode(

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -501,7 +501,9 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         """Init TuyaHaLight."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
         color_modes: set[ColorMode] = {ColorMode.ONOFF}
 
         # Determine DPCodes

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -501,9 +501,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         """Init TuyaHaLight."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
         color_modes: set[ColorMode] = {ColorMode.ONOFF}
 
         # Determine DPCodes

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -396,9 +396,7 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
         """Init Tuya sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
 
         if int_type := self.find_dpcode(
             description.key, dptype=DPType.INTEGER, prefer_function=True

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -396,7 +396,9 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
         """Init Tuya sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
 
         if int_type := self.find_dpcode(
             description.key, dptype=DPType.INTEGER, prefer_function=True

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -404,9 +404,7 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         """Init Tuya sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
 
         self._attr_options: list[str] = []
         if enum_type := self.find_dpcode(

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -404,7 +404,9 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         """Init Tuya sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
 
         self._attr_options: list[str] = []
         if enum_type := self.find_dpcode(

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -1429,8 +1429,10 @@ class TuyaSensorEntity(TuyaEntity, SensorEntity):
         """Init Tuya sensor."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = (
-            f"{super().unique_id}{description.key}{description.subkey or ''}"
+        self._attr_unique_id = ".".join(
+            part
+            for part in (super().unique_id, description.key, description.subkey)
+            if part
         )
 
         if int_type := self.find_dpcode(description.key, dptype=DPType.INTEGER):

--- a/homeassistant/components/tuya/siren.py
+++ b/homeassistant/components/tuya/siren.py
@@ -104,7 +104,7 @@ class TuyaSirenEntity(TuyaEntity, SirenEntity):
         """Init Tuya Siren."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -886,7 +886,9 @@ class TuyaSwitchEntity(TuyaEntity, SwitchEntity):
         """Init TuyaHaSwitch."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = ".".join(
+            part for part in (super().unique_id, description.key) if part
+        )
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -886,9 +886,7 @@ class TuyaSwitchEntity(TuyaEntity, SwitchEntity):
         """Init TuyaHaSwitch."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = ".".join(
-            part for part in (super().unique_id, description.key) if part
-        )
+        self._attr_unique_id = f"{super().unique_id}_{description.key}"
 
     @property
     def is_on(self) -> bool:

--- a/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
@@ -30,7 +30,7 @@
     'suggested_object_id': None,
     'supported_features': <AlarmControlPanelEntityFeature: 11>,
     'translation_key': None,
-    'unique_id': 'tuya.123123aba12312312dazubmaster_mode',
+    'unique_id': 'tuya.123123aba12312312dazub_master_mode',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_binary_sensor.ambr
@@ -30,7 +30,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpinco2_state',
+    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpin_co2_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -79,7 +79,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'defrost',
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqdefrost',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgq_defrost',
     'unit_of_measurement': None,
   })
 # ---
@@ -128,7 +128,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'tankfull',
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqtankfull',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgq_tankfull',
     'unit_of_measurement': None,
   })
 # ---
@@ -177,7 +177,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'wet',
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqwet',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgq_wet',
     'unit_of_measurement': None,
   })
 # ---
@@ -226,7 +226,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'defrost',
-    'unique_id': 'tuya.mock_device_iddefrost',
+    'unique_id': 'tuya.mock_device_id_defrost',
     'unit_of_measurement': None,
   })
 # ---
@@ -275,7 +275,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'tankfull',
-    'unique_id': 'tuya.mock_device_idtankfull',
+    'unique_id': 'tuya.mock_device_id_tankfull',
     'unit_of_measurement': None,
   })
 # ---
@@ -324,7 +324,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'tuya.bf5cccf9027080e2dbb9w3switch',
+    'unique_id': 'tuya.bf5cccf9027080e2dbb9w3_switch',
     'unit_of_measurement': None,
   })
 # ---
@@ -373,7 +373,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'tuya.ebb9d0eb5014f98cfboxbzgas_sensor_status',
+    'unique_id': 'tuya.ebb9d0eb5014f98cfboxbz_gas_sensor_status',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_cover.ambr
+++ b/tests/components/tuya/snapshots/test_cover.ambr
@@ -30,7 +30,7 @@
     'suggested_object_id': None,
     'supported_features': <CoverEntityFeature: 15>,
     'translation_key': 'curtain',
-    'unique_id': 'tuya.zah67ekdcontrol',
+    'unique_id': 'tuya.zah67ekd_control',
     'unit_of_measurement': None,
   })
 # ---
@@ -81,7 +81,7 @@
     'suggested_object_id': None,
     'supported_features': <CoverEntityFeature: 15>,
     'translation_key': 'curtain',
-    'unique_id': 'tuya.bf1fa053e0ba4e002c6we8control',
+    'unique_id': 'tuya.bf1fa053e0ba4e002c6we8_control',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_event.ambr
+++ b/tests/components/tuya/snapshots/test_event.ambr
@@ -35,7 +35,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'numbered_button',
-    'unique_id': 'tuya.mocked_device_idswitch_mode1',
+    'unique_id': 'tuya.mocked_device_id_switch_mode1',
     'unit_of_measurement': None,
   })
 # ---
@@ -94,7 +94,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'numbered_button',
-    'unique_id': 'tuya.mocked_device_idswitch_mode2',
+    'unique_id': 'tuya.mocked_device_id_switch_mode2',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_humidifier.ambr
+++ b/tests/components/tuya/snapshots/test_humidifier.ambr
@@ -33,7 +33,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqswitch',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgq_switch',
     'unit_of_measurement': None,
   })
 # ---
@@ -90,7 +90,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'tuya.mock_device_idswitch',
+    'unique_id': 'tuya.mock_device_id_switch',
     'unit_of_measurement': None,
   })
 # ---
@@ -145,7 +145,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'tuya.mock_device_idswitch',
+    'unique_id': 'tuya.mock_device_id_switch',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_light.ambr
+++ b/tests/components/tuya/snapshots/test_light.ambr
@@ -34,7 +34,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'backlight',
-    'unique_id': 'tuya.bf1fa053e0ba4e002c6we8switch_backlight',
+    'unique_id': 'tuya.bf1fa053e0ba4e002c6we8_switch_backlight',
     'unit_of_measurement': None,
   })
 # ---
@@ -91,7 +91,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'tuya.REDACTEDswitch_led',
+    'unique_id': 'tuya.REDACTED_switch_led',
     'unit_of_measurement': None,
   })
 # ---
@@ -167,7 +167,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'tuya.eb3e988f33c233290cfs3lswitch_led',
+    'unique_id': 'tuya.eb3e988f33c233290cfs3l_switch_led',
     'unit_of_measurement': None,
   })
 # ---
@@ -235,7 +235,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'backlight',
-    'unique_id': 'tuya.mock_device_idlight',
+    'unique_id': 'tuya.mock_device_id_light',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_number.ambr
+++ b/tests/components/tuya/snapshots/test_number.ambr
@@ -35,7 +35,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'alarm_duration',
-    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpinalarm_time',
+    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpin_alarm_time',
     'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
   })
 # ---
@@ -94,7 +94,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'feed',
-    'unique_id': 'tuya.bfd0273e59494eb34esvrxmanual_feed',
+    'unique_id': 'tuya.bfd0273e59494eb34esvrx_manual_feed',
     'unit_of_measurement': '',
   })
 # ---
@@ -152,7 +152,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'alarm_delay',
-    'unique_id': 'tuya.123123aba12312312dazubalarm_delay_time',
+    'unique_id': 'tuya.123123aba12312312dazub_alarm_delay_time',
     'unit_of_measurement': 's',
   })
 # ---
@@ -211,7 +211,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'arm_delay',
-    'unique_id': 'tuya.123123aba12312312dazubdelay_set',
+    'unique_id': 'tuya.123123aba12312312dazub_delay_set',
     'unit_of_measurement': 's',
   })
 # ---
@@ -270,7 +270,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'siren_duration',
-    'unique_id': 'tuya.123123aba12312312dazubalarm_time',
+    'unique_id': 'tuya.123123aba12312312dazub_alarm_time',
     'unit_of_measurement': 'min',
   })
 # ---
@@ -329,7 +329,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'temp_correction',
-    'unique_id': 'tuya.bfb45cb8a9452fba66lexgtemp_correction',
+    'unique_id': 'tuya.bfb45cb8a9452fba66lexg_temp_correction',
     'unit_of_measurement': '℃',
   })
 # ---

--- a/tests/components/tuya/snapshots/test_select.ambr
+++ b/tests/components/tuya/snapshots/test_select.ambr
@@ -35,7 +35,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'curtain_motor_mode',
-    'unique_id': 'tuya.zah67ekdcontrol_back_mode',
+    'unique_id': 'tuya.zah67ekd_control_back_mode',
     'unit_of_measurement': None,
   })
 # ---
@@ -94,7 +94,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'volume',
-    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpinalarm_volume',
+    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpin_alarm_volume',
     'unit_of_measurement': None,
   })
 # ---
@@ -155,7 +155,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'countdown',
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqcountdown_set',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgq_countdown_set',
     'unit_of_measurement': None,
   })
 # ---
@@ -216,7 +216,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'countdown',
-    'unique_id': 'tuya.mock_device_idcountdown_set',
+    'unique_id': 'tuya.mock_device_id_countdown_set',
     'unit_of_measurement': None,
   })
 # ---
@@ -275,7 +275,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'odor_elimination_mode',
-    'unique_id': 'tuya.bf6574iutyikgwkxwork_mode',
+    'unique_id': 'tuya.bf6574iutyikgwkx_work_mode',
     'unit_of_measurement': None,
   })
 # ---
@@ -336,7 +336,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'countdown',
-    'unique_id': 'tuya.CENSOREDcountdown_set',
+    'unique_id': 'tuya.CENSORED_countdown_set',
     'unit_of_measurement': None,
   })
 # ---
@@ -398,7 +398,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'relay_status',
-    'unique_id': 'tuya.bf082711d275c0c883vb4prelay_status',
+    'unique_id': 'tuya.bf082711d275c0c883vb4p_relay_status',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -32,7 +32,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'battery',
-    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpinbattery_percentage',
+    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpin.battery_percentage',
     'unit_of_measurement': '%',
   })
 # ---
@@ -85,7 +85,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'formaldehyde',
-    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpinch2o_value',
+    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpin.ch2o_value',
     'unit_of_measurement': 'mg/m3',
   })
 # ---
@@ -137,7 +137,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'humidity',
-    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpinhumidity_value',
+    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpin.humidity_value',
     'unit_of_measurement': '%',
   })
 # ---
@@ -193,7 +193,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'temperature',
-    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpintemp_current',
+    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpin.temp_current',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -246,7 +246,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'voc',
-    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpinvoc_value',
+    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpin.voc_value',
     'unit_of_measurement': 'mg/m³',
   })
 # ---
@@ -299,7 +299,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'humidity',
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqhumidity_indoor',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgq.humidity_indoor',
     'unit_of_measurement': '%',
   })
 # ---
@@ -352,7 +352,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'humidity',
-    'unique_id': 'tuya.mock_device_idhumidity_indoor',
+    'unique_id': 'tuya.mock_device_id.humidity_indoor',
     'unit_of_measurement': '%',
   })
 # ---
@@ -405,7 +405,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'battery',
-    'unique_id': 'tuya.bf6574iutyikgwkxbattery_percentage',
+    'unique_id': 'tuya.bf6574iutyikgwkx.battery_percentage',
     'unit_of_measurement': '%',
   })
 # ---
@@ -456,7 +456,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'odor_elimination_status',
-    'unique_id': 'tuya.bf6574iutyikgwkxwork_state_e',
+    'unique_id': 'tuya.bf6574iutyikgwkx.work_state_e',
     'unit_of_measurement': None,
   })
 # ---
@@ -506,7 +506,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'last_amount',
-    'unique_id': 'tuya.bfd0273e59494eb34esvrxfeed_report',
+    'unique_id': 'tuya.bfd0273e59494eb34esvrx.feed_report',
     'unit_of_measurement': '',
   })
 # ---
@@ -561,7 +561,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'filter_duration',
-    'unique_id': 'tuya.23536058083a8dc57d96filter_life',
+    'unique_id': 'tuya.23536058083a8dc57d96.filter_life',
     'unit_of_measurement': 'min',
   })
 # ---
@@ -617,7 +617,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'uv_runtime',
-    'unique_id': 'tuya.23536058083a8dc57d96uv_runtime',
+    'unique_id': 'tuya.23536058083a8dc57d96.uv_runtime',
     'unit_of_measurement': 's',
   })
 # ---
@@ -668,7 +668,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'water_level_state',
-    'unique_id': 'tuya.23536058083a8dc57d96water_level',
+    'unique_id': 'tuya.23536058083a8dc57d96.water_level',
     'unit_of_measurement': None,
   })
 # ---
@@ -721,7 +721,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'pump_time',
-    'unique_id': 'tuya.23536058083a8dc57d96pump_time',
+    'unique_id': 'tuya.23536058083a8dc57d96.pump_time',
     'unit_of_measurement': 'min',
   })
 # ---
@@ -777,7 +777,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'water_time',
-    'unique_id': 'tuya.23536058083a8dc57d96water_time',
+    'unique_id': 'tuya.23536058083a8dc57d96.water_time',
     'unit_of_measurement': 'min',
   })
 # ---
@@ -836,7 +836,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'current',
-    'unique_id': 'tuya.eb0c772dabbb19d653ssi5cur_current',
+    'unique_id': 'tuya.eb0c772dabbb19d653ssi5.cur_current',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -892,7 +892,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'power',
-    'unique_id': 'tuya.eb0c772dabbb19d653ssi5cur_power',
+    'unique_id': 'tuya.eb0c772dabbb19d653ssi5.cur_power',
     'unit_of_measurement': 'W',
   })
 # ---
@@ -951,7 +951,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'voltage',
-    'unique_id': 'tuya.eb0c772dabbb19d653ssi5cur_voltage',
+    'unique_id': 'tuya.eb0c772dabbb19d653ssi5.cur_voltage',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
@@ -1010,7 +1010,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'current',
-    'unique_id': 'tuya.mocked_device_idcur_current',
+    'unique_id': 'tuya.mocked_device_id.cur_current',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -1066,7 +1066,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'power',
-    'unique_id': 'tuya.mocked_device_idcur_power',
+    'unique_id': 'tuya.mocked_device_id.cur_power',
     'unit_of_measurement': 'W',
   })
 # ---
@@ -1125,7 +1125,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'voltage',
-    'unique_id': 'tuya.mocked_device_idcur_voltage',
+    'unique_id': 'tuya.mocked_device_id.cur_voltage',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
@@ -1181,7 +1181,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_a_current',
-    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27phase_aelectriccurrent',
+    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27.phase_a.electriccurrent',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -1237,7 +1237,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_a_power',
-    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27phase_apower',
+    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27.phase_a.power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -1293,7 +1293,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_a_voltage',
-    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27phase_avoltage',
+    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27.phase_a.voltage',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
@@ -1349,7 +1349,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_b_current',
-    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27phase_belectriccurrent',
+    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27.phase_b.electriccurrent',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -1405,7 +1405,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_b_power',
-    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27phase_bpower',
+    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27.phase_b.power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -1461,7 +1461,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_b_voltage',
-    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27phase_bvoltage',
+    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27.phase_b.voltage',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
@@ -1517,7 +1517,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_c_current',
-    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27phase_celectriccurrent',
+    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27.phase_c.electriccurrent',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -1573,7 +1573,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_c_power',
-    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27phase_cpower',
+    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27.phase_c.power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -1629,7 +1629,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_c_voltage',
-    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27phase_cvoltage',
+    'unique_id': 'tuya.bf5e5bde2c52cb5994cd27.phase_c.voltage',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
@@ -1682,7 +1682,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'battery',
-    'unique_id': 'tuya.bf5cccf9027080e2dbb9w3battery',
+    'unique_id': 'tuya.bf5cccf9027080e2dbb9w3.battery',
     'unit_of_measurement': '%',
   })
 # ---
@@ -1733,7 +1733,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'battery_state',
-    'unique_id': 'tuya.bff00f6abe0563b284t77pbattery_state',
+    'unique_id': 'tuya.bff00f6abe0563b284t77p.battery_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -1783,7 +1783,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'humidity',
-    'unique_id': 'tuya.bff00f6abe0563b284t77phumidity_value',
+    'unique_id': 'tuya.bff00f6abe0563b284t77p.humidity_value',
     'unit_of_measurement': '%',
   })
 # ---
@@ -1839,7 +1839,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'temperature_external',
-    'unique_id': 'tuya.bff00f6abe0563b284t77ptemp_current_external',
+    'unique_id': 'tuya.bff00f6abe0563b284t77p.temp_current_external',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -1895,7 +1895,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'temperature',
-    'unique_id': 'tuya.bff00f6abe0563b284t77ptemp_current',
+    'unique_id': 'tuya.bff00f6abe0563b284t77p.temp_current',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -1946,7 +1946,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'battery_state',
-    'unique_id': 'tuya.bf84c743a84eb2c8abeurzbattery_state',
+    'unique_id': 'tuya.bf84c743a84eb2c8abeurz.battery_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -1996,7 +1996,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'humidity',
-    'unique_id': 'tuya.bf84c743a84eb2c8abeurzhumidity_value',
+    'unique_id': 'tuya.bf84c743a84eb2c8abeurz.humidity_value',
     'unit_of_measurement': '%',
   })
 # ---
@@ -2049,7 +2049,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'illuminance',
-    'unique_id': 'tuya.bf84c743a84eb2c8abeurzbright_value',
+    'unique_id': 'tuya.bf84c743a84eb2c8abeurz.bright_value',
     'unit_of_measurement': 'lx',
   })
 # ---
@@ -2105,7 +2105,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'temperature_external',
-    'unique_id': 'tuya.bf84c743a84eb2c8abeurztemp_current_external',
+    'unique_id': 'tuya.bf84c743a84eb2c8abeurz.temp_current_external',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -2161,7 +2161,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'temperature',
-    'unique_id': 'tuya.bf84c743a84eb2c8abeurztemp_current',
+    'unique_id': 'tuya.bf84c743a84eb2c8abeurz.temp_current',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -2214,7 +2214,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'gas',
-    'unique_id': 'tuya.ebb9d0eb5014f98cfboxbzgas_sensor_value',
+    'unique_id': 'tuya.ebb9d0eb5014f98cfboxbz.gas_sensor_value',
     'unit_of_measurement': 'ppm',
   })
 # ---
@@ -2266,7 +2266,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'battery',
-    'unique_id': 'tuya.bfb45cb8a9452fba66lexgbattery_percentage',
+    'unique_id': 'tuya.bfb45cb8a9452fba66lexg.battery_percentage',
     'unit_of_measurement': '%',
   })
 # ---
@@ -2319,7 +2319,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'battery',
-    'unique_id': 'tuya.bf316b8707b061f044th18battery_percentage',
+    'unique_id': 'tuya.bf316b8707b061f044th18.battery_percentage',
     'unit_of_measurement': '%',
   })
 # ---
@@ -2372,7 +2372,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'humidity',
-    'unique_id': 'tuya.bf316b8707b061f044th18va_humidity',
+    'unique_id': 'tuya.bf316b8707b061f044th18.va_humidity',
     'unit_of_measurement': '%',
   })
 # ---
@@ -2428,7 +2428,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'temperature',
-    'unique_id': 'tuya.bf316b8707b061f044th18va_temperature',
+    'unique_id': 'tuya.bf316b8707b061f044th18.va_temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -2481,7 +2481,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'battery',
-    'unique_id': 'tuya.mocked_device_idbattery_percentage',
+    'unique_id': 'tuya.mocked_device_id.battery_percentage',
     'unit_of_measurement': '%',
   })
 # ---
@@ -2537,7 +2537,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_a_current',
-    'unique_id': 'tuya.bfe33b4c74661f1f1bgacyphase_aelectriccurrent',
+    'unique_id': 'tuya.bfe33b4c74661f1f1bgacy.phase_a.electriccurrent',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -2593,7 +2593,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_a_power',
-    'unique_id': 'tuya.bfe33b4c74661f1f1bgacyphase_apower',
+    'unique_id': 'tuya.bfe33b4c74661f1f1bgacy.phase_a.power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -2649,7 +2649,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'phase_a_voltage',
-    'unique_id': 'tuya.bfe33b4c74661f1f1bgacyphase_avoltage',
+    'unique_id': 'tuya.bfe33b4c74661f1f1bgacy.phase_a.voltage',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_siren.ambr
+++ b/tests/components/tuya/snapshots/test_siren.ambr
@@ -30,7 +30,7 @@
     'suggested_object_id': None,
     'supported_features': <SirenEntityFeature: 3>,
     'translation_key': None,
-    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpinalarm_switch',
+    'unique_id': 'tuya.eb14fd1dd93ca2ea34vpin_alarm_switch',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -30,7 +30,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'child_lock',
-    'unique_id': 'tuya.bf3fce6af592f12df3gbgqchild_lock',
+    'unique_id': 'tuya.bf3fce6af592f12df3gbgq_child_lock',
     'unit_of_measurement': None,
   })
 # ---
@@ -79,7 +79,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'child_lock',
-    'unique_id': 'tuya.mock_device_idchild_lock',
+    'unique_id': 'tuya.mock_device_id_child_lock',
     'unit_of_measurement': None,
   })
 # ---
@@ -128,7 +128,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'ionizer',
-    'unique_id': 'tuya.mock_device_idanion',
+    'unique_id': 'tuya.mock_device_id_anion',
     'unit_of_measurement': None,
   })
 # ---
@@ -177,7 +177,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'switch',
-    'unique_id': 'tuya.bf6574iutyikgwkxswitch',
+    'unique_id': 'tuya.bf6574iutyikgwkx_switch',
     'unit_of_measurement': None,
   })
 # ---
@@ -225,7 +225,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'filter_reset',
-    'unique_id': 'tuya.23536058083a8dc57d96filter_reset',
+    'unique_id': 'tuya.23536058083a8dc57d96_filter_reset',
     'unit_of_measurement': None,
   })
 # ---
@@ -273,7 +273,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'power',
-    'unique_id': 'tuya.23536058083a8dc57d96switch',
+    'unique_id': 'tuya.23536058083a8dc57d96_switch',
     'unit_of_measurement': None,
   })
 # ---
@@ -321,7 +321,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'reset_of_water_usage_days',
-    'unique_id': 'tuya.23536058083a8dc57d96water_reset',
+    'unique_id': 'tuya.23536058083a8dc57d96_water_reset',
     'unit_of_measurement': None,
   })
 # ---
@@ -369,7 +369,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'uv_sterilization',
-    'unique_id': 'tuya.23536058083a8dc57d96uv',
+    'unique_id': 'tuya.23536058083a8dc57d96_uv',
     'unit_of_measurement': None,
   })
 # ---
@@ -417,7 +417,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'water_pump_reset',
-    'unique_id': 'tuya.23536058083a8dc57d96pump_reset',
+    'unique_id': 'tuya.23536058083a8dc57d96_pump_reset',
     'unit_of_measurement': None,
   })
 # ---
@@ -465,7 +465,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'socket_1',
-    'unique_id': 'tuya.eb0c772dabbb19d653ssi5switch_1',
+    'unique_id': 'tuya.eb0c772dabbb19d653ssi5_switch_1',
     'unit_of_measurement': None,
   })
 # ---
@@ -514,7 +514,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'socket_2',
-    'unique_id': 'tuya.eb0c772dabbb19d653ssi5switch_2',
+    'unique_id': 'tuya.eb0c772dabbb19d653ssi5_switch_2',
     'unit_of_measurement': None,
   })
 # ---
@@ -563,7 +563,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'child_lock',
-    'unique_id': 'tuya.mocked_device_idchild_lock',
+    'unique_id': 'tuya.mocked_device_id_child_lock',
     'unit_of_measurement': None,
   })
 # ---
@@ -611,7 +611,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'switch',
-    'unique_id': 'tuya.mocked_device_idswitch',
+    'unique_id': 'tuya.mocked_device_id_switch',
     'unit_of_measurement': None,
   })
 # ---
@@ -659,7 +659,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'switch_1',
-    'unique_id': 'tuya.0665305284f3ebe9fdc1switch_1',
+    'unique_id': 'tuya.0665305284f3ebe9fdc1_switch_1',
     'unit_of_measurement': None,
   })
 # ---
@@ -708,7 +708,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'power',
-    'unique_id': 'tuya.CENSOREDswitch',
+    'unique_id': 'tuya.CENSORED_switch',
     'unit_of_measurement': None,
   })
 # ---
@@ -756,7 +756,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'ionizer',
-    'unique_id': 'tuya.mock_device_idanion',
+    'unique_id': 'tuya.mock_device_id_anion',
     'unit_of_measurement': None,
   })
 # ---
@@ -804,7 +804,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'arm_beep',
-    'unique_id': 'tuya.123123aba12312312dazubswitch_alarm_sound',
+    'unique_id': 'tuya.123123aba12312312dazub_switch_alarm_sound',
     'unit_of_measurement': None,
   })
 # ---
@@ -852,7 +852,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'siren',
-    'unique_id': 'tuya.123123aba12312312dazubswitch_alarm_light',
+    'unique_id': 'tuya.123123aba12312312dazub_switch_alarm_light',
     'unit_of_measurement': None,
   })
 # ---
@@ -900,7 +900,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'switch',
-    'unique_id': 'tuya.bf83514d9c14b426f0fz5yswitch',
+    'unique_id': 'tuya.bf83514d9c14b426f0fz5y_switch',
     'unit_of_measurement': None,
   })
 # ---
@@ -948,7 +948,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'switch',
-    'unique_id': 'tuya.bfb9bfc18eeaed2d85yt5mswitch',
+    'unique_id': 'tuya.bfb9bfc18eeaed2d85yt5m_switch',
     'unit_of_measurement': None,
   })
 # ---
@@ -996,7 +996,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'switch_1',
-    'unique_id': 'tuya.bf082711d275c0c883vb4pswitch_1',
+    'unique_id': 'tuya.bf082711d275c0c883vb4p_switch_1',
     'unit_of_measurement': None,
   })
 # ---
@@ -1045,7 +1045,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'switch_2',
-    'unique_id': 'tuya.bf082711d275c0c883vb4pswitch_2',
+    'unique_id': 'tuya.bf082711d275c0c883vb4p_switch_2',
     'unit_of_measurement': None,
   })
 # ---
@@ -1094,7 +1094,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'switch_3',
-    'unique_id': 'tuya.bf082711d275c0c883vb4pswitch_3',
+    'unique_id': 'tuya.bf082711d275c0c883vb4p_switch_3',
     'unit_of_measurement': None,
   })
 # ---
@@ -1143,7 +1143,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'switch_4',
-    'unique_id': 'tuya.bf082711d275c0c883vb4pswitch_4',
+    'unique_id': 'tuya.bf082711d275c0c883vb4p_switch_4',
     'unit_of_measurement': None,
   })
 # ---
@@ -1192,7 +1192,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'child_lock',
-    'unique_id': 'tuya.bfb45cb8a9452fba66lexgchild_lock',
+    'unique_id': 'tuya.bfb45cb8a9452fba66lexg_child_lock',
     'unit_of_measurement': None,
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
I want to assume this can cause some breaking changes but I am not 100% sure.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The goal is to improve the format of the unique ID. Currently, it looks like this:
`tuya.bfe33b4c74661f1f1bgacyphase_aelectriccurrent`
This format makes it difficult to distinguish between key and subkey.

To make it easier to parse, especially during testing, I propose updating the format to:
`tuya.bfe33b4c74661f1f1bgacy_phase_a_electriccurrent`

This change allows each part of the ID to be clearly separated and easier to work with.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
