### PR TITLE
Octoprint: Add services to set Tool and Bed temperatures

### DIFF
--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -36,8 +36,8 @@ from homeassistant.util.ssl import get_default_context, get_default_no_verify_co
 from .const import (
     CONF_BAUDRATE,
     CONF_BED_TEMPERATURE,
-    CONF_TOOL_TEMPERATURE,
     CONF_TOOL_INDEX,
+    CONF_TOOL_TEMPERATURE,
     DOMAIN,
     SERVICE_CONNECT,
     SERVICE_SET_BED_TEMPERATURE,
@@ -160,6 +160,7 @@ SERVICE_SET_TOOL_TEMPERATURE_SCHEMA = vol.Schema(
     }
 )
 
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the OctoPrint component."""
     if DOMAIN not in config:
@@ -251,7 +252,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_set_tool_temperature(call: ServiceCall) -> None:
         """Set tool temperature."""
         client = async_get_client_for_service_call(hass, call)
-        await client.set_tool_temperature(f"tool{call.data.get(CONF_TOOL_INDEX, 0)}", call.data[CONF_TOOL_TEMPERATURE])
+        await client.set_tool_temperature(
+            f"tool{call.data.get(CONF_TOOL_INDEX, 0)}", call.data[CONF_TOOL_TEMPERATURE]
+        )
 
     if not hass.services.has_service(DOMAIN, SERVICE_CONNECT):
         hass.services.async_register(

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_BED_TEMPERATURE,
     CONF_TOOL_INDEX,
     CONF_TOOL_TEMPERATURE,
+    DEFAULT_TOOL_INDEX,
     DOMAIN,
     SERVICE_CONNECT,
     SERVICE_SET_BED_TEMPERATURE,
@@ -156,7 +157,7 @@ SERVICE_SET_TOOL_TEMPERATURE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DEVICE_ID): cv.string,
         vol.Required(CONF_TOOL_TEMPERATURE): vol.All(vol.Coerce(int), vol.Range(min=0, max=999)),
-        vol.Optional(CONF_TOOL_INDEX): vol.All(vol.Coerce(int), vol.Range(min=0, max=999)),
+        vol.Optional(CONF_TOOL_INDEX, default=DEFAULT_TOOL_INDEX): vol.All(vol.Coerce(int), vol.Range(min=0, max=999)),
     }
 )
 
@@ -253,7 +254,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Set tool temperature."""
         client = async_get_client_for_service_call(hass, call)
         await client.set_tool_temperature(
-            f"tool{call.data.get(CONF_TOOL_INDEX, 0)}", call.data[CONF_TOOL_TEMPERATURE]
+            f"tool{call.data.get(CONF_TOOL_INDEX, DEFAULT_TOOL_INDEX)}", call.data[CONF_TOOL_TEMPERATURE]
         )
 
     if not hass.services.has_service(DOMAIN, SERVICE_CONNECT):

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -148,15 +148,15 @@ SERVICE_CONNECT_SCHEMA = vol.Schema(
 SERVICE_SET_BED_TEMPERATURE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Required(CONF_BED_TEMPERATURE): vol.All(vol.Coerce(int), vol.Range(min=0)),
+        vol.Required(CONF_BED_TEMPERATURE): vol.All(vol.Coerce(int), vol.Range(min=0, max=999)),
     }
 )
 
 SERVICE_SET_TOOL_TEMPERATURE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Required(CONF_TOOL_TEMPERATURE): vol.All(vol.Coerce(int), vol.Range(min=0)),
-        vol.Optional(CONF_TOOL_INDEX): vol.All(vol.Coerce(int), vol.Range(min=0)),
+        vol.Required(CONF_TOOL_TEMPERATURE): vol.All(vol.Coerce(int), vol.Range(min=0, max=999)),
+        vol.Optional(CONF_TOOL_INDEX): vol.All(vol.Coerce(int), vol.Range(min=0, max=999)),
     }
 )
 

--- a/homeassistant/components/octoprint/const.py
+++ b/homeassistant/components/octoprint/const.py
@@ -3,6 +3,7 @@
 DOMAIN = "octoprint"
 
 DEFAULT_NAME = "OctoPrint"
+DEFAULT_TOOL_INDEX = 0
 
 SERVICE_CONNECT = "printer_connect"
 SERVICE_SET_TOOL_TEMPERATURE = "set_tool_temperature"

--- a/homeassistant/components/octoprint/const.py
+++ b/homeassistant/components/octoprint/const.py
@@ -5,4 +5,10 @@ DOMAIN = "octoprint"
 DEFAULT_NAME = "OctoPrint"
 
 SERVICE_CONNECT = "printer_connect"
+SERVICE_SET_TOOL_TEMPERATURE = "set_tool_temperature"
+SERVICE_SET_BED_TEMPERATURE = "set_bed_temperature"
+
 CONF_BAUDRATE = "baudrate"
+CONF_BED_TEMPERATURE = "bed_temperature"
+CONF_TOOL_TEMPERATURE = "tool_temperature"
+CONF_TOOL_INDEX = "tool_index"

--- a/homeassistant/components/octoprint/icons.json
+++ b/homeassistant/components/octoprint/icons.json
@@ -2,6 +2,12 @@
   "services": {
     "printer_connect": {
       "service": "mdi:lan-connect"
+    },
+    "set_bed_temperature": {
+      "service": "mdi:radiator"
+    },
+    "set_tool_temperature": {
+      "service": "mdi:printer-3d-nozzle-heat"
     }
   }
 }

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -13,5 +13,6 @@
       "deviceType": "urn:schemas-upnp-org:device:Basic:1"
     }
   ],
-  "zeroconf": ["_octoprint._tcp.local."]
+  "zeroconf": ["_octoprint._tcp.local."],
+  "version": "2025.07.30"
 }

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -13,6 +13,5 @@
       "deviceType": "urn:schemas-upnp-org:device:Basic:1"
     }
   ],
-  "zeroconf": ["_octoprint._tcp.local."],
-  "version": "2025.07.30"
+  "zeroconf": ["_octoprint._tcp.local."]
 }

--- a/homeassistant/components/octoprint/services.yaml
+++ b/homeassistant/components/octoprint/services.yaml
@@ -39,6 +39,7 @@ set_bed_temperature:
       selector:
         number:
           min: 0
+          max: 999
           step: 1
           unit_of_measurement: "°C"
 
@@ -55,6 +56,7 @@ set_tool_temperature:
       selector:
         number:
           min: 0
+          max: 999
           step: 1
           unit_of_measurement: "°C"
     tool_index:
@@ -64,4 +66,5 @@ set_tool_temperature:
       selector:
         number:
           min: 0
+          max: 999
           step: 1

--- a/homeassistant/components/octoprint/services.yaml
+++ b/homeassistant/components/octoprint/services.yaml
@@ -51,6 +51,7 @@ set_tool_temperature:
           integration: octoprint
     tool_temperature:
       required: true
+      example: 200
       selector:
         number:
           min: 0

--- a/homeassistant/components/octoprint/services.yaml
+++ b/homeassistant/components/octoprint/services.yaml
@@ -25,3 +25,42 @@ printer_connect:
             - "115200"
             - "230400"
             - "250000"
+
+set_bed_temperature:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: octoprint
+    bed_temperature:
+      required: true
+      example: 60
+      selector:
+        number:
+          min: 0
+          step: 1
+          unit_of_measurement: "°C"
+
+set_tool_temperature:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: octoprint
+    tool_temperature:
+      required: true
+      selector:
+        number:
+          min: 0
+          step: 1
+          unit_of_measurement: "°C"
+    tool_index:
+      optional: true
+      example: 0
+      default: 0
+      selector:
+        number:
+          min: 0
+          step: 1

--- a/homeassistant/components/octoprint/strings.json
+++ b/homeassistant/components/octoprint/strings.json
@@ -69,8 +69,8 @@
       "description": "Sets the target temperature for the printer's heated bed.",
       "fields": {
         "device_id": {
-          "name": "Server",
-          "description": "The server that should connect."
+          "name": "[%key:component::octoprint::services::printer_connect::fields::device_id::name%]",
+          "description": "[%key:component::octoprint::services::printer_connect::fields::device_id::description%]"
         },
         "bed_temperature": {
           "name": "Bed temperature",
@@ -83,8 +83,8 @@
       "description": "Sets the target temperature for the printer's tool (hotend).",
       "fields": {
         "device_id": {
-          "name": "Server",
-          "description": "The server that should connect."
+          "name": "[%key:component::octoprint::services::printer_connect::fields::device_id::name%]",
+          "description": "[%key:component::octoprint::services::printer_connect::fields::device_id::description%]"
         },
         "tool_temperature": {
           "name": "Tool temperature",

--- a/homeassistant/components/octoprint/strings.json
+++ b/homeassistant/components/octoprint/strings.json
@@ -63,6 +63,38 @@
           "description": "Baud rate."
         }
       }
+    },
+    "set_bed_temperature": {
+      "name": "Set bed temperature",
+      "description": "Sets the target temperature for the printer's heated bed.",
+      "fields": {
+        "device_id": {
+          "name": "Server",
+          "description": "The server that should connect."
+        },
+        "bed_temperature": {
+          "name": "Bed temperature",
+          "description": "Target temperature for the bed in degrees Celsius. 0 to turn off the bed."
+        }
+      }
+    },
+    "set_tool_temperature": {
+      "name": "Set tool temperature",
+      "description": "Sets the target temperature for the printer's tool (hotend).",
+      "fields": {
+        "device_id": {
+          "name": "Server",
+          "description": "The server that should connect."
+        },
+        "tool_temperature": {
+          "name": "Tool temperature",
+          "description": "Target temperature for the tool in degrees Celsius. 0 to turn off the tool."
+        },
+        "tool_index": {
+          "name": "Tool index",
+          "description": "Index of the tool to set the temperature for. Defaults to 0."
+        }
+      }
     }
   }
 }

--- a/tests/components/octoprint/test_services.py
+++ b/tests/components/octoprint/test_services.py
@@ -4,8 +4,13 @@ from unittest.mock import patch
 
 from homeassistant.components.octoprint.const import (
     CONF_BAUDRATE,
+    CONF_BED_TEMPERATURE,
+    CONF_TOOL_INDEX,
+    CONF_TOOL_TEMPERATURE,
     DOMAIN,
     SERVICE_CONNECT,
+    SERVICE_SET_BED_TEMPERATURE,
+    SERVICE_SET_TOOL_TEMPERATURE,
 )
 from homeassistant.const import ATTR_DEVICE_ID, CONF_PORT, CONF_PROFILE_NAME
 from homeassistant.core import HomeAssistant
@@ -65,3 +70,72 @@ async def test_connect_all_arguments(
         connect_command.assert_called_with(
             port="VIRTUAL", printer_profile="Test Profile", baud_rate=9600
         )
+
+async def test_set_bed_temperature(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test the set bed temperature service."""
+    await init_integration(hass, "sensor")
+
+    device = dr.async_entries_for_config_entry(device_registry, "uuid")[0]
+
+    with patch("pyoctoprintapi.OctoprintClient.set_bed_temperature") as set_bed_temp_command:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_BED_TEMPERATURE,
+            {
+                ATTR_DEVICE_ID: device.id,
+                CONF_BED_TEMPERATURE: 60,
+            },
+            blocking=True,
+        )
+
+        assert len(set_bed_temp_command.mock_calls) == 1
+        set_bed_temp_command.assert_called_with(60)
+
+
+async def test_set_tool_temperature_default(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test the set tool temperature service with default tool index."""
+    await init_integration(hass, "sensor")
+
+    device = dr.async_entries_for_config_entry(device_registry, "uuid")[0]
+
+    with patch("pyoctoprintapi.OctoprintClient.set_tool_temperature") as set_tool_temp_command:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_TOOL_TEMPERATURE,
+            {
+                ATTR_DEVICE_ID: device.id,
+                CONF_TOOL_TEMPERATURE: 210,
+            },
+            blocking=True,
+        )
+
+        assert len(set_tool_temp_command.mock_calls) == 1
+        set_tool_temp_command.assert_called_with("tool0", 210)
+
+
+async def test_set_tool_temperature_with_index(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test the set tool temperature service with specific tool index."""
+    await init_integration(hass, "sensor")
+
+    device = dr.async_entries_for_config_entry(device_registry, "uuid")[0]
+
+    with patch("pyoctoprintapi.OctoprintClient.set_tool_temperature") as set_tool_temp_command:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_TOOL_TEMPERATURE,
+            {
+                ATTR_DEVICE_ID: device.id,
+                CONF_TOOL_TEMPERATURE: 210,
+                CONF_TOOL_INDEX: 1,
+            },
+            blocking=True,
+        )
+
+        assert len(set_tool_temp_command.mock_calls) == 1
+        set_tool_temp_command.assert_called_with("tool1", 210)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add two new services `set_bed_temperature` and `set_tool_temperature` to the Octoprint integration.
These services set temperature of print bed and extruder, and can be called as an action from automation or a button. They can be configured fully in the UI.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
`set_bed_temperature` and `set_tool_temperature` use API that already exists in the underlying dependency [rfleming71/pyoctoprintapi](https://github.com/rfleming71/pyoctoprintapi), so no changes to the dependency were needed.. 

### Example usage
A common use case is to create an automation to:
1) Start the printer
2) Connect OctoPrint to the printer using existing service `printer_connect`
3) Sets target bed and extruder temperatures using newly added services `set_bed_temperature` and `set_tool_temperature`

This can be configured fully in the UI, but for clarity's sake, here is YAML that illustrates usage of the services:

### Example automation to call both services
```
alias: Preheat 3D printer
description: "Sets 215/60 temperature"
triggers:
  - trigger: state
    entity_id:
      - input_button.preheat_3d_printer
conditions: []
actions:
  - action: octoprint.set_bed_temperature
    data:
      device_id: 0a6ac5da...
      bed_temperature: 60
  - action: octoprint.set_tool_temperature
    data:
      tool_temperature: 215
      device_id: 0a6ac5da...
mode: single
```
<img width="1074" height="910" alt="image" src="https://github.com/user-attachments/assets/ff2c9c9a-a8f5-4715-9369-eee29e49db1c" />

### Example button to call single service
```
show_name: true
show_icon: true
type: button
tap_action:
  action: perform-action
  perform_action: octoprint.set_bed_temperature
  target: {}
  data:
    device_id: 0a6ac5da784a9ddcf89ef69c1657d1a7
    bed_temperature: 60
name: Preheat 3D printer
icon: mdi:fire
```
<img width="475" height="509" alt="image" src="https://github.com/user-attachments/assets/e7ba2498-149f-4135-8f26-ffa488c38775" />


- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40240
- Link to developer documentation pull request: N/A, but I'd be happy to add it if you tell me where.
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
  - Couldn't get tests to run locally
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/40240

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
