### PR TITLE
Consolidate REST sensor encoding tests using pytest parametrize

### DIFF
--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -144,14 +144,49 @@ async def test_setup_minimum(
     assert len(hass.states.async_all(SENSOR_DOMAIN)) == 1
 
 
-async def test_setup_encoding(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+@pytest.mark.parametrize(
+    ("content_text", "content_encoding", "headers", "expected_state"),
+    [
+        # Test setup with non-utf8 encoding
+        pytest.param(
+            "tack själv",
+            "iso-8859-1",
+            None,
+            "tack själv",
+            id="simple_iso88591",
+        ),
+        # Test that configured encoding is used when no charset in Content-Type
+        pytest.param(
+            "Björk Guðmundsdóttir",
+            "iso-8859-1",
+            {"Content-Type": "text/plain"},  # No charset!
+            "Björk Guðmundsdóttir",
+            id="fallback_when_no_charset",
+        ),
+        # Test that charset in Content-Type overrides configured encoding
+        pytest.param(
+            "Björk Guðmundsdóttir",
+            "utf-8",
+            {"Content-Type": "text/plain; charset=utf-8"},
+            "Björk Guðmundsdóttir",
+            id="charset_overrides_config",
+        ),
+    ],
+)
+async def test_setup_with_encoding_config(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    content_text: str,
+    content_encoding: str,
+    headers: dict[str, str] | None,
+    expected_state: str,
 ) -> None:
-    """Test setup with non-utf8 encoding."""
+    """Test setup with encoding configuration in sensor config."""
     aioclient_mock.get(
         "http://localhost",
         status=HTTPStatus.OK,
-        content="tack själv".encode(encoding="iso-8859-1"),
+        content=content_text.encode(content_encoding),
+        headers=headers,
     )
     assert await async_setup_component(
         hass,
@@ -168,10 +203,10 @@ async def test_setup_encoding(
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all(SENSOR_DOMAIN)) == 1
-    assert hass.states.get("sensor.mysensor").state == "tack själv"
+    assert hass.states.get("sensor.mysensor").state == expected_state
 
 
-async def test_setup_auto_encoding_from_content_type(
+async def test_setup_with_charset_from_header(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test setup with encoding auto-detected from Content-Type header."""
@@ -188,7 +223,7 @@ async def test_setup_auto_encoding_from_content_type(
         {
             SENSOR_DOMAIN: {
                 "name": "mysensor",
-                # encoding defaults to UTF-8, but should be ignored when charset present
+                # No encoding config - should use charset from header
                 "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
@@ -197,65 +232,6 @@ async def test_setup_auto_encoding_from_content_type(
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all(SENSOR_DOMAIN)) == 1
-    assert hass.states.get("sensor.mysensor").state == "Björk Guðmundsdóttir"
-
-
-async def test_setup_encoding_fallback_no_charset(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that configured encoding is used when no charset in Content-Type."""
-    # No charset in Content-Type header
-    aioclient_mock.get(
-        "http://localhost",
-        status=HTTPStatus.OK,
-        content="Björk Guðmundsdóttir".encode("iso-8859-1"),
-        headers={"Content-Type": "text/plain"},  # No charset!
-    )
-    assert await async_setup_component(
-        hass,
-        SENSOR_DOMAIN,
-        {
-            SENSOR_DOMAIN: {
-                "name": "mysensor",
-                "encoding": "iso-8859-1",  # This will be used as fallback
-                "platform": DOMAIN,
-                "resource": "http://localhost",
-                "method": "GET",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    assert len(hass.states.async_all(SENSOR_DOMAIN)) == 1
-    assert hass.states.get("sensor.mysensor").state == "Björk Guðmundsdóttir"
-
-
-async def test_setup_charset_overrides_encoding_config(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that charset in Content-Type overrides configured encoding."""
-    # Server sends UTF-8 with correct charset header
-    aioclient_mock.get(
-        "http://localhost",
-        status=HTTPStatus.OK,
-        content="Björk Guðmundsdóttir".encode(),
-        headers={"Content-Type": "text/plain; charset=utf-8"},
-    )
-    assert await async_setup_component(
-        hass,
-        SENSOR_DOMAIN,
-        {
-            SENSOR_DOMAIN: {
-                "name": "mysensor",
-                "encoding": "iso-8859-1",  # Config says ISO-8859-1, but charset=utf-8 should win
-                "platform": DOMAIN,
-                "resource": "http://localhost",
-                "method": "GET",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    assert len(hass.states.async_all(SENSOR_DOMAIN)) == 1
-    # This should work because charset=utf-8 overrides the iso-8859-1 config
     assert hass.states.get("sensor.mysensor").state == "Björk Guðmundsdóttir"
 
 

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -223,7 +223,7 @@ async def test_setup_with_charset_from_header(
         {
             SENSOR_DOMAIN: {
                 "name": "mysensor",
-                # No encoding config - should use charset from header
+                # No encoding config - should use charset from header.
                 "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",


### PR DESCRIPTION
## Proposed change
This PR addresses feedback from PR #148223 by consolidating the REST sensor encoding tests. Per abmantis's suggestion, this refactors four separate encoding test functions into two parameterized tests, reducing code duplication while maintaining the same test coverage.

The refactoring groups tests by their branching logic:
- `test_setup_with_encoding_config` - Tests scenarios where encoding is specified in the sensor configuration
- `test_setup_with_charset_from_header` - Tests auto-detection of encoding from Content-Type header

## Type of change
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to issue: #148223 (follow-up from PR feedback)

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

