### PR TITLE
Revert "Use OptionsFlowWithReload in mqtt"

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -246,6 +246,14 @@ MQTT_PUBLISH_SCHEMA = vol.Schema(
 )
 
 
+async def _async_config_entry_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle signals of config entry being updated.
+
+    Causes for this is config entry options changing.
+    """
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
 @callback
 def _async_remove_mqtt_issues(hass: HomeAssistant, mqtt_data: MqttData) -> None:
     """Unregister open config issues."""
@@ -427,6 +435,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 mqtt_data.subscriptions_to_restore
             )
             mqtt_data.subscriptions_to_restore = set()
+        mqtt_data.reload_dispatchers.append(
+            entry.add_update_listener(_async_config_entry_updated)
+        )
 
         return (mqtt_data, conf)
 

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -52,7 +52,7 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
     ConfigSubentryFlow,
-    OptionsFlowWithReload,
+    OptionsFlow,
     SubentryFlowResult,
 )
 from homeassistant.const import (
@@ -2537,7 +2537,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         )
 
 
-class MQTTOptionsFlowHandler(OptionsFlowWithReload):
+class MQTTOptionsFlowHandler(OptionsFlow):
     """Handle MQTT options."""
 
     async def async_step_init(self, user_input: None = None) -> ConfigFlowResult:
@@ -3353,7 +3353,7 @@ def _validate_pki_file(
 
 
 async def async_get_broker_settings(  # noqa: C901
-    flow: ConfigFlow | OptionsFlowWithReload,
+    flow: ConfigFlow | OptionsFlow,
     fields: OrderedDict[Any, Any],
     entry_config: MappingProxyType[str, Any] | None,
     user_input: dict[str, Any] | None,


### PR DESCRIPTION
Reverts home-assistant/core#149092

It seems this change breaks MQTT subentries when they are created or updated as the MQTT entry is no longer reloaded automatically.