### PR TITLE
Discover ZWA-2 LED as a configuration entity in Z-Wave

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -786,7 +786,6 @@ DISCOVERY_SCHEMAS = [
             SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
         ],
         entity_category=EntityCategory.CONFIG,
-        entity_registry_enabled_default=False,
     ),
     ## Day-1 firmware update (1.1) -> Binary Switch CC
     ZWaveDiscoverySchema(
@@ -801,7 +800,6 @@ DISCOVERY_SCHEMAS = [
             SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
         ],
         entity_category=EntityCategory.CONFIG,
-        entity_registry_enabled_default=False,
     ),
     # ====== START OF GENERIC MAPPING SCHEMAS =======
     # locks

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -772,6 +772,37 @@ DISCOVERY_SCHEMAS = [
             },
         ),
     ),
+    # ZWA-2, discover LED control as configuration, default disabled
+    ## Production firmware (1.0) -> Color Switch CC
+    ZWaveDiscoverySchema(
+        platform=Platform.LIGHT,
+        manufacturer_id={0x0466},
+        product_id={0x0001},
+        product_type={0x0001},
+        hint="color_onoff",
+        primary_value=COLOR_SWITCH_CURRENT_VALUE_SCHEMA,
+        absent_values=[
+            SWITCH_BINARY_CURRENT_VALUE_SCHEMA,
+            SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
+        ],
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+    ),
+    ## Day-1 firmware update (1.1) -> Binary Switch CC
+    ZWaveDiscoverySchema(
+        platform=Platform.LIGHT,
+        manufacturer_id={0x0466},
+        product_id={0x0001},
+        product_type={0x0001},
+        hint="onoff",
+        primary_value=SWITCH_BINARY_CURRENT_VALUE_SCHEMA,
+        absent_values=[
+            COLOR_SWITCH_CURRENT_VALUE_SCHEMA,
+            SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
+        ],
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+    ),
     # ====== START OF GENERIC MAPPING SCHEMAS =======
     # locks
     # Door Lock CC

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -183,7 +183,10 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         if self._supports_color_temp:
             self._supported_color_modes.add(ColorMode.COLOR_TEMP)
         if not self._supported_color_modes:
-            self._supported_color_modes.add(ColorMode.BRIGHTNESS)
+            if self.info.primary_value.command_class == CommandClass.SWITCH_BINARY:
+                self._supported_color_modes.add(ColorMode.ONOFF)
+            else:
+                self._supported_color_modes.add(ColorMode.BRIGHTNESS)
         self._calculate_color_values()
 
         # Entity class attributes

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -538,6 +538,24 @@ def zcombo_smoke_co_alarm_state_fixture() -> NodeDataType:
     )
 
 
+@pytest.fixture(name="nabu_casa_zwa2_state")
+def nabu_casa_zwa2_state_fixture() -> NodeDataType:
+    """Load node with fixture data for Nabu Casa ZWA-2."""
+    return cast(
+        NodeDataType,
+        load_json_object_fixture("nabu_casa_zwa2_state.json", DOMAIN),
+    )
+
+
+@pytest.fixture(name="nabu_casa_zwa2_legacy_state")
+def nabu_casa_zwa2_legacy_state_fixture() -> NodeDataType:
+    """Load node with fixture data for Nabu Casa ZWA-2 (legacy firmware)."""
+    return cast(
+        NodeDataType,
+        load_json_object_fixture("nabu_casa_zwa2_legacy_state.json", DOMAIN),
+    )
+
+
 # model fixtures
 
 
@@ -1356,5 +1374,25 @@ def zcombo_smoke_co_alarm_fixture(
 ) -> Node:
     """Load node for ZCombo-G Smoke/CO Alarm."""
     node = Node(client, zcombo_smoke_co_alarm_state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="nabu_casa_zwa2")
+def nabu_casa_zwa2_fixture(
+    client: MagicMock, nabu_casa_zwa2_state: NodeDataType
+) -> Node:
+    """Load node for Nabu Casa ZWA-2."""
+    node = Node(client, nabu_casa_zwa2_state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="nabu_casa_zwa2_legacy")
+def nabu_casa_zwa2_legacy_fixture(
+    client: MagicMock, nabu_casa_zwa2_legacy_state: NodeDataType
+) -> Node:
+    """Load node for Nabu Casa ZWA-2 (legacy firmware)."""
+    node = Node(client, nabu_casa_zwa2_legacy_state)
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/fixtures/nabu_casa_zwa2_legacy_state.json
+++ b/tests/components/zwave_js/fixtures/nabu_casa_zwa2_legacy_state.json
@@ -1,0 +1,231 @@
+{
+  "nodeId": 1,
+  "index": 0,
+  "status": 4,
+  "ready": true,
+  "isListening": true,
+  "isRouting": true,
+  "manufacturerId": 1126,
+  "productId": 1,
+  "productType": 1,
+  "firmwareVersion": "1.0",
+  "deviceConfig": {
+    "filename": "/data/db/devices/0x0466/zwa-2.json",
+    "isEmbedded": true,
+    "manufacturer": "Nabu Casa",
+    "manufacturerId": 1126,
+    "label": "Home Assistant Connect ZWA-2",
+    "description": "Z-Wave Adapter",
+    "devices": [
+      {
+        "productType": 1,
+        "productId": 1
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "preferred": false
+  },
+  "label": "Home Assistant Connect ZWA-2",
+  "interviewAttempts": 0,
+  "isFrequentListening": false,
+  "maxDataRate": 100000,
+  "supportedDataRates": [40000, 100000],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "deviceClass": {
+    "basic": {
+      "key": 2,
+      "label": "Static Controller"
+    },
+    "generic": {
+      "key": 2,
+      "label": "Static Controller"
+    },
+    "specific": {
+      "key": 1,
+      "label": "PC Controller"
+    }
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0466:0x0001:0x0001:1.0",
+  "statistics": {
+    "commandsTX": 0,
+    "commandsRX": 0,
+    "commandsDroppedRX": 0,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 0
+  },
+  "isControllerNode": true,
+  "keepAwake": false,
+  "protocol": 0,
+  "sdkVersion": "7.23.1",
+  "values": [
+    {
+      "commandClass": 51,
+      "commandClassName": "Color Switch",
+      "property": "currentColor",
+      "propertyKey": 2,
+      "propertyName": "currentColor",
+      "propertyKeyName": "Red",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "description": "The current value of the Red channel.",
+        "label": "Current value (Red)",
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 255
+    },
+    {
+      "commandClass": 51,
+      "commandClassName": "Color Switch",
+      "property": "currentColor",
+      "propertyKey": 3,
+      "propertyName": "currentColor",
+      "propertyKeyName": "Green",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "description": "The current value of the Green channel.",
+        "label": "Current value (Green)",
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 227
+    },
+    {
+      "commandClass": 51,
+      "commandClassName": "Color Switch",
+      "property": "currentColor",
+      "propertyKey": 4,
+      "propertyName": "currentColor",
+      "propertyKeyName": "Blue",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "description": "The current value of the Blue channel.",
+        "label": "Current value (Blue)",
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 181
+    },
+    {
+      "commandClass": 51,
+      "commandClassName": "Color Switch",
+      "property": "currentColor",
+      "propertyName": "currentColor",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Current color",
+        "stateful": true,
+        "secret": false
+      },
+      "value": {
+        "red": 255,
+        "green": 227,
+        "blue": 181
+      }
+    },
+    {
+      "commandClass": 51,
+      "commandClassName": "Color Switch",
+      "property": "targetColor",
+      "propertyName": "targetColor",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true,
+        "label": "Target color",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "commandClass": 51,
+      "commandClassName": "Color Switch",
+      "property": "hexColor",
+      "propertyName": "hexColor",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "color",
+        "readable": true,
+        "writeable": true,
+        "label": "RGB Color",
+        "valueChangeOptions": ["transitionDuration"],
+        "minLength": 6,
+        "maxLength": 7,
+        "stateful": true,
+        "secret": false
+      },
+      "value": "ffe3b5"
+    },
+    {
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 0,
+      "propertyName": "enableTiltIndicator",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Enable Tilt Indicator",
+        "default": 1,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false
+      },
+      "value": 1
+    }
+  ],
+  "endpoints": [
+    {
+      "nodeId": 1,
+      "index": 0,
+      "deviceClass": {
+        "basic": {
+          "key": 2,
+          "label": "Static Controller"
+        },
+        "generic": {
+          "key": 2,
+          "label": "Static Controller"
+        },
+        "specific": {
+          "key": 1,
+          "label": "PC Controller"
+        }
+      },
+      "commandClasses": []
+    }
+  ]
+}

--- a/tests/components/zwave_js/fixtures/nabu_casa_zwa2_state.json
+++ b/tests/components/zwave_js/fixtures/nabu_casa_zwa2_state.json
@@ -1,0 +1,146 @@
+{
+  "nodeId": 1,
+  "index": 0,
+  "status": 4,
+  "ready": true,
+  "isListening": true,
+  "isRouting": true,
+  "manufacturerId": 1126,
+  "productId": 1,
+  "productType": 1,
+  "firmwareVersion": "1.0",
+  "deviceConfig": {
+    "filename": "/home/dominic/Repositories/zwavejs2mqtt/store/.config-db/devices/0x0466/zwa-2.json",
+    "isEmbedded": true,
+    "manufacturer": "Nabu Casa",
+    "manufacturerId": 1126,
+    "label": "Home Assistant Connect ZWA-2",
+    "description": "Z-Wave Adapter",
+    "devices": [
+      {
+        "productType": 1,
+        "productId": 1
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "preferred": false
+  },
+  "label": "Home Assistant Connect ZWA-2",
+  "interviewAttempts": 0,
+  "isFrequentListening": false,
+  "maxDataRate": 100000,
+  "supportedDataRates": [40000, 100000],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "deviceClass": {
+    "basic": {
+      "key": 2,
+      "label": "Static Controller"
+    },
+    "generic": {
+      "key": 2,
+      "label": "Static Controller"
+    },
+    "specific": {
+      "key": 1,
+      "label": "PC Controller"
+    }
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0466:0x0001:0x0001:1.0",
+  "statistics": {
+    "commandsTX": 0,
+    "commandsRX": 0,
+    "commandsDroppedRX": 0,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 0
+  },
+  "isControllerNode": true,
+  "keepAwake": false,
+  "protocol": 0,
+  "sdkVersion": "7.23.1",
+  "values": [
+    {
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "stateful": true,
+        "secret": false
+      },
+      "value": true
+    },
+    {
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "stateful": true,
+        "secret": false
+      },
+      "value": true
+    },
+    {
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 0,
+      "propertyName": "enableTiltIndicator",
+      "ccVersion": 0,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Enable Tilt Indicator",
+        "default": 1,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Disable",
+          "1": "Enable"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false
+      },
+      "value": 1
+    }
+  ],
+  "endpoints": [
+    {
+      "nodeId": 1,
+      "index": 0,
+      "deviceClass": {
+        "basic": {
+          "key": 2,
+          "label": "Static Controller"
+        },
+        "generic": {
+          "key": 2,
+          "label": "Static Controller"
+        },
+        "specific": {
+          "key": 1,
+          "label": "PC Controller"
+        }
+      },
+      "commandClasses": []
+    }
+  ]
+}

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -495,3 +495,53 @@ async def test_aeotec_smart_switch_7(
     entity_entry = entity_registry.async_get(state.entity_id)
     assert entity_entry
     assert entity_entry.entity_category is EntityCategory.CONFIG
+
+
+async def test_nabu_casa_zwa2(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    nabu_casa_zwa2: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test ZWA-2 discovery."""
+    state = hass.states.get("light.z_wave_adapter")
+    assert state is None, "The LED indicator should be disabled by default"
+
+    entry = entity_registry.async_get("light.z_wave_adapter")
+    assert entry, "Entity for the LED indicator not found"
+
+    assert entry.capabilities.get(ATTR_SUPPORTED_COLOR_MODES) == [
+        ColorMode.ONOFF,
+    ], "The LED indicator should be an ON/OFF light"
+
+    assert entry.disabled, "The entity should be disabled by default"
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+    assert entry.entity_category is EntityCategory.CONFIG, (
+        "The LED indicator should be configuration"
+    )
+
+
+async def test_nabu_casa_zwa2_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    nabu_casa_zwa2_legacy: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test ZWA-2 discovery with legacy firmware."""
+    state = hass.states.get("light.z_wave_adapter")
+    assert state is None, "The LED indicator should be disabled by default"
+
+    entry = entity_registry.async_get("light.z_wave_adapter")
+    assert entry, "Entity for the LED indicator not found"
+
+    assert entry.capabilities.get(ATTR_SUPPORTED_COLOR_MODES) == [
+        ColorMode.HS,
+    ], "The LED indicator should be a color light"
+
+    assert entry.disabled, "The entity should be disabled by default"
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+    assert entry.entity_category is EntityCategory.CONFIG, (
+        "The LED indicator should be configuration"
+    )

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -505,17 +505,16 @@ async def test_nabu_casa_zwa2(
 ) -> None:
     """Test ZWA-2 discovery."""
     state = hass.states.get("light.z_wave_adapter")
-    assert state is None, "The LED indicator should be disabled by default"
+    assert state, "The LED indicator should be enabled by default"
 
-    entry = entity_registry.async_get("light.z_wave_adapter")
+    entry = entity_registry.async_get(state.entity_id)
     assert entry, "Entity for the LED indicator not found"
 
     assert entry.capabilities.get(ATTR_SUPPORTED_COLOR_MODES) == [
         ColorMode.ONOFF,
     ], "The LED indicator should be an ON/OFF light"
 
-    assert entry.disabled, "The entity should be disabled by default"
-    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert not entry.disabled, "The entity should be enabled by default"
 
     assert entry.entity_category is EntityCategory.CONFIG, (
         "The LED indicator should be configuration"
@@ -530,17 +529,16 @@ async def test_nabu_casa_zwa2_legacy(
 ) -> None:
     """Test ZWA-2 discovery with legacy firmware."""
     state = hass.states.get("light.z_wave_adapter")
-    assert state is None, "The LED indicator should be disabled by default"
+    assert state, "The LED indicator should be enabled by default"
 
-    entry = entity_registry.async_get("light.z_wave_adapter")
+    entry = entity_registry.async_get(state.entity_id)
     assert entry, "Entity for the LED indicator not found"
 
     assert entry.capabilities.get(ATTR_SUPPORTED_COLOR_MODES) == [
         ColorMode.HS,
     ], "The LED indicator should be a color light"
 
-    assert entry.disabled, "The entity should be disabled by default"
-    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert not entry.disabled, "The entity should be enabled by default"
 
     assert entry.entity_category is EntityCategory.CONFIG, (
         "The LED indicator should be configuration"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The LED indicator for the ZWA-2 is currently discovered as a primary control, which is not the intended purpose. This PR moves it to the Configuration section and disables it by default.
The PR adds two discovery schemes, one for the existing behavior where it is discovered as a color light, and one for the upcoming firmware/zwave-js behavior where it can only be toggled on and off.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/63
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
