### PR TITLE
Fix async open and unlock commands in Matter lock

### DIFF
--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -93,19 +93,10 @@ class MatterLock(MatterEntity, LockEntity):
             )
         code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
-        if self._attr_supported_features & LockEntityFeature.OPEN:
-            # if the lock reports it has separate unbolt support,
-            # the unlock command should unbolt only on the unlock command
-            # and unlatch on the HA 'open' command.
-            await self.send_device_command(
-                command=clusters.DoorLock.Commands.UnboltDoor(code_bytes),
-                timed_request_timeout_ms=1000,
-            )
-        else:
-            await self.send_device_command(
-                command=clusters.DoorLock.Commands.UnlockDoor(code_bytes),
-                timed_request_timeout_ms=1000,
-            )
+        await self.send_device_command(
+            command=clusters.DoorLock.Commands.UnlockDoor(code_bytes),
+            timed_request_timeout_ms=1000,
+        )
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open the door latch."""
@@ -119,10 +110,20 @@ class MatterLock(MatterEntity, LockEntity):
         )
         code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
-        await self.send_device_command(
-            command=clusters.DoorLock.Commands.UnlockDoor(code_bytes),
-            timed_request_timeout_ms=1000,
-        )
+
+        if self._attr_supported_features & LockEntityFeature.OPEN:
+            # if the lock reports it has separate unbolt support,
+            # the unlock command should unbolt only on the unlock command
+            # and unlatch on the HA 'open' command.
+            await self.send_device_command(
+                command=clusters.DoorLock.Commands.UnboltDoor(code_bytes),
+                timed_request_timeout_ms=1000,
+            )
+        else:
+            await self.send_device_command(
+                command=clusters.DoorLock.Commands.UnlockDoor(code_bytes),
+                timed_request_timeout_ms=1000,
+            )
 
     @callback
     def _update_from_device(self) -> None:

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -197,15 +197,15 @@ async def test_lock_with_unbolt(
         blocking=True,
     )
     assert matter_client.send_device_command.call_count == 1
-    # unlock should unbolt on a lock with unbolt feature
+    # unlock should not unbolt, even on a lock with unbolt feature
     assert matter_client.send_device_command.call_args == call(
         node_id=matter_node.node_id,
         endpoint_id=1,
-        command=clusters.DoorLock.Commands.UnboltDoor(),
+        command=clusters.DoorLock.Commands.UnlockDoor(),
         timed_request_timeout_ms=1000,
     )
     matter_client.send_device_command.reset_mock()
-    # test open / unlatch
+    # open should unbolt on a lock with unbolt feature
     await hass.services.async_call(
         "lock",
         "open",
@@ -218,7 +218,7 @@ async def test_lock_with_unbolt(
     assert matter_client.send_device_command.call_args == call(
         node_id=matter_node.node_id,
         endpoint_id=1,
-        command=clusters.DoorLock.Commands.UnlockDoor(),
+        command=clusters.DoorLock.Commands.UnboltDoor(),
         timed_request_timeout_ms=1000,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Might impact user automations if a user relied on the incorrect operations noted below.

## Proposed change
For locks that  support the latch-pull / unbolt operation, the existing code  activates pulling of the latch from within "async_unlock" instead of from within "async_open". Developer notes here: https://developers.home-assistant.io/docs/core/entity/lock explain that it is the "async_open" function that should do the unbolting. This is fixed in this update.

This fix was originally part of a larger set of code changes in this PR: https://github.com/home-assistant/core/pull/148734.  To make review easier, I am changing that PR 148734 into 3 smaller PRs. This is the first of those. The second is: https://github.com/home-assistant/core/pull/149861. Once those are accepted, I expect to follow this with another PR that will add support for lock "jamming" detection.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Bugfix (non-breaking change which fixes an issue)
Might be considered a "breaking" change if user somehow relied on the incorrect operation (e.g., in an automation maybe).

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been **updated** to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
