### PR TITLE
Adds a DeviceSensor class as a binary sensor for syncthing and bumped…

### DIFF
--- a/homeassistant/components/syncthing/__init__.py
+++ b/homeassistant/components/syncthing/__init__.py
@@ -25,7 +25,7 @@ from .const import (
     SERVER_UNAVAILABLE,
 )
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/syncthing/binary_sensor.py
+++ b/homeassistant/components/syncthing/binary_sensor.py
@@ -1,0 +1,153 @@
+"""Support for monitoring the Syncthing device connectivity instance."""
+
+import aiosyncthing
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+
+from .const import DOMAIN, SCAN_INTERVAL, SERVER_AVAILABLE, SERVER_UNAVAILABLE
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Syncthing device connectivity binary sensors."""
+    syncthing = hass.data[DOMAIN][config_entry.entry_id]
+
+    try:
+        version = await syncthing.system.version()
+        connections = await syncthing.system.connections()
+    except aiosyncthing.exceptions.SyncthingError as exception:
+        raise PlatformNotReady from exception
+
+    server_id = syncthing.server_id
+
+    entities = [
+        DeviceSensor(
+            syncthing,
+            server_id,
+            device_id,
+            device_info.get("address", "Unknown"),
+            version["version"],
+        )
+        for device_id, device_info in connections.get("connections", {}).items()
+    ]
+
+    async_add_entities(entities)
+
+
+class DeviceSensor(BinarySensorEntity):
+    """A Syncthing device connectivity binary sensor."""
+
+    _attr_should_poll = False
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, syncthing, server_id, device_id, address, version):
+        """Initialize the binary sensor."""
+        self._syncthing = syncthing
+        self._server_id = server_id
+        self._device_id = device_id
+        self._address = address
+        self._connected = None
+        self._unsub_timer = None
+
+        self._short_server_id = server_id.split("-")[0]
+        self._attr_name = f"{self._short_server_id} Device {device_id}"
+        self._attr_unique_id = f"{self._short_server_id}-device-{device_id}"
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, self._server_id)},
+            manufacturer="Syncthing Team",
+            name=f"Syncthing ({syncthing.url})",
+            sw_version=version,
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the sensor."""
+        return bool(self._connected)
+
+    @property
+    def available(self) -> bool:
+        """Could the device be accessed during the last update call."""
+        return self._connected is not None
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            "device_id": self._device_id,
+            "address": self._address,
+        }
+
+    async def async_update_status(self):
+        """Request device connection status and update state."""
+        try:
+            connections = await self._syncthing.system.connections()
+            device_info = connections["connections"].get(self._device_id, {})
+            self._connected = device_info.get("connected", False)
+        except aiosyncthing.exceptions.SyncthingError:
+            self._connected = None
+        self.async_write_ha_state()
+
+    def subscribe(self):
+        """Start polling syncthing device connection status."""
+        if self._unsub_timer is None:
+
+            async def refresh(event_time):
+                await self.async_update_status()
+
+            self._unsub_timer = async_track_time_interval(
+                self.hass, refresh, SCAN_INTERVAL
+            )
+
+    @callback
+    def unsubscribe(self):
+        """Stop polling syncthing device status."""
+        if self._unsub_timer is not None:
+            self._unsub_timer()
+            self._unsub_timer = None
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+
+        @callback
+        def handle_server_unavailable():
+            self._connected = None
+            self.unsubscribe()
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SERVER_UNAVAILABLE}-{self._server_id}",
+                handle_server_unavailable,
+            )
+        )
+
+        async def handle_server_available():
+            self.subscribe()
+            await self.async_update_status()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SERVER_AVAILABLE}-{self._server_id}",
+                handle_server_available,
+            )
+        )
+
+        self.subscribe()
+        self.async_on_remove(self.unsubscribe)
+        await self.async_update_status()

--- a/homeassistant/components/syncthing/manifest.json
+++ b/homeassistant/components/syncthing/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/syncthing",
   "iot_class": "local_polling",
   "loggers": ["aiosyncthing"],
-  "requirements": ["aiosyncthing==0.5.1"]
+  "requirements": ["aiosyncthing==0.6.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -405,7 +405,7 @@ aiostreammagic==2.11.0
 aioswitcher==6.0.0
 
 # homeassistant.components.syncthing
-aiosyncthing==0.5.1
+aiosyncthing==0.6.3
 
 # homeassistant.components.tankerkoenig
 aiotankerkoenig==0.4.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -387,7 +387,7 @@ aiostreammagic==2.11.0
 aioswitcher==6.0.0
 
 # homeassistant.components.syncthing
-aiosyncthing==0.5.1
+aiosyncthing==0.6.3
 
 # homeassistant.components.tankerkoenig
 aiotankerkoenig==0.4.2


### PR DESCRIPTION
… aiosyncthing

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

As per this discussion (https://github.com/orgs/home-assistant/discussions/372#discussioncomment-13808213) The current syncthing intergration does not report the state of devices, ergo a folder can be synced but you do not know if a device is online. So for the server it may as appear as synced but an important client might be disconnected. This adds a binary sensor for the device that states if a client is connected or not. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
The bump of aiosyncthing was due to the newer version having the connections type under aiosyncthing.system. Previous version was 0.5.1 newer version is 0.6.3. https://github.com/zhulik/aiosyncthing/releases, no major changes expect for the additional endpoints that are required

- This PR fixes or closes issue: [fixes Synching device status
](https://github.com/orgs/home-assistant/discussions/372#discussioncomment-13808213)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
