### PR TITLE
Avoid double reloading for config entries with update listener

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3446,6 +3446,8 @@ class ConfigFlow(ConfigEntryBaseFlow):
             options=options,
         )
         if reload_even_if_entry_is_unchanged or result:
+            if entry.update_listeners:
+                raise ValueError("Cannot update entry with update listeners")
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         if reason is UNDEFINED:
             reason = "reauth_successful"

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3070,6 +3070,8 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if entry.source == SOURCE_IGNORE and self.source == SOURCE_USER:
             return
         if should_reload:
+            if entry.update_listeners:
+                raise ValueError("Cannot update entry with update listeners")
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         raise data_entry_flow.AbortFlow(error, description_placeholders)
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3059,6 +3059,9 @@ class ConfigFlow(ConfigEntryBaseFlow):
             # Existing config entry present, and the
             # entry data just changed
             should_reload = True
+            if entry.update_listeners:
+                # If listeners are present, those should be used to reload instead
+                raise ValueError("Cannot update and reload entry with update listeners")
         elif (
             self.source in DISCOVERY_SOURCES
             and entry.state is ConfigEntryState.SETUP_RETRY
@@ -3070,8 +3073,6 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if entry.source == SOURCE_IGNORE and self.source == SOURCE_USER:
             return
         if should_reload:
-            if entry.update_listeners:
-                raise ValueError("Cannot update entry with update listeners")
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         raise data_entry_flow.AbortFlow(error, description_placeholders)
 
@@ -3449,7 +3450,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         )
         if reload_even_if_entry_is_unchanged or result:
             if entry.update_listeners:
-                raise ValueError("Cannot update entry with update listeners")
+                raise ValueError("Cannot update and reload entry with update listeners")
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         if reason is UNDEFINED:
             reason = "reauth_successful"

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6461,7 +6461,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data2"},
             {"vendor": "options2"},
             (2, 1),
-            None,
+            does_not_raise(),
         ),
         (
             {
@@ -6475,7 +6475,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data"},
             {"vendor": "options"},
             (2, 1),
-            None,
+            does_not_raise(),
         ),
         (
             {
@@ -6490,7 +6490,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data2"},
             {"vendor": "options2"},
             (2, 1),
-            None,
+            does_not_raise(),
         ),
         (
             {
@@ -6505,7 +6505,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data"},
             {"vendor": "options"},
             (1, 0),
-            None,
+            does_not_raise(),
         ),
         (
             {},
@@ -6514,7 +6514,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data"},
             {"vendor": "options"},
             (2, 1),
-            None,
+            does_not_raise(),
         ),
         (
             {"data": {"buyer": "me"}, "options": {}},
@@ -6523,7 +6523,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"buyer": "me"},
             {},
             (2, 1),
-            None,
+            does_not_raise(),
         ),
         (
             {"data_updates": {"buyer": "me"}},
@@ -6532,7 +6532,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data", "buyer": "me"},
             {"vendor": "options"},
             (2, 1),
-            None,
+            does_not_raise(),
         ),
         (
             {
@@ -6547,7 +6547,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data"},
             {"vendor": "options"},
             (1, 0),
-            ValueError,
+            pytest.raises(ValueError),
         ),
     ],
     ids=[
@@ -6613,15 +6613,11 @@ async def test_update_entry_and_reload(
             """Mock Reconfigure."""
             return self.async_update_reload_and_abort(entry, **kwargs)
 
-    err: Exception
-    with mock_config_flow("comp", MockFlowHandler):
-        try:
-            if source == config_entries.SOURCE_REAUTH:
-                result = await entry.start_reauth_flow(hass)
-            elif source == config_entries.SOURCE_RECONFIGURE:
-                result = await entry.start_reconfigure_flow(hass)
-        except Exception as ex:  # noqa: BLE001
-            err = ex
+    with mock_config_flow("comp", MockFlowHandler), raises:
+        if source == config_entries.SOURCE_REAUTH:
+            await entry.start_reauth_flow(hass)
+        elif source == config_entries.SOURCE_RECONFIGURE:
+            await entry.start_reconfigure_flow(hass)
 
     await hass.async_block_till_done()
 
@@ -6630,14 +6626,61 @@ async def test_update_entry_and_reload(
     assert entry.data == expected_data
     assert entry.options == expected_options
     assert entry.state == config_entries.ConfigEntryState.LOADED
-    if raises:
-        assert isinstance(err, raises)
-    else:
-        assert result["type"] is FlowResultType.ABORT
-        assert result["reason"] == reason
     # Assert entry was reloaded
     assert len(comp.async_setup_entry.mock_calls) == calls_entry_load_unload[0]
     assert len(comp.async_unload_entry.mock_calls) == calls_entry_load_unload[1]
+
+
+async def test_update_entry_and_reload_with_listener(hass: HomeAssistant) -> None:
+    """Test updating an entry and reloading."""
+    entry = MockConfigEntry(
+        domain="comp",
+        unique_id="1234",
+        title="Test",
+        data={"vendor": "data"},
+        options={"vendor": "options"},
+    )
+    entry.add_to_hass(hass)
+    entry.add_update_listener(AsyncMock())
+
+    comp = MockModule(
+        "comp",
+        async_setup_entry=AsyncMock(return_value=True),
+        async_unload_entry=AsyncMock(return_value=True),
+    )
+    mock_integration(hass, comp)
+    mock_platform(hass, "comp.config_flow", None)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    class MockFlowHandler(config_entries.ConfigFlow):
+        """Define a mock flow handler."""
+
+        VERSION = 1
+
+        async def async_step_reauth(self, data):
+            """Mock Reauth."""
+            self._abort_if_unique_id_configured(updates={"vendor": "data2"})
+
+        async def async_step_reconfigure(self, data):
+            """Mock Reconfigure."""
+            return self.async_update_reload_and_abort(entry, data={"vendor": "data2"})
+
+    with (
+        mock_config_flow("comp", MockFlowHandler),
+        pytest.raises(
+            ValueError, match="Cannot update and reload entry with update listeners"
+        ),
+    ):
+        await entry.start_reauth_flow(hass)
+
+    with (
+        mock_config_flow("comp", MockFlowHandler),
+        pytest.raises(
+            ValueError, match="Cannot update and reload entry with update listeners"
+        ),
+    ):
+        await entry.start_reconfigure_flow(hass)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Breaking change


## Proposed change
WIP: Don't use `async_update_reload_and_abort` with reloading and config entry update listeners.

For now to see which integrations has this "issue".

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 