### PR TITLE
Use OptionsFlowWithReload in control4

### DIFF
--- a/homeassistant/components/control4/__init__.py
+++ b/homeassistant/components/control4/__init__.py
@@ -54,16 +54,18 @@ class Control4RuntimeData:
 type Control4ConfigEntry = ConfigEntry[Control4RuntimeData]
 
 
-async def call_c4_api_retry(func, *func_args):  # noqa: RET503
+async def call_c4_api_retry(func, *func_args):
     """Call C4 API function and retry on failure."""
-    # Ruff doesn't understand this loop - the exception is always raised after the retries
+    exc = None
     for i in range(API_RETRY_TIMES):
         try:
             return await func(*func_args)
         except client_exceptions.ClientError as exception:
-            _LOGGER.error("Error connecting to Control4 account API: %s", exception)
-            if i == API_RETRY_TIMES - 1:
-                raise ConfigEntryNotReady(exception) from exception
+            _LOGGER.error(
+                "Try: %d, Error connecting to Control4 account API: %s", i, exception
+            )
+            exc = exception
+    raise ConfigEntryNotReady(exc) from exc
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: Control4ConfigEntry) -> bool:
@@ -141,19 +143,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: Control4ConfigEntry) -> 
         ui_configuration=ui_configuration,
     )
 
-    entry.async_on_unload(entry.add_update_listener(update_listener))
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
-
-
-async def update_listener(
-    hass: HomeAssistant, config_entry: Control4ConfigEntry
-) -> None:
-    """Update when config_entry options update."""
-    _LOGGER.debug("Config entry was updated, rerunning setup")
-    await hass.config_entries.async_reload(config_entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: Control4ConfigEntry) -> bool:

--- a/homeassistant/components/control4/__init__.py
+++ b/homeassistant/components/control4/__init__.py
@@ -62,7 +62,9 @@ async def call_c4_api_retry(func, *func_args):
             return await func(*func_args)
         except client_exceptions.ClientError as exception:
             _LOGGER.error(
-                "Try: %d, Error connecting to Control4 account API: %s", i, exception
+                "Try: %d, Error connecting to Control4 account API: %s",
+                i + 1,
+                exception,
             )
             exc = exception
     raise ConfigEntryNotReady(exc) from exc

--- a/homeassistant/components/control4/config_flow.py
+++ b/homeassistant/components/control4/config_flow.py
@@ -11,7 +11,11 @@ from pyControl4.director import C4Director
 from pyControl4.error_handling import NotFound, Unauthorized
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.config_entries import (
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -153,7 +157,7 @@ class Control4ConfigFlow(ConfigFlow, domain=DOMAIN):
         return OptionsFlowHandler()
 
 
-class OptionsFlowHandler(OptionsFlow):
+class OptionsFlowHandler(OptionsFlowWithReload):
     """Handle a option flow for Control4."""
 
     async def async_step_init(


### PR DESCRIPTION
## Breaking change


## Proposed change
Also modifies to looping to comply with ruff rules

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 