### PR TITLE
Disable "last seen" Z-Wave entity by default

### DIFF
--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -558,7 +558,7 @@ ENTITY_DESCRIPTION_NODE_STATISTICS_LIST = [
         key="last_seen",
         translation_key="last_seen",
         device_class=SensorDeviceClass.TIMESTAMP,
-        entity_registry_enabled_default=True,
+        entity_registry_enabled_default=False,
     ),
 ]
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -514,8 +514,8 @@ async def test_on_node_added_not_ready(
     assert len(device.identifiers) == 1
 
     entities = er.async_entries_for_device(entity_registry, device.id)
-    # the only entities are the node status sensor, last_seen sensor, and ping button
-    assert len(entities) == 3
+    # the only entities are the node status sensor, and ping button
+    assert len(entities) == 2
 
 
 async def test_existing_node_ready(
@@ -631,8 +631,8 @@ async def test_existing_node_not_ready(
     assert len(device.identifiers) == 1
 
     entities = er.async_entries_for_device(entity_registry, device.id)
-    # the only entities are the node status sensor, last_seen sensor, and ping button
-    assert len(entities) == 3
+    # the only entities are the node status sensor, and ping button
+    assert len(entities) == 2
 
 
 async def test_existing_node_not_replaced_when_not_ready(

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -1030,6 +1030,19 @@ async def test_last_seen_statistics_sensors(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert hass.states.get(entity_id) is None  # disabled by default
+
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "2024-01-01T12:00:00+00:00"
 
 
 ENERGY_PRODUCTION_ENTITY_MAP = {

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -869,7 +869,7 @@ async def test_statistics_sensors_migration(
             )
 
 
-async def test_statistics_sensors_no_last_seen(
+async def test_statistics_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     zp3111,
@@ -877,7 +877,7 @@ async def test_statistics_sensors_no_last_seen(
     integration,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test all statistics sensors but last seen which is enabled by default."""
+    """Test statistics sensors."""
 
     for prefix, suffixes in (
         (CONTROLLER_STATISTICS_ENTITY_PREFIX, CONTROLLER_STATISTICS_SUFFIXES),
@@ -1029,11 +1029,7 @@ async def test_last_seen_statistics_sensors(
     entity_id = f"{NODE_STATISTICS_ENTITY_PREFIX}last_seen"
     entry = entity_registry.async_get(entity_id)
     assert entry
-    assert not entry.disabled
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == "2024-01-01T12:00:00+00:00"
+    assert entry.disabled
 
 
 ENERGY_PRODUCTION_ENTITY_MAP = {

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -647,7 +647,7 @@ async def test_zwave_js_event(
     await hass.async_block_till_done()
 
     assert len(node_no_event_data_filter) == 1
-    assert len(node_event_data_filter) == 1
+    assert len(node_event_data_filter) == 0
     assert len(controller_no_event_data_filter) == 0
     assert len(controller_event_data_filter) == 0
     assert len(driver_no_event_data_filter) == 0
@@ -697,7 +697,7 @@ async def test_zwave_js_event(
     assert len(node_no_event_data_filter) == 0
     assert len(node_event_data_filter) == 0
     assert len(controller_no_event_data_filter) == 1
-    assert len(controller_event_data_filter) == 1
+    assert len(controller_event_data_filter) == 0
     assert len(driver_no_event_data_filter) == 0
     assert len(driver_event_data_filter) == 0
     assert len(node_event_data_no_partial_dict_match_filter) == 0
@@ -801,7 +801,7 @@ async def test_zwave_js_event(
     assert len(driver_no_event_data_filter) == 0
     assert len(driver_event_data_filter) == 0
     assert len(node_event_data_no_partial_dict_match_filter) == 0
-    assert len(node_event_data_partial_dict_match_filter) == 1
+    assert len(node_event_data_partial_dict_match_filter) == 0
 
     clear_events()
 

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -647,7 +647,7 @@ async def test_zwave_js_event(
     await hass.async_block_till_done()
 
     assert len(node_no_event_data_filter) == 1
-    assert len(node_event_data_filter) == 0
+    assert len(node_event_data_filter) == 1
     assert len(controller_no_event_data_filter) == 0
     assert len(controller_event_data_filter) == 0
     assert len(driver_no_event_data_filter) == 0
@@ -697,7 +697,7 @@ async def test_zwave_js_event(
     assert len(node_no_event_data_filter) == 0
     assert len(node_event_data_filter) == 0
     assert len(controller_no_event_data_filter) == 1
-    assert len(controller_event_data_filter) == 0
+    assert len(controller_event_data_filter) == 1
     assert len(driver_no_event_data_filter) == 0
     assert len(driver_event_data_filter) == 0
     assert len(node_event_data_no_partial_dict_match_filter) == 0
@@ -801,7 +801,7 @@ async def test_zwave_js_event(
     assert len(driver_no_event_data_filter) == 0
     assert len(driver_event_data_filter) == 0
     assert len(node_event_data_no_partial_dict_match_filter) == 0
-    assert len(node_event_data_partial_dict_match_filter) == 0
+    assert len(node_event_data_partial_dict_match_filter) == 1
 
     clear_events()
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Originally enabled with #109191
We generally want to have this enabled for easier debugging but it has to be excluded from the device logbook and there is no easy way to do that now. Hope to enable it again in the future

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/128
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
