### PR TITLE
Bump Plugwise to v1.7.8 preventing rogue KeyError

### DIFF
--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -165,7 +165,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         if "regulation_modes" in self._gateway_data:
             hvac_modes.append(HVACMode.OFF)
 
-        if "available_schedules" in self.device:
+        if self.device.get("available_schedules"):
             hvac_modes.append(HVACMode.AUTO)
 
         if self.coordinator.api.cooling_present:

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "quality_scale": "platinum",
-  "requirements": ["plugwise==1.7.7"],
+  "requirements": ["plugwise==1.7.8"],
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -70,7 +70,7 @@ async def async_setup_entry(
             PlugwiseSelectEntity(coordinator, device_id, description)
             for device_id in coordinator.new_devices
             for description in SELECT_TYPES
-            if description.options_key in coordinator.data[device_id]
+            if coordinator.data[device_id].get(description.options_key)
         )
 
     _add_entities()
@@ -98,7 +98,7 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
             self._location = location
 
     @property
-    def current_option(self) -> str:
+    def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         return self.device[self.entity_description.key]
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1693,7 +1693,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.14
 
 # homeassistant.components.plugwise
-plugwise==1.7.7
+plugwise==1.7.8
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1431,7 +1431,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.14
 
 # homeassistant.components.plugwise
-plugwise==1.7.7
+plugwise==1.7.8
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/tests/components/plugwise/fixtures/m_adam_jip/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_jip/data.json
@@ -1,11 +1,13 @@
 {
   "06aecb3d00354375924f50c47af36bd2": {
     "active_preset": "no_frost",
+    "available_schedules": [],
     "climate_mode": "off",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Slaapkamer",
     "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "select_schedule": null,
     "sensors": {
       "temperature": 24.2
     },
@@ -23,12 +25,14 @@
   },
   "13228dab8ce04617af318a2888b3c548": {
     "active_preset": "home",
+    "available_schedules": [],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
     "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "select_schedule": null,
     "sensors": {
       "temperature": 27.4
     },
@@ -236,12 +240,14 @@
   },
   "d27aede973b54be484f6842d1b2802ad": {
     "active_preset": "home",
+    "available_schedules": [],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Kinderkamer",
     "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "select_schedule": null,
     "sensors": {
       "temperature": 30.0
     },
@@ -283,12 +289,14 @@
   },
   "d58fec52899f4f1c92e4f8fad6d8c48c": {
     "active_preset": "home",
+    "available_schedules": [],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Logeerkamer",
     "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "select_schedule": null,
     "sensors": {
       "temperature": 30.0
     },

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -433,13 +433,16 @@ async def test_anna_climate_entity_climate_changes(
         "c784ee9fdab44e1395b8dee7d7a497d5", HVACMode.OFF
     )
 
+    # Mock user deleting last schedule from app or browser
     data = mock_smile_anna.async_update.return_value
-    data["3cb70739631c4d17a86b8b12e8a5161b"].pop("available_schedules")
+    data["3cb70739631c4d17a86b8b12e8a5161b"]["available_schedules"] = {}
+    data["3cb70739631c4d17a86b8b12e8a5161b"]["select_schedule"] = None
+    data["3cb70739631c4d17a86b8b12e8a5161b"]["climate_mode"] = "heat_cool"
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         freezer.tick(timedelta(minutes=1))
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
         state = hass.states.get("climate.anna")
-        assert state.state == HVACMode.HEAT
+        assert state.state == HVACMode.HEAT_COOL
         assert state.attributes[ATTR_HVAC_MODES] == [HVACMode.HEAT_COOL]

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -435,7 +435,7 @@ async def test_anna_climate_entity_climate_changes(
 
     # Mock user deleting last schedule from app or browser
     data = mock_smile_anna.async_update.return_value
-    data["3cb70739631c4d17a86b8b12e8a5161b"]["available_schedules"] = {}
+    data["3cb70739631c4d17a86b8b12e8a5161b"]["available_schedules"] = []
     data["3cb70739631c4d17a86b8b12e8a5161b"]["select_schedule"] = None
     data["3cb70739631c4d17a86b8b12e8a5161b"]["climate_mode"] = "heat_cool"
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
Bump to new version correctly adjusting when the last schedule is removed from a Thermostat. `pytest` only warned on the KeyError due to the test `pop`ing the key and in local testing sometimes even leading to test failures. So mostly testing related cleanup and potential corner case for removal of all schedules on the thermostat.

https://github.com/plugwise/python-plugwise/releases/tag/v1.7.8

https://github.com/plugwise/python-plugwise/compare/v1.7.7...v1.7.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
