### PR TITLE
Improve config flow tests in Onkyo

### DIFF
--- a/homeassistant/components/onkyo/quality_scale.yaml
+++ b/homeassistant/components/onkyo/quality_scale.yaml
@@ -8,10 +8,7 @@ rules:
   brands: done
   common-modules: done
   config-flow: done
-  config-flow-test-coverage:
-    status: todo
-    comment: |
-      Coverage is 100%, but the tests need to be improved.
+  config-flow-test-coverage: done
   dependency-transparency: done
   docs-actions: done
   docs-high-level-description: done
@@ -39,9 +36,9 @@ rules:
   parallel-updates: todo
   reauthentication-flow:
     status: exempt
-    comment: |
-      This integration does not require authentication.
-  test-coverage: todo
+    comment: This integration does not require authentication.
+  test-coverage: done
+
   # Gold
   devices: todo
   diagnostics: todo

--- a/tests/components/onkyo/conftest.py
+++ b/tests/components/onkyo/conftest.py
@@ -8,9 +8,8 @@ from aioonkyo import Code, Instruction, Kind, Receiver, Status, Zone, status
 import pytest
 
 from homeassistant.components.onkyo.const import DOMAIN
-from homeassistant.const import CONF_HOST
 
-from . import RECEIVER_INFO, mock_discovery
+from . import RECEIVER_INFO, RECEIVER_INFO_2, mock_discovery
 
 from tests.common import MockConfigEntry
 
@@ -24,7 +23,7 @@ def mock_default_discovery() -> Generator[None]:
             DEVICE_INTERVIEW_TIMEOUT=1,
             DEVICE_DISCOVERY_TIMEOUT=1,
         ),
-        mock_discovery([RECEIVER_INFO]),
+        mock_discovery([RECEIVER_INFO, RECEIVER_INFO_2]),
     ):
         yield
 
@@ -164,7 +163,7 @@ def mock_receiver(
 @pytest.fixture
 def mock_config_entry() -> MockConfigEntry:
     """Mock a config entry."""
-    data = {CONF_HOST: RECEIVER_INFO.host}
+    data = {"host": RECEIVER_INFO.host}
     options = {
         "volume_resolution": 80,
         "max_volume": 100,

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -1,5 +1,7 @@
 """Test Onkyo config flow."""
 
+from contextlib import AbstractContextManager, nullcontext
+
 from aioonkyo import ReceiverInfo
 import pytest
 
@@ -15,7 +17,7 @@ from homeassistant.components.onkyo.const import (
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType, InvalidData
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
     SsdpServiceInfo,
@@ -30,345 +32,282 @@ def _entry_title(receiver_info: ReceiverInfo) -> str:
     return f"{receiver_info.model_name} ({receiver_info.host})"
 
 
-async def test_user_initial_menu(hass: HomeAssistant) -> None:
-    """Test initial menu."""
-    init_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    assert init_result["type"] is FlowResultType.MENU
-    # Check if the values are there, but ignore order
-    assert not set(init_result["menu_options"]) ^ {"manual", "eiscp_discovery"}
-
-
-async def test_manual_valid_host(hass: HomeAssistant) -> None:
-    """Test valid host entered."""
-    init_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    form_result = await hass.config_entries.flow.async_configure(
-        init_result["flow_id"],
-        {"next_step_id": "manual"},
-    )
-
-    select_result = await hass.config_entries.flow.async_configure(
-        form_result["flow_id"],
-        user_input={CONF_HOST: RECEIVER_INFO.host},
-    )
-
-    assert select_result["step_id"] == "configure_receiver"
-    assert select_result["description_placeholders"]["name"] == _entry_title(
-        RECEIVER_INFO
-    )
-
-
-async def test_manual_invalid_host(hass: HomeAssistant) -> None:
-    """Test invalid host entered."""
-    init_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    form_result = await hass.config_entries.flow.async_configure(
-        init_result["flow_id"],
-        {"next_step_id": "manual"},
-    )
-
-    with mock_discovery([]):
-        host_result = await hass.config_entries.flow.async_configure(
-            form_result["flow_id"],
-            user_input={CONF_HOST: "sample-host-name"},
-        )
-
-    assert host_result["step_id"] == "manual"
-    assert host_result["errors"]["base"] == "cannot_connect"
-
-
-async def test_manual_valid_host_unexpected_error(hass: HomeAssistant) -> None:
-    """Test valid host entered."""
-
-    init_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    form_result = await hass.config_entries.flow.async_configure(
-        init_result["flow_id"],
-        {"next_step_id": "manual"},
-    )
-
-    with mock_discovery(None):
-        host_result = await hass.config_entries.flow.async_configure(
-            form_result["flow_id"],
-            user_input={CONF_HOST: "sample-host-name"},
-        )
-
-    assert host_result["step_id"] == "manual"
-    assert host_result["errors"]["base"] == "unknown"
-
-
-async def test_eiscp_discovery_no_devices_found(hass: HomeAssistant) -> None:
-    """Test eiscp discovery with no devices found."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    with mock_discovery([]):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"next_step_id": "eiscp_discovery"},
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "no_devices_found"
-
-
-async def test_eiscp_discovery_unexpected_exception(hass: HomeAssistant) -> None:
-    """Test eiscp discovery with an unexpected exception."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    with mock_discovery(None):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"next_step_id": "eiscp_discovery"},
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "unknown"
-
-
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_eiscp_discovery(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test eiscp discovery."""
-    mock_config_entry.add_to_hass(hass)
-
+async def test_manual(hass: HomeAssistant) -> None:
+    """Test successful manual."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
+        DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with mock_discovery([RECEIVER_INFO, RECEIVER_INFO_2]):
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "manual"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+
+    with mock_discovery(None):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"next_step_id": "eiscp_discovery"},
+            result["flow_id"], user_input={CONF_HOST: RECEIVER_INFO_2.host}
         )
 
     assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+    assert result["errors"] == {"base": "unknown"}
 
-    assert result["data_schema"] is not None
-    schema = result["data_schema"].schema
-    container = schema["device"].container
-    assert container == {RECEIVER_INFO_2.identifier: _entry_title(RECEIVER_INFO_2)}
+    with mock_discovery([]):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_HOST: RECEIVER_INFO_2.host}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    with mock_discovery([RECEIVER_INFO]):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_HOST: RECEIVER_INFO_2.host}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+    assert result["errors"] == {"base": "cannot_connect"}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={"device": RECEIVER_INFO_2.identifier},
+        result["flow_id"], user_input={CONF_HOST: RECEIVER_INFO_2.host}
     )
 
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_receiver"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            "volume_resolution": 200,
-            "input_sources": ["TV"],
-            "listening_modes": ["THX"],
+            OPTION_VOLUME_RESOLUTION: 200,
+            OPTION_INPUT_SOURCES: ["TV"],
+            OPTION_LISTENING_MODES: ["THX"],
         },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"]["host"] == RECEIVER_INFO_2.host
+    assert result["data"][CONF_HOST] == RECEIVER_INFO_2.host
     assert result["result"].unique_id == RECEIVER_INFO_2.identifier
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_ssdp_discovery_success(hass: HomeAssistant) -> None:
-    """Test SSDP discovery with valid host."""
-    discovery_info = SsdpServiceInfo(
-        ssdp_location="http://192.168.0.101:8080",
-        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
-        ssdp_usn="uuid:mock_usn",
-        ssdp_udn="uuid:00000000-0000-0000-0000-000000000000",
-        ssdp_st="mock_st",
-    )
+async def test_manual_error(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test manual with an error."""
+    await setup_integration(hass, mock_config_entry)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_SSDP},
-        data=discovery_info,
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "manual"}
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "configure_receiver"
+    assert result["step_id"] == "manual"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={
-            "volume_resolution": 200,
-            "input_sources": ["TV"],
-            "listening_modes": ["THX"],
-        },
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"]["host"] == RECEIVER_INFO.host
-    assert result["result"].unique_id == RECEIVER_INFO.identifier
-
-
-async def test_ssdp_discovery_already_configured(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
-) -> None:
-    """Test SSDP discovery with already configured device."""
-    mock_config_entry.add_to_hass(hass)
-
-    discovery_info = SsdpServiceInfo(
-        ssdp_location="http://192.168.0.101:8080",
-        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
-        ssdp_usn="uuid:mock_usn",
-        ssdp_udn="uuid:00000000-0000-0000-0000-000000000000",
-        ssdp_st="mock_st",
-    )
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_SSDP},
-        data=discovery_info,
+        result["flow_id"], user_input={CONF_HOST: RECEIVER_INFO.host}
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
-async def test_ssdp_discovery_host_info_error(hass: HomeAssistant) -> None:
-    """Test SSDP discovery with host info error."""
-    discovery_info = SsdpServiceInfo(
-        ssdp_location="http://192.168.1.100:8080",
-        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
-        ssdp_usn="uuid:mock_usn",
-        ssdp_st="mock_st",
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_eiscp_discovery(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test successful eiscp discovery."""
+    await setup_integration(hass, mock_config_entry)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with mock_discovery(None):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_SSDP},
-            data=discovery_info,
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "eiscp_discovery"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "eiscp_discovery"
+
+    devices = result["data_schema"].schema["device"].container
+    assert devices == {RECEIVER_INFO_2.identifier: _entry_title(RECEIVER_INFO_2)}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"device": RECEIVER_INFO_2.identifier}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configure_receiver"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            OPTION_VOLUME_RESOLUTION: 200,
+            OPTION_INPUT_SOURCES: ["TV"],
+            OPTION_LISTENING_MODES: ["THX"],
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_HOST] == RECEIVER_INFO_2.host
+    assert result["result"].unique_id == RECEIVER_INFO_2.identifier
+
+
+@pytest.mark.parametrize(
+    ("mock_discovery", "error_reason"),
+    [
+        (mock_discovery(None), "unknown"),
+        (mock_discovery([]), "no_devices_found"),
+        (mock_discovery([RECEIVER_INFO]), "no_devices_found"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_eiscp_discovery_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AbstractContextManager,
+    error_reason: str,
+) -> None:
+    """Test eiscp discovery with an error."""
+    await setup_integration(hass, mock_config_entry)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
+    with mock_discovery:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "eiscp_discovery"}
         )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "unknown"
+    assert result["reason"] == error_reason
 
 
-async def test_ssdp_discovery_host_none_info(hass: HomeAssistant) -> None:
-    """Test SSDP discovery with host info error."""
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_ssdp_discovery(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test successful SSDP discovery."""
+    await setup_integration(hass, mock_config_entry)
+
     discovery_info = SsdpServiceInfo(
-        ssdp_location="http://192.168.1.100:8080",
+        ssdp_location=f"http://{RECEIVER_INFO_2.host}:8080",
         upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
         ssdp_usn="uuid:mock_usn",
-        ssdp_st="mock_st",
-    )
-
-    with mock_discovery([]):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_SSDP},
-            data=discovery_info,
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
-
-
-async def test_ssdp_discovery_no_location(hass: HomeAssistant) -> None:
-    """Test SSDP discovery with no location."""
-    discovery_info = SsdpServiceInfo(
-        ssdp_location=None,
-        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
-        ssdp_usn="uuid:mock_usn",
+        ssdp_udn="uuid:00000000-0000-0000-0000-000000000000",
         ssdp_st="mock_st",
     )
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_SSDP},
-        data=discovery_info,
+        DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=discovery_info
     )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "unknown"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configure_receiver"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            OPTION_VOLUME_RESOLUTION: 200,
+            OPTION_INPUT_SOURCES: ["TV"],
+            OPTION_LISTENING_MODES: ["THX"],
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_HOST] == RECEIVER_INFO_2.host
+    assert result["result"].unique_id == RECEIVER_INFO_2.identifier
 
 
-async def test_ssdp_discovery_no_host(hass: HomeAssistant) -> None:
-    """Test SSDP discovery with no host."""
+@pytest.mark.parametrize(
+    ("ssdp_location", "mock_discovery", "error_reason"),
+    [
+        (None, nullcontext(), "unknown"),
+        ("http://", nullcontext(), "unknown"),
+        (f"http://{RECEIVER_INFO_2.host}:8080", mock_discovery(None), "unknown"),
+        (f"http://{RECEIVER_INFO_2.host}:8080", mock_discovery([]), "cannot_connect"),
+        (
+            f"http://{RECEIVER_INFO_2.host}:8080",
+            mock_discovery([RECEIVER_INFO]),
+            "cannot_connect",
+        ),
+        (f"http://{RECEIVER_INFO.host}:8080", nullcontext(), "already_configured"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_ssdp_discovery_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    ssdp_location: str | None,
+    mock_discovery: AbstractContextManager,
+    error_reason: str,
+) -> None:
+    """Test SSDP discovery with an error."""
+    await setup_integration(hass, mock_config_entry)
+
     discovery_info = SsdpServiceInfo(
-        ssdp_location="http://",
+        ssdp_location=ssdp_location,
         upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
         ssdp_usn="uuid:mock_usn",
+        ssdp_udn="uuid:00000000-0000-0000-0000-000000000000",
         ssdp_st="mock_st",
     )
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_SSDP},
-        data=discovery_info,
-    )
+    with mock_discovery:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=discovery_info
+        )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "unknown"
-
-
-async def test_configure_no_resolution(hass: HomeAssistant) -> None:
-    """Test receiver configure with no resolution set."""
-
-    init_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    form_result = await hass.config_entries.flow.async_configure(
-        init_result["flow_id"],
-        {"next_step_id": "manual"},
-    )
-
-    select_result = await hass.config_entries.flow.async_configure(
-        form_result["flow_id"],
-        user_input={CONF_HOST: "sample-host-name"},
-    )
-
-    with pytest.raises(InvalidData):
-        await hass.config_entries.flow.async_configure(
-            select_result["flow_id"],
-            user_input={"input_sources": ["TV"]},
-        )
+    assert result["reason"] == error_reason
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_configure(hass: HomeAssistant) -> None:
     """Test receiver configure."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
+        DOMAIN, context={"source": SOURCE_USER}
     )
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"next_step_id": "manual"},
-    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_HOST: RECEIVER_INFO.host},
+        result["flow_id"], {"next_step_id": "manual"}
     )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: RECEIVER_INFO.host}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configure_receiver"
+    assert result["description_placeholders"]["name"] == _entry_title(RECEIVER_INFO)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -378,6 +317,8 @@ async def test_configure(hass: HomeAssistant) -> None:
             OPTION_LISTENING_MODES: ["THX"],
         },
     )
+
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_receiver"
     assert result["errors"] == {OPTION_INPUT_SOURCES: "empty_input_source_list"}
 
@@ -389,6 +330,8 @@ async def test_configure(hass: HomeAssistant) -> None:
             OPTION_LISTENING_MODES: [],
         },
     )
+
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_receiver"
     assert result["errors"] == {OPTION_LISTENING_MODES: "empty_listening_mode_list"}
 
@@ -400,6 +343,7 @@ async def test_configure(hass: HomeAssistant) -> None:
             OPTION_LISTENING_MODES: ["THX"],
         },
     )
+
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["options"] == {
         OPTION_VOLUME_RESOLUTION: 200,
@@ -409,36 +353,11 @@ async def test_configure(hass: HomeAssistant) -> None:
     }
 
 
-async def test_configure_invalid_resolution_set(hass: HomeAssistant) -> None:
-    """Test receiver configure with invalid resolution."""
-
-    init_result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    form_result = await hass.config_entries.flow.async_configure(
-        init_result["flow_id"],
-        {"next_step_id": "manual"},
-    )
-
-    select_result = await hass.config_entries.flow.async_configure(
-        form_result["flow_id"],
-        user_input={CONF_HOST: "sample-host-name"},
-    )
-
-    with pytest.raises(InvalidData):
-        await hass.config_entries.flow.async_configure(
-            select_result["flow_id"],
-            user_input={"volume_resolution": 42, "input_sources": ["TV"]},
-        )
-
-
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_reconfigure(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test the reconfigure config flow."""
+    """Test successful reconfigure flow."""
     await setup_integration(hass, mock_config_entry)
 
     old_host = mock_config_entry.data[CONF_HOST]
@@ -449,21 +368,19 @@ async def test_reconfigure(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "manual"
 
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={"host": mock_config_entry.data[CONF_HOST]}
-    )
-    await hass.async_block_till_done()
-
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "configure_receiver"
-
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
-        user_input={OPTION_VOLUME_RESOLUTION: 200},
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: mock_config_entry.data[CONF_HOST]}
     )
 
-    assert result3["type"] is FlowResultType.ABORT
-    assert result3["reason"] == "reconfigure_successful"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "configure_receiver"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={OPTION_VOLUME_RESOLUTION: 200}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
 
     assert mock_config_entry.data[CONF_HOST] == old_host
     assert mock_config_entry.options[OPTION_VOLUME_RESOLUTION] == 200
@@ -474,24 +391,25 @@ async def test_reconfigure(
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_reconfigure_new_device(
+async def test_reconfigure_error(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test the reconfigure config flow with new device."""
+    """Test reconfigure flow with an error."""
     await setup_integration(hass, mock_config_entry)
 
     old_unique_id = mock_config_entry.unique_id
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
 
-    with mock_discovery([RECEIVER_INFO_2]):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_HOST: RECEIVER_INFO_2.host}
-        )
-        await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
 
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "unique_id_mismatch"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: RECEIVER_INFO_2.host}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"
 
     # unique id should remain unchanged
     assert mock_config_entry.unique_id == old_unique_id
@@ -518,6 +436,9 @@ async def test_options_flow(
     old_volume_resolution = mock_config_entry.options[OPTION_VOLUME_RESOLUTION]
 
     result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve config flow tests in Onkyo.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
