### PR TITLE
Update Z-Wave LED entity name for ZWA-2

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -779,7 +779,7 @@ DISCOVERY_SCHEMAS = [
         manufacturer_id={0x0466},
         product_id={0x0001},
         product_type={0x0001},
-        hint="color_onoff",
+        hint="zwa2_led_color",
         primary_value=COLOR_SWITCH_CURRENT_VALUE_SCHEMA,
         absent_values=[
             SWITCH_BINARY_CURRENT_VALUE_SCHEMA,
@@ -793,7 +793,7 @@ DISCOVERY_SCHEMAS = [
         manufacturer_id={0x0466},
         product_id={0x0001},
         product_type={0x0001},
-        hint="onoff",
+        hint="zwa2_led_onoff",
         primary_value=SWITCH_BINARY_CURRENT_VALUE_SCHEMA,
         absent_values=[
             COLOR_SWITCH_CURRENT_VALUE_SCHEMA,

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -77,7 +77,11 @@ async def async_setup_entry(
         driver = client.driver
         assert driver is not None  # Driver is ready before platforms are loaded.
 
-        if info.platform_hint == "color_onoff":
+        if info.platform_hint == "zwa2_led_color":
+            async_add_entities([ZWA2LEDColorLight(config_entry, driver, info)])
+        elif info.platform_hint == "zwa2_led_onoff":
+            async_add_entities([ZWA2LEDOnOffLight(config_entry, driver, info)])
+        elif info.platform_hint == "color_onoff":
             async_add_entities([ZwaveColorOnOffLight(config_entry, driver, info)])
         else:
             async_add_entities([ZwaveLight(config_entry, driver, info)])
@@ -680,3 +684,29 @@ class ZwaveColorOnOffLight(ZwaveLight):
                 colors,
                 kwargs.get(ATTR_TRANSITION),
             )
+
+
+class ZWA2LEDColorLight(ZwaveColorOnOffLight):
+    """Representation of a ZWA-2 LED color light."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, config_entry: ZwaveJSConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
+    ) -> None:
+        """Initialize the ZWA-2 LED color light."""
+        super().__init__(config_entry, driver, info)
+        self._attr_name = "LED"
+
+
+class ZWA2LEDOnOffLight(ZwaveLight):
+    """Representation of a ZWA-2 LED on/off light."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, config_entry: ZwaveJSConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
+    ) -> None:
+        """Initialize the ZWA-2 LED on/off light."""
+        super().__init__(config_entry, driver, info)
+        self._attr_name = "LED"

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -687,26 +687,26 @@ class ZwaveColorOnOffLight(ZwaveLight):
 
 
 class ZWA2LEDColorLight(ZwaveColorOnOffLight):
-    """Representation of a ZWA-2 LED color light."""
+    """LED entity specific to the ZWA-2 (legacy firmware)."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self, config_entry: ZwaveJSConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
-        """Initialize the ZWA-2 LED color light."""
+        """Initialize the ZWA-2 LED entity."""
         super().__init__(config_entry, driver, info)
         self._attr_name = "LED"
 
 
 class ZWA2LEDOnOffLight(ZwaveLight):
-    """Representation of a ZWA-2 LED on/off light."""
+    """LED entity specific to the ZWA-2."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self, config_entry: ZwaveJSConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
     ) -> None:
-        """Initialize the ZWA-2 LED on/off light."""
+        """Initialize the ZWA-2 LED entity."""
         super().__init__(config_entry, driver, info)
         self._attr_name = "LED"

--- a/tests/components/zwave_js/fixtures/nabu_casa_zwa2_legacy_state.json
+++ b/tests/components/zwave_js/fixtures/nabu_casa_zwa2_legacy_state.json
@@ -14,8 +14,8 @@
     "isEmbedded": true,
     "manufacturer": "Nabu Casa",
     "manufacturerId": 1126,
-    "label": "Home Assistant Connect ZWA-2",
-    "description": "Z-Wave Adapter",
+    "label": "NC-ZWA-9734",
+    "description": "Home Assistant Connect ZWA-2",
     "devices": [
       {
         "productType": 1,
@@ -28,7 +28,7 @@
     },
     "preferred": false
   },
-  "label": "Home Assistant Connect ZWA-2",
+  "label": "NC-ZWA-9734",
   "interviewAttempts": 0,
   "isFrequentListening": false,
   "maxDataRate": 100000,

--- a/tests/components/zwave_js/fixtures/nabu_casa_zwa2_state.json
+++ b/tests/components/zwave_js/fixtures/nabu_casa_zwa2_state.json
@@ -14,8 +14,8 @@
     "isEmbedded": true,
     "manufacturer": "Nabu Casa",
     "manufacturerId": 1126,
-    "label": "Home Assistant Connect ZWA-2",
-    "description": "Z-Wave Adapter",
+    "label": "NC-ZWA-9734",
+    "description": "Home Assistant Connect ZWA-2",
     "devices": [
       {
         "productType": 1,
@@ -28,7 +28,7 @@
     },
     "preferred": false
   },
-  "label": "Home Assistant Connect ZWA-2",
+  "label": "NC-ZWA-9734",
   "interviewAttempts": 0,
   "isFrequentListening": false,
   "maxDataRate": 100000,

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -504,7 +504,7 @@ async def test_nabu_casa_zwa2(
     integration: MockConfigEntry,
 ) -> None:
     """Test ZWA-2 discovery."""
-    state = hass.states.get("light.z_wave_adapter")
+    state = hass.states.get("light.home_assistant_connect_zwa_2_led")
     assert state, "The LED indicator should be enabled by default"
 
     entry = entity_registry.async_get(state.entity_id)
@@ -520,6 +520,14 @@ async def test_nabu_casa_zwa2(
         "The LED indicator should be configuration"
     )
 
+    # Test that the entity name is properly set to "LED"
+    assert entry.original_name == "LED", (
+        "The LED entity should have the original name 'LED'"
+    )
+    assert state.attributes["friendly_name"] == "Home Assistant Connect ZWA-2 LED", (
+        "The LED should have the correct friendly name"
+    )
+
 
 async def test_nabu_casa_zwa2_legacy(
     hass: HomeAssistant,
@@ -528,7 +536,7 @@ async def test_nabu_casa_zwa2_legacy(
     integration: MockConfigEntry,
 ) -> None:
     """Test ZWA-2 discovery with legacy firmware."""
-    state = hass.states.get("light.z_wave_adapter")
+    state = hass.states.get("light.home_assistant_connect_zwa_2_led")
     assert state, "The LED indicator should be enabled by default"
 
     entry = entity_registry.async_get(state.entity_id)
@@ -542,4 +550,12 @@ async def test_nabu_casa_zwa2_legacy(
 
     assert entry.entity_category is EntityCategory.CONFIG, (
         "The LED indicator should be configuration"
+    )
+
+    # Test that the entity name is properly set to "LED"
+    assert entry.original_name == "LED", (
+        "The LED entity should have the original name 'LED'"
+    )
+    assert state.attributes["friendly_name"] == "Home Assistant Connect ZWA-2 LED", (
+        "The LED should have the correct friendly name"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This renames the LED entity of the ZWA-2 to just "LED" to make it clear that you're not turning the entire adapter on or off.
<img width="261" height="180" alt="grafik" src="https://github.com/user-attachments/assets/120d2e3e-61e7-4875-9071-c42d30d4cce4" />

Also I updated the fixtures to have the correct label/descriptions as of Z-Wave JS 15.10.0.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
