### PR TITLE
Fix ESPHome unnecessary probing on DHCP discovery

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -317,9 +317,10 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             raise AbortFlow("already_configured")
         configured_host: str | None = entry.data.get(CONF_HOST)
         configured_port: int | None = entry.data.get(CONF_PORT)
-        if configured_host == host and configured_port == port:
+        # When port is None (from DHCP discovery), only compare hosts
+        if configured_host == host and (port is None or configured_port == port):
             # Don't probe to verify the mac is correct since
-            # the host and port matches.
+            # the host matches (and port matches if provided).
             raise AbortFlow("already_configured")
         configured_psk: str | None = entry.data.get(CONF_NOISE_PSK)
         await self._fetch_device_info(host, port or configured_port, configured_psk)

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -316,7 +316,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             # Don't call _fetch_device_info() for ignored entries
             raise AbortFlow("already_configured")
         configured_host: str | None = entry.data.get(CONF_HOST)
-        configured_port: int | None = entry.data.get(CONF_PORT)
+        configured_port: int = entry.data.get(CONF_PORT, DEFAULT_PORT)
         # When port is None (from DHCP discovery), only compare hosts
         if configured_host == host and (port is None or configured_port == port):
             # Don't probe to verify the mac is correct since


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix ESPHome integration unnecessarily probing devices on DHCP discovery events.

When ESPHome devices renew their DHCP lease or reconnect to the network, the integration was probing them even when the IP address hadn't changed. This was causing rapid connect/disconnect cycles visible in ESPHome logs:

```
[11:28:23][D][api:144]: Accept 192.168.107.8
[11:28:23][W][api.connection:164]: 192.168.107.8: Reading failed CONNECTION_CLOSED errno=11
[11:28:23][D][api:144]: Accept 192.168.107.8
[11:28:23][D][api.connection:1358]: Home Assistant 2025.8.0.dev0 (192.168.107.8) connected
```

The issue occurred because DHCP discovery passes `port=None`, but the code was comparing `configured_port == port` (e.g., `6053 == None`), which always failed and triggered unnecessary probing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr