### PR TITLE
UnifiProtect refactor sensor retrieval in tests to use get_sensor_by_key function

### DIFF
--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -30,6 +30,7 @@ from homeassistant.components.unifiprotect.sensor import (
     NVR_DISABLED_SENSORS,
     NVR_SENSORS,
     SENSE_SENSORS,
+    ProtectSensorEntityDescription,
 )
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
@@ -56,7 +57,7 @@ from .utils import (
 from tests.common import async_capture_events
 
 
-def get_sensor_by_key(sensors: tuple, key: str):
+def get_sensor_by_key(sensors: tuple, key: str) -> ProtectSensorEntityDescription:
     """Get sensor description by key."""
     for sensor in sensors:
         if sensor.key == key:
@@ -405,7 +406,7 @@ async def test_sensor_setup_camera(
     unique_id, entity_id = ids_from_device_description(
         Platform.SENSOR,
         doorbell,
-        get_sensor_by_key(ALL_DEVICES_SENSORS, "wifi_signal_strength"),
+        get_sensor_by_key(ALL_DEVICES_SENSORS, "wifi_signal"),
     )
 
     entity = entity_registry.async_get(entity_id)

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -55,6 +55,16 @@ from .utils import (
 
 from tests.common import async_capture_events
 
+
+def get_sensor_by_key(sensors: tuple, key: str):
+    """Get sensor description by key."""
+    for sensor in sensors:
+        if sensor.key == key:
+            return sensor
+    raise ValueError(f"Sensor with key '{key}' not found")
+
+
+# Constants for test slicing (subsets of sensor tuples)
 CAMERA_SENSORS_WRITE = CAMERA_SENSORS[:5]
 SENSE_SENSORS_WRITE = SENSE_SENSORS[:8]
 
@@ -123,7 +133,9 @@ async def test_sensor_setup_sensor(
 
     # BLE signal
     unique_id, entity_id = ids_from_device_description(
-        Platform.SENSOR, sensor_all, ALL_DEVICES_SENSORS[1]
+        Platform.SENSOR,
+        sensor_all,
+        get_sensor_by_key(ALL_DEVICES_SENSORS, "ble_signal"),
     )
 
     entity = entity_registry.async_get(entity_id)
@@ -269,7 +281,7 @@ async def test_sensor_nvr_missing_values(
     assert_entity_counts(hass, Platform.SENSOR, 12, 9)
 
     # Uptime
-    description = NVR_SENSORS[0]
+    description = get_sensor_by_key(NVR_SENSORS, "uptime")
     unique_id, entity_id = ids_from_device_description(
         Platform.SENSOR, nvr, description
     )
@@ -285,8 +297,8 @@ async def test_sensor_nvr_missing_values(
     assert state.state == STATE_UNKNOWN
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
-    # Memory
-    description = NVR_SENSORS[8]
+    # Recording capacity
+    description = get_sensor_by_key(NVR_SENSORS, "record_capacity")
     unique_id, entity_id = ids_from_device_description(
         Platform.SENSOR, nvr, description
     )
@@ -300,8 +312,8 @@ async def test_sensor_nvr_missing_values(
     assert state.state == "0"
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
-    # Memory
-    description = NVR_DISABLED_SENSORS[2]
+    # Memory utilization
+    description = get_sensor_by_key(NVR_DISABLED_SENSORS, "memory_utilization")
     unique_id, entity_id = ids_from_device_description(
         Platform.SENSOR, nvr, description
     )
@@ -372,9 +384,9 @@ async def test_sensor_setup_camera(
         assert state.state == expected_values[index]
         assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
-    # Wired signal
+    # Wired signal (phy_rate / link speed)
     unique_id, entity_id = ids_from_device_description(
-        Platform.SENSOR, doorbell, ALL_DEVICES_SENSORS[2]
+        Platform.SENSOR, doorbell, get_sensor_by_key(ALL_DEVICES_SENSORS, "phy_rate")
     )
 
     entity = entity_registry.async_get(entity_id)
@@ -391,7 +403,9 @@ async def test_sensor_setup_camera(
 
     # WiFi signal
     unique_id, entity_id = ids_from_device_description(
-        Platform.SENSOR, doorbell, ALL_DEVICES_SENSORS[3]
+        Platform.SENSOR,
+        doorbell,
+        get_sensor_by_key(ALL_DEVICES_SENSORS, "wifi_signal_strength"),
     )
 
     entity = entity_registry.async_get(entity_id)
@@ -422,7 +436,9 @@ async def test_sensor_setup_camera_with_last_trip_time(
 
     # Last Trip Time
     unique_id, entity_id = ids_from_device_description(
-        Platform.SENSOR, doorbell, MOTION_TRIP_SENSORS[0]
+        Platform.SENSOR,
+        doorbell,
+        get_sensor_by_key(MOTION_TRIP_SENSORS, "motion_last_trip_time"),
     )
 
     entity = entity_registry.async_get(entity_id)
@@ -447,7 +463,7 @@ async def test_sensor_update_alarm(
     assert_entity_counts(hass, Platform.SENSOR, 22, 14)
 
     _, entity_id = ids_from_device_description(
-        Platform.SENSOR, sensor_all, SENSE_SENSORS_WRITE[4]
+        Platform.SENSOR, sensor_all, get_sensor_by_key(SENSE_SENSORS, "alarm_sound")
     )
 
     event_metadata = EventMetadata(sensor_id=sensor_all.id, alarm_type="smoke")
@@ -498,7 +514,9 @@ async def test_sensor_update_alarm_with_last_trip_time(
 
     # Last Trip Time
     unique_id, entity_id = ids_from_device_description(
-        Platform.SENSOR, sensor_all, SENSE_SENSORS_WRITE[-3]
+        Platform.SENSOR,
+        sensor_all,
+        get_sensor_by_key(SENSE_SENSORS, "door_last_trip_time"),
     )
 
     entity = entity_registry.async_get(entity_id)
@@ -529,7 +547,9 @@ async def test_camera_update_license_plate(
     assert_entity_counts(hass, Platform.SENSOR, 23, 13)
 
     _, entity_id = ids_from_device_description(
-        Platform.SENSOR, camera, LICENSE_PLATE_EVENT_SENSORS[0]
+        Platform.SENSOR,
+        camera,
+        get_sensor_by_key(LICENSE_PLATE_EVENT_SENSORS, "smart_obj_licenseplate"),
     )
 
     event_metadata = EventMetadata(
@@ -644,7 +664,9 @@ async def test_camera_update_license_plate_changes_number_during_detect(
     assert_entity_counts(hass, Platform.SENSOR, 23, 13)
 
     _, entity_id = ids_from_device_description(
-        Platform.SENSOR, camera, LICENSE_PLATE_EVENT_SENSORS[0]
+        Platform.SENSOR,
+        camera,
+        get_sensor_by_key(LICENSE_PLATE_EVENT_SENSORS, "smart_obj_licenseplate"),
     )
 
     event_metadata = EventMetadata(
@@ -731,7 +753,9 @@ async def test_camera_update_license_plate_multiple_updates(
     assert_entity_counts(hass, Platform.SENSOR, 23, 13)
 
     _, entity_id = ids_from_device_description(
-        Platform.SENSOR, camera, LICENSE_PLATE_EVENT_SENSORS[0]
+        Platform.SENSOR,
+        camera,
+        get_sensor_by_key(LICENSE_PLATE_EVENT_SENSORS, "smart_obj_licenseplate"),
     )
 
     event_metadata = EventMetadata(
@@ -854,7 +878,9 @@ async def test_camera_update_license_no_dupes(
     assert_entity_counts(hass, Platform.SENSOR, 23, 13)
 
     _, entity_id = ids_from_device_description(
-        Platform.SENSOR, camera, LICENSE_PLATE_EVENT_SENSORS[0]
+        Platform.SENSOR,
+        camera,
+        get_sensor_by_key(LICENSE_PLATE_EVENT_SENSORS, "smart_obj_licenseplate"),
     )
 
     event_metadata = EventMetadata(
@@ -946,6 +972,8 @@ async def test_sensor_precision(
     assert_entity_counts(hass, Platform.SENSOR, 22, 14)
     nvr: NVR = ufp.api.bootstrap.nvr
 
-    _, entity_id = ids_from_device_description(Platform.SENSOR, nvr, NVR_SENSORS[6])
+    _, entity_id = ids_from_device_description(
+        Platform.SENSOR, nvr, get_sensor_by_key(NVR_SENSORS, "resolution_4K")
+    )
 
     assert hass.states.get(entity_id).state == "17.49"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

refactor sensor retrieval in tests to use get_sensor_by_key function

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
