### PR TITLE
Replace RuntimeError with TYPE_CHECKING in Tuya

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -307,17 +307,16 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     def set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         if TYPE_CHECKING:
-            # We can rely on supported_features from __init__
+            # guarded by ClimateEntityFeature.FAN_MODE
             assert self._fan_mode_dp_code is not None
 
         self._send_command([{"code": self._fan_mode_dp_code, "value": fan_mode}])
 
     def set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
-        if self._set_humidity is None:
-            raise RuntimeError(
-                "Cannot set humidity, device doesn't provide methods to set it"
-            )
+        if TYPE_CHECKING:
+            # guarded by ClimateEntityFeature.TARGET_HUMIDITY
+            assert self._set_humidity is not None
 
         self._send_command(
             [
@@ -355,11 +354,9 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
 
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        if self._set_temperature is None:
-            raise RuntimeError(
-                "Cannot set target temperature, device doesn't provide methods to"
-                " set it"
-            )
+        if TYPE_CHECKING:
+            # guarded by ClimateEntityFeature.TARGET_TEMPERATURE
+            assert self._set_temperature is not None
 
         self._send_command(
             [

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from tuya_sharing import CustomerDevice, Manager
 
@@ -333,10 +333,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
     def set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        if self._set_position is None:
-            raise RuntimeError(
-                "Cannot set position, device doesn't provide methods to set it"
-            )
+        if TYPE_CHECKING:
+            # guarded by CoverEntityFeature.SET_POSITION
+            assert self._set_position is not None
 
         self._send_command(
             [
@@ -364,10 +363,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
     def set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
-        if self._tilt is None:
-            raise RuntimeError(
-                "Cannot set tilt, device doesn't provide methods to set it"
-            )
+        if TYPE_CHECKING:
+            # guarded by CoverEntityFeature.SET_TILT_POSITION
+            assert self._tilt is not None
 
         self._send_command(
             [

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -11,6 +11,8 @@ from tuya_sharing import CustomerDevice
 from homeassistant.components.climate import (
     DOMAIN as CLIMATE_DOMAIN,
     SERVICE_SET_FAN_MODE,
+    SERVICE_SET_HUMIDITY,
+    SERVICE_SET_TEMPERATURE,
 )
 from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
@@ -59,6 +61,36 @@ async def test_platform_setup_no_discovery(
 
     assert not er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["kt_serenelife_slpac905wuk_air_conditioner"],
+)
+async def test_set_temperature(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test set temperature service."""
+    entity_id = "climate.air_conditioner"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            "entity_id": entity_id,
+            "temperature": 22.7,
+        },
+    )
+    await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id, [{"code": "temp_set", "value": 22}]
     )
 
 
@@ -122,6 +154,34 @@ async def test_fan_mode_no_valid_code(
             {
                 "entity_id": entity_id,
                 "fan_mode": 2,
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["kt_serenelife_slpac905wuk_air_conditioner"],
+)
+async def test_set_humidity_not_supported(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test set humidity service (not available on this device)."""
+    entity_id = "climate.air_conditioner"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    with pytest.raises(ServiceNotSupported):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HUMIDITY,
+            {
+                "entity_id": entity_id,
+                "humidity": 50,
             },
             blocking=True,
         )

--- a/tests/components/tuya/test_cover.py
+++ b/tests/components/tuya/test_cover.py
@@ -8,9 +8,17 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_SET_COVER_POSITION,
+    SERVICE_SET_COVER_TILT_POSITION,
+)
 from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceNotSupported
 from homeassistant.helpers import entity_registry as er
 
 from . import DEVICE_MOCKS, initialize_entry
@@ -61,6 +69,107 @@ async def test_platform_setup_no_discovery(
     "mock_device_code",
     ["cl_am43_corded_motor_zigbee_cover"],
 )
+@patch("homeassistant.components.tuya.PLATFORMS", [Platform.COVER])
+async def test_open_service(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test open service."""
+    entity_id = "cover.kitchen_blinds_curtain"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {
+            "entity_id": entity_id,
+        },
+    )
+    await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "control", "value": "open"},
+            {"code": "percent_control", "value": 0},
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["cl_am43_corded_motor_zigbee_cover"],
+)
+@patch("homeassistant.components.tuya.PLATFORMS", [Platform.COVER])
+async def test_close_service(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test close service."""
+    entity_id = "cover.kitchen_blinds_curtain"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {
+            "entity_id": entity_id,
+        },
+    )
+    await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "control", "value": "close"},
+            {"code": "percent_control", "value": 100},
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["cl_am43_corded_motor_zigbee_cover"],
+)
+async def test_set_position(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test set position service (not available on this device)."""
+    entity_id = "cover.kitchen_blinds_curtain"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {
+            "entity_id": entity_id,
+            "position": 25,
+        },
+    )
+    await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "percent_control", "value": 75},
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["cl_am43_corded_motor_zigbee_cover"],
+)
 @pytest.mark.parametrize(
     ("percent_control", "percent_state"),
     [
@@ -89,3 +198,31 @@ async def test_percent_state_on_cover(
     state = hass.states.get(entity_id)
     assert state is not None, f"{entity_id} does not exist"
     assert state.attributes["current_position"] == percent_state
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["cl_am43_corded_motor_zigbee_cover"],
+)
+async def test_set_tilt_position_not_supported(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test set tilt position service (not available on this device)."""
+    entity_id = "cover.kitchen_blinds_curtain"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    with pytest.raises(ServiceNotSupported):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_TILT_POSITION,
+            {
+                "entity_id": entity_id,
+                "tilt_position": 50,
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For climate and cover platform, the actions are guarded by EntityFeature property

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
