### PR TITLE
Fix initialisation of Apps and Radios list for Squeezebox

### DIFF
--- a/homeassistant/components/squeezebox/browse_media.py
+++ b/homeassistant/components/squeezebox/browse_media.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass, field
+import logging
 from typing import Any
 
 from pysqueezebox import Player
@@ -20,6 +21,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import is_internal_request
 
 from .const import DOMAIN, UNPLAYABLE_TYPES
+
+_LOGGER = logging.getLogger(__name__)
 
 LIBRARY = [
     "favorites",
@@ -138,18 +141,42 @@ class BrowseData:
         self.squeezebox_id_by_type.update(SQUEEZEBOX_ID_BY_TYPE)
         self.media_type_to_squeezebox.update(MEDIA_TYPE_TO_SQUEEZEBOX)
 
+    def add_new_command(self, cmd: str | MediaType, type: str) -> None:
+        """Add items to maps for new apps or radios."""
+        self.known_apps_radios.add(cmd)
+        self.media_type_to_squeezebox[cmd] = cmd
+        self.squeezebox_id_by_type[cmd] = type
+        self.content_type_media_class[cmd] = {
+            "item": MediaClass.DIRECTORY,
+            "children": MediaClass.TRACK,
+        }
+        self.content_type_to_child_type[cmd] = MediaType.TRACK
 
-def _add_new_command_to_browse_data(
-    browse_data: BrowseData, cmd: str | MediaType, type: str
-) -> None:
-    """Add items to maps for new apps or radios."""
-    browse_data.media_type_to_squeezebox[cmd] = cmd
-    browse_data.squeezebox_id_by_type[cmd] = type
-    browse_data.content_type_media_class[cmd] = {
-        "item": MediaClass.DIRECTORY,
-        "children": MediaClass.TRACK,
-    }
-    browse_data.content_type_to_child_type[cmd] = MediaType.TRACK
+    async def async_init(self, player: Player, browse_limit: int) -> None:
+        """Initialize known apps and radios from the player."""
+
+        cmd = ["apps", 0, browse_limit]
+        result = await player.async_query(*cmd)
+        for app in result["appss_loop"]:
+            app_cmd = "app-" + app["cmd"]
+            if app_cmd not in self.known_apps_radios:
+                self.add_new_command(app_cmd, "item_id")
+                _LOGGER.debug(
+                    "Adding new command %s to browse data for player %s",
+                    app_cmd,
+                    player.player_id,
+                )
+        cmd = ["radios", 0, browse_limit]
+        result = await player.async_query(*cmd)
+        for app in result["radioss_loop"]:
+            app_cmd = "app-" + app["cmd"]
+            if app_cmd not in self.known_apps_radios:
+                self.add_new_command(app_cmd, "item_id")
+                _LOGGER.debug(
+                    "Adding new command %s to browse data for player %s",
+                    app_cmd,
+                    player.player_id,
+                )
 
 
 def _build_response_apps_radios_category(
@@ -292,8 +319,7 @@ async def build_item_response(
                 app_cmd = "app-" + item["cmd"]
 
                 if app_cmd not in browse_data.known_apps_radios:
-                    browse_data.known_apps_radios.add(app_cmd)
-                    _add_new_command_to_browse_data(browse_data, app_cmd, "item_id")
+                    browse_data.add_new_command(app_cmd, "item_id")
 
                 child_media = _build_response_apps_radios_category(
                     browse_data=browse_data, cmd=app_cmd, item=item

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -311,6 +311,11 @@ class SqueezeBoxMediaPlayerEntity(SqueezeboxEntity, MediaPlayerEntity):
         )
         return None
 
+    async def async_added_to_hass(self) -> None:
+        """Call when entity is added to hass."""
+        await super().async_added_to_hass()
+        await self._browse_data.async_init(self._player, self.browse_limit)
+
     async def async_will_remove_from_hass(self) -> None:
         """Remove from list of known players when removed from hass."""
         self.coordinator.config_entry.runtime_data.known_player_ids.remove(

--- a/tests/components/squeezebox/test_media_player.py
+++ b/tests/components/squeezebox/test_media_player.py
@@ -765,9 +765,7 @@ async def test_squeezebox_call_query(
         },
         blocking=True,
     )
-    configured_player.async_query.assert_called_once_with(
-        "test_command", "param1", "param2"
-    )
+    configured_player.async_query.assert_called_with("test_command", "param1", "param2")
 
 
 async def test_squeezebox_call_method(
@@ -784,9 +782,7 @@ async def test_squeezebox_call_method(
         },
         blocking=True,
     )
-    configured_player.async_query.assert_called_once_with(
-        "test_command", "param1", "param2"
-    )
+    configured_player.async_query.assert_called_with("test_command", "param1", "param2")
 
 
 async def test_squeezebox_invalid_state(


### PR DESCRIPTION
## Proposed change
The Squeezebox integration maintains a list of known apps and radios plugins on the LMS for each player.  Currently, this list is built dynamically when it's used by the media browser.  However, this will cause automations to fail if they try and use one of these apps before the media browser is used manually.  This fix adds a async_added_to_hass to the media_player entity which calls a new function in the browse_data class, async_init, which initialises the list of known apps and radio plugins on startup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #149701
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
