### PR TITLE
Add friend tracking to PlayStation Network

### DIFF
--- a/homeassistant/components/playstation_network/__init__.py
+++ b/homeassistant/components/playstation_network/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 from .const import CONF_NPSSO
 from .coordinator import (
     PlaystationNetworkConfigEntry,
+    PlaystationNetworkFriendDataCoordinator,
     PlaystationNetworkGroupsUpdateCoordinator,
     PlaystationNetworkRuntimeData,
     PlaystationNetworkTrophyTitlesCoordinator,
@@ -39,12 +40,31 @@ async def async_setup_entry(
     groups = PlaystationNetworkGroupsUpdateCoordinator(hass, psn, entry)
     await groups.async_config_entry_first_refresh()
 
+    friends = {}
+
+    for subentry_id, subentry in entry.subentries.items():
+        friend_coordinator = PlaystationNetworkFriendDataCoordinator(
+            hass, psn, entry, subentry
+        )
+        await friend_coordinator.async_config_entry_first_refresh()
+        friends[subentry_id] = friend_coordinator
+
     entry.runtime_data = PlaystationNetworkRuntimeData(
-        coordinator, trophy_titles, groups
+        coordinator, trophy_titles, groups, friends
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
     return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: PlaystationNetworkConfigEntry
+) -> None:
+    """Handle update."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(

--- a/homeassistant/components/playstation_network/config_flow.py
+++ b/homeassistant/components/playstation_network/config_flow.py
@@ -168,19 +168,20 @@ class FriendSubentryFlowHandler(ConfigSubentryFlow):
         """Subentry user flow."""
         errors: dict[str, str] = {}
         config_entry: PlaystationNetworkConfigEntry = self._get_entry()
-        if user_input is None:
-            self.friends_list = await self.hass.async_add_executor_job(
-                lambda: {
-                    friend.account_id: friend
-                    for friend in config_entry.runtime_data.user_data.psn.user.friends_list()
-                }
-            )
+
         if user_input is not None:
             return self.async_create_entry(
                 title=self.friends_list[user_input[CONF_ACCOUNT_ID]].online_id,
                 data=user_input,
                 unique_id=user_input[CONF_ACCOUNT_ID],
             )
+
+        self.friends_list = await self.hass.async_add_executor_job(
+            lambda: {
+                friend.account_id: friend
+                for friend in config_entry.runtime_data.user_data.psn.user.friends_list()
+            }
+        )
 
         options = [
             SelectOptionDict(

--- a/homeassistant/components/playstation_network/config_flow.py
+++ b/homeassistant/components/playstation_network/config_flow.py
@@ -191,7 +191,7 @@ class FriendSubentryFlowHandler(ConfigSubentryFlow):
 
             return self.async_create_entry(
                 title=self.friends_list[user_input[CONF_ACCOUNT_ID]].online_id,
-                data=user_input,
+                data={},
                 unique_id=user_input[CONF_ACCOUNT_ID],
             )
 

--- a/homeassistant/components/playstation_network/const.py
+++ b/homeassistant/components/playstation_network/const.py
@@ -6,6 +6,7 @@ from psnawp_api.models.trophies import PlatformType
 
 DOMAIN = "playstation_network"
 CONF_NPSSO: Final = "npsso"
+CONF_ACCOUNT_ID: Final = "account_id"
 
 SUPPORTED_PLATFORMS = {
     PlatformType.PS_VITA,

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -6,21 +6,30 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import Any
 
 from psnawp_api.core.psnawp_exceptions import (
     PSNAWPAuthenticationError,
     PSNAWPClientError,
+    PSNAWPError,
+    PSNAWPForbiddenError,
+    PSNAWPNotFoundError,
     PSNAWPServerError,
 )
+from psnawp_api.models import User
 from psnawp_api.models.group.group_datatypes import GroupDetails
 from psnawp_api.models.trophies import TrophyTitle
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import CONF_ACCOUNT_ID, DOMAIN
 from .helpers import PlaystationNetwork, PlaystationNetworkData
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,6 +44,7 @@ class PlaystationNetworkRuntimeData:
     user_data: PlaystationNetworkUserDataCoordinator
     trophy_titles: PlaystationNetworkTrophyTitlesCoordinator
     groups: PlaystationNetworkGroupsUpdateCoordinator
+    friends: dict[str, PlaystationNetworkFriendDataCoordinator]
 
 
 class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
@@ -74,6 +84,7 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
                 translation_key="not_ready",
             ) from error
         except (PSNAWPServerError, PSNAWPClientError) as error:
+            _LOGGER.exception("Update failed:")
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="update_failed",
@@ -98,6 +109,7 @@ class PlaystationNetworkUserDataCoordinator(
                 translation_key="not_ready",
             ) from error
         except (PSNAWPServerError, PSNAWPClientError) as error:
+            _LOGGER.exception("Update failed:")
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="update_failed",
@@ -140,3 +152,78 @@ class PlaystationNetworkGroupsUpdateCoordinator(
                 if not group_info.group_id.startswith("~")
             }
         )
+
+
+class PlaystationNetworkFriendDataCoordinator(
+    PlayStationNetworkBaseCoordinator[PlaystationNetworkData]
+):
+    """Friend status data update coordinator for PSN."""
+
+    user: User
+    profile: dict[str, Any]
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        psn: PlaystationNetwork,
+        config_entry: PlaystationNetworkConfigEntry,
+        subentry: ConfigSubentry,
+    ) -> None:
+        """Initialize the Coordinator."""
+        self._update_interval = timedelta(
+            seconds=max(9 * len(config_entry.subentries), 180)
+        )
+        super().__init__(hass, psn, config_entry)
+        self.subentry = subentry
+
+    def _setup(self) -> None:
+        """Set up the coordinator."""
+        self.user = self.psn.psn.user(account_id=self.subentry.data[CONF_ACCOUNT_ID])
+        self.profile = self.user.profile()
+
+    async def _async_setup(self) -> None:
+        """Set up the coordinator."""
+
+        try:
+            await self.hass.async_add_executor_job(self._setup)
+        except PSNAWPNotFoundError as error:
+            raise ConfigEntryError(
+                translation_domain=DOMAIN,
+                translation_key="user_not_found",
+                translation_placeholders={"user": self.subentry.title},
+            ) from error
+
+        except PSNAWPAuthenticationError as error:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="not_ready",
+            ) from error
+
+        except (PSNAWPServerError, PSNAWPClientError) as error:
+            _LOGGER.debug("Update failed", exc_info=True)
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+            ) from error
+
+    def _update_data(self) -> PlaystationNetworkData:
+        """Update friend status data."""
+        try:
+            return PlaystationNetworkData(
+                username=self.user.online_id,
+                account_id=self.user.account_id,
+                presence=self.user.get_presence(),
+                profile=self.profile,
+            )
+        except PSNAWPForbiddenError as error:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="user_profile_private",
+                translation_placeholders={"user": self.subentry.title},
+            ) from error
+        except PSNAWPError:
+            raise
+
+    async def update_data(self) -> PlaystationNetworkData:
+        """Update friend status data."""
+        return await self.hass.async_add_executor_job(self._update_data)

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -84,7 +84,6 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
                 translation_key="not_ready",
             ) from error
         except (PSNAWPServerError, PSNAWPClientError) as error:
-            _LOGGER.exception("Update failed:")
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="update_failed",
@@ -109,7 +108,6 @@ class PlaystationNetworkUserDataCoordinator(
                 translation_key="not_ready",
             ) from error
         except (PSNAWPServerError, PSNAWPClientError) as error:
-            _LOGGER.exception("Update failed:")
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="update_failed",

--- a/homeassistant/components/playstation_network/entity.py
+++ b/homeassistant/components/playstation_network/entity.py
@@ -31,10 +31,12 @@ class PlaystationNetworkServiceEntity(
             assert coordinator.config_entry.unique_id
         self.entity_description = entity_description
         self.subentry = subentry
-        unique_id = coordinator.config_entry.unique_id
+        unique_id = (
+            subentry.unique_id
+            if subentry is not None and subentry.unique_id
+            else coordinator.config_entry.unique_id
+        )
 
-        if subentry is not None:
-            unique_id += f"_{subentry.unique_id}"
         self._attr_unique_id = f"{unique_id}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)},

--- a/homeassistant/components/playstation_network/entity.py
+++ b/homeassistant/components/playstation_network/entity.py
@@ -34,7 +34,7 @@ class PlaystationNetworkServiceEntity(
         unique_id = coordinator.config_entry.unique_id
 
         if subentry is not None:
-            unique_id += f"_{subentry.subentry_id}"
+            unique_id += f"_{subentry.unique_id}"
         self._attr_unique_id = f"{unique_id}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)},

--- a/homeassistant/components/playstation_network/entity.py
+++ b/homeassistant/components/playstation_network/entity.py
@@ -2,12 +2,14 @@
 
 from typing import TYPE_CHECKING
 
+from homeassistant.config_entries import ConfigSubentry
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import PlayStationNetworkBaseCoordinator
+from .helpers import PlaystationNetworkData
 
 
 class PlaystationNetworkServiceEntity(
@@ -21,18 +23,30 @@ class PlaystationNetworkServiceEntity(
         self,
         coordinator: PlayStationNetworkBaseCoordinator,
         entity_description: EntityDescription,
+        subentry: ConfigSubentry | None = None,
     ) -> None:
         """Initialize PlayStation Network Service Entity."""
         super().__init__(coordinator)
         if TYPE_CHECKING:
             assert coordinator.config_entry.unique_id
         self.entity_description = entity_description
-        self._attr_unique_id = (
-            f"{coordinator.config_entry.unique_id}_{entity_description.key}"
-        )
+        self.subentry = subentry
+        unique_id = coordinator.config_entry.unique_id
+
+        if subentry is not None:
+            unique_id += f"_{subentry.subentry_id}"
+        self._attr_unique_id = f"{unique_id}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.config_entry.unique_id)},
-            name=coordinator.psn.user.online_id,
+            identifiers={(DOMAIN, unique_id)},
+            name=(
+                coordinator.data.username
+                if isinstance(coordinator.data, PlaystationNetworkData)
+                else coordinator.psn.user.online_id
+            ),
             entry_type=DeviceEntryType.SERVICE,
             manufacturer="Sony Interactive Entertainment",
         )
+        if subentry:
+            self._attr_device_info.update(
+                DeviceInfo(via_device=(DOMAIN, coordinator.config_entry.unique_id))
+            )

--- a/homeassistant/components/playstation_network/helpers.py
+++ b/homeassistant/components/playstation_network/helpers.py
@@ -38,7 +38,6 @@ class PlaystationNetworkData:
     presence: dict[str, Any] = field(default_factory=dict)
     username: str = ""
     account_id: str = ""
-    availability: str = "unavailable"
     active_sessions: dict[PlatformType, SessionData] = field(default_factory=dict)
     registered_platforms: set[PlatformType] = field(default_factory=set)
     trophy_summary: TrophySummary | None = None
@@ -61,6 +60,7 @@ class PlaystationNetwork:
         self.legacy_profile: dict[str, Any] | None = None
         self.trophy_titles: list[TrophyTitle] = []
         self._title_icon_urls: dict[str, str] = {}
+        self.friends_list: dict[str, User] | None = None
 
     def _setup(self) -> None:
         """Setup PSN."""
@@ -97,6 +97,7 @@ class PlaystationNetwork:
         # check legacy platforms if owned
         if LEGACY_PLATFORMS & data.registered_platforms:
             self.legacy_profile = self.client.get_profile_legacy()
+
         return data
 
     async def get_data(self) -> PlaystationNetworkData:
@@ -105,7 +106,6 @@ class PlaystationNetwork:
         data.username = self.user.online_id
         data.account_id = self.user.account_id
         data.shareable_profile_link = self.shareable_profile_link
-        data.availability = data.presence["basicPresence"]["availability"]
 
         if "platform" in data.presence["basicPresence"]["primaryPlatformInfo"]:
             primary_platform = PlatformType(
@@ -193,3 +193,17 @@ class PlaystationNetwork:
 def normalize_title(name: str) -> str:
     """Normalize trophy title."""
     return name.removesuffix("Trophies").removesuffix("Trophy Set").strip()
+
+
+def get_game_title_info(presence: dict[str, Any]) -> dict[str, Any]:
+    """Retrieve title info from presence."""
+
+    return (
+        next((title for title in game_title_info), {})
+        if (
+            game_title_info := presence.get("basicPresence", {}).get(
+                "gameTitleInfoList"
+            )
+        )
+        else {}
+    )

--- a/homeassistant/components/playstation_network/icons.json
+++ b/homeassistant/components/playstation_network/icons.json
@@ -42,6 +42,13 @@
           "availabletocommunicate": "mdi:cellphone",
           "offline": "mdi:account-off-outline"
         }
+      },
+      "now_playing": {
+        "default": "mdi:controller",
+        "state": {
+          "unknown": "mdi:controller-off",
+          "unavailable": "mdi:controller-off"
+        }
       }
     },
     "image": {
@@ -50,6 +57,9 @@
       },
       "avatar": {
         "default": "mdi:account-circle"
+      },
+      "now_playing_image": {
+        "default": "mdi:image"
       }
     },
     "notify": {

--- a/homeassistant/components/playstation_network/icons.json
+++ b/homeassistant/components/playstation_network/icons.json
@@ -57,9 +57,6 @@
       },
       "avatar": {
         "default": "mdi:account-circle"
-      },
-      "now_playing_image": {
-        "default": "mdi:image"
       }
     },
     "notify": {

--- a/homeassistant/components/playstation_network/image.py
+++ b/homeassistant/components/playstation_network/image.py
@@ -150,27 +150,8 @@ class PlaystationNetworkImageEntity(PlaystationNetworkImageBaseEntity):
 
     coordinator: PlaystationNetworkUserDataCoordinator
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        coordinator: PlaystationNetworkUserDataCoordinator,
-        entity_description: PlaystationNetworkImageEntityDescription,
-    ) -> None:
-        """Initialize the image entity."""
-        super().__init__(hass, coordinator, entity_description)
-
 
 class PlaystationNetworkFriendImageEntity(PlaystationNetworkImageBaseEntity):
     """An image entity."""
 
     coordinator: PlaystationNetworkFriendDataCoordinator
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        coordinator: PlaystationNetworkFriendDataCoordinator,
-        entity_description: PlaystationNetworkImageEntityDescription,
-        subentry: ConfigSubentry,
-    ) -> None:
-        """Initialize the image entity."""
-        super().__init__(hass, coordinator, entity_description, subentry)

--- a/homeassistant/components/playstation_network/image.py
+++ b/homeassistant/components/playstation_network/image.py
@@ -63,9 +63,6 @@ IMAGE_DESCRIPTIONS_ALL: tuple[PlaystationNetworkImageEntityDescription, ...] = (
             )
         ),
     ),
-)
-
-IMAGE_DESCRIPTIONS_FRIENDS: tuple[PlaystationNetworkImageEntityDescription, ...] = (
     PlaystationNetworkImageEntityDescription(
         key=PlaystationNetworkImage.NOW_PLAYING_IMAGE,
         translation_key=PlaystationNetworkImage.NOW_PLAYING_IMAGE,
@@ -105,7 +102,7 @@ async def async_setup_entry(
                     description,
                     config_entry.subentries[subentry_id],
                 )
-                for description in IMAGE_DESCRIPTIONS_ALL + IMAGE_DESCRIPTIONS_FRIENDS
+                for description in IMAGE_DESCRIPTIONS_ALL
             ],
             config_subentry_id=subentry_id,
         )

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -21,9 +21,11 @@ from homeassistant.util import dt as dt_util
 from .coordinator import (
     PlaystationNetworkConfigEntry,
     PlaystationNetworkData,
+    PlaystationNetworkFriendDataCoordinator,
     PlaystationNetworkUserDataCoordinator,
 )
 from .entity import PlaystationNetworkServiceEntity
+from .helpers import get_game_title_info
 
 PARALLEL_UPDATES = 0
 
@@ -33,7 +35,6 @@ class PlaystationNetworkSensorEntityDescription(SensorEntityDescription):
     """PlayStation Network sensor description."""
 
     value_fn: Callable[[PlaystationNetworkData], StateType | datetime]
-    entity_picture: str | None = None
     available_fn: Callable[[PlaystationNetworkData], bool] = lambda _: True
 
 
@@ -49,9 +50,10 @@ class PlaystationNetworkSensor(StrEnum):
     ONLINE_ID = "online_id"
     LAST_ONLINE = "last_online"
     ONLINE_STATUS = "online_status"
+    NOW_PLAYING = "now_playing"
 
 
-SENSOR_DESCRIPTIONS: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
+SENSOR_DESCRIPTIONS_TROPHY: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.TROPHY_LEVEL,
         translation_key=PlaystationNetworkSensor.TROPHY_LEVEL,
@@ -103,6 +105,8 @@ SENSOR_DESCRIPTIONS: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
             else None
         ),
     ),
+)
+SENSOR_DESCRIPTIONS_USER: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.ONLINE_ID,
         translation_key=PlaystationNetworkSensor.ONLINE_ID,
@@ -122,9 +126,22 @@ SENSOR_DESCRIPTIONS: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.ONLINE_STATUS,
         translation_key=PlaystationNetworkSensor.ONLINE_STATUS,
-        value_fn=lambda psn: psn.availability.lower().replace("unavailable", "offline"),
+        value_fn=(
+            lambda psn: psn.presence["basicPresence"]["availability"]
+            .lower()
+            .replace("unavailable", "offline")
+        ),
         device_class=SensorDeviceClass.ENUM,
         options=["offline", "availabletoplay", "availabletocommunicate", "busy"],
+    ),
+)
+
+
+SENSOR_DESCRIPTIONS_FRIEND: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
+    PlaystationNetworkSensorEntityDescription(
+        key=PlaystationNetworkSensor.NOW_PLAYING,
+        translation_key=PlaystationNetworkSensor.NOW_PLAYING,
+        value_fn=lambda psn: get_game_title_info(psn.presence).get("titleName"),
     ),
 )
 
@@ -138,15 +155,31 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data.user_data
     async_add_entities(
         PlaystationNetworkSensorEntity(coordinator, description)
-        for description in SENSOR_DESCRIPTIONS
+        for description in SENSOR_DESCRIPTIONS_TROPHY + SENSOR_DESCRIPTIONS_USER
     )
 
+    for (
+        subentry_id,
+        friend_data_coordinator,
+    ) in config_entry.runtime_data.friends.items():
+        async_add_entities(
+            [
+                PlaystationNetworkFriendSensorEntity(
+                    friend_data_coordinator,
+                    description,
+                    config_entry.subentries[subentry_id],
+                )
+                for description in SENSOR_DESCRIPTIONS_USER + SENSOR_DESCRIPTIONS_FRIEND
+            ],
+            config_subentry_id=subentry_id,
+        )
 
-class PlaystationNetworkSensorEntity(
+
+class PlaystationNetworkSensorBaseEntity(
     PlaystationNetworkServiceEntity,
     SensorEntity,
 ):
-    """Representation of a PlayStation Network sensor entity."""
+    """Base sensor entity."""
 
     entity_description: PlaystationNetworkSensorEntityDescription
     coordinator: PlaystationNetworkUserDataCoordinator
@@ -169,14 +202,24 @@ class PlaystationNetworkSensorEntity(
                 (pic.get("url") for pic in profile_pictures if pic.get("size") == "xl"),
                 None,
             )
-
         return super().entity_picture
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
 
-        return (
-            self.entity_description.available_fn(self.coordinator.data)
-            and super().available
+        return super().available and self.entity_description.available_fn(
+            self.coordinator.data
         )
+
+
+class PlaystationNetworkSensorEntity(PlaystationNetworkSensorBaseEntity):
+    """Representation of a PlayStation Network sensor entity."""
+
+    coordinator: PlaystationNetworkUserDataCoordinator
+
+
+class PlaystationNetworkFriendSensorEntity(PlaystationNetworkSensorBaseEntity):
+    """Representation of a PlayStation Network sensor entity."""
+
+    coordinator: PlaystationNetworkFriendDataCoordinator

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
 
 from .coordinator import (
+    PlayStationNetworkBaseCoordinator,
     PlaystationNetworkConfigEntry,
     PlaystationNetworkData,
     PlaystationNetworkFriendDataCoordinator,
@@ -182,7 +183,7 @@ class PlaystationNetworkSensorBaseEntity(
     """Base sensor entity."""
 
     entity_description: PlaystationNetworkSensorEntityDescription
-    coordinator: PlaystationNetworkUserDataCoordinator
+    coordinator: PlayStationNetworkBaseCoordinator
 
     @property
     def native_value(self) -> StateType | datetime:

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -135,10 +135,6 @@ SENSOR_DESCRIPTIONS_USER: tuple[PlaystationNetworkSensorEntityDescription, ...] 
         device_class=SensorDeviceClass.ENUM,
         options=["offline", "availabletoplay", "availabletocommunicate", "busy"],
     ),
-)
-
-
-SENSOR_DESCRIPTIONS_FRIEND: tuple[PlaystationNetworkSensorEntityDescription, ...] = (
     PlaystationNetworkSensorEntityDescription(
         key=PlaystationNetworkSensor.NOW_PLAYING,
         translation_key=PlaystationNetworkSensor.NOW_PLAYING,
@@ -170,7 +166,7 @@ async def async_setup_entry(
                     description,
                     config_entry.subentries[subentry_id],
                 )
-                for description in SENSOR_DESCRIPTIONS_USER + SENSOR_DESCRIPTIONS_FRIEND
+                for description in SENSOR_DESCRIPTIONS_USER
             ],
             config_subentry_id=subentry_id,
         )

--- a/homeassistant/components/playstation_network/strings.json
+++ b/homeassistant/components/playstation_network/strings.json
@@ -39,6 +39,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_configured_as_subentry": "Already configured as a friend for another account. Delete the existing entry first.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "unique_id_mismatch": "The provided NPSSO token corresponds to the account {wrong_account}. Please re-authenticate with the account **{name}**",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
@@ -67,7 +68,8 @@
         "unknown": "[%key:common::config_flow::error::unknown%]"
       },
       "abort": {
-        "already_configured": "Friend is already configured"
+        "already_configured_as_entry": "Already configured as a service. This account cannot be added as a friend.",
+        "already_configured": "Already configured as a friend in this or another account."
       }
     }
   },

--- a/homeassistant/components/playstation_network/strings.json
+++ b/homeassistant/components/playstation_network/strings.json
@@ -44,6 +44,33 @@
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
+  "config_subentries": {
+    "friend": {
+      "step": {
+        "user": {
+          "title": "Friend online status",
+          "description": "Track the online status of a PlayStation Network friend.",
+          "data": {
+            "account_id": "Online ID"
+          },
+          "data_description": {
+            "account_id": "Select a friend from your friend list to track their online status."
+          }
+        }
+      },
+      "initiate_flow": {
+        "user": "Add friend"
+      },
+      "entry_type": "Friend",
+      "error": {
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "unknown": "[%key:common::config_flow::error::unknown%]"
+      },
+      "abort": {
+        "already_configured": "Friend is already configured"
+      }
+    }
+  },
   "exceptions": {
     "not_ready": {
       "message": "Authentication to the PlayStation Network failed."
@@ -59,6 +86,12 @@
     },
     "send_message_failed": {
       "message": "Failed to send message to group {group_name}. Try again later."
+    },
+    "user_profile_private": {
+      "message": "Unable to retrieve data for {user}. Privacy settings restrict access to activity."
+    },
+    "user_not_found": {
+      "message": "Unable to retrieve data for {user}. User does not exist or has been removed."
     }
   },
   "entity": {
@@ -104,6 +137,9 @@
           "availabletocommunicate": "Online on PS App",
           "busy": "Away"
         }
+      },
+      "now_playing": {
+        "name": "Now playing"
       }
     },
     "image": {
@@ -112,6 +148,9 @@
       },
       "avatar": {
         "name": "Avatar"
+      },
+      "now_playing_image": {
+        "name": "[%key:component::playstation_network::entity::sensor::now_playing::name%]"
       }
     },
     "notify": {

--- a/tests/components/playstation_network/conftest.py
+++ b/tests/components/playstation_network/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from psnawp_api.models import User
 from psnawp_api.models.group.group import Group
 from psnawp_api.models.trophies import (
     PlatformType,
@@ -13,7 +14,12 @@ from psnawp_api.models.trophies import (
 )
 import pytest
 
-from homeassistant.components.playstation_network.const import CONF_NPSSO, DOMAIN
+from homeassistant.components.playstation_network.const import (
+    CONF_ACCOUNT_ID,
+    CONF_NPSSO,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigSubentryData
 
 from tests.common import MockConfigEntry
 
@@ -32,6 +38,15 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_NPSSO: NPSSO_TOKEN,
         },
         unique_id=PSN_ID,
+        subentries_data=[
+            ConfigSubentryData(
+                data={CONF_ACCOUNT_ID: "fren-psn-id"},
+                subentry_id="ABCDEF",
+                subentry_type="friend",
+                title="PublicUniversalFriend",
+                unique_id="fren-psn-id",
+            )
+        ],
     )
 
 
@@ -170,6 +185,12 @@ def mock_psnawpapi(mock_user: MagicMock) -> Generator[MagicMock]:
             ],
         }
         client.me.return_value.get_groups.return_value = [group]
+        fren = MagicMock(
+            spec=User, account_id="fren-psn-id", online_id="PublicUniversalFriend"
+        )
+
+        client.user.return_value.friends_list.return_value = [fren]
+
         yield client
 
 

--- a/tests/components/playstation_network/snapshots/test_diagnostics.ambr
+++ b/tests/components/playstation_network/snapshots/test_diagnostics.ambr
@@ -21,7 +21,6 @@
           'title_name': "Assassin's Creed® III Liberation",
         }),
       }),
-      'availability': 'availableToPlay',
       'presence': dict({
         'basicPresence': dict({
           'availability': 'availableToPlay',

--- a/tests/components/playstation_network/snapshots/test_sensor.ambr
+++ b/tests/components/playstation_network/snapshots/test_sensor.ambr
@@ -275,7 +275,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <PlaystationNetworkSensor.NOW_PLAYING: 'now_playing'>,
-    'unique_id': 'fren-psn-id_now_playing',
+    'unique_id': 'my-psn-id_now_playing',
     'unit_of_measurement': None,
   })
 # ---
@@ -286,6 +286,54 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.testuser_now_playing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'STAR WARS Jedi: Survivor™',
+  })
+# ---
+# name: test_sensors[sensor.testuser_now_playing_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_now_playing_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Now playing',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.NOW_PLAYING: 'now_playing'>,
+    'unique_id': 'fren-psn-id_now_playing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.testuser_now_playing_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'testuser Now playing',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_now_playing_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/playstation_network/snapshots/test_sensor.ambr
+++ b/tests/components/playstation_network/snapshots/test_sensor.ambr
@@ -177,7 +177,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <PlaystationNetworkSensor.LAST_ONLINE: 'last_online'>,
-    'unique_id': 'my-psn-id_fren-psn-id_last_online',
+    'unique_id': 'fren-psn-id_last_online',
     'unit_of_measurement': None,
   })
 # ---
@@ -275,7 +275,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <PlaystationNetworkSensor.NOW_PLAYING: 'now_playing'>,
-    'unique_id': 'my-psn-id_fren-psn-id_now_playing',
+    'unique_id': 'fren-psn-id_now_playing',
     'unit_of_measurement': None,
   })
 # ---
@@ -372,7 +372,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <PlaystationNetworkSensor.ONLINE_ID: 'online_id'>,
-    'unique_id': 'my-psn-id_fren-psn-id_online_id',
+    'unique_id': 'fren-psn-id_online_id',
     'unit_of_measurement': None,
   })
 # ---
@@ -490,7 +490,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <PlaystationNetworkSensor.ONLINE_STATUS: 'online_status'>,
-    'unique_id': 'my-psn-id_fren-psn-id_online_status',
+    'unique_id': 'fren-psn-id_online_status',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/playstation_network/snapshots/test_sensor.ambr
+++ b/tests/components/playstation_network/snapshots/test_sensor.ambr
@@ -177,7 +177,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <PlaystationNetworkSensor.LAST_ONLINE: 'last_online'>,
-    'unique_id': 'my-psn-id_ABCDEF_last_online',
+    'unique_id': 'my-psn-id_fren-psn-id_last_online',
     'unit_of_measurement': None,
   })
 # ---
@@ -275,7 +275,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <PlaystationNetworkSensor.NOW_PLAYING: 'now_playing'>,
-    'unique_id': 'my-psn-id_ABCDEF_now_playing',
+    'unique_id': 'my-psn-id_fren-psn-id_now_playing',
     'unit_of_measurement': None,
   })
 # ---
@@ -372,7 +372,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <PlaystationNetworkSensor.ONLINE_ID: 'online_id'>,
-    'unique_id': 'my-psn-id_ABCDEF_online_id',
+    'unique_id': 'my-psn-id_fren-psn-id_online_id',
     'unit_of_measurement': None,
   })
 # ---
@@ -490,7 +490,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <PlaystationNetworkSensor.ONLINE_STATUS: 'online_status'>,
-    'unique_id': 'my-psn-id_ABCDEF_online_status',
+    'unique_id': 'my-psn-id_fren-psn-id_online_status',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/playstation_network/snapshots/test_sensor.ambr
+++ b/tests/components/playstation_network/snapshots/test_sensor.ambr
@@ -146,6 +146,55 @@
     'state': '2025-06-30T01:42:15+00:00',
   })
 # ---
+# name: test_sensors[sensor.testuser_last_online_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_last_online_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last online',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.LAST_ONLINE: 'last_online'>,
+    'unique_id': 'my-psn-id_ABCDEF_last_online',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.testuser_last_online_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'testuser Last online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_last_online_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-06-30T01:42:15+00:00',
+  })
+# ---
 # name: test_sensors[sensor.testuser_next_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -195,6 +244,54 @@
     'state': '19',
   })
 # ---
+# name: test_sensors[sensor.testuser_now_playing-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_now_playing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Now playing',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.NOW_PLAYING: 'now_playing'>,
+    'unique_id': 'my-psn-id_ABCDEF_now_playing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.testuser_now_playing-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'testuser Now playing',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_now_playing',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'STAR WARS Jedi: Survivor™',
+  })
+# ---
 # name: test_sensors[sensor.testuser_online_id-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -238,6 +335,55 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.testuser_online_id',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'testuser',
+  })
+# ---
+# name: test_sensors[sensor.testuser_online_id_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_online_id_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Online ID',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.ONLINE_ID: 'online_id'>,
+    'unique_id': 'my-psn-id_ABCDEF_online_id',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.testuser_online_id_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'http://static-resource.np.community.playstation.net/avatar_xl/WWS_A/UP90001312L24_DD96EB6A4FF5FE883C09_XL.png',
+      'friendly_name': 'testuser Online ID',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_online_id_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -300,6 +446,68 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.testuser_online_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'availabletoplay',
+  })
+# ---
+# name: test_sensors[sensor.testuser_online_status_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'offline',
+        'availabletoplay',
+        'availabletocommunicate',
+        'busy',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.testuser_online_status_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Online status',
+    'platform': 'playstation_network',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <PlaystationNetworkSensor.ONLINE_STATUS: 'online_status'>,
+    'unique_id': 'my-psn-id_ABCDEF_online_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.testuser_online_status_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'testuser Online status',
+      'options': list([
+        'offline',
+        'availabletoplay',
+        'availabletocommunicate',
+        'busy',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.testuser_online_status_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/playstation_network/test_config_flow.py
+++ b/tests/components/playstation_network/test_config_flow.py
@@ -409,7 +409,7 @@ async def test_add_friend_flow(hass: HomeAssistant) -> None:
     subentry_id = list(config_entry.subentries)[0]
     assert config_entry.subentries == {
         subentry_id: ConfigSubentry(
-            data={CONF_ACCOUNT_ID: "fren-psn-id"},
+            data={},
             subentry_id=subentry_id,
             subentry_type="friend",
             title="PublicUniversalFriend",

--- a/tests/components/playstation_network/test_config_flow.py
+++ b/tests/components/playstation_network/test_config_flow.py
@@ -400,4 +400,4 @@ async def test_add_friend_flow_already_configured(
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "already_configured_friend"

--- a/tests/components/playstation_network/test_config_flow.py
+++ b/tests/components/playstation_network/test_config_flow.py
@@ -15,7 +15,12 @@ from homeassistant.components.playstation_network.const import (
     CONF_NPSSO,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_USER, ConfigEntryState, ConfigSubentry
+from homeassistant.config_entries import (
+    SOURCE_USER,
+    ConfigEntryState,
+    ConfigSubentry,
+    ConfigSubentryData,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -69,6 +74,45 @@ async def test_form_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_psnawpapi")
+async def test_form_already_configured_as_subentry(hass: HomeAssistant) -> None:
+    """Test we abort form login when entry is already configured as subentry of another entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="PublicUniversalFriend",
+        data={
+            CONF_NPSSO: NPSSO_TOKEN,
+        },
+        unique_id="fren-psn-id",
+        subentries_data=[
+            ConfigSubentryData(
+                data={CONF_ACCOUNT_ID: PSN_ID},
+                subentry_id="ABCDEF",
+                subentry_type="friend",
+                title="test-user",
+                unique_id=PSN_ID,
+            )
+        ],
+    )
+
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_NPSSO: NPSSO_TOKEN},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_as_subentry"
 
 
 @pytest.mark.parametrize(
@@ -400,4 +444,52 @@ async def test_add_friend_flow_already_configured(
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured_friend"
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_psnawpapi")
+async def test_add_friend_flow_already_configured_as_entry(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test we abort add friend subentry flow when already configured as config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        data={
+            CONF_NPSSO: NPSSO_TOKEN,
+        },
+        unique_id=PSN_ID,
+    )
+    fren_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="PublicUniversalFriend",
+        data={
+            CONF_NPSSO: NPSSO_TOKEN,
+        },
+        unique_id="fren-psn-id",
+    )
+
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    fren_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(fren_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, "friend"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        user_input={CONF_ACCOUNT_ID: "fren-psn-id"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_as_entry"

--- a/tests/components/playstation_network/test_init.py
+++ b/tests/components/playstation_network/test_init.py
@@ -7,6 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 from psnawp_api.core import (
     PSNAWPAuthenticationError,
     PSNAWPClientError,
+    PSNAWPForbiddenError,
     PSNAWPNotFoundError,
     PSNAWPServerError,
 )
@@ -263,3 +264,83 @@ async def test_trophy_title_coordinator_play_new_game(
         state.attributes["entity_picture"]
         == "https://image.api.playstation.com/trophy/np/NPWR03134_00_0008206095F67FD3BB385E9E00A7C9CFE6F5A4AB96/5F87A6997DD23D1C4D4CC0D1F958ED79CB905331.PNG"
     )
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [PSNAWPNotFoundError, PSNAWPServerError, PSNAWPClientError, PSNAWPForbiddenError],
+)
+async def test_friends_coordinator_update_data_failed(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+    exception: Exception,
+) -> None:
+    """Test friends coordinator setup fails in _update_data."""
+
+    mock_psnawpapi.user.return_value.get_presence.side_effect = [
+        mock_psnawpapi.user.return_value.get_presence.return_value,
+        exception,
+    ]
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize(
+    ("exception", "state"),
+    [
+        (PSNAWPNotFoundError, ConfigEntryState.SETUP_ERROR),
+        (PSNAWPAuthenticationError, ConfigEntryState.SETUP_ERROR),
+        (PSNAWPServerError, ConfigEntryState.SETUP_RETRY),
+        (PSNAWPClientError, ConfigEntryState.SETUP_RETRY),
+    ],
+)
+async def test_friends_coordinator_setup_failed(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+    exception: Exception,
+    state: ConfigEntryState,
+) -> None:
+    """Test friends coordinator setup fails in _async_setup."""
+
+    mock_psnawpapi.user.side_effect = [
+        mock_psnawpapi.user.return_value,
+        exception,
+    ]
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is state
+
+
+async def test_friends_coordinator_auth_failed(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_psnawpapi: MagicMock,
+) -> None:
+    """Test friends coordinator starts reauth on authentication error."""
+    mock_psnawpapi.user.side_effect = [
+        mock_psnawpapi.user.return_value,
+        PSNAWPAuthenticationError,
+    ]
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow.get("step_id") == "reauth_confirm"
+    assert flow.get("handler") == DOMAIN
+
+    assert "context" in flow
+    assert flow["context"].get("source") == SOURCE_REAUTH
+    assert flow["context"].get("entry_id") == config_entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds support for tracking the online status of selected friends

This feature does **not** automatically track all users from the friend list. Instead, individual friends must be manually selected through subentries during the configuration flow. The flow will retrieve the entire friend list, allowing users to choose which friends to track. 

This limitation exists due to rate limits imposed by the PSN API. Based on current usage, it is estimated that tracking up to 20 friends with an interval of 3 minutes is sustainable. The integration currently consumes approximately 120–150 of the maximum 300 requests per 15 minutes.

If more than 20 friends are selected, the polling interval will be dynamically increased to ensure the integration remains within the API rate limits.

For each selected friend, a device is created with **six entities**:

- **2 image entities**:
  - Avatar
  - Now playing (Current title image if the friend is playing a game)
  
- **4 sensor entities**:
  - Online ID
  - Now playing (Currently playing game title name)
  - Online status
  - Last online
 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40168
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
