### PR TITLE
Use OptionsFlowWithReload in motioneye

### DIFF
--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -277,11 +277,6 @@ def _add_camera(
     )
 
 
-async def _async_entry_updated(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
-    """Handle entry updates."""
-    await hass.config_entries.async_reload(config_entry.entry_id)
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up motionEye from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -382,7 +377,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator.async_add_listener(_async_process_motioneye_cameras)
     )
     await coordinator.async_refresh()
-    entry.async_on_unload(entry.add_update_listener(_async_entry_updated))
 
     return True
 

--- a/homeassistant/components/motioneye/config_flow.py
+++ b/homeassistant/components/motioneye/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
-    OptionsFlow,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import CONF_URL, CONF_WEBHOOK_ID
 from homeassistant.core import callback
@@ -186,7 +186,7 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
         return MotionEyeOptionsFlow()
 
 
-class MotionEyeOptionsFlow(OptionsFlow):
+class MotionEyeOptionsFlow(OptionsFlowWithReload):
     """motionEye options flow."""
 
     async def async_step_init(

--- a/tests/components/motioneye/test_config_flow.py
+++ b/tests/components/motioneye/test_config_flow.py
@@ -532,7 +532,7 @@ async def test_advanced_options(hass: HomeAssistant) -> None:
         assert result["data"][CONF_WEBHOOK_SET_OVERWRITE]
         assert CONF_STREAM_URL_TEMPLATE not in result["data"]
         assert len(mock_setup.mock_calls) == 0
-        assert len(mock_setup_entry.mock_calls) == 0
+        assert len(mock_setup_entry.mock_calls) == 1
 
         result = await hass.config_entries.options.async_init(
             config_entry.entry_id, context={"show_advanced_options": True}
@@ -551,4 +551,4 @@ async def test_advanced_options(hass: HomeAssistant) -> None:
         assert result["data"][CONF_WEBHOOK_SET_OVERWRITE]
         assert result["data"][CONF_STREAM_URL_TEMPLATE] == "http://moo"
         assert len(mock_setup.mock_calls) == 0
-        assert len(mock_setup_entry.mock_calls) == 0
+        assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/motioneye/test_web_hooks.py
+++ b/tests/components/motioneye/test_web_hooks.py
@@ -116,7 +116,6 @@ async def test_setup_camera_with_wrong_webhook(
     )
     assert not client.async_set_camera.called
 
-    # Update the options, which will trigger a reload with the new behavior.
     with patch(
         "homeassistant.components.motioneye.MotionEyeClient",
         return_value=client,
@@ -124,6 +123,7 @@ async def test_setup_camera_with_wrong_webhook(
         hass.config_entries.async_update_entry(
             config_entry, options={CONF_WEBHOOK_SET_OVERWRITE: True}
         )
+        await hass.config_entries.async_reload(config_entry.entry_id)
         await hass.async_block_till_done()
 
     device = device_registry.async_get_device(


### PR DESCRIPTION
## Breaking change


## Proposed change
SSIA

Ref: https://github.com/home-assistant/core/pull/146910

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 