### PR TITLE
Improve code quality for garage door modules in homematicip_cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -283,19 +283,19 @@ class HomematicipGarageDoorModule(HomematicipGenericEntity, CoverEntity):
     @property
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
-        return self._device.doorState == DoorState.CLOSED
+        return self.functional_channel.doorState == DoorState.CLOSED
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self._device.send_door_command_async(DoorCommand.OPEN)
+        await self.functional_channel.async_send_door_command(DoorCommand.OPEN)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        await self._device.send_door_command_async(DoorCommand.CLOSE)
+        await self.functional_channel.async_send_door_command(DoorCommand.CLOSE)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self._device.send_door_command_async(DoorCommand.STOP)
+        await self.functional_channel.async_send_door_command(DoorCommand.STOP)
 
 
 class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -365,14 +365,16 @@ async def test_hmip_garage_door_tormatic(
 
     assert ha_state.state == "closed"
     assert ha_state.attributes["current_position"] == 0
-    service_call_counter = len(hmip_device.mock_calls)
+    service_call_counter = len(hmip_device.functionalChannels[1].mock_calls)
 
     await hass.services.async_call(
         "cover", "open_cover", {"entity_id": entity_id}, blocking=True
     )
-    assert len(hmip_device.mock_calls) == service_call_counter + 1
-    assert hmip_device.mock_calls[-1][0] == "send_door_command_async"
-    assert hmip_device.mock_calls[-1][1] == (DoorCommand.OPEN,)
+    assert len(hmip_device.functionalChannels[1].mock_calls) == service_call_counter + 1
+    assert (
+        hmip_device.functionalChannels[1].mock_calls[-1][0] == "async_send_door_command"
+    )
+    assert hmip_device.functionalChannels[1].mock_calls[-1][1] == (DoorCommand.OPEN,)
     await async_manipulate_test_data(hass, hmip_device, "doorState", DoorState.OPEN)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == CoverState.OPEN
@@ -381,9 +383,11 @@ async def test_hmip_garage_door_tormatic(
     await hass.services.async_call(
         "cover", "close_cover", {"entity_id": entity_id}, blocking=True
     )
-    assert len(hmip_device.mock_calls) == service_call_counter + 3
-    assert hmip_device.mock_calls[-1][0] == "send_door_command_async"
-    assert hmip_device.mock_calls[-1][1] == (DoorCommand.CLOSE,)
+    assert len(hmip_device.functionalChannels[1].mock_calls) == service_call_counter + 2
+    assert (
+        hmip_device.functionalChannels[1].mock_calls[-1][0] == "async_send_door_command"
+    )
+    assert hmip_device.functionalChannels[1].mock_calls[-1][1] == (DoorCommand.CLOSE,)
     await async_manipulate_test_data(hass, hmip_device, "doorState", DoorState.CLOSED)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == CoverState.CLOSED
@@ -392,9 +396,11 @@ async def test_hmip_garage_door_tormatic(
     await hass.services.async_call(
         "cover", "stop_cover", {"entity_id": entity_id}, blocking=True
     )
-    assert len(hmip_device.mock_calls) == service_call_counter + 5
-    assert hmip_device.mock_calls[-1][0] == "send_door_command_async"
-    assert hmip_device.mock_calls[-1][1] == (DoorCommand.STOP,)
+    assert len(hmip_device.functionalChannels[1].mock_calls) == service_call_counter + 3
+    assert (
+        hmip_device.functionalChannels[1].mock_calls[-1][0] == "async_send_door_command"
+    )
+    assert hmip_device.functionalChannels[1].mock_calls[-1][1] == (DoorCommand.STOP,)
 
 
 async def test_hmip_garage_door_hoermann(
@@ -414,14 +420,16 @@ async def test_hmip_garage_door_hoermann(
 
     assert ha_state.state == "closed"
     assert ha_state.attributes["current_position"] == 0
-    service_call_counter = len(hmip_device.mock_calls)
+    service_call_counter = len(hmip_device.functionalChannels[1].mock_calls)
 
     await hass.services.async_call(
         "cover", "open_cover", {"entity_id": entity_id}, blocking=True
     )
-    assert len(hmip_device.mock_calls) == service_call_counter + 1
-    assert hmip_device.mock_calls[-1][0] == "send_door_command_async"
-    assert hmip_device.mock_calls[-1][1] == (DoorCommand.OPEN,)
+    assert len(hmip_device.functionalChannels[1].mock_calls) == service_call_counter + 1
+    assert (
+        hmip_device.functionalChannels[1].mock_calls[-1][0] == "async_send_door_command"
+    )
+    assert hmip_device.functionalChannels[1].mock_calls[-1][1] == (DoorCommand.OPEN,)
     await async_manipulate_test_data(hass, hmip_device, "doorState", DoorState.OPEN)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == CoverState.OPEN
@@ -430,9 +438,11 @@ async def test_hmip_garage_door_hoermann(
     await hass.services.async_call(
         "cover", "close_cover", {"entity_id": entity_id}, blocking=True
     )
-    assert len(hmip_device.mock_calls) == service_call_counter + 3
-    assert hmip_device.mock_calls[-1][0] == "send_door_command_async"
-    assert hmip_device.mock_calls[-1][1] == (DoorCommand.CLOSE,)
+    assert len(hmip_device.functionalChannels[1].mock_calls) == service_call_counter + 2
+    assert (
+        hmip_device.functionalChannels[1].mock_calls[-1][0] == "async_send_door_command"
+    )
+    assert hmip_device.functionalChannels[1].mock_calls[-1][1] == (DoorCommand.CLOSE,)
     await async_manipulate_test_data(hass, hmip_device, "doorState", DoorState.CLOSED)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == CoverState.CLOSED
@@ -441,9 +451,11 @@ async def test_hmip_garage_door_hoermann(
     await hass.services.async_call(
         "cover", "stop_cover", {"entity_id": entity_id}, blocking=True
     )
-    assert len(hmip_device.mock_calls) == service_call_counter + 5
-    assert hmip_device.mock_calls[-1][0] == "send_door_command_async"
-    assert hmip_device.mock_calls[-1][1] == (DoorCommand.STOP,)
+    assert len(hmip_device.functionalChannels[1].mock_calls) == service_call_counter + 3
+    assert (
+        hmip_device.functionalChannels[1].mock_calls[-1][0] == "async_send_door_command"
+    )
+    assert hmip_device.functionalChannels[1].mock_calls[-1][1] == (DoorCommand.STOP,)
 
 
 async def test_hmip_cover_shutter_group(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve code quality for garage door modules. Call functions for functional channels directly instead of using deprecated functions in devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/hahn-th/homematicip-rest-api/issues/589
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
