### PR TITLE
Bump pymysensors library version

### DIFF
--- a/homeassistant/components/mysensors/manifest.json
+++ b/homeassistant/components/mysensors/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/mysensors",
   "iot_class": "local_push",
   "loggers": ["mysensors"],
-  "requirements": ["pymysensors==0.25.0"]
+  "requirements": ["pymysensors==0.26.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2161,7 +2161,7 @@ pymonoprice==0.4
 pymsteams==0.1.12
 
 # homeassistant.components.mysensors
-pymysensors==0.25.0
+pymysensors==0.26.0
 
 # homeassistant.components.iron_os
 pynecil==4.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1797,7 +1797,7 @@ pymodbus==3.9.2
 pymonoprice==0.4
 
 # homeassistant.components.mysensors
-pymysensors==0.25.0
+pymysensors==0.26.0
 
 # homeassistant.components.iron_os
 pynecil==4.1.1


### PR DESCRIPTION
## Proposed change
Bump pymysensors to support V_TILT in the MySensors protocol  -> https://github.com/theolind/pymysensors/compare/0.25.0...0.26.0

## Type of change

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure