### PR TITLE
Use async_create_clientsession in Alexa Devices

### DIFF
--- a/homeassistant/components/alexa_devices/__init__.py
+++ b/homeassistant/components/alexa_devices/__init__.py
@@ -2,6 +2,7 @@
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
 
 from .coordinator import AmazonConfigEntry, AmazonDevicesCoordinator
 
@@ -16,7 +17,8 @@ PLATFORMS = [
 async def async_setup_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> bool:
     """Set up Alexa Devices platform."""
 
-    coordinator = AmazonDevicesCoordinator(hass, entry)
+    session = aiohttp_client.async_create_clientsession(hass)
+    coordinator = AmazonDevicesCoordinator(hass, entry, session)
 
     await coordinator.async_config_entry_first_refresh()
 
@@ -29,8 +31,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> bo
 
 async def async_unload_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> bool:
     """Unload a config entry."""
-    coordinator = entry.runtime_data
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        await coordinator.api.close()
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/alexa_devices/config_flow.py
+++ b/homeassistant/components/alexa_devices/config_flow.py
@@ -17,6 +17,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_CODE, CONF_COUNTRY, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import CountrySelector
 
@@ -33,18 +34,15 @@ STEP_REAUTH_DATA_SCHEMA = vol.Schema(
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
 
+    session = aiohttp_client.async_create_clientsession(hass)
     api = AmazonEchoApi(
+        session,
         data[CONF_COUNTRY],
         data[CONF_USERNAME],
         data[CONF_PASSWORD],
     )
 
-    try:
-        data = await api.login_mode_interactive(data[CONF_CODE])
-    finally:
-        await api.close()
-
-    return data
+    return await api.login_mode_interactive(data[CONF_CODE])
 
 
 class AmazonDevicesConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/alexa_devices/coordinator.py
+++ b/homeassistant/components/alexa_devices/coordinator.py
@@ -8,6 +8,7 @@ from aioamazondevices.exceptions import (
     CannotConnect,
     CannotRetrieveData,
 )
+from aiohttp import ClientSession
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_COUNTRY, CONF_PASSWORD, CONF_USERNAME
@@ -31,6 +32,7 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
         self,
         hass: HomeAssistant,
         entry: AmazonConfigEntry,
+        session: ClientSession,
     ) -> None:
         """Initialize the scanner."""
         super().__init__(
@@ -41,6 +43,7 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
             update_interval=timedelta(seconds=SCAN_INTERVAL),
         )
         self.api = AmazonEchoApi(
+            session,
             entry.data[CONF_COUNTRY],
             entry.data[CONF_USERNAME],
             entry.data[CONF_PASSWORD],

--- a/homeassistant/components/alexa_devices/manifest.json
+++ b/homeassistant/components/alexa_devices/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aioamazondevices"],
   "quality_scale": "silver",
-  "requirements": ["aioamazondevices==3.5.1"]
+  "requirements": ["aioamazondevices==3.6.0"]
 }

--- a/homeassistant/components/alexa_devices/manifest.json
+++ b/homeassistant/components/alexa_devices/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aioamazondevices"],
   "quality_scale": "silver",
-  "requirements": ["aioamazondevices==3.6.0"]
+  "requirements": ["aioamazondevices==4.0.0"]
 }

--- a/homeassistant/components/alexa_devices/quality_scale.yaml
+++ b/homeassistant/components/alexa_devices/quality_scale.yaml
@@ -70,5 +70,5 @@ rules:
 
   # Platinum
   async-dependency: done
-  inject-websession: todo
+  inject-websession: done
   strict-typing: done

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioairzone-cloud==0.7.1
 aioairzone==1.0.0
 
 # homeassistant.components.alexa_devices
-aioamazondevices==3.5.1
+aioamazondevices==3.6.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioairzone-cloud==0.7.1
 aioairzone==1.0.0
 
 # homeassistant.components.alexa_devices
-aioamazondevices==3.6.0
+aioamazondevices==4.0.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,7 +173,7 @@ aioairzone-cloud==0.7.1
 aioairzone==1.0.0
 
 # homeassistant.components.alexa_devices
-aioamazondevices==3.5.1
+aioamazondevices==3.6.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,7 +173,7 @@ aioairzone-cloud==0.7.1
 aioairzone==1.0.0
 
 # homeassistant.components.alexa_devices
-aioamazondevices==3.6.0
+aioamazondevices==4.0.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Inject aiohttp ClientSession instead of creating it inside the library.

HomeAssistant will create  a new session instead of using the common shared session because Amazon needs specific cookies in CookieJar.

Needs `aioamazondevices` v4.0.0 because of a breaking change

changelog: https://github.com/chemelli74/aioamazondevices/releases/tag/v4.0.0
diff: https://github.com/chemelli74/aioamazondevices/compare/v3.5.1...v4.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148786
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
