### PR TITLE
Paramatarize platform test in conftest for Squeezebox

### DIFF
--- a/tests/components/squeezebox/conftest.py
+++ b/tests/components/squeezebox/conftest.py
@@ -333,54 +333,17 @@ def mock_pysqueezebox_server(
         return mock_lms
 
 
-async def configure_squeezebox_media_player_platform(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    lms: MagicMock,
+async def configure_squeezebox_platform(
+    hass: HomeAssistant, config_entry: MockConfigEntry, lms: MagicMock, platform: str
 ) -> None:
     """Configure a squeezebox config entry with appropriate mocks for media_player."""
     with (
         patch(
             "homeassistant.components.squeezebox.PLATFORMS",
-            [Platform.MEDIA_PLAYER],
+            [platform],
         ),
         patch("homeassistant.components.squeezebox.Server", return_value=lms),
     ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-
-async def configure_squeezebox_media_player_button_platform(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    lms: MagicMock,
-) -> None:
-    """Configure a squeezebox config entry with appropriate mocks for media_player."""
-    with (
-        patch(
-            "homeassistant.components.squeezebox.PLATFORMS",
-            [Platform.BUTTON],
-        ),
-        patch("homeassistant.components.squeezebox.Server", return_value=lms),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-
-async def configure_squeezebox_switch_platform(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    lms: MagicMock,
-) -> None:
-    """Configure a squeezebox config entry with appropriate mocks for switch."""
-    with (
-        patch(
-            "homeassistant.components.squeezebox.PLATFORMS",
-            [Platform.SWITCH],
-        ),
-        patch("homeassistant.components.squeezebox.Server", return_value=lms),
-    ):
-        # Set up the switch platform.
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -404,7 +367,7 @@ async def mock_alarms_player(
             "volume": 50,
         },
     ]
-    await configure_squeezebox_switch_platform(hass, config_entry, lms)
+    await configure_squeezebox_platform(hass, config_entry, lms, Platform.SWITCH)
     return players[0]
 
 
@@ -413,7 +376,7 @@ async def configured_player(
     hass: HomeAssistant, config_entry: MockConfigEntry, lms: MagicMock
 ) -> MagicMock:
     """Fixture mocking calls to pysqueezebox Player from a configured squeezebox."""
-    await configure_squeezebox_media_player_platform(hass, config_entry, lms)
+    await configure_squeezebox_platform(hass, config_entry, lms, Platform.MEDIA_PLAYER)
     return (await lms.async_get_players())[0]
 
 
@@ -422,7 +385,7 @@ async def configured_player_with_button(
     hass: HomeAssistant, config_entry: MockConfigEntry, lms: MagicMock
 ) -> MagicMock:
     """Fixture mocking calls to pysqueezebox Player from a configured squeezebox."""
-    await configure_squeezebox_media_player_button_platform(hass, config_entry, lms)
+    await configure_squeezebox_platform(hass, config_entry, lms, Platform.BUTTON)
     return (await lms.async_get_players())[0]
 
 
@@ -432,5 +395,5 @@ async def configured_players(
 ) -> list[MagicMock]:
     """Fixture mocking calls to two pysqueezebox Players from a configured squeezebox."""
     lms = lms_factory(3, uuid=SERVER_UUIDS[0])
-    await configure_squeezebox_media_player_platform(hass, config_entry, lms)
+    await configure_squeezebox_platform(hass, config_entry, lms, Platform.MEDIA_PLAYER)
     return await lms.async_get_players()

--- a/tests/components/squeezebox/test_media_player.py
+++ b/tests/components/squeezebox/test_media_player.py
@@ -65,6 +65,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_UP,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
@@ -76,7 +77,7 @@ from .conftest import (
     FAKE_VALID_ITEM_ID,
     TEST_MAC,
     TEST_VOLUME_STEP,
-    configure_squeezebox_media_player_platform,
+    configure_squeezebox_platform,
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
@@ -126,7 +127,7 @@ async def test_squeezebox_new_player_discovery(
 ) -> None:
     """Test discovery of a new squeezebox player."""
     # Initial setup with one player (from the 'lms' fixture)
-    await configure_squeezebox_media_player_platform(hass, config_entry, lms)
+    await configure_squeezebox_platform(hass, config_entry, lms, Platform.MEDIA_PLAYER)
     await hass.async_block_till_done(wait_background_tasks=True)
     assert hass.states.get("media_player.test_player") is not None
     assert hass.states.get("media_player.test_player_2") is None


### PR DESCRIPTION



## Proposed change
Consolidate three functions into one in conftest by passing parameter to configure_squeezebox_platform


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
