### PR TITLE
Use OptionsFlowWithReload in onkyo

### DIFF
--- a/homeassistant/components/onkyo/__init__.py
+++ b/homeassistant/components/onkyo/__init__.py
@@ -47,7 +47,6 @@ async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: OnkyoConfigEntry) -> bool:
     """Set up the Onkyo config entry."""
-    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     host = entry.data[CONF_HOST]
 
@@ -82,8 +81,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: OnkyoConfigEntry) -> bo
     receiver.conn.close()
 
     return unload_ok
-
-
-async def update_listener(hass: HomeAssistant, entry: OnkyoConfigEntry) -> None:
-    """Handle options update."""
-    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/onkyo/config_flow.py
+++ b/homeassistant/components/onkyo/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
-    OptionsFlow,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
@@ -329,7 +329,7 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlowWithReload:
         """Return the options flow."""
         return OnkyoOptionsFlowHandler()
 
@@ -357,7 +357,7 @@ OPTIONS_STEP_INIT_SCHEMA = vol.Schema(
 )
 
 
-class OnkyoOptionsFlowHandler(OptionsFlow):
+class OnkyoOptionsFlowHandler(OptionsFlowWithReload):
     """Handle an options flow for Onkyo."""
 
     _data: dict[str, Any]

--- a/tests/components/onkyo/test_init.py
+++ b/tests/components/onkyo/test_init.py
@@ -33,26 +33,6 @@ async def test_load_unload_entry(
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_update_entry(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-) -> None:
-    """Test update options."""
-
-    with patch.object(hass.config_entries, "async_reload", return_value=True):
-        config_entry = create_empty_config_entry()
-        receiver_info = create_receiver_info(1)
-        await setup_integration(hass, config_entry, receiver_info)
-
-        # Force option change
-        assert hass.config_entries.async_update_entry(
-            config_entry, options={"option": "new_value"}
-        )
-        await hass.async_block_till_done()
-
-        hass.config_entries.async_reload.assert_called_with(config_entry.entry_id)
-
-
 async def test_no_connection(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,


### PR DESCRIPTION
## Breaking change


## Proposed change
SSIA

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 