### PR TITLE
Replace duplicated strings and fix "street name" in `waze_travel_time`

### DIFF
--- a/homeassistant/components/waze_travel_time/strings.json
+++ b/homeassistant/components/waze_travel_time/strings.json
@@ -27,8 +27,8 @@
         "data": {
           "units": "Units",
           "vehicle_type": "Vehicle type",
-          "incl_filter": "Exact streetname which must be part of the selected route",
-          "excl_filter": "Exact streetname which must NOT be part of the selected route",
+          "incl_filter": "Exact street name which must be part of the selected route",
+          "excl_filter": "Exact street name which must NOT be part of the selected route",
           "realtime": "Realtime travel time?",
           "avoid_toll_roads": "Avoid toll roads?",
           "avoid_ferries": "Avoid ferries?",
@@ -103,12 +103,12 @@
           "description": "Whether to avoid subscription roads."
         },
         "incl_filter": {
-          "name": "[%key:component::waze_travel_time::options::step::init::data::incl_filter%]",
-          "description": "Exact streetname which must be part of the selected route."
+          "name": "Streets to include",
+          "description": "[%key:component::waze_travel_time::options::step::init::data::incl_filter%]"
         },
         "excl_filter": {
-          "name": "[%key:component::waze_travel_time::options::step::init::data::excl_filter%]",
-          "description": "Exact streetname which must NOT be part of the selected route."
+          "name": "Streets to exclude",
+          "description": "[%key:component::waze_travel_time::options::step::init::data::excl_filter%]"
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently the name and description of the `incl_filter` and `excl_filter` fields in the `waze_travel_time.get_travel_times` action are duplicates of each other:

<img width="752" height="235" alt="Screenshot 2025-07-27 09 23 53" src="https://github.com/user-attachments/assets/d404020f-b1e2-402b-b1ac-9a9254ade5b4" />

This commit resolves this by replacing the names with the shorter strings "Streets to include / exclude" and moving the references into the description fields.

In addition the spelling of "[street name](https://en.wiktionary.org/wiki/street_name)" is fixed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
