### PR TITLE
Adds support for hide_states options in state selector

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1335,7 +1335,7 @@ class StateSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent an state selector config."""
 
     entity_id: str
-    exclude_states: list[str]
+    hide_states: list[str]
 
 
 @SELECTORS.register("state")
@@ -1347,7 +1347,7 @@ class StateSelector(Selector[StateSelectorConfig]):
     CONFIG_SCHEMA = BASE_SELECTOR_CONFIG_SCHEMA.extend(
         {
             vol.Optional("entity_id"): cv.entity_id,
-            vol.Optional("exclude_states"): [str],
+            vol.Optional("hide_states"): [str],
             # The attribute to filter on, is currently deliberately not
             # configurable/exposed. We are considering separating state
             # selectors into two types: one for state and one for attribute.

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1334,8 +1334,16 @@ class TargetSelectorConfig(BaseSelectorConfig, total=False):
 class StateSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent an state selector config."""
 
-    entity_id: str
+    entity_id: str | list[str]
     hide_states: list[str]
+    combine_mode: StateCombineMode
+
+
+class StateCombineMode(StrEnum):
+    """Possible units for a color temperature selector."""
+
+    UNION = "union"
+    INTERSECTION = "intersection"
 
 
 @SELECTORS.register("state")
@@ -1348,6 +1356,9 @@ class StateSelector(Selector[StateSelectorConfig]):
         {
             vol.Optional("entity_id"): cv.entity_id,
             vol.Optional("hide_states"): [str],
+            vol.Optional("combine_mode", default=StateCombineMode.UNION): vol.All(
+                vol.Coerce(StateCombineMode), lambda val: val.value
+            ),
             # The attribute to filter on, is currently deliberately not
             # configurable/exposed. We are considering separating state
             # selectors into two types: one for state and one for attribute.

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1334,16 +1334,8 @@ class TargetSelectorConfig(BaseSelectorConfig, total=False):
 class StateSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent an state selector config."""
 
-    entity_id: str | list[str]
+    entity_id: str
     hide_states: list[str]
-    combine_mode: StateCombineMode
-
-
-class StateCombineMode(StrEnum):
-    """Possible units for a color temperature selector."""
-
-    UNION = "union"
-    INTERSECTION = "intersection"
 
 
 @SELECTORS.register("state")
@@ -1356,9 +1348,6 @@ class StateSelector(Selector[StateSelectorConfig]):
         {
             vol.Optional("entity_id"): cv.entity_id,
             vol.Optional("hide_states"): [str],
-            vol.Optional("combine_mode", default=StateCombineMode.UNION): vol.All(
-                vol.Coerce(StateCombineMode), lambda val: val.value
-            ),
             # The attribute to filter on, is currently deliberately not
             # configurable/exposed. We are considering separating state
             # selectors into two types: one for state and one for attribute.

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1334,7 +1334,8 @@ class TargetSelectorConfig(BaseSelectorConfig, total=False):
 class StateSelectorConfig(BaseSelectorConfig, total=False):
     """Class to represent an state selector config."""
 
-    entity_id: Required[str]
+    entity_id: str
+    exclude_states: list[str]
 
 
 @SELECTORS.register("state")
@@ -1345,7 +1346,8 @@ class StateSelector(Selector[StateSelectorConfig]):
 
     CONFIG_SCHEMA = BASE_SELECTOR_CONFIG_SCHEMA.extend(
         {
-            vol.Required("entity_id"): cv.entity_id,
+            vol.Optional("entity_id"): cv.entity_id,
+            vol.Optional("exclude_states"): [str],
             # The attribute to filter on, is currently deliberately not
             # configurable/exposed. We are considering separating state
             # selectors into two types: one for state and one for attribute.

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -542,7 +542,7 @@ def test_time_selector_schema(schema, valid_selections, invalid_selections) -> N
             (None, True, 1),
         ),
         (
-            {"exclude_states": ["unknown", "unavailable"]},
+            {"hide_states": ["unknown", "unavailable"]},
             (),
             (),
         ),

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -541,6 +541,11 @@ def test_time_selector_schema(schema, valid_selections, invalid_selections) -> N
             ("on", "armed"),
             (None, True, 1),
         ),
+        (
+            {"exclude_states": ["unknown", "unavailable"]},
+            (),
+            (),
+        ),
     ],
 )
 def test_state_selector_schema(schema, valid_selections, invalid_selections) -> None:

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -546,6 +546,11 @@ def test_time_selector_schema(schema, valid_selections, invalid_selections) -> N
             (),
             (),
         ),
+        (
+            {"combine_mode": "union"},
+            (),
+            (),
+        ),
     ],
 )
 def test_state_selector_schema(schema, valid_selections, invalid_selections) -> None:

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -546,11 +546,6 @@ def test_time_selector_schema(schema, valid_selections, invalid_selections) -> N
             (),
             (),
         ),
-        (
-            {"combine_mode": "union"},
-            (),
-            (),
-        ),
     ],
 )
 def test_state_selector_schema(schema, valid_selections, invalid_selections) -> None:


### PR DESCRIPTION
## Proposed change

Adds support for `hide_states` options in state selector.
Change `entity_id` to optional as the `entity_id` can be provided dynamically by the front-end

Required for https://github.com/home-assistant/core/pull/148960

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40050
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/26207

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
