### PR TITLE
Remove stale devices in Uptime Kuma

### DIFF
--- a/homeassistant/components/uptime_kuma/__init__.py
+++ b/homeassistant/components/uptime_kuma/__init__.py
@@ -6,7 +6,7 @@ from pythonkuma.update import UpdateChecker
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.hass_dict import HassKey
 
@@ -41,6 +41,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: UptimeKumaConfigEntry) -
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 
     return True
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: UptimeKumaConfigEntry,
+    device_entry: dr.DeviceEntry,
+) -> bool:
+    """Remove a stale device from a config entry."""
+
+    def normalize_key(id: str) -> int | str:
+        key = id.removeprefix(f"{config_entry.entry_id}_")
+        return int(key) if key.isnumeric() else key
+
+    return not any(
+        identifier
+        for identifier in device_entry.identifiers
+        if identifier[0] == DOMAIN
+        and (
+            identifier[1] == config_entry.entry_id
+            or normalize_key(identifier[1]) in config_entry.runtime_data.data
+        )
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: UptimeKumaConfigEntry) -> bool:

--- a/tests/components/uptime_kuma/test_init.py
+++ b/tests/components/uptime_kuma/test_init.py
@@ -8,8 +8,11 @@ from pythonkuma import UptimeKumaAuthenticationException, UptimeKumaException
 from homeassistant.components.uptime_kuma.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 @pytest.mark.usefixtures("mock_pythonkuma")
@@ -77,3 +80,85 @@ async def test_config_reauth_flow(
     assert "context" in flow
     assert flow["context"].get("source") == SOURCE_REAUTH
     assert flow["context"].get("entry_id") == config_entry.entry_id
+
+
+@pytest.mark.usefixtures("mock_pythonkuma")
+async def test_remove_stale_device(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test we can remove a device that is not in the coordinator data."""
+    assert await async_setup_component(hass, "config", {})
+    ws_client = await hass_ws_client(hass)
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "123456789_1")}
+    )
+
+    config_entry.runtime_data.data.pop(1)
+    response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
+
+    assert response["success"]
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, "123456789_1")}) is None
+    )
+
+
+@pytest.mark.usefixtures("mock_pythonkuma")
+async def test_remove_current_device(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test we cannot remove a device if it is still active."""
+    assert await async_setup_component(hass, "config", {})
+    ws_client = await hass_ws_client(hass)
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "123456789_1")}
+    )
+
+    response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
+
+    assert response["success"] is False
+    assert device_registry.async_get_device(identifiers={(DOMAIN, "123456789_1")})
+
+
+@pytest.mark.usefixtures("mock_pythonkuma")
+async def test_remove_entry_device(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test we cannot remove the device with the update entity."""
+    assert await async_setup_component(hass, "config", {})
+    ws_client = await hass_ws_client(hass)
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "123456789")})
+
+    response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
+
+    assert response["success"] is False
+    assert device_registry.async_get_device(identifiers={(DOMAIN, "123456789")})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Users can manually remove stale devices. The integration will verify whether the corresponding monitor is no longer provided by the API. If the monitor is no longer present, removal will be allowed. However, if the monitor is still propagated by the API, or if it is the device that represents the uptime kuma service itself (the one containing the update entity), removal will be denied.

Automatic removal of stale devices is not possible, as the absence of a monitor in the API may also occur when a monitor is temporarily paused.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
