### PR TITLE
Allow Bluetooth proxy for Shelly devices only if Zigbee firmware is not active

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -298,7 +298,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
                     translation_key="firmware_unsupported",
                     translation_placeholders={"device": entry.title},
                 )
-            runtime_data.rpc_zigbee_enabled = device.zigbee_enabled
+            runtime_data.rpc_zigbee_firmware = device.zigbee_firmware
             runtime_data.rpc_supports_scripts = await device.supports_scripts()
             if runtime_data.rpc_supports_scripts:
                 runtime_data.rpc_script_events = await get_rpc_scripts_event_types(

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -475,8 +475,8 @@ class OptionsFlowHandler(OptionsFlow):
             return self.async_abort(reason="cannot_connect")
         if not supports_scripts:
             return self.async_abort(reason="no_scripts_support")
-        if self.config_entry.runtime_data.rpc_zigbee_enabled:
-            return self.async_abort(reason="zigbee_enabled")
+        if self.config_entry.runtime_data.rpc_zigbee_firmware:
+            return self.async_abort(reason="zigbee_firmware")
 
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -94,7 +94,7 @@ class ShellyEntryData:
     rpc_poll: ShellyRpcPollingCoordinator | None = None
     rpc_script_events: dict[int, list[str]] | None = None
     rpc_supports_scripts: bool | None = None
-    rpc_zigbee_enabled: bool | None = None
+    rpc_zigbee_firmware: bool | None = None
 
 
 type ShellyConfigEntry = ConfigEntry[ShellyEntryData]
@@ -730,7 +730,7 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
         if not self.sleep_period:
             if (
                 self.config_entry.runtime_data.rpc_supports_scripts
-                and not self.config_entry.runtime_data.rpc_zigbee_enabled
+                and not self.config_entry.runtime_data.rpc_zigbee_firmware
             ):
                 await self._async_connect_ble_scanner()
         else:

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -105,7 +105,7 @@
     "abort": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "no_scripts_support": "Device does not support scripts and cannot be used as a Bluetooth scanner.",
-      "zigbee_firmware": "Device with Zigbee firmware cannot be used as a Bluetooth scanner. Please update to Matter firmware to use the device as a Bluetooth scanner."
+      "zigbee_firmware": "Device with a Zigbee firmware cannot be used as a Bluetooth scanner. Please switch to Matter firmware to use the device as a Bluetooth scanner."
     }
   },
   "selector": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -105,7 +105,7 @@
     "abort": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "no_scripts_support": "Device does not support scripts and cannot be used as a Bluetooth scanner.",
-      "zigbee_enabled": "Device with Zigbee enabled cannot be used as a Bluetooth scanner. Please disable it to use the device as a Bluetooth scanner."
+      "zigbee_firmware": "Device with Zigbee firmware cannot be used as a Bluetooth scanner. Please update to Matter firmwareto use the device as a Bluetooth scanner."
     }
   },
   "selector": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -105,7 +105,7 @@
     "abort": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "no_scripts_support": "Device does not support scripts and cannot be used as a Bluetooth scanner.",
-      "zigbee_firmware": "Device with Zigbee firmware cannot be used as a Bluetooth scanner. Please update to Matter firmwareto use the device as a Bluetooth scanner."
+      "zigbee_firmware": "Device with Zigbee firmware cannot be used as a Bluetooth scanner. Please update to Matter firmware to use the device as a Bluetooth scanner."
     }
   },
   "selector": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -105,7 +105,7 @@
     "abort": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "no_scripts_support": "Device does not support scripts and cannot be used as a Bluetooth scanner.",
-      "zigbee_firmware": "Device with a Zigbee firmware cannot be used as a Bluetooth scanner. Please switch to Matter firmware to use the device as a Bluetooth scanner."
+      "zigbee_firmware": "A device with Zigbee firmware cannot be used as a Bluetooth scanner. Please switch to Matter firmware to use the device as a Bluetooth scanner."
     }
   },
   "selector": {

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -548,6 +548,7 @@ def _mock_rpc_device(version: str | None = None):
         ),
         xmod_info={},
         zigbee_enabled=False,
+        zigbee_firmware=False,
         ip_address="10.10.10.10",
     )
     type(device).name = PropertyMock(return_value="Test name")

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -870,17 +870,17 @@ async def test_options_flow_abort_no_scripts_support(
     assert result["reason"] == "no_scripts_support"
 
 
-async def test_options_flow_abort_zigbee_enabled(
+async def test_options_flow_abort_zigbee_firmware(
     hass: HomeAssistant, mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test ble options abort if Zigbee is enabled for the device."""
-    monkeypatch.setattr(mock_rpc_device, "zigbee_enabled", True)
+    """Test ble options abort if Zigbee firmware is used."""
+    monkeypatch.setattr(mock_rpc_device, "zigbee_firmware", True)
     entry = await init_integration(hass, 4)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "zigbee_enabled"
+    assert result["reason"] == "zigbee_firmware"
 
 
 async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -873,7 +873,7 @@ async def test_options_flow_abort_no_scripts_support(
 async def test_options_flow_abort_zigbee_firmware(
     hass: HomeAssistant, mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test ble options abort if Zigbee firmware is used."""
+    """Test ble options abort if Zigbee firmware is active."""
     monkeypatch.setattr(mock_rpc_device, "zigbee_firmware", True)
     entry = await init_integration(hass, 4)
 

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -864,7 +864,7 @@ async def test_rpc_update_entry_fw_ver(
 
 
 @pytest.mark.parametrize(
-    ("supports_scripts", "zigbee_enabled", "result"),
+    ("supports_scripts", "zigbee_firmware", "result"),
     [
         (True, False, True),
         (True, True, False),
@@ -877,14 +877,14 @@ async def test_rpc_runs_connected_events_when_initialized(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
     supports_scripts: bool,
-    zigbee_enabled: bool,
+    zigbee_firmware: bool,
     result: bool,
 ) -> None:
     """Test RPC runs connected events when initialized."""
     monkeypatch.setattr(
         mock_rpc_device, "supports_scripts", AsyncMock(return_value=supports_scripts)
     )
-    monkeypatch.setattr(mock_rpc_device, "zigbee_enabled", zigbee_enabled)
+    monkeypatch.setattr(mock_rpc_device, "zigbee_firmware", zigbee_firmware)
     monkeypatch.setattr(mock_rpc_device, "initialized", False)
     await init_integration(hass, 2)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If Zigbee firmware is active on the Shelly Gen4 device then BLE scanning is not available and we cannot allow the use of BLE proxy script.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148945
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
