### PR TITLE
Fix a bug in rainbird device migration that results in additional devices

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -218,6 +218,9 @@ def _async_fix_device_id(
     for device_entry in device_entries:
         unique_id = str(next(iter(device_entry.identifiers))[1])
         device_entry_map[unique_id] = device_entry
+        if unique_id.startswith(mac_address):
+            # Already in the correct format
+            continue
         if (suffix := unique_id.removeprefix(str(serial_number))) != unique_id:
             migrations[unique_id] = f"{mac_address}{suffix}"
 

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -449,3 +449,75 @@ async def test_fix_duplicate_device_ids(
     assert device_entry.identifiers == {(DOMAIN, MAC_ADDRESS_UNIQUE_ID)}
     assert device_entry.name_by_user == expected_device_name
     assert device_entry.disabled_by == expected_disabled_by
+
+
+async def test_reload_migration_with_leading_zero_mac(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test migration and reload of a device with a mac address with a leading zero."""
+    mac_address = "01:02:03:04:05:06"
+    mac_address_unique_id = dr.format_mac(mac_address)
+    serial_number = "0"
+
+    # Setup the config entry to be in a pre-migrated state
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=serial_number,
+        data={
+            "host": "127.0.0.1",
+            "password": "password",
+            CONF_MAC: mac_address,
+            "serial_number": serial_number,
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    # Create a device and entity with the old unique id format
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"{serial_number}-1")},
+    )
+    entity_entry = entity_registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        f"{serial_number}-1-zone1",
+        suggested_object_id="zone1",
+        config_entry=config_entry,
+        device_id=device_entry.id,
+    )
+
+    # Setup the integration, which will migrate the unique ids
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify the device and entity were migrated to the new format
+    migrated_device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{mac_address_unique_id}-1")}
+    )
+    assert migrated_device_entry is not None
+    migrated_entity_entry = entity_registry.async_get(entity_entry.entity_id)
+    assert migrated_entity_entry is not None
+    assert migrated_entity_entry.unique_id == f"{mac_address_unique_id}-1-zone1"
+
+    # Reload the integration
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify the device and entity still have the correct identifiers and were not duplicated
+    reloaded_device_entry = device_registry.async_get(migrated_device_entry.id)
+    assert reloaded_device_entry is not None
+    assert reloaded_device_entry.identifiers == {(DOMAIN, f"{mac_address_unique_id}-1")}
+    reloaded_entity_entry = entity_registry.async_get(entity_entry.entity_id)
+    assert reloaded_entity_entry is not None
+    assert reloaded_entity_entry.unique_id == f"{mac_address_unique_id}-1-zone1"
+
+    assert (
+        len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
+        == 1
+    )
+    assert (
+        len(er.async_entries_for_config_entry(entity_registry, config_entry.entry_id))
+        == 1
+    )


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix a bug in rainbird device migration that results in additional devices when the serial number is zero. The new check prevents migration when the device id is already in the correct format. Adds a test that was able to reproduce the issue before fixing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146381
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
