### PR TITLE
Use non-autospec mock in Reolink's media source, number, sensor and siren tests

### DIFF
--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -67,6 +67,7 @@ def _init_host_mock(host_mock: MagicMock) -> None:
     host_mock.get_host_data = AsyncMock(return_value=None)
     host_mock.get_states = AsyncMock(return_value=None)
     host_mock.get_state = AsyncMock()
+    host_mock.async_get_time = AsyncMock()
     host_mock.check_new_firmware = AsyncMock(return_value=False)
     host_mock.subscribe = AsyncMock()
     host_mock.unsubscribe = AsyncMock(return_value=True)
@@ -80,12 +81,16 @@ def _init_host_mock(host_mock: MagicMock) -> None:
     host_mock.pull_point_request = AsyncMock()
     host_mock.set_audio = AsyncMock()
     host_mock.set_email = AsyncMock()
+    host_mock.set_siren = AsyncMock()
     host_mock.ONVIF_event_callback = AsyncMock()
     host_mock.set_whiteled = AsyncMock()
     host_mock.set_state_light = AsyncMock()
     host_mock.renew = AsyncMock()
     host_mock.get_vod_source = AsyncMock()
+    host_mock.request_vod_files = AsyncMock()
     host_mock.expire_session = AsyncMock()
+    host_mock.set_volume = AsyncMock()
+    host_mock.set_hub_audio = AsyncMock()
     host_mock.is_nvr = True
     host_mock.is_hub = False
     host_mock.mac_address = TEST_MAC
@@ -168,6 +173,7 @@ def _init_host_mock(host_mock: MagicMock) -> None:
         0: {"chnID": 0, "aitype": 34615},
         "Host": {"pushAlarm": 7},
     }
+    host_mock.baichuan.set_smart_ai = AsyncMock()
     host_mock.baichuan.smart_location_list.return_value = [0]
     host_mock.baichuan.smart_ai_type_list.return_value = ["people"]
     host_mock.baichuan.smart_ai_index.return_value = 1
@@ -281,6 +287,7 @@ def reolink_chime(reolink_host: MagicMock) -> None:
         "visitor": {"switch": 1, "musicId": 2},
     }
     TEST_CHIME.remove = AsyncMock()
+    TEST_CHIME.set_option = AsyncMock()
 
     reolink_host.chime_list = [TEST_CHIME]
     reolink_host.chime.return_value = TEST_CHIME

--- a/tests/components/reolink/test_media_source.py
+++ b/tests/components/reolink/test_media_source.py
@@ -89,7 +89,7 @@ async def test_platform_loads_before_config_entry(
 
 async def test_resolve(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -99,7 +99,7 @@ async def test_resolve(
     caplog.set_level(logging.DEBUG)
 
     file_id = f"FILE|{config_entry.entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_FILE_NAME}|{TEST_START}|{TEST_END}"
-    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
 
     play_media = await async_resolve_media(
         hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
@@ -107,14 +107,14 @@ async def test_resolve(
     assert play_media.mime_type == TEST_MIME_TYPE_MP4
 
     file_id = f"FILE|{config_entry.entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_FILE_NAME_MP4}|{TEST_START}|{TEST_END}"
-    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL2)
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL2)
 
     play_media = await async_resolve_media(
         hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
     )
     assert play_media.mime_type == TEST_MIME_TYPE_MP4
 
-    reolink_connect.is_nvr = False
+    reolink_host.is_nvr = False
 
     play_media = await async_resolve_media(
         hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
@@ -122,7 +122,7 @@ async def test_resolve(
     assert play_media.mime_type == TEST_MIME_TYPE_MP4
 
     file_id = f"FILE|{config_entry.entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_FILE_NAME}|{TEST_START}|{TEST_END}"
-    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE, TEST_URL)
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE, TEST_URL)
 
     play_media = await async_resolve_media(
         hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
@@ -132,16 +132,16 @@ async def test_resolve(
 
 async def test_browsing(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test browsing the Reolink three."""
     entry_id = config_entry.entry_id
-    reolink_connect.supported.return_value = 1
-    reolink_connect.model = "Reolink TrackMix PoE"
-    reolink_connect.is_nvr = False
+    reolink_host.supported.return_value = 1
+    reolink_host.model = "Reolink TrackMix PoE"
+    reolink_host.is_nvr = False
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.CAMERA]):
         assert await hass.config_entries.async_setup(entry_id) is True
@@ -184,7 +184,7 @@ async def test_browsing(
     mock_status.year = TEST_YEAR
     mock_status.month = TEST_MONTH
     mock_status.days = (TEST_DAY, TEST_DAY2)
-    reolink_connect.request_vod_files.return_value = ([mock_status], [])
+    reolink_host.request_vod_files.return_value = ([mock_status], [])
 
     browse = await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}/{browse_res_sub_id}")
     assert browse.domain == DOMAIN
@@ -223,7 +223,7 @@ async def test_browsing(
     mock_vod_file.duration = timedelta(minutes=5)
     mock_vod_file.file_name = TEST_FILE_NAME
     mock_vod_file.triggers = VOD_trigger.PERSON
-    reolink_connect.request_vod_files.return_value = ([mock_status], [mock_vod_file])
+    reolink_host.request_vod_files.return_value = ([mock_status], [mock_vod_file])
 
     browse = await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}/{browse_day_0_id}")
 
@@ -236,7 +236,7 @@ async def test_browsing(
     )
     assert browse.identifier == browse_files_id
     assert browse.children[0].identifier == browse_file_id
-    reolink_connect.request_vod_files.assert_called_with(
+    reolink_host.request_vod_files.assert_called_with(
         int(TEST_CHANNEL),
         TEST_START_TIME,
         TEST_END_TIME,
@@ -245,10 +245,10 @@ async def test_browsing(
         trigger=None,
     )
 
-    reolink_connect.model = TEST_HOST_MODEL
+    reolink_host.model = TEST_HOST_MODEL
 
     # browse event trigger person on a NVR
-    reolink_connect.is_nvr = True
+    reolink_host.is_nvr = True
     browse_event_person_id = f"EVE|{entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_YEAR}|{TEST_MONTH}|{TEST_DAY}|{VOD_trigger.PERSON.name}"
 
     browse = await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}/{browse_day_0_id}")
@@ -265,7 +265,7 @@ async def test_browsing(
     )
     assert browse.identifier == browse_files_id
     assert browse.children[0].identifier == browse_file_id
-    reolink_connect.request_vod_files.assert_called_with(
+    reolink_host.request_vod_files.assert_called_with(
         int(TEST_CHANNEL),
         TEST_START_TIME,
         TEST_END_TIME,
@@ -274,17 +274,15 @@ async def test_browsing(
         trigger=VOD_trigger.PERSON,
     )
 
-    reolink_connect.is_nvr = False
-
 
 async def test_browsing_h265_encoding(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
 ) -> None:
     """Test browsing a Reolink camera with h265 stream encoding."""
     entry_id = config_entry.entry_id
-    reolink_connect.is_nvr = True
+    reolink_host.is_nvr = True
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.CAMERA]):
         assert await hass.config_entries.async_setup(entry_id) is True
@@ -296,10 +294,10 @@ async def test_browsing_h265_encoding(
     mock_status.year = TEST_YEAR
     mock_status.month = TEST_MONTH
     mock_status.days = (TEST_DAY, TEST_DAY2)
-    reolink_connect.request_vod_files.return_value = ([mock_status], [])
-    reolink_connect.time.return_value = None
-    reolink_connect.get_encoding.return_value = "h265"
-    reolink_connect.supported.return_value = False
+    reolink_host.request_vod_files.return_value = ([mock_status], [])
+    reolink_host.time.return_value = None
+    reolink_host.get_encoding.return_value = "h265"
+    reolink_host.supported.return_value = False
 
     browse = await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}/{browse_root_id}")
 
@@ -331,7 +329,7 @@ async def test_browsing_h265_encoding(
 
 async def test_browsing_rec_playback_unsupported(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
 ) -> None:
     """Test browsing a Reolink camera which does not support playback of recordings."""
@@ -342,7 +340,7 @@ async def test_browsing_rec_playback_unsupported(
             return False
         return True
 
-    reolink_connect.supported = test_supported
+    reolink_host.supported = test_supported
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.CAMERA]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -356,12 +354,10 @@ async def test_browsing_rec_playback_unsupported(
     assert browse.identifier is None
     assert browse.children == []
 
-    reolink_connect.supported = lambda ch, key: True  # Reset supported function
-
 
 async def test_browsing_errors(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
 ) -> None:
     """Test browsing a Reolink camera errors."""
@@ -378,7 +374,7 @@ async def test_browsing_errors(
 
 async def test_browsing_not_loaded(
     hass: HomeAssistant,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     config_entry: MockConfigEntry,
 ) -> None:
     """Test browsing a Reolink camera integration which is not loaded."""
@@ -386,7 +382,7 @@ async def test_browsing_not_loaded(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    reolink_connect.get_host_data.side_effect = ReolinkError("Test error")
+    reolink_host.get_host_data.side_effect = ReolinkError("Test error")
     config_entry2 = MockConfigEntry(
         domain=DOMAIN,
         unique_id=format_mac(TEST_MAC2),
@@ -414,5 +410,3 @@ async def test_browsing_not_loaded(
     assert browse.title == "Reolink"
     assert browse.identifier is None
     assert len(browse.children) == 1
-
-    reolink_connect.get_host_data.side_effect = None

--- a/tests/components/reolink/test_number.py
+++ b/tests/components/reolink/test_number.py
@@ -1,6 +1,6 @@
 """Test the Reolink number platform."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from reolink_aio.api import Chime
@@ -24,10 +24,10 @@ from tests.common import MockConfigEntry
 async def test_number(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test number entity with volume."""
-    reolink_connect.volume.return_value = 80
+    reolink_host.volume.return_value = 80
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.NUMBER]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -44,9 +44,9 @@ async def test_number(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 50},
         blocking=True,
     )
-    reolink_connect.set_volume.assert_called_with(0, volume=50)
+    reolink_host.set_volume.assert_called_with(0, volume=50)
 
-    reolink_connect.set_volume.side_effect = ReolinkError("Test error")
+    reolink_host.set_volume.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -55,7 +55,7 @@ async def test_number(
             blocking=True,
         )
 
-    reolink_connect.set_volume.side_effect = InvalidParameterError("Test error")
+    reolink_host.set_volume.side_effect = InvalidParameterError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -63,18 +63,16 @@ async def test_number(
             {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 50},
             blocking=True,
         )
-
-    reolink_connect.set_volume.reset_mock(side_effect=True)
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_smart_ai_number(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test number entity with smart ai sensitivity."""
-    reolink_connect.baichuan.smart_ai_sensitivity.return_value = 80
+    reolink_host.baichuan.smart_ai_sensitivity.return_value = 80
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.NUMBER]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -91,13 +89,11 @@ async def test_smart_ai_number(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 50},
         blocking=True,
     )
-    reolink_connect.baichuan.set_smart_ai.assert_called_with(
+    reolink_host.baichuan.set_smart_ai.assert_called_with(
         0, "crossline", 0, sensitivity=50
     )
 
-    reolink_connect.baichuan.set_smart_ai.side_effect = InvalidParameterError(
-        "Test error"
-    )
+    reolink_host.baichuan.set_smart_ai.side_effect = InvalidParameterError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -106,16 +102,14 @@ async def test_smart_ai_number(
             blocking=True,
         )
 
-    reolink_connect.baichuan.set_smart_ai.reset_mock(side_effect=True)
-
 
 async def test_host_number(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test number entity with volume."""
-    reolink_connect.alarm_volume = 85
+    reolink_host.alarm_volume = 85
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.NUMBER]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -132,9 +126,9 @@ async def test_host_number(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 45},
         blocking=True,
     )
-    reolink_connect.set_hub_audio.assert_called_with(alarm_volume=45)
+    reolink_host.set_hub_audio.assert_called_with(alarm_volume=45)
 
-    reolink_connect.set_hub_audio.side_effect = ReolinkError("Test error")
+    reolink_host.set_hub_audio.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -143,7 +137,7 @@ async def test_host_number(
             blocking=True,
         )
 
-    reolink_connect.set_hub_audio.side_effect = InvalidParameterError("Test error")
+    reolink_host.set_hub_audio.side_effect = InvalidParameterError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -156,11 +150,11 @@ async def test_host_number(
 async def test_chime_number(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
-    test_chime: Chime,
+    reolink_host: MagicMock,
+    reolink_chime: Chime,
 ) -> None:
     """Test number entity of a chime with chime volume."""
-    test_chime.volume = 3
+    reolink_chime.volume = 3
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.NUMBER]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -171,16 +165,15 @@ async def test_chime_number(
 
     assert hass.states.get(entity_id).state == "3"
 
-    test_chime.set_option = AsyncMock()
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 2},
         blocking=True,
     )
-    test_chime.set_option.assert_called_with(volume=2)
+    reolink_chime.set_option.assert_called_with(volume=2)
 
-    test_chime.set_option.side_effect = ReolinkError("Test error")
+    reolink_chime.set_option.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -189,7 +182,7 @@ async def test_chime_number(
             blocking=True,
         )
 
-    test_chime.set_option.side_effect = InvalidParameterError("Test error")
+    reolink_chime.set_option.side_effect = InvalidParameterError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -197,5 +190,3 @@ async def test_chime_number(
             {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 1},
             blocking=True,
         )
-
-    test_chime.set_option.reset_mock(side_effect=True)

--- a/tests/components/reolink/test_sensor.py
+++ b/tests/components/reolink/test_sensor.py
@@ -17,14 +17,14 @@ from tests.common import MockConfigEntry
 async def test_sensors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test sensor entities."""
-    reolink_connect.ptz_pan_position.return_value = 1200
-    reolink_connect.wifi_connection = True
-    reolink_connect.wifi_signal.return_value = -55
-    reolink_connect.hdd_list = [0]
-    reolink_connect.hdd_storage.return_value = 95
+    reolink_host.ptz_pan_position.return_value = 1200
+    reolink_host.wifi_connection = True
+    reolink_host.wifi_signal.return_value = -55
+    reolink_host.hdd_list = [0]
+    reolink_host.hdd_storage.return_value = 95
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SENSOR]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -45,13 +45,13 @@ async def test_sensors(
 async def test_hdd_sensors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test hdd sensor entity."""
-    reolink_connect.hdd_list = [0]
-    reolink_connect.hdd_type.return_value = "HDD"
-    reolink_connect.hdd_storage.return_value = 85
-    reolink_connect.hdd_available.return_value = False
+    reolink_host.hdd_list = [0]
+    reolink_host.hdd_type.return_value = "HDD"
+    reolink_host.hdd_storage.return_value = 85
+    reolink_host.hdd_available.return_value = False
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SENSOR]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/reolink/test_siren.py
+++ b/tests/components/reolink/test_siren.py
@@ -30,7 +30,7 @@ from tests.common import MockConfigEntry
 async def test_siren(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test siren entity."""
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SIREN]):
@@ -48,8 +48,8 @@ async def test_siren(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    reolink_connect.set_volume.assert_not_called()
-    reolink_connect.set_siren.assert_called_with(0, True, None)
+    reolink_host.set_volume.assert_not_called()
+    reolink_host.set_siren.assert_called_with(0, True, None)
 
     await hass.services.async_call(
         SIREN_DOMAIN,
@@ -57,8 +57,8 @@ async def test_siren(
         {ATTR_ENTITY_ID: entity_id, ATTR_VOLUME_LEVEL: 0.85, ATTR_DURATION: 2},
         blocking=True,
     )
-    reolink_connect.set_volume.assert_called_with(0, volume=85)
-    reolink_connect.set_siren.assert_called_with(0, True, 2)
+    reolink_host.set_volume.assert_called_with(0, 85)
+    reolink_host.set_siren.assert_called_with(0, True, 2)
 
     # test siren turn off
     await hass.services.async_call(
@@ -67,7 +67,7 @@ async def test_siren(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    reolink_connect.set_siren.assert_called_with(0, False, None)
+    reolink_host.set_siren.assert_called_with(0, False, None)
 
 
 @pytest.mark.parametrize("attr", ["set_volume", "set_siren"])
@@ -87,7 +87,7 @@ async def test_siren(
 async def test_siren_turn_on_errors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
     attr: str,
     value: Any,
     expected: Any,
@@ -100,8 +100,8 @@ async def test_siren_turn_on_errors(
 
     entity_id = f"{Platform.SIREN}.{TEST_NVR_NAME}_siren"
 
-    original = getattr(reolink_connect, attr)
-    setattr(reolink_connect, attr, value)
+    original = getattr(reolink_host, attr)
+    setattr(reolink_host, attr, value)
     with pytest.raises(expected):
         await hass.services.async_call(
             SIREN_DOMAIN,
@@ -110,13 +110,13 @@ async def test_siren_turn_on_errors(
             blocking=True,
         )
 
-    setattr(reolink_connect, attr, original)
+    setattr(reolink_host, attr, original)
 
 
 async def test_siren_turn_off_errors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
+    reolink_host: MagicMock,
 ) -> None:
     """Test errors when calling siren turn off service."""
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SIREN]):
@@ -126,7 +126,7 @@ async def test_siren_turn_off_errors(
 
     entity_id = f"{Platform.SIREN}.{TEST_NVR_NAME}_siren"
 
-    reolink_connect.set_siren.side_effect = ReolinkError("Test error")
+    reolink_host.set_siren.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SIREN_DOMAIN,
@@ -134,5 +134,3 @@ async def test_siren_turn_off_errors(
             {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
-
-    reolink_connect.set_siren.reset_mock(side_effect=True)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to #146969

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
