### PR TITLE
Move holiday object to runtime data in workday

### DIFF
--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from functools import partial
 
-from holidays import HolidayBase, country_holidays
+from holidays import PUBLIC, HolidayBase, country_holidays
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE
@@ -12,12 +13,18 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.setup import SetupPhases, async_pause_setup
+from homeassistant.util import dt as dt_util
 
-from .const import CONF_PROVINCE, DOMAIN, PLATFORMS
+from .const import CONF_CATEGORY, CONF_OFFSET, CONF_PROVINCE, DOMAIN, LOGGER, PLATFORMS
+
+type WorkdayConfigEntry = ConfigEntry[HolidayBase]
 
 
 async def _async_validate_country_and_province(
-    hass: HomeAssistant, entry: ConfigEntry, country: str | None, province: str | None
+    hass: HomeAssistant,
+    entry: WorkdayConfigEntry,
+    country: str | None,
+    province: str | None,
 ) -> None:
     """Validate country and province."""
 
@@ -73,32 +80,107 @@ async def _async_validate_country_and_province(
         ) from ex
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+def _get_obj_holidays(
+    country: str | None,
+    province: str | None,
+    year: int,
+    language: str | None,
+    categories: list[str] | None,
+) -> HolidayBase:
+    """Get the object for the requested country and year."""
+    if not country:
+        return HolidayBase()
+
+    set_categories = None
+    if categories:
+        category_list = [PUBLIC]
+        category_list.extend(categories)
+        set_categories = tuple(category_list)
+
+    obj_holidays: HolidayBase = country_holidays(
+        country,
+        subdiv=province,
+        years=[year, year + 1],
+        language=language,
+        categories=set_categories,
+    )
+
+    supported_languages = obj_holidays.supported_languages
+    default_language = obj_holidays.default_language
+
+    if default_language and not language:
+        # If no language is set, use the default language
+        LOGGER.debug("Changing language from None to %s", default_language)
+        return country_holidays(  # Return default if no language
+            country,
+            subdiv=province,
+            years=year,
+            language=default_language,
+            categories=set_categories,
+        )
+
+    if (
+        default_language
+        and language
+        and language not in supported_languages
+        and language.startswith("en")
+    ):
+        # If language does not match supported languages, use the first English variant
+        if default_language.startswith("en"):
+            LOGGER.debug("Changing language from %s to %s", language, default_language)
+            return country_holidays(  # Return default English if default language
+                country,
+                subdiv=province,
+                years=year,
+                language=default_language,
+                categories=set_categories,
+            )
+        for lang in supported_languages:
+            if lang.startswith("en"):
+                LOGGER.debug("Changing language from %s to %s", language, lang)
+                return country_holidays(
+                    country,
+                    subdiv=province,
+                    years=year,
+                    language=lang,
+                    categories=set_categories,
+                )
+
+    if default_language and language and language not in supported_languages:
+        # If language does not match supported languages, use the default language
+        LOGGER.debug("Changing language from %s to %s", language, default_language)
+        return country_holidays(  # Return default English if default language
+            country,
+            subdiv=province,
+            years=year,
+            language=default_language,
+            categories=set_categories,
+        )
+
+    return obj_holidays
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> bool:
     """Set up Workday from a config entry."""
 
     country: str | None = entry.options.get(CONF_COUNTRY)
     province: str | None = entry.options.get(CONF_PROVINCE)
+    days_offset: int = int(entry.options[CONF_OFFSET])
+    year: int = (dt_util.now() + timedelta(days=days_offset)).year
+    language: str | None = entry.options.get(CONF_LANGUAGE)
+    categories: list[str] | None = entry.options.get(CONF_CATEGORY)
 
     await _async_validate_country_and_province(hass, entry, country, province)
 
-    if country and CONF_LANGUAGE not in entry.options:
-        with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
-            # import executor job is used here because multiple integrations use
-            # the holidays library and it is not thread safe to import it in parallel
-            # https://github.com/python/cpython/issues/83065
-            cls: HolidayBase = await hass.async_add_import_executor_job(
-                partial(country_holidays, country, subdiv=province)
-            )
-        default_language = cls.default_language
-        new_options = entry.options.copy()
-        new_options[CONF_LANGUAGE] = default_language
-        hass.config_entries.async_update_entry(entry, options=new_options)
+    entry.runtime_data = _get_obj_holidays(
+        country, province, year, language, categories
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> bool:
     """Unload Workday config entry."""
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -265,8 +265,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> b
 
     await _async_validate_country_and_province(hass, entry, country, province)
 
-    entry.runtime_data = _get_obj_holidays(
-        country, province, year, language, categories
+    entry.runtime_data = await hass.async_add_executor_job(
+        _get_obj_holidays, country, province, year, language, categories
     )
 
     add_remove_custom_holidays(

--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -3,18 +3,14 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from functools import partial
 from typing import cast
 
-from holidays import PUBLIC, DateLike, HolidayBase, country_holidays
+from holidays import DateLike, HolidayBase
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.setup import SetupPhases, async_pause_setup
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_ADD_HOLIDAYS,
@@ -22,229 +18,17 @@ from .const import (
     CONF_OFFSET,
     CONF_PROVINCE,
     CONF_REMOVE_HOLIDAYS,
-    DOMAIN,
     LOGGER,
     PLATFORMS,
 )
-from .util import validate_dates
+from .util import (
+    add_remove_custom_holidays,
+    async_validate_country_and_province,
+    get_holidays_object,
+    validate_dates,
+)
 
 type WorkdayConfigEntry = ConfigEntry[HolidayBase]
-
-
-async def _async_validate_country_and_province(
-    hass: HomeAssistant,
-    entry: WorkdayConfigEntry,
-    country: str | None,
-    province: str | None,
-) -> None:
-    """Validate country and province."""
-
-    if not country:
-        return
-    try:
-        with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
-            # import executor job is used here because multiple integrations use
-            # the holidays library and it is not thread safe to import it in parallel
-            # https://github.com/python/cpython/issues/83065
-            await hass.async_add_import_executor_job(country_holidays, country)
-    except NotImplementedError as ex:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            "bad_country",
-            is_fixable=True,
-            is_persistent=False,
-            severity=IssueSeverity.ERROR,
-            translation_key="bad_country",
-            translation_placeholders={"title": entry.title},
-            data={"entry_id": entry.entry_id, "country": None},
-        )
-        raise ConfigEntryError(f"Selected country {country} is not valid") from ex
-
-    if not province:
-        return
-    try:
-        with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
-            # import executor job is used here because multiple integrations use
-            # the holidays library and it is not thread safe to import it in parallel
-            # https://github.com/python/cpython/issues/83065
-            await hass.async_add_import_executor_job(
-                partial(country_holidays, country, subdiv=province)
-            )
-    except NotImplementedError as ex:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            "bad_province",
-            is_fixable=True,
-            is_persistent=False,
-            severity=IssueSeverity.ERROR,
-            translation_key="bad_province",
-            translation_placeholders={
-                CONF_COUNTRY: country,
-                "title": entry.title,
-            },
-            data={"entry_id": entry.entry_id, "country": country},
-        )
-        raise ConfigEntryError(
-            f"Selected province {province} for country {country} is not valid"
-        ) from ex
-
-
-def _get_obj_holidays(
-    country: str | None,
-    province: str | None,
-    year: int,
-    language: str | None,
-    categories: list[str] | None,
-) -> HolidayBase:
-    """Get the object for the requested country and year."""
-    if not country:
-        return HolidayBase()
-
-    set_categories = None
-    if categories:
-        category_list = [PUBLIC]
-        category_list.extend(categories)
-        set_categories = tuple(category_list)
-
-    obj_holidays: HolidayBase = country_holidays(
-        country,
-        subdiv=province,
-        years=[year, year + 1],
-        language=language,
-        categories=set_categories,
-    )
-
-    supported_languages = obj_holidays.supported_languages
-    default_language = obj_holidays.default_language
-
-    if default_language and not language:
-        # If no language is set, use the default language
-        LOGGER.debug("Changing language from None to %s", default_language)
-        return country_holidays(  # Return default if no language
-            country,
-            subdiv=province,
-            years=year,
-            language=default_language,
-            categories=set_categories,
-        )
-
-    if (
-        default_language
-        and language
-        and language not in supported_languages
-        and language.startswith("en")
-    ):
-        # If language does not match supported languages, use the first English variant
-        if default_language.startswith("en"):
-            LOGGER.debug("Changing language from %s to %s", language, default_language)
-            return country_holidays(  # Return default English if default language
-                country,
-                subdiv=province,
-                years=year,
-                language=default_language,
-                categories=set_categories,
-            )
-        for lang in supported_languages:
-            if lang.startswith("en"):
-                LOGGER.debug("Changing language from %s to %s", language, lang)
-                return country_holidays(
-                    country,
-                    subdiv=province,
-                    years=year,
-                    language=lang,
-                    categories=set_categories,
-                )
-
-    if default_language and language and language not in supported_languages:
-        # If language does not match supported languages, use the default language
-        LOGGER.debug("Changing language from %s to %s", language, default_language)
-        return country_holidays(  # Return default English if default language
-            country,
-            subdiv=province,
-            years=year,
-            language=default_language,
-            categories=set_categories,
-        )
-
-    return obj_holidays
-
-
-def add_remove_custom_holidays(
-    hass: HomeAssistant,
-    entry: WorkdayConfigEntry,
-    country: str | None,
-    calc_add_holidays: list[DateLike],
-    calc_remove_holidays: list[str],
-) -> None:
-    """Add or remove custom holidays."""
-    next_year = dt_util.now().year + 1
-
-    # Add custom holidays
-    try:
-        entry.runtime_data.append(calc_add_holidays)
-    except ValueError as error:
-        LOGGER.error("Could not add custom holidays: %s", error)
-
-    # Remove custom holidays
-    for remove_holiday in calc_remove_holidays:
-        try:
-            # is this formatted as a date?
-            if dt_util.parse_date(remove_holiday):
-                # remove holiday by date
-                removed = entry.runtime_data.pop(remove_holiday)
-                LOGGER.debug("Removed %s", remove_holiday)
-            else:
-                # remove holiday by name
-                LOGGER.debug("Treating '%s' as named holiday", remove_holiday)
-                removed = entry.runtime_data.pop_named(remove_holiday)
-                for holiday in removed:
-                    LOGGER.debug("Removed %s by name '%s'", holiday, remove_holiday)
-        except KeyError as unmatched:
-            LOGGER.warning("No holiday found matching %s", unmatched)
-            if _date := dt_util.parse_date(remove_holiday):
-                if _date.year <= next_year:
-                    # Only check and raise issues for max next year
-                    async_create_issue(
-                        hass,
-                        DOMAIN,
-                        f"bad_date_holiday-{entry.entry_id}-{slugify(remove_holiday)}",
-                        is_fixable=True,
-                        is_persistent=False,
-                        severity=IssueSeverity.WARNING,
-                        translation_key="bad_date_holiday",
-                        translation_placeholders={
-                            CONF_COUNTRY: country if country else "-",
-                            "title": entry.title,
-                            CONF_REMOVE_HOLIDAYS: remove_holiday,
-                        },
-                        data={
-                            "entry_id": entry.entry_id,
-                            "country": country,
-                            "named_holiday": remove_holiday,
-                        },
-                    )
-            else:
-                async_create_issue(
-                    hass,
-                    DOMAIN,
-                    f"bad_named_holiday-{entry.entry_id}-{slugify(remove_holiday)}",
-                    is_fixable=True,
-                    is_persistent=False,
-                    severity=IssueSeverity.WARNING,
-                    translation_key="bad_named_holiday",
-                    translation_placeholders={
-                        CONF_COUNTRY: country if country else "-",
-                        "title": entry.title,
-                        CONF_REMOVE_HOLIDAYS: remove_holiday,
-                    },
-                    data={
-                        "entry_id": entry.entry_id,
-                        "country": country,
-                        "named_holiday": remove_holiday,
-                    },
-                )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> bool:
@@ -263,10 +47,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> b
     province: str | None = entry.options.get(CONF_PROVINCE)
     year: int = (dt_util.now() + timedelta(days=days_offset)).year
 
-    await _async_validate_country_and_province(hass, entry, country, province)
+    await async_validate_country_and_province(hass, entry, country, province)
 
     entry.runtime_data = await hass.async_add_executor_job(
-        _get_obj_holidays, country, province, year, language, categories
+        get_holidays_object, country, province, year, language, categories
     )
 
     add_remove_custom_holidays(

--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 from functools import partial
+from typing import cast
 
-from holidays import PUBLIC, HolidayBase, country_holidays
+from holidays import PUBLIC, DateLike, HolidayBase, country_holidays
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE
@@ -13,9 +14,19 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.setup import SetupPhases, async_pause_setup
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, slugify
 
-from .const import CONF_CATEGORY, CONF_OFFSET, CONF_PROVINCE, DOMAIN, LOGGER, PLATFORMS
+from .const import (
+    CONF_ADD_HOLIDAYS,
+    CONF_CATEGORY,
+    CONF_OFFSET,
+    CONF_PROVINCE,
+    CONF_REMOVE_HOLIDAYS,
+    DOMAIN,
+    LOGGER,
+    PLATFORMS,
+)
+from .util import validate_dates
 
 type WorkdayConfigEntry = ConfigEntry[HolidayBase]
 
@@ -160,21 +171,113 @@ def _get_obj_holidays(
     return obj_holidays
 
 
+def add_remove_custom_holidays(
+    hass: HomeAssistant,
+    entry: WorkdayConfigEntry,
+    country: str | None,
+    calc_add_holidays: list[DateLike],
+    calc_remove_holidays: list[str],
+) -> None:
+    """Add or remove custom holidays."""
+    next_year = dt_util.now().year + 1
+
+    # Add custom holidays
+    try:
+        entry.runtime_data.append(calc_add_holidays)
+    except ValueError as error:
+        LOGGER.error("Could not add custom holidays: %s", error)
+
+    # Remove custom holidays
+    for remove_holiday in calc_remove_holidays:
+        try:
+            # is this formatted as a date?
+            if dt_util.parse_date(remove_holiday):
+                # remove holiday by date
+                removed = entry.runtime_data.pop(remove_holiday)
+                LOGGER.debug("Removed %s", remove_holiday)
+            else:
+                # remove holiday by name
+                LOGGER.debug("Treating '%s' as named holiday", remove_holiday)
+                removed = entry.runtime_data.pop_named(remove_holiday)
+                for holiday in removed:
+                    LOGGER.debug("Removed %s by name '%s'", holiday, remove_holiday)
+        except KeyError as unmatched:
+            LOGGER.warning("No holiday found matching %s", unmatched)
+            if _date := dt_util.parse_date(remove_holiday):
+                if _date.year <= next_year:
+                    # Only check and raise issues for max next year
+                    async_create_issue(
+                        hass,
+                        DOMAIN,
+                        f"bad_date_holiday-{entry.entry_id}-{slugify(remove_holiday)}",
+                        is_fixable=True,
+                        is_persistent=False,
+                        severity=IssueSeverity.WARNING,
+                        translation_key="bad_date_holiday",
+                        translation_placeholders={
+                            CONF_COUNTRY: country if country else "-",
+                            "title": entry.title,
+                            CONF_REMOVE_HOLIDAYS: remove_holiday,
+                        },
+                        data={
+                            "entry_id": entry.entry_id,
+                            "country": country,
+                            "named_holiday": remove_holiday,
+                        },
+                    )
+            else:
+                async_create_issue(
+                    hass,
+                    DOMAIN,
+                    f"bad_named_holiday-{entry.entry_id}-{slugify(remove_holiday)}",
+                    is_fixable=True,
+                    is_persistent=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="bad_named_holiday",
+                    translation_placeholders={
+                        CONF_COUNTRY: country if country else "-",
+                        "title": entry.title,
+                        CONF_REMOVE_HOLIDAYS: remove_holiday,
+                    },
+                    data={
+                        "entry_id": entry.entry_id,
+                        "country": country,
+                        "named_holiday": remove_holiday,
+                    },
+                )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> bool:
     """Set up Workday from a config entry."""
 
-    country: str | None = entry.options.get(CONF_COUNTRY)
-    province: str | None = entry.options.get(CONF_PROVINCE)
-    days_offset: int = int(entry.options[CONF_OFFSET])
-    year: int = (dt_util.now() + timedelta(days=days_offset)).year
-    language: str | None = entry.options.get(CONF_LANGUAGE)
+    calc_add_holidays = cast(
+        list[DateLike], validate_dates(entry.options[CONF_ADD_HOLIDAYS])
+    )
+    calc_remove_holidays: list[str] = validate_dates(
+        entry.options[CONF_REMOVE_HOLIDAYS]
+    )
     categories: list[str] | None = entry.options.get(CONF_CATEGORY)
+    country: str | None = entry.options.get(CONF_COUNTRY)
+    days_offset: int = int(entry.options[CONF_OFFSET])
+    language: str | None = entry.options.get(CONF_LANGUAGE)
+    province: str | None = entry.options.get(CONF_PROVINCE)
+    year: int = (dt_util.now() + timedelta(days=days_offset)).year
 
     await _async_validate_country_and_province(hass, entry, country, province)
 
     entry.runtime_data = _get_obj_holidays(
         country, province, year, language, categories
     )
+
+    add_remove_custom_holidays(
+        hass, entry, country, calc_add_holidays, calc_remove_holidays
+    )
+
+    LOGGER.debug("Found the following holidays for your configuration:")
+    for holiday_date, name in sorted(entry.runtime_data.items()):
+        # Make explicit str variable to avoid "Incompatible types in assignment"
+        _holiday_string = holiday_date.strftime("%Y-%m-%d")
+        LOGGER.debug("%s %s", _holiday_string, name)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -3,19 +3,13 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
-from holidays import (
-    PUBLIC,
-    HolidayBase,
-    __version__ as python_holidays_version,
-    country_holidays,
-)
+from holidays import HolidayBase, __version__ as python_holidays_version
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_COUNTRY, CONF_LANGUAGE, CONF_NAME
+from homeassistant.const import CONF_COUNTRY, CONF_NAME
 from homeassistant.core import (
     CALLBACK_TYPE,
     HomeAssistant,
@@ -36,15 +30,16 @@ from homeassistant.util import dt as dt_util, slugify
 from .const import (
     ALLOWED_DAYS,
     CONF_ADD_HOLIDAYS,
-    CONF_CATEGORY,
     CONF_EXCLUDES,
     CONF_OFFSET,
-    CONF_PROVINCE,
     CONF_REMOVE_HOLIDAYS,
     CONF_WORKDAYS,
     DOMAIN,
     LOGGER,
 )
+
+if TYPE_CHECKING:
+    from . import WorkdayConfigEntry
 
 SERVICE_CHECK_DATE: Final = "check_date"
 CHECK_DATE: Final = "check_date"
@@ -70,89 +65,9 @@ def validate_dates(holiday_list: list[str]) -> list[str]:
     return calc_holidays
 
 
-def _get_obj_holidays(
-    country: str | None,
-    province: str | None,
-    year: int,
-    language: str | None,
-    categories: list[str] | None,
-) -> HolidayBase:
-    """Get the object for the requested country and year."""
-    if not country:
-        return HolidayBase()
-
-    set_categories = None
-    if categories:
-        category_list = [PUBLIC]
-        category_list.extend(categories)
-        set_categories = tuple(category_list)
-
-    obj_holidays: HolidayBase = country_holidays(
-        country,
-        subdiv=province,
-        years=[year, year + 1],
-        language=language,
-        categories=set_categories,
-    )
-
-    supported_languages = obj_holidays.supported_languages
-    default_language = obj_holidays.default_language
-
-    if default_language and not language:
-        # If no language is set, use the default language
-        LOGGER.debug("Changing language from None to %s", default_language)
-        return country_holidays(  # Return default if no language
-            country,
-            subdiv=province,
-            years=year,
-            language=default_language,
-            categories=set_categories,
-        )
-
-    if (
-        default_language
-        and language
-        and language not in supported_languages
-        and language.startswith("en")
-    ):
-        # If language does not match supported languages, use the first English variant
-        if default_language.startswith("en"):
-            LOGGER.debug("Changing language from %s to %s", language, default_language)
-            return country_holidays(  # Return default English if default language
-                country,
-                subdiv=province,
-                years=year,
-                language=default_language,
-                categories=set_categories,
-            )
-        for lang in supported_languages:
-            if lang.startswith("en"):
-                LOGGER.debug("Changing language from %s to %s", language, lang)
-                return country_holidays(
-                    country,
-                    subdiv=province,
-                    years=year,
-                    language=lang,
-                    categories=set_categories,
-                )
-
-    if default_language and language and language not in supported_languages:
-        # If language does not match supported languages, use the default language
-        LOGGER.debug("Changing language from %s to %s", language, default_language)
-        return country_holidays(  # Return default English if default language
-            country,
-            subdiv=province,
-            years=year,
-            language=default_language,
-            categories=set_categories,
-        )
-
-    return obj_holidays
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: WorkdayConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Workday sensor."""
@@ -161,16 +76,10 @@ async def async_setup_entry(
     country: str | None = entry.options.get(CONF_COUNTRY)
     days_offset: int = int(entry.options[CONF_OFFSET])
     excludes: list[str] = entry.options[CONF_EXCLUDES]
-    province: str | None = entry.options.get(CONF_PROVINCE)
     sensor_name: str = entry.options[CONF_NAME]
     workdays: list[str] = entry.options[CONF_WORKDAYS]
-    language: str | None = entry.options.get(CONF_LANGUAGE)
-    categories: list[str] | None = entry.options.get(CONF_CATEGORY)
 
-    year: int = (dt_util.now() + timedelta(days=days_offset)).year
-    obj_holidays: HolidayBase = await hass.async_add_executor_job(
-        _get_obj_holidays, country, province, year, language, categories
-    )
+    obj_holidays = entry.runtime_data
     calc_add_holidays: list[str] = validate_dates(add_holidays)
     calc_remove_holidays: list[str] = validate_dates(remove_holidays)
     next_year = dt_util.now().year + 1

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 from holidays import HolidayBase, __version__ as python_holidays_version
 import voluptuous as vol
@@ -26,10 +26,8 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util import dt as dt_util
 
+from . import WorkdayConfigEntry
 from .const import ALLOWED_DAYS, CONF_EXCLUDES, CONF_OFFSET, CONF_WORKDAYS, DOMAIN
-
-if TYPE_CHECKING:
-    from . import WorkdayConfigEntry
 
 SERVICE_CHECK_DATE: Final = "check_date"
 CHECK_DATE: Final = "check_date"

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -9,7 +9,7 @@ from holidays import HolidayBase, __version__ as python_holidays_version
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import CONF_COUNTRY, CONF_NAME
+from homeassistant.const import CONF_NAME
 from homeassistant.core import (
     CALLBACK_TYPE,
     HomeAssistant,
@@ -24,19 +24,9 @@ from homeassistant.helpers.entity_platform import (
     async_get_current_platform,
 )
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
 
-from .const import (
-    ALLOWED_DAYS,
-    CONF_ADD_HOLIDAYS,
-    CONF_EXCLUDES,
-    CONF_OFFSET,
-    CONF_REMOVE_HOLIDAYS,
-    CONF_WORKDAYS,
-    DOMAIN,
-    LOGGER,
-)
+from .const import ALLOWED_DAYS, CONF_EXCLUDES, CONF_OFFSET, CONF_WORKDAYS, DOMAIN
 
 if TYPE_CHECKING:
     from . import WorkdayConfigEntry
@@ -45,115 +35,17 @@ SERVICE_CHECK_DATE: Final = "check_date"
 CHECK_DATE: Final = "check_date"
 
 
-def validate_dates(holiday_list: list[str]) -> list[str]:
-    """Validate and adds to list of dates to add or remove."""
-    calc_holidays: list[str] = []
-    for add_date in holiday_list:
-        if add_date.find(",") > 0:
-            dates = add_date.split(",", maxsplit=1)
-            d1 = dt_util.parse_date(dates[0])
-            d2 = dt_util.parse_date(dates[1])
-            if d1 is None or d2 is None:
-                LOGGER.error("Incorrect dates in date range: %s", add_date)
-                continue
-            _range: timedelta = d2 - d1
-            for i in range(_range.days + 1):
-                day: date = d1 + timedelta(days=i)
-                calc_holidays.append(day.strftime("%Y-%m-%d"))
-            continue
-        calc_holidays.append(add_date)
-    return calc_holidays
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: WorkdayConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Workday sensor."""
-    add_holidays: list[str] = entry.options[CONF_ADD_HOLIDAYS]
-    remove_holidays: list[str] = entry.options[CONF_REMOVE_HOLIDAYS]
-    country: str | None = entry.options.get(CONF_COUNTRY)
     days_offset: int = int(entry.options[CONF_OFFSET])
     excludes: list[str] = entry.options[CONF_EXCLUDES]
     sensor_name: str = entry.options[CONF_NAME]
     workdays: list[str] = entry.options[CONF_WORKDAYS]
-
     obj_holidays = entry.runtime_data
-    calc_add_holidays: list[str] = validate_dates(add_holidays)
-    calc_remove_holidays: list[str] = validate_dates(remove_holidays)
-    next_year = dt_util.now().year + 1
-
-    # Add custom holidays
-    try:
-        obj_holidays.append(calc_add_holidays)  # type: ignore[arg-type]
-    except ValueError as error:
-        LOGGER.error("Could not add custom holidays: %s", error)
-
-    # Remove holidays
-    for remove_holiday in calc_remove_holidays:
-        try:
-            # is this formatted as a date?
-            if dt_util.parse_date(remove_holiday):
-                # remove holiday by date
-                removed = obj_holidays.pop(remove_holiday)
-                LOGGER.debug("Removed %s", remove_holiday)
-            else:
-                # remove holiday by name
-                LOGGER.debug("Treating '%s' as named holiday", remove_holiday)
-                removed = obj_holidays.pop_named(remove_holiday)
-                for holiday in removed:
-                    LOGGER.debug("Removed %s by name '%s'", holiday, remove_holiday)
-        except KeyError as unmatched:
-            LOGGER.warning("No holiday found matching %s", unmatched)
-            if _date := dt_util.parse_date(remove_holiday):
-                if _date.year <= next_year:
-                    # Only check and raise issues for current and next year
-                    async_create_issue(
-                        hass,
-                        DOMAIN,
-                        f"bad_date_holiday-{entry.entry_id}-{slugify(remove_holiday)}",
-                        is_fixable=True,
-                        is_persistent=False,
-                        severity=IssueSeverity.WARNING,
-                        translation_key="bad_date_holiday",
-                        translation_placeholders={
-                            CONF_COUNTRY: country if country else "-",
-                            "title": entry.title,
-                            CONF_REMOVE_HOLIDAYS: remove_holiday,
-                        },
-                        data={
-                            "entry_id": entry.entry_id,
-                            "country": country,
-                            "named_holiday": remove_holiday,
-                        },
-                    )
-            else:
-                async_create_issue(
-                    hass,
-                    DOMAIN,
-                    f"bad_named_holiday-{entry.entry_id}-{slugify(remove_holiday)}",
-                    is_fixable=True,
-                    is_persistent=False,
-                    severity=IssueSeverity.WARNING,
-                    translation_key="bad_named_holiday",
-                    translation_placeholders={
-                        CONF_COUNTRY: country if country else "-",
-                        "title": entry.title,
-                        CONF_REMOVE_HOLIDAYS: remove_holiday,
-                    },
-                    data={
-                        "entry_id": entry.entry_id,
-                        "country": country,
-                        "named_holiday": remove_holiday,
-                    },
-                )
-
-    LOGGER.debug("Found the following holidays for your configuration:")
-    for holiday_date, name in sorted(obj_holidays.items()):
-        # Make explicit str variable to avoid "Incompatible types in assignment"
-        _holiday_string = holiday_date.strftime("%Y-%m-%d")
-        LOGGER.debug("%s %s", _holiday_string, name)
 
     platform = async_get_current_platform()
     platform.async_register_entity_service(

--- a/homeassistant/components/workday/util.py
+++ b/homeassistant/components/workday/util.py
@@ -8,7 +8,7 @@ from .const import LOGGER
 
 
 def validate_dates(holiday_list: list[str]) -> list[str]:
-    """Validate and adds to list of dates to add or remove."""
+    """Validate and add to list of dates to add or remove."""
     calc_holidays: list[str] = []
     for add_date in holiday_list:
         if add_date.find(",") > 0:

--- a/homeassistant/components/workday/util.py
+++ b/homeassistant/components/workday/util.py
@@ -1,0 +1,27 @@
+"""Helpers functions for the Workday component."""
+
+from datetime import date, timedelta
+
+from homeassistant.util import dt as dt_util
+
+from .const import LOGGER
+
+
+def validate_dates(holiday_list: list[str]) -> list[str]:
+    """Validate and adds to list of dates to add or remove."""
+    calc_holidays: list[str] = []
+    for add_date in holiday_list:
+        if add_date.find(",") > 0:
+            dates = add_date.split(",", maxsplit=1)
+            d1 = dt_util.parse_date(dates[0])
+            d2 = dt_util.parse_date(dates[1])
+            if d1 is None or d2 is None:
+                LOGGER.error("Incorrect dates in date range: %s", add_date)
+                continue
+            _range: timedelta = d2 - d1
+            for i in range(_range.days + 1):
+                day: date = d1 + timedelta(days=i)
+                calc_holidays.append(day.strftime("%Y-%m-%d"))
+            continue
+        calc_holidays.append(add_date)
+    return calc_holidays

--- a/homeassistant/components/workday/util.py
+++ b/homeassistant/components/workday/util.py
@@ -1,10 +1,81 @@
 """Helpers functions for the Workday component."""
 
 from datetime import date, timedelta
+from functools import partial
+from typing import TYPE_CHECKING
 
-from homeassistant.util import dt as dt_util
+from holidays import PUBLIC, DateLike, HolidayBase, country_holidays
 
-from .const import LOGGER
+from homeassistant.const import CONF_COUNTRY
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.setup import SetupPhases, async_pause_setup
+from homeassistant.util import dt as dt_util, slugify
+
+if TYPE_CHECKING:
+    from . import WorkdayConfigEntry
+from .const import CONF_REMOVE_HOLIDAYS, DOMAIN, LOGGER
+
+
+async def async_validate_country_and_province(
+    hass: HomeAssistant,
+    entry: "WorkdayConfigEntry",
+    country: str | None,
+    province: str | None,
+) -> None:
+    """Validate country and province."""
+
+    if not country:
+        return
+    try:
+        with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
+            # import executor job is used here because multiple integrations use
+            # the holidays library and it is not thread safe to import it in parallel
+            # https://github.com/python/cpython/issues/83065
+            await hass.async_add_import_executor_job(country_holidays, country)
+    except NotImplementedError as ex:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "bad_country",
+            is_fixable=True,
+            is_persistent=False,
+            severity=IssueSeverity.ERROR,
+            translation_key="bad_country",
+            translation_placeholders={"title": entry.title},
+            data={"entry_id": entry.entry_id, "country": None},
+        )
+        raise ConfigEntryError(f"Selected country {country} is not valid") from ex
+
+    if not province:
+        return
+    try:
+        with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
+            # import executor job is used here because multiple integrations use
+            # the holidays library and it is not thread safe to import it in parallel
+            # https://github.com/python/cpython/issues/83065
+            await hass.async_add_import_executor_job(
+                partial(country_holidays, country, subdiv=province)
+            )
+    except NotImplementedError as ex:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "bad_province",
+            is_fixable=True,
+            is_persistent=False,
+            severity=IssueSeverity.ERROR,
+            translation_key="bad_province",
+            translation_placeholders={
+                CONF_COUNTRY: country,
+                "title": entry.title,
+            },
+            data={"entry_id": entry.entry_id, "country": country},
+        )
+        raise ConfigEntryError(
+            f"Selected province {province} for country {country} is not valid"
+        ) from ex
 
 
 def validate_dates(holiday_list: list[str]) -> list[str]:
@@ -25,3 +96,159 @@ def validate_dates(holiday_list: list[str]) -> list[str]:
             continue
         calc_holidays.append(add_date)
     return calc_holidays
+
+
+def get_holidays_object(
+    country: str | None,
+    province: str | None,
+    year: int,
+    language: str | None,
+    categories: list[str] | None,
+) -> HolidayBase:
+    """Get the object for the requested country and year."""
+    if not country:
+        return HolidayBase()
+
+    set_categories = None
+    if categories:
+        category_list = [PUBLIC]
+        category_list.extend(categories)
+        set_categories = tuple(category_list)
+
+    obj_holidays: HolidayBase = country_holidays(
+        country,
+        subdiv=province,
+        years=[year, year + 1],
+        language=language,
+        categories=set_categories,
+    )
+
+    supported_languages = obj_holidays.supported_languages
+    default_language = obj_holidays.default_language
+
+    if default_language and not language:
+        # If no language is set, use the default language
+        LOGGER.debug("Changing language from None to %s", default_language)
+        return country_holidays(  # Return default if no language
+            country,
+            subdiv=province,
+            years=year,
+            language=default_language,
+            categories=set_categories,
+        )
+
+    if (
+        default_language
+        and language
+        and language not in supported_languages
+        and language.startswith("en")
+    ):
+        # If language does not match supported languages, use the first English variant
+        if default_language.startswith("en"):
+            LOGGER.debug("Changing language from %s to %s", language, default_language)
+            return country_holidays(  # Return default English if default language
+                country,
+                subdiv=province,
+                years=year,
+                language=default_language,
+                categories=set_categories,
+            )
+        for lang in supported_languages:
+            if lang.startswith("en"):
+                LOGGER.debug("Changing language from %s to %s", language, lang)
+                return country_holidays(
+                    country,
+                    subdiv=province,
+                    years=year,
+                    language=lang,
+                    categories=set_categories,
+                )
+
+    if default_language and language and language not in supported_languages:
+        # If language does not match supported languages, use the default language
+        LOGGER.debug("Changing language from %s to %s", language, default_language)
+        return country_holidays(  # Return default English if default language
+            country,
+            subdiv=province,
+            years=year,
+            language=default_language,
+            categories=set_categories,
+        )
+
+    return obj_holidays
+
+
+def add_remove_custom_holidays(
+    hass: HomeAssistant,
+    entry: "WorkdayConfigEntry",
+    country: str | None,
+    calc_add_holidays: list[DateLike],
+    calc_remove_holidays: list[str],
+) -> None:
+    """Add or remove custom holidays."""
+    next_year = dt_util.now().year + 1
+
+    # Add custom holidays
+    try:
+        entry.runtime_data.append(calc_add_holidays)
+    except ValueError as error:
+        LOGGER.error("Could not add custom holidays: %s", error)
+
+    # Remove custom holidays
+    for remove_holiday in calc_remove_holidays:
+        try:
+            # is this formatted as a date?
+            if dt_util.parse_date(remove_holiday):
+                # remove holiday by date
+                removed = entry.runtime_data.pop(remove_holiday)
+                LOGGER.debug("Removed %s", remove_holiday)
+            else:
+                # remove holiday by name
+                LOGGER.debug("Treating '%s' as named holiday", remove_holiday)
+                removed = entry.runtime_data.pop_named(remove_holiday)
+                for holiday in removed:
+                    LOGGER.debug("Removed %s by name '%s'", holiday, remove_holiday)
+        except KeyError as unmatched:
+            LOGGER.warning("No holiday found matching %s", unmatched)
+            if _date := dt_util.parse_date(remove_holiday):
+                if _date.year <= next_year:
+                    # Only check and raise issues for max next year
+                    async_create_issue(
+                        hass,
+                        DOMAIN,
+                        f"bad_date_holiday-{entry.entry_id}-{slugify(remove_holiday)}",
+                        is_fixable=True,
+                        is_persistent=False,
+                        severity=IssueSeverity.WARNING,
+                        translation_key="bad_date_holiday",
+                        translation_placeholders={
+                            CONF_COUNTRY: country if country else "-",
+                            "title": entry.title,
+                            CONF_REMOVE_HOLIDAYS: remove_holiday,
+                        },
+                        data={
+                            "entry_id": entry.entry_id,
+                            "country": country,
+                            "named_holiday": remove_holiday,
+                        },
+                    )
+            else:
+                async_create_issue(
+                    hass,
+                    DOMAIN,
+                    f"bad_named_holiday-{entry.entry_id}-{slugify(remove_holiday)}",
+                    is_fixable=True,
+                    is_persistent=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="bad_named_holiday",
+                    translation_placeholders={
+                        CONF_COUNTRY: country if country else "-",
+                        "title": entry.title,
+                        CONF_REMOVE_HOLIDAYS: remove_holiday,
+                    },
+                    data={
+                        "entry_id": entry.entry_id,
+                        "country": country,
+                        "named_holiday": remove_holiday,
+                    },
+                )


### PR DESCRIPTION
## Breaking change


## Proposed change
Move the holiday object to runtime data.
Prep for adding a calendar.

Only moving code, no modifications to any functions.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 