### PR TITLE
Add support for EVs in `ituran`

### DIFF
--- a/homeassistant/components/ituran/device_tracker.py
+++ b/homeassistant/components/ituran/device_tracker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from propcache.api import cached_property
+
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -38,12 +40,12 @@ class IturanDeviceTracker(IturanBaseEntity, TrackerEntity):
         """Initialize the device tracker."""
         super().__init__(coordinator, license_plate, "device_tracker")
 
-    @property
+    @cached_property
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
         return self.vehicle.gps_coordinates[0]
 
-    @property
+    @cached_property
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
         return self.vehicle.gps_coordinates[1]

--- a/homeassistant/components/ituran/icons.json
+++ b/homeassistant/components/ituran/icons.json
@@ -9,6 +9,9 @@
       "address": {
         "default": "mdi:map-marker"
       },
+      "battery_range": {
+        "default": "mdi:ev-station"
+      },
       "battery_voltage": {
         "default": "mdi:car-battery"
       },

--- a/homeassistant/components/ituran/sensor.py
+++ b/homeassistant/components/ituran/sensor.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 
+from propcache.api import cached_property
 from pyituran import Vehicle
 
 from homeassistant.components.sensor import (
@@ -15,6 +16,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     DEGREE,
+    PERCENTAGE,
     UnitOfElectricPotential,
     UnitOfLength,
     UnitOfSpeed,
@@ -33,6 +35,7 @@ class IturanSensorEntityDescription(SensorEntityDescription):
     """Describes Ituran sensor entity."""
 
     value_fn: Callable[[Vehicle], StateType | datetime]
+    supported_fn: Callable[[Vehicle], bool] = lambda _: True
 
 
 SENSOR_TYPES: list[IturanSensorEntityDescription] = [
@@ -41,6 +44,22 @@ SENSOR_TYPES: list[IturanSensorEntityDescription] = [
         translation_key="address",
         entity_registry_enabled_default=False,
         value_fn=lambda vehicle: vehicle.address,
+    ),
+    IturanSensorEntityDescription(
+        key="battery_level",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda vehicle: vehicle.battery_level,
+        supported_fn=lambda vehicle: vehicle.is_electric_vehicle,
+    ),
+    IturanSensorEntityDescription(
+        key="battery_range",
+        translation_key="battery_range",
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        suggested_display_precision=0,
+        value_fn=lambda vehicle: vehicle.battery_range,
+        supported_fn=lambda vehicle: vehicle.is_electric_vehicle,
     ),
     IturanSensorEntityDescription(
         key="battery_voltage",
@@ -92,14 +111,15 @@ async def async_setup_entry(
     """Set up the Ituran sensors from config entry."""
     coordinator = config_entry.runtime_data
     async_add_entities(
-        IturanSensor(coordinator, license_plate, description)
+        IturanSensor(coordinator, vehicle.license_plate, description)
+        for vehicle in coordinator.data.values()
         for description in SENSOR_TYPES
-        for license_plate in coordinator.data
+        if description.supported_fn(vehicle)
     )
 
 
 class IturanSensor(IturanBaseEntity, SensorEntity):
-    """Ituran device tracker."""
+    """Ituran sensor."""
 
     entity_description: IturanSensorEntityDescription
 
@@ -113,7 +133,7 @@ class IturanSensor(IturanBaseEntity, SensorEntity):
         super().__init__(coordinator, license_plate, description.key)
         self.entity_description = description
 
-    @property
+    @cached_property
     def native_value(self) -> StateType | datetime:
         """Return the state of the device."""
         return self.entity_description.value_fn(self.vehicle)

--- a/homeassistant/components/ituran/strings.json
+++ b/homeassistant/components/ituran/strings.json
@@ -40,6 +40,9 @@
       "address": {
         "name": "Address"
       },
+      "battery_range": {
+        "name": "Remaining range"
+      },
       "battery_voltage": {
         "name": "Battery voltage"
       },

--- a/tests/components/ituran/conftest.py
+++ b/tests/components/ituran/conftest.py
@@ -47,7 +47,7 @@ def mock_config_entry() -> MockConfigEntry:
 class MockVehicle:
     """Mock vehicle."""
 
-    def __init__(self) -> None:
+    def __init__(self, is_electric_vehicle=False) -> None:
         """Initialize mock vehicle."""
         self.license_plate = "12345678"
         self.make = "mock make"
@@ -61,11 +61,18 @@ class MockVehicle:
             2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("Asia/Jerusalem")
         )
         self.battery_voltage = 12.0
+        self.is_electric_vehicle = is_electric_vehicle
+        if is_electric_vehicle:
+            self.battery_level = 42
+            self.battery_range = 150
+        else:
+            self.battery_level = 0
+            self.battery_range = 0
 
 
 @pytest.fixture
-def mock_ituran() -> Generator[AsyncMock]:
-    """Return a mocked PalazzettiClient."""
+def mock_ituran(request: pytest.FixtureRequest) -> Generator[AsyncMock]:
+    """Return a mocked Ituran."""
     with (
         patch(
             "homeassistant.components.ituran.coordinator.Ituran",
@@ -79,7 +86,8 @@ def mock_ituran() -> Generator[AsyncMock]:
         mock_ituran = ituran.return_value
         mock_ituran.is_authenticated.return_value = False
         mock_ituran.authenticate.return_value = True
-        mock_ituran.get_vehicles.return_value = [MockVehicle()]
+        is_electric_vehicle = getattr(request, "param", False)
+        mock_ituran.get_vehicles.return_value = [MockVehicle(is_electric_vehicle)]
         type(mock_ituran).mobile_id = PropertyMock(
             return_value=MOCK_CONFIG_DATA[CONF_MOBILE_ID]
         )

--- a/tests/components/ituran/snapshots/test_sensor.ambr
+++ b/tests/components/ituran/snapshots/test_sensor.ambr
@@ -1,4 +1,415 @@
 # serializer version: 1
+# name: test_ev_sensor[True][sensor.mock_model_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_model_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Address',
+    'platform': 'ituran',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'address',
+    'unique_id': '12345678-address',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mock model Address',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_model_address',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Bermuda Triangle',
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_model_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'ituran',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '12345678-battery_level',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'mock model Battery',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_model_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '42',
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_battery_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_model_battery_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Battery voltage',
+    'platform': 'ituran',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery_voltage',
+    'unique_id': '12345678-battery_voltage',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_battery_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'mock model Battery voltage',
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_model_battery_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12.0',
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_heading-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_model_heading',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Heading',
+    'platform': 'ituran',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'heading',
+    'unique_id': '12345678-heading',
+    'unit_of_measurement': '°',
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_heading-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mock model Heading',
+      'unit_of_measurement': '°',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_model_heading',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '150',
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_last_update_from_vehicle-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_model_last_update_from_vehicle',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last update from vehicle',
+    'platform': 'ituran',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_update_from_vehicle',
+    'unique_id': '12345678-last_update_from_vehicle',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_last_update_from_vehicle-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'mock model Last update from vehicle',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_model_last_update_from_vehicle',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-12-31T22:00:00+00:00',
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_mileage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_model_mileage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+    'original_icon': None,
+    'original_name': 'Mileage',
+    'platform': 'ituran',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mileage',
+    'unique_id': '12345678-mileage',
+    'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_mileage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'mock model Mileage',
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_model_mileage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1000',
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_remaining_range-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_model_remaining_range',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+    'original_icon': None,
+    'original_name': 'Remaining range',
+    'platform': 'ituran',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery_range',
+    'unique_id': '12345678-battery_range',
+    'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_remaining_range-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'mock model Remaining range',
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_model_remaining_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '150',
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_model_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.SPEED: 'speed'>,
+    'original_icon': None,
+    'original_name': 'Speed',
+    'platform': 'ituran',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '12345678-speed',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_ev_sensor[True][sensor.mock_model_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'mock model Speed',
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_model_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20',
+  })
+# ---
 # name: test_sensor[sensor.mock_model_address-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/ituran/test_sensor.py
+++ b/tests/components/ituran/test_sensor.py
@@ -32,13 +32,27 @@ async def test_sensor(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_availability(
+@pytest.mark.parametrize("mock_ituran", [True], indirect=True)
+async def test_ev_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_ituran: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test state of sensor."""
+    with patch("homeassistant.components.ituran.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def __test_availability(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_ituran: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    ev_entity_names: list[str] | None = None,
 ) -> None:
-    """Test sensor is marked as unavailable when we can't reach the Ituran service."""
     entities = [
         "sensor.mock_model_address",
         "sensor.mock_model_battery_voltage",
@@ -46,6 +60,7 @@ async def test_availability(
         "sensor.mock_model_last_update_from_vehicle",
         "sensor.mock_model_mileage",
         "sensor.mock_model_speed",
+        *(ev_entity_names if ev_entity_names is not None else []),
     ]
 
     await setup_integration(hass, mock_config_entry)
@@ -74,3 +89,32 @@ async def test_availability(
         state = hass.states.get(entity_id)
         assert state
         assert state.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_availability(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_ituran: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test ICE sensor is marked as unavailable when we can't reach the Ituran service."""
+    await __test_availability(hass, freezer, mock_ituran, mock_config_entry)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("mock_ituran", [True], indirect=True)
+async def test_ev_availability(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_ituran: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test EV sensor is marked as unavailable when we can't reach the Ituran service."""
+    ev_entities = [
+        "sensor.mock_model_battery",
+        "sensor.mock_model_remaining_range",
+    ]
+    await __test_availability(
+        hass, freezer, mock_ituran, mock_config_entry, ev_entities
+    )


### PR DESCRIPTION
## Proposed change
Add support for EV-related entities in `ituran`

`pyituran` changelog for v0.1.5: https://github.com/shmuelzon/pyituran/releases/tag/0.1.5

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: (from `pyituran`) https://github.com/shmuelzon/pyituran/issues/7
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40153
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
