### PR TITLE
2025.7.3

### DIFF
--- a/homeassistant/components/alexa_devices/manifest.json
+++ b/homeassistant/components/alexa_devices/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aioamazondevices"],
   "quality_scale": "bronze",
-  "requirements": ["aioamazondevices==3.2.10"]
+  "requirements": ["aioamazondevices==3.5.0"]
 }

--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
   "iot_class": "local_push",
   "loggers": ["async_upnp_client"],
-  "requirements": ["async-upnp-client==0.44.0", "getmac==0.9.5"],
+  "requirements": ["async-upnp-client==0.45.0", "getmac==0.9.5"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",

--- a/homeassistant/components/dlna_dms/manifest.json
+++ b/homeassistant/components/dlna_dms/manifest.json
@@ -7,7 +7,7 @@
   "dependencies": ["ssdp"],
   "documentation": "https://www.home-assistant.io/integrations/dlna_dms",
   "iot_class": "local_polling",
-  "requirements": ["async-upnp-client==0.44.0"],
+  "requirements": ["async-upnp-client==0.45.0"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaServer:1",

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
   "quality_scale": "platinum",
-  "requirements": ["pyenphase==2.2.1"],
+  "requirements": ["pyenphase==2.2.2"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["home-assistant-frontend==20250702.2"]
+  "requirements": ["home-assistant-frontend==20250702.3"]
 }

--- a/homeassistant/components/gios/manifest.json
+++ b/homeassistant/components/gios/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["dacite", "gios"],
-  "requirements": ["gios==6.1.1"]
+  "requirements": ["gios==6.1.2"]
 }

--- a/homeassistant/components/gios/manifest.json
+++ b/homeassistant/components/gios/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["dacite", "gios"],
-  "requirements": ["gios==6.1.0"]
+  "requirements": ["gios==6.1.1"]
 }

--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -306,6 +306,11 @@ class WebRTCProvider(CameraWebRTCProvider):
             await self.teardown()
             raise HomeAssistantError("Camera has no stream source")
 
+        if camera.platform.platform_name == "generic":
+            # This is a workaround to use ffmpeg for generic cameras
+            # A proper fix will be added in the future together with supporting multiple streams per camera
+            stream_source = "ffmpeg:" + stream_source
+
         if not self.async_is_supported(stream_source):
             await self.teardown()
             raise HomeAssistantError("Stream source is not supported by go2rtc")

--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/homematicip_cloud",
   "iot_class": "cloud_push",
   "loggers": ["homematicip"],
-  "requirements": ["homematicip==2.0.6"]
+  "requirements": ["homematicip==2.0.7"]
 }

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -98,6 +98,12 @@ def validate_sensor_state_and_device_class_config(config: ConfigType) -> ConfigT
             f"together with state class `{state_class}`"
         )
 
+    unit_of_measurement: str | None
+    if (
+        unit_of_measurement := config.get(CONF_UNIT_OF_MEASUREMENT)
+    ) is not None and not unit_of_measurement.strip():
+        config.pop(CONF_UNIT_OF_MEASUREMENT)
+
     # Only allow `options` to be set for `enum` sensors
     # to limit the possible sensor values
     if (options := config.get(CONF_OPTIONS)) is not None:

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -40,7 +40,7 @@
     "samsungctl[websocket]==0.7.1",
     "samsungtvws[async,encrypted]==2.7.2",
     "wakeonlan==3.1.0",
-    "async-upnp-client==0.44.0"
+    "async-upnp-client==0.45.0"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -868,8 +868,8 @@ RPC_SENSORS: Final = {
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
-        available=lambda status: (status and status["n_current"]) is not None,
-        removal_condition=lambda _config, status, _key: "n_current" not in status,
+        removal_condition=lambda _config, status, key: status[key].get("n_current")
+        is None,
         entity_registry_enabled_default=False,
     ),
     "total_current": RpcSensorDescription(

--- a/homeassistant/components/smartthings/manifest.json
+++ b/homeassistant/components/smartthings/manifest.json
@@ -30,5 +30,5 @@
   "iot_class": "cloud_push",
   "loggers": ["pysmartthings"],
   "quality_scale": "bronze",
-  "requirements": ["pysmartthings==3.2.7"]
+  "requirements": ["pysmartthings==3.2.8"]
 }

--- a/homeassistant/components/sonos/favorites.py
+++ b/homeassistant/components/sonos/favorites.py
@@ -72,7 +72,7 @@ class SonosFavorites(SonosHouseholdCoordinator):
         """Process the event payload in an async lock and update entities."""
         event_id = event.variables["favorites_update_id"]
         container_ids = event.variables["container_update_i_ds"]
-        if not (match := re.search(r"FV:2,(\d+)", container_ids)):
+        if not container_ids or not (match := re.search(r"FV:2,(\d+)", container_ids)):
             return
 
         container_id = int(match.groups()[0])

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["async_upnp_client"],
   "quality_scale": "internal",
-  "requirements": ["async-upnp-client==0.44.0"]
+  "requirements": ["async-upnp-client==0.45.0"]
 }

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -41,5 +41,5 @@
   "iot_class": "local_push",
   "loggers": ["switchbot"],
   "quality_scale": "gold",
-  "requirements": ["PySwitchbot==0.68.1"]
+  "requirements": ["PySwitchbot==0.68.2"]
 }

--- a/homeassistant/components/syncthru/coordinator.py
+++ b/homeassistant/components/syncthru/coordinator.py
@@ -28,6 +28,7 @@ class SyncthruCoordinator(DataUpdateCoordinator[SyncThru]):
             hass,
             _LOGGER,
             name=DOMAIN,
+            config_entry=entry,
             update_interval=timedelta(seconds=30),
         )
         self.syncthru = SyncThru(

--- a/homeassistant/components/tesla_fleet/manifest.json
+++ b/homeassistant/components/tesla_fleet/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tesla_fleet",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==1.2.0"]
+  "requirements": ["tesla-fleet-api==1.2.2"]
 }

--- a/homeassistant/components/teslemetry/button.py
+++ b/homeassistant/components/teslemetry/button.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import TeslemetryConfigEntry
-from .entity import TeslemetryVehiclePollingEntity
+from .entity import TeslemetryVehicleStreamEntity
 from .helpers import handle_command, handle_vehicle_command
 from .models import TeslemetryVehicleData
 
@@ -74,7 +74,7 @@ async def async_setup_entry(
     )
 
 
-class TeslemetryButtonEntity(TeslemetryVehiclePollingEntity, ButtonEntity):
+class TeslemetryButtonEntity(TeslemetryVehicleStreamEntity, ButtonEntity):
     """Base class for Teslemetry buttons."""
 
     api: Vehicle

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/teslemetry",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==1.2.0", "teslemetry-stream==0.7.9"]
+  "requirements": ["tesla-fleet-api==1.2.2", "teslemetry-stream==0.7.9"]
 }

--- a/homeassistant/components/tessie/manifest.json
+++ b/homeassistant/components/tessie/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tessie",
   "iot_class": "cloud_polling",
   "loggers": ["tessie", "tesla-fleet-api"],
-  "requirements": ["tessie-api==0.1.1", "tesla-fleet-api==1.2.0"]
+  "requirements": ["tessie-api==0.1.1", "tesla-fleet-api==1.2.2"]
 }

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client"],
-  "requirements": ["async-upnp-client==0.44.0", "getmac==0.9.5"],
+  "requirements": ["async-upnp-client==0.45.0", "getmac==0.9.5"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -16,7 +16,7 @@
   },
   "iot_class": "local_push",
   "loggers": ["async_upnp_client", "yeelight"],
-  "requirements": ["yeelight==0.7.16", "async-upnp-client==0.44.0"],
+  "requirements": ["yeelight==0.7.16", "async-upnp-client==0.45.0"],
   "zeroconf": [
     {
       "type": "_miio._udp.local.",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2025
 MINOR_VERSION: Final = 7
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 2)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -38,7 +38,7 @@ habluetooth==3.49.0
 hass-nabucasa==0.106.0
 hassil==2.2.3
 home-assistant-bluetooth==1.13.1
-home-assistant-frontend==20250702.2
+home-assistant-frontend==20250702.3
 home-assistant-intents==2025.6.23
 httpx==0.28.1
 ifaddr==0.2.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,7 @@ aiozoneinfo==0.2.3
 annotatedyaml==0.4.5
 astral==2.2
 async-interrupt==1.2.2
-async-upnp-client==0.44.0
+async-upnp-client==0.45.0
 atomicwrites-homeassistant==1.4.1
 attrs==25.3.0
 audioop-lts==0.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant"
-version = "2025.7.2"
+version = "2025.7.3"
 license = "Apache-2.0"
 license-files = ["LICENSE*", "homeassistant/backports/LICENSE*"]
 description = "Open-source home automation platform running on Python 3."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2348,7 +2348,7 @@ pysmappee==0.2.29
 pysmarlaapi==0.9.0
 
 # homeassistant.components.smartthings
-pysmartthings==3.2.7
+pysmartthings==3.2.8
 
 # homeassistant.components.smarty
 pysmarty2==0.10.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1020,7 +1020,7 @@ georss-qld-bushfire-alert-client==0.8
 getmac==0.9.5
 
 # homeassistant.components.gios
-gios==6.1.1
+gios==6.1.2
 
 # homeassistant.components.gitter
 gitterpy==0.1.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioairzone-cloud==0.6.12
 aioairzone==1.0.0
 
 # homeassistant.components.alexa_devices
-aioamazondevices==3.2.10
+aioamazondevices==3.5.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -84,7 +84,7 @@ PyQRCode==1.2.1
 PyRMVtransport==0.3.3
 
 # homeassistant.components.switchbot
-PySwitchbot==0.68.1
+PySwitchbot==0.68.2
 
 # homeassistant.components.switchmate
 PySwitchmate==0.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1174,7 +1174,7 @@ home-assistant-frontend==20250702.2
 home-assistant-intents==2025.6.23
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.0.6
+homematicip==2.0.7
 
 # homeassistant.components.horizon
 horimote==0.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1168,7 +1168,7 @@ hole==0.8.0
 holidays==0.75
 
 # homeassistant.components.frontend
-home-assistant-frontend==20250702.2
+home-assistant-frontend==20250702.3
 
 # homeassistant.components.conversation
 home-assistant-intents==2025.6.23

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1962,7 +1962,7 @@ pyeiscp==0.0.7
 pyemoncms==0.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==2.2.1
+pyenphase==2.2.2
 
 # homeassistant.components.envisalink
 pyenvisalink==4.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2904,7 +2904,7 @@ temperusb==1.6.1
 # homeassistant.components.tesla_fleet
 # homeassistant.components.teslemetry
 # homeassistant.components.tessie
-tesla-fleet-api==1.2.0
+tesla-fleet-api==1.2.2
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -527,7 +527,7 @@ asmog==0.0.6
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.44.0
+async-upnp-client==0.45.0
 
 # homeassistant.components.arve
 asyncarve==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1020,7 +1020,7 @@ georss-qld-bushfire-alert-client==0.8
 getmac==0.9.5
 
 # homeassistant.components.gios
-gios==6.1.0
+gios==6.1.1
 
 # homeassistant.components.gitter
 gitterpy==0.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -890,7 +890,7 @@ georss-qld-bushfire-alert-client==0.8
 getmac==0.9.5
 
 # homeassistant.components.gios
-gios==6.1.0
+gios==6.1.1
 
 # homeassistant.components.glances
 glances-api==0.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -491,7 +491,7 @@ arcam-fmj==1.8.1
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.44.0
+async-upnp-client==0.45.0
 
 # homeassistant.components.arve
 asyncarve==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1023,7 +1023,7 @@ home-assistant-frontend==20250702.2
 home-assistant-intents==2025.6.23
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.0.6
+homematicip==2.0.7
 
 # homeassistant.components.remember_the_milk
 httplib2==0.20.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -890,7 +890,7 @@ georss-qld-bushfire-alert-client==0.8
 getmac==0.9.5
 
 # homeassistant.components.gios
-gios==6.1.1
+gios==6.1.2
 
 # homeassistant.components.glances
 glances-api==0.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1951,7 +1951,7 @@ pysmappee==0.2.29
 pysmarlaapi==0.9.0
 
 # homeassistant.components.smartthings
-pysmartthings==3.2.7
+pysmartthings==3.2.8
 
 # homeassistant.components.smarty
 pysmarty2==0.10.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1637,7 +1637,7 @@ pyeiscp==0.0.7
 pyemoncms==0.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==2.2.1
+pyenphase==2.2.2
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1017,7 +1017,7 @@ hole==0.8.0
 holidays==0.75
 
 # homeassistant.components.frontend
-home-assistant-frontend==20250702.2
+home-assistant-frontend==20250702.3
 
 # homeassistant.components.conversation
 home-assistant-intents==2025.6.23

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,7 +173,7 @@ aioairzone-cloud==0.6.12
 aioairzone==1.0.0
 
 # homeassistant.components.alexa_devices
-aioamazondevices==3.2.10
+aioamazondevices==3.5.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -81,7 +81,7 @@ PyQRCode==1.2.1
 PyRMVtransport==0.3.3
 
 # homeassistant.components.switchbot
-PySwitchbot==0.68.1
+PySwitchbot==0.68.2
 
 # homeassistant.components.syncthru
 PySyncThru==0.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2390,7 +2390,7 @@ temperusb==1.6.1
 # homeassistant.components.tesla_fleet
 # homeassistant.components.teslemetry
 # homeassistant.components.tessie
-tesla-fleet-api==1.2.0
+tesla-fleet-api==1.2.2
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -670,3 +670,32 @@ async def test_async_get_image(
         HomeAssistantError, match="Stream source is not supported by go2rtc"
     ):
         await async_get_image(hass, camera.entity_id)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_generic_workaround(
+    hass: HomeAssistant,
+    init_test_integration: MockCamera,
+    rest_client: AsyncMock,
+) -> None:
+    """Test workaround for generic integration cameras."""
+    camera = init_test_integration
+    assert isinstance(camera._webrtc_provider, WebRTCProvider)
+
+    image_bytes = load_fixture_bytes("snapshot.jpg", DOMAIN)
+
+    rest_client.get_jpeg_snapshot.return_value = image_bytes
+    camera.set_stream_source("https://my_stream_url.m3u8")
+
+    with patch.object(camera.platform, "platform_name", "generic"):
+        image = await async_get_image(hass, camera.entity_id)
+        assert image.content == image_bytes
+
+    rest_client.streams.add.assert_called_once_with(
+        camera.entity_id,
+        [
+            "ffmpeg:https://my_stream_url.m3u8",
+            f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+            f"ffmpeg:{camera.entity_id}#video=mjpeg",
+        ],
+    )

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -195,9 +195,14 @@ async def test_hap_reconnected(
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_UNAVAILABLE
 
-    mock_hap._accesspoint_connected = False
-    await async_manipulate_test_data(hass, mock_hap.home, "connected", True)
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.AsyncHome.websocket_is_connected",
+        return_value=True,
+    ):
+        await async_manipulate_test_data(hass, mock_hap.home, "connected", True)
+        await mock_hap.ws_connected_handler()
+        await hass.async_block_till_done()
+
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_ON
 

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -1,6 +1,6 @@
 """Test HomematicIP Cloud accesspoint."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homematicip.auth import Auth
 from homematicip.connection.connection_context import ConnectionContext
@@ -242,7 +242,14 @@ async def test_get_state_after_disconnect(
     hap = HomematicipHAP(hass, hmip_config_entry)
     assert hap
 
-    with patch.object(hap, "get_state") as mock_get_state:
+    simple_mock_home = AsyncMock(spec=AsyncHome, autospec=True)
+    hap.home = simple_mock_home
+    hap.home.websocket_is_connected = Mock(side_effect=[False, True])
+
+    with (
+        patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        patch.object(hap, "get_state") as mock_get_state,
+    ):
         assert not hap._ws_connection_closed.is_set()
 
         await hap.ws_connected_handler()
@@ -250,8 +257,54 @@ async def test_get_state_after_disconnect(
 
         await hap.ws_disconnected_handler()
         assert hap._ws_connection_closed.is_set()
-        await hap.ws_connected_handler()
-        mock_get_state.assert_called_once()
+        with patch(
+            "homeassistant.components.homematicip_cloud.hap.AsyncHome.websocket_is_connected",
+            return_value=True,
+        ):
+            await hap.ws_connected_handler()
+            mock_get_state.assert_called_once()
+
+    assert not hap._ws_connection_closed.is_set()
+    hap.home.websocket_is_connected.assert_called()
+    mock_sleep.assert_awaited_with(2)
+
+
+async def test_try_get_state_exponential_backoff() -> None:
+    """Test _try_get_state waits for websocket connection."""
+
+    # Arrange: Create instance and mock home
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+    hap.home.websocket_is_connected = Mock(return_value=True)
+
+    hap.get_state = AsyncMock(
+        side_effect=[HmipConnectionError, HmipConnectionError, True]
+    )
+
+    with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await hap._try_get_state()
+
+    assert mock_sleep.mock_calls[0].args[0] == 8
+    assert mock_sleep.mock_calls[1].args[0] == 16
+    assert hap.get_state.call_count == 3
+
+
+async def test_try_get_state_handle_exception() -> None:
+    """Test _try_get_state handles exceptions."""
+    # Arrange: Create instance and mock home
+    hap = HomematicipHAP(MagicMock(), MagicMock())
+    hap.home = MagicMock()
+
+    expected_exception = Exception("Connection error")
+    future = AsyncMock()
+    future.result = Mock(side_effect=expected_exception)
+
+    with patch("homeassistant.components.homematicip_cloud.hap._LOGGER") as mock_logger:
+        hap.get_state_finished(future)
+
+    mock_logger.error.assert_called_once_with(
+        "Error updating state after HMIP access point reconnect: %s", expected_exception
+    )
 
 
 async def test_async_connect(

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -924,6 +924,30 @@ async def test_invalid_unit_of_measurement(
                         "device_class": None,
                         "unit_of_measurement": None,
                     },
+                    {
+                        "name": "Test 4",
+                        "state_topic": "test-topic",
+                        "device_class": "ph",
+                        "unit_of_measurement": "",
+                    },
+                    {
+                        "name": "Test 5",
+                        "state_topic": "test-topic",
+                        "device_class": "ph",
+                        "unit_of_measurement": " ",
+                    },
+                    {
+                        "name": "Test 6",
+                        "state_topic": "test-topic",
+                        "device_class": None,
+                        "unit_of_measurement": "",
+                    },
+                    {
+                        "name": "Test 7",
+                        "state_topic": "test-topic",
+                        "device_class": None,
+                        "unit_of_measurement": " ",
+                    },
                 ]
             }
         }
@@ -936,10 +960,25 @@ async def test_valid_device_class_and_uom(
     await mqtt_mock_entry()
 
     state = hass.states.get("sensor.test_1")
+    assert state is not None
     assert state.attributes["device_class"] == "temperature"
     state = hass.states.get("sensor.test_2")
+    assert state is not None
     assert "device_class" not in state.attributes
     state = hass.states.get("sensor.test_3")
+    assert state is not None
+    assert "device_class" not in state.attributes
+    state = hass.states.get("sensor.test_4")
+    assert state is not None
+    assert state.attributes["device_class"] == "ph"
+    state = hass.states.get("sensor.test_5")
+    assert state is not None
+    assert state.attributes["device_class"] == "ph"
+    state = hass.states.get("sensor.test_6")
+    assert state is not None
+    assert "device_class" not in state.attributes
+    state = hass.states.get("sensor.test_7")
+    assert state is not None
     assert "device_class" not in state.attributes
 
 

--- a/tests/components/shelly/fixtures/pro_3em.json
+++ b/tests/components/shelly/fixtures/pro_3em.json
@@ -151,7 +151,7 @@
       "c_pf": 0.72,
       "c_voltage": 230.2,
       "id": 0,
-      "n_current": null,
+      "n_current": 3.124,
       "total_act_power": 2413.825,
       "total_aprt_power": 2525.779,
       "total_current": 11.116,

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -4303,6 +4303,62 @@
     'state': '230.2',
   })
 # ---
+# name: test_shelly_pro_3em[sensor.test_name_phase_n_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_name_phase_n_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Phase N current',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-em:0-n_current',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_shelly_pro_3em[sensor.test_name_phase_n_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Test name Phase N current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_name_phase_n_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.124',
+  })
+# ---
 # name: test_shelly_pro_3em[sensor.test_name_rssi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
- Handle connection issues after websocket reconnected in homematicip_cloud ([@hahn-th] - [#147731]) ([homematicip_cloud docs])
- Fix Shelly `n_current` sensor removal condition ([@bieniu] - [#148740]) ([shelly docs])
- Bump pySmartThings to 3.2.8 ([@joostlek] - [#148761]) ([smartthings docs]) (dependency)
- Bump Tesla Fleet API to 1.2.2 ([@Bre77] - [#148776]) ([tessie docs]) ([teslemetry docs]) ([tesla_fleet docs]) (dependency)
- Use ffmpeg for generic cameras in go2rtc ([@edenhaus] - [#148818]) ([go2rtc docs])
- Add guard to prevent exception in Sonos Favorites ([@PeteRager] - [#148854]) ([sonos docs])
- Fix button platform parent class in Teslemetry ([@Bre77] - [#148863]) ([teslemetry docs])
- Bump pyenphase to 2.2.2 ([@catsmanac] - [#148870]) ([enphase_envoy docs]) (dependency)
- Bump gios to version 6.1.1 ([@bieniu] - [#148414]) ([gios docs]) (dependency)
- Bump `gios` to version 6.1.2 ([@bieniu] - [#148884]) ([gios docs]) (dependency)
- Bump async-upnp-client to 0.45.0 ([@StevenLooman] - [#148961]) ([upnp docs]) ([yeelight docs]) ([dlna_dmr docs]) ([samsungtv docs]) ([ssdp docs]) ([dlna_dms docs]) (dependency)
- Pass Syncthru entry to coordinator ([@joostlek] - [#148974]) ([syncthru docs])
- Update frontend to 20250702.3 ([@bramkragten] - [#148994]) ([frontend docs]) (dependency)
- Bump PySwitchbot to 0.68.2 ([@bdraco] - [#148996]) ([switchbot docs]) (dependency)
- Ignore MQTT sensor unit of measurement if it is an empty string ([@jbouwh] - [#149006]) ([mqtt docs])
- Bump aioamazondevices to 3.5.0 ([@chemelli74] - [#149011]) ([alexa_devices docs]) (dependency)

[#147533]: https://github.com/home-assistant/core/pull/147533
[#147731]: https://github.com/home-assistant/core/pull/147731
[#148171]: https://github.com/home-assistant/core/pull/148171
[#148414]: https://github.com/home-assistant/core/pull/148414
[#148725]: https://github.com/home-assistant/core/pull/148725
[#148740]: https://github.com/home-assistant/core/pull/148740
[#148761]: https://github.com/home-assistant/core/pull/148761
[#148776]: https://github.com/home-assistant/core/pull/148776
[#148818]: https://github.com/home-assistant/core/pull/148818
[#148854]: https://github.com/home-assistant/core/pull/148854
[#148863]: https://github.com/home-assistant/core/pull/148863
[#148870]: https://github.com/home-assistant/core/pull/148870
[#148884]: https://github.com/home-assistant/core/pull/148884
[#148961]: https://github.com/home-assistant/core/pull/148961
[#148974]: https://github.com/home-assistant/core/pull/148974
[#148994]: https://github.com/home-assistant/core/pull/148994
[#148996]: https://github.com/home-assistant/core/pull/148996
[#149006]: https://github.com/home-assistant/core/pull/149006
[#149011]: https://github.com/home-assistant/core/pull/149011
[@Bre77]: https://github.com/Bre77
[@PeteRager]: https://github.com/PeteRager
[@StevenLooman]: https://github.com/StevenLooman
[@bdraco]: https://github.com/bdraco
[@bieniu]: https://github.com/bieniu
[@bramkragten]: https://github.com/bramkragten
[@catsmanac]: https://github.com/catsmanac
[@chemelli74]: https://github.com/chemelli74
[@edenhaus]: https://github.com/edenhaus
[@frenck]: https://github.com/frenck
[@hahn-th]: https://github.com/hahn-th
[@jbouwh]: https://github.com/jbouwh
[@joostlek]: https://github.com/joostlek
[abode docs]: https://www.home-assistant.io/integrations/abode/
[adax docs]: https://www.home-assistant.io/integrations/adax/
[aemet docs]: https://www.home-assistant.io/integrations/aemet/
[agent_dvr docs]: https://www.home-assistant.io/integrations/agent_dvr/
[ai_task docs]: https://www.home-assistant.io/integrations/ai_task/
[alexa_devices docs]: https://www.home-assistant.io/integrations/alexa_devices/
[dlna_dmr docs]: https://www.home-assistant.io/integrations/dlna_dmr/
[dlna_dms docs]: https://www.home-assistant.io/integrations/dlna_dms/
[enphase_envoy docs]: https://www.home-assistant.io/integrations/enphase_envoy/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[gios docs]: https://www.home-assistant.io/integrations/gios/
[go2rtc docs]: https://www.home-assistant.io/integrations/go2rtc/
[homematicip_cloud docs]: https://www.home-assistant.io/integrations/homematicip_cloud/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[samsungtv docs]: https://www.home-assistant.io/integrations/samsungtv/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[smartthings docs]: https://www.home-assistant.io/integrations/smartthings/
[sonos docs]: https://www.home-assistant.io/integrations/sonos/
[ssdp docs]: https://www.home-assistant.io/integrations/ssdp/
[switchbot docs]: https://www.home-assistant.io/integrations/switchbot/
[syncthru docs]: https://www.home-assistant.io/integrations/syncthru/
[tesla_fleet docs]: https://www.home-assistant.io/integrations/tesla_fleet/
[teslemetry docs]: https://www.home-assistant.io/integrations/teslemetry/
[tessie docs]: https://www.home-assistant.io/integrations/tessie/
[upnp docs]: https://www.home-assistant.io/integrations/upnp/
[yeelight docs]: https://www.home-assistant.io/integrations/yeelight/