### PR TITLE
Fix multiple webhook secrets for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/webhooks.py
+++ b/homeassistant/components/telegram_bot/webhooks.py
@@ -82,7 +82,7 @@ class PushBot(BaseTelegramBot):
         self.base_url = config.data.get(CONF_URL) or get_url(
             hass, require_ssl=True, allow_internal=False
         )
-        self.webhook_url = f"{self.base_url}{TELEGRAM_WEBHOOK_URL}"
+        self.webhook_url = self.base_url + _get_webhook_url(bot)
 
     async def shutdown(self) -> None:
         """Shutdown the app."""
@@ -98,9 +98,11 @@ class PushBot(BaseTelegramBot):
                     api_kwargs={"secret_token": self.secret_token},
                     connect_timeout=5,
                 )
-            except TelegramError:
+            except TelegramError as err:
                 retry_num += 1
-                _LOGGER.warning("Error trying to set webhook (retry #%d)", retry_num)
+                _LOGGER.warning(
+                    "Error trying to set webhook (retry #%d)", retry_num, exc_info=err
+                )
 
         return False
 
@@ -143,7 +145,6 @@ class PushBotView(HomeAssistantView):
     """View for handling webhook calls from Telegram."""
 
     requires_auth = False
-    url = TELEGRAM_WEBHOOK_URL
     name = "telegram_webhooks"
 
     def __init__(
@@ -160,6 +161,7 @@ class PushBotView(HomeAssistantView):
         self.application = application
         self.trusted_networks = trusted_networks
         self.secret_token = secret_token
+        self.url = _get_webhook_url(bot)
 
     async def post(self, request: HomeAssistantRequest) -> Response | None:
         """Accept the POST from telegram."""
@@ -183,3 +185,7 @@ class PushBotView(HomeAssistantView):
         await self.application.process_update(update)
 
         return None
+
+
+def _get_webhook_url(bot: Bot) -> str:
+    return f"{TELEGRAM_WEBHOOK_URL}_{bot.id}"

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -364,7 +364,7 @@ async def test_webhook_endpoint_generates_telegram_text_event(
     events = async_capture_events(hass, "telegram_text")
 
     response = await client.post(
-        TELEGRAM_WEBHOOK_URL,
+        f"{TELEGRAM_WEBHOOK_URL}_123456",
         json=update_message_text,
         headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
     )
@@ -391,7 +391,7 @@ async def test_webhook_endpoint_generates_telegram_command_event(
     events = async_capture_events(hass, "telegram_command")
 
     response = await client.post(
-        TELEGRAM_WEBHOOK_URL,
+        f"{TELEGRAM_WEBHOOK_URL}_123456",
         json=update_message_command,
         headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
     )
@@ -418,7 +418,7 @@ async def test_webhook_endpoint_generates_telegram_callback_event(
     events = async_capture_events(hass, "telegram_callback")
 
     response = await client.post(
-        TELEGRAM_WEBHOOK_URL,
+        f"{TELEGRAM_WEBHOOK_URL}_123456",
         json=update_callback_query,
         headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
     )
@@ -594,7 +594,7 @@ async def test_webhook_endpoint_unauthorized_update_doesnt_generate_telegram_tex
     events = async_capture_events(hass, "telegram_text")
 
     response = await client.post(
-        TELEGRAM_WEBHOOK_URL,
+        f"{TELEGRAM_WEBHOOK_URL}_123456",
         json=unauthorized_update_message_text,
         headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
     )
@@ -618,7 +618,7 @@ async def test_webhook_endpoint_without_secret_token_is_denied(
     async_capture_events(hass, "telegram_text")
 
     response = await client.post(
-        TELEGRAM_WEBHOOK_URL,
+        f"{TELEGRAM_WEBHOOK_URL}_123456",
         json=update_message_text,
     )
     assert response.status == 401
@@ -636,7 +636,7 @@ async def test_webhook_endpoint_invalid_secret_token_is_denied(
     async_capture_events(hass, "telegram_text")
 
     response = await client.post(
-        TELEGRAM_WEBHOOK_URL,
+        f"{TELEGRAM_WEBHOOK_URL}_123456",
         json=update_message_text,
         headers={"X-Telegram-Bot-Api-Secret-Token": incorrect_secret_token},
     )

--- a/tests/components/telegram_bot/test_webhooks.py
+++ b/tests/components/telegram_bot/test_webhooks.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 from telegram import WebhookInfo
 from telegram.error import TimedOut
 
+from homeassistant.components.telegram_bot.webhooks import TELEGRAM_WEBHOOK_URL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -115,7 +116,7 @@ async def test_webhooks_update_invalid_json(
     client = await hass_client()
 
     response = await client.post(
-        "/api/telegram_webhooks",
+        f"{TELEGRAM_WEBHOOK_URL}_123456",
         headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
     )
     assert response.status == 400
@@ -139,7 +140,7 @@ async def test_webhooks_unauthorized_network(
         return_value=IPv4Network("1.2.3.4"),
     ) as mock_remote:
         response = await client.post(
-            "/api/telegram_webhooks",
+            f"{TELEGRAM_WEBHOOK_URL}_123456",
             json="mock json",
             headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When registering a webhook bot, a secret is generated and a `HomeAssistantView` is created.
If the user defined multiple webhook bots, this results in a "Invalid secret token from x.x.x.x" error as different secrets are registered to the same url.

This change appends the bot id to the url to avoid conflicts so that there are multiple views each with its distinct url and associated secret token.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #149020
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
