### PR TITLE
Add logging to Tuya for devices that cannot be supported

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -153,7 +153,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
     # Register known device IDs
     device_registry = dr.async_get(hass)
     for device in manager.device_map.values():
-        model = f"{device.product_name} (unsupported)"
         if not device.status and not device.status_range and not device.function:
             # If the device has no status, status_range or function, it cannot be supported
             LOGGER.info(
@@ -162,13 +161,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
                 device.product_name,
                 device.id,
             )
-            model = f"{device.product_name} (unsupported)"
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, device.id)},
             manufacturer="Tuya",
             name=device.name,
-            model=model,
+            model=f"{device.product_name} (unsupported)",
             model_id=device.product_id,
         )
 

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -153,12 +153,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
     # Register known device IDs
     device_registry = dr.async_get(hass)
     for device in manager.device_map.values():
+        model = f"{device.product_name} (unsupported)"
+        if not device.status and not device.status_range and not device.function:
+            # If the device has no status, status_range or function, it cannot be supported
+            LOGGER.info(
+                "Device %s (%s) has been ignored as it does not provide any DPCode"
+                " (status, status_range and function are all empty)",
+                device.product_name,
+                device.id,
+            )
+            model = f"{device.product_name} (unsupported)"
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, device.id)},
             manufacturer="Tuya",
             name=device.name,
-            model=f"{device.product_name} (unsupported)",
+            model=model,
             model_id=device.product_id,
         )
 

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -154,12 +154,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool
     device_registry = dr.async_get(hass)
     for device in manager.device_map.values():
         if not device.status and not device.status_range and not device.function:
-            # If the device has no status, status_range or function, it cannot be supported
+            # If the device has no status, status_range or function,
+            # it cannot be supported
             LOGGER.info(
-                "Device %s (%s) has been ignored as it does not provide any DPCode"
-                " (status, status_range and function are all empty)",
+                "Device %s (%s) has been ignored as it does not provide any"
+                " standard instructions (status, status_range and function are"
+                " all empty) - see %s",
                 device.product_name,
                 device.id,
+                "https://github.com/tuya/tuya-device-sharing-sdk/issues/11",
             )
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -148,6 +148,10 @@ DEVICE_MOCKS = {
         Platform.SELECT,
         Platform.SWITCH,
     ],
+    "ydkt_dolceclima_unsupported": [
+        # https://github.com/orgs/home-assistant/discussions/288
+        # unsupported device - no platforms
+    ],
     "wk_wifi_smart_gas_boiler_thermostat": [
         # https://github.com/orgs/home-assistant/discussions/243
         Platform.CLIMATE,

--- a/tests/components/tuya/fixtures/ydkt_dolceclima_unsupported.json
+++ b/tests/components/tuya/fixtures/ydkt_dolceclima_unsupported.json
@@ -1,0 +1,23 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "terminal_id": "mock_terminal_id",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "id": "mock_device_id",
+  "name": "DOLCECLIMA 10 HP WIFI",
+  "category": "ydkt",
+  "product_id": "jevroj5aguwdbs2e",
+  "product_name": "DOLCECLIMA 10 HP WIFI",
+  "online": true,
+  "sub": false,
+  "time_zone": "+02:00",
+  "active_time": "2025-07-09T18:39:25+00:00",
+  "create_time": "2025-07-09T18:39:25+00:00",
+  "update_time": "2025-07-09T18:39:25+00:00",
+  "function": {},
+  "status_range": {},
+  "status": {},
+  "set_up": false,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: test_unsupported_device[ydkt_dolceclima_unsupported]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'config_entries_subentries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'tuya',
+          'mock_device_id',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'Tuya',
+      'model': 'DOLCECLIMA 10 HP WIFI (unsupported)',
+      'model_id': 'jevroj5aguwdbs2e',
+      'name': 'DOLCECLIMA 10 HP WIFI',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -43,6 +43,7 @@ async def test_unsupported_device(
     # Information log entry added
     assert (
         "Device DOLCECLIMA 10 HP WIFI (mock_device_id) has been ignored"
-        " as it does not provide any DPCode (status, status_range and function"
-        " are all empty)" in caplog.text
+        " as it does not provide any standard instructions (status, status_range"
+        " and function are all empty) - see "
+        "https://github.com/tuya/tuya-device-sharing-sdk/issues/11" in caplog.text
     )

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -1,0 +1,48 @@
+"""Test Tuya fan platform."""
+
+from __future__ import annotations
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from tuya_sharing import CustomerDevice
+
+from homeassistant.components.tuya import ManagerCompat
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import initialize_entry
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize("mock_device_code", ["ydkt_dolceclima_unsupported"])
+async def test_unsupported_device(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test unsupported device."""
+
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    # Device is registered
+    assert (
+        dr.async_entries_for_config_entry(device_registry, mock_config_entry.entry_id)
+        == snapshot
+    )
+    # No entities registered
+    assert not er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    # Information log entry added
+    assert (
+        "Device DOLCECLIMA 10 HP WIFI (mock_device_id) has been ignored"
+        " as it does not provide any DPCode (status, status_range and function"
+        " are all empty)" in caplog.text
+    )

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -1,4 +1,4 @@
-"""Test Tuya fan platform."""
+"""Test Tuya initialization."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
People are requesting support for new devices when those devices do not provide anything in function / status_range / status

I think it's worth logging as info (warning seems too much)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
