### PR TITLE
Fix Z-Wave handling of driver ready event

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -105,7 +105,6 @@ from .const import (
     CONF_USB_PATH,
     CONF_USE_ADDON,
     DOMAIN,
-    DRIVER_READY_TIMEOUT,
     EVENT_DEVICE_ADDED_TO_REGISTRY,
     EVENT_VALUE_UPDATED,
     LIB_LOGGER,
@@ -136,6 +135,7 @@ from .models import ZwaveJSConfigEntry, ZwaveJSData
 from .services import async_setup_services
 
 CONNECT_TIMEOUT = 10
+DRIVER_READY_TIMEOUT = 60
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -365,6 +365,16 @@ class DriverEvents:
                 self.controller_events.async_on_node_added(node)
                 for node in controller.nodes.values()
                 if node != controller.own_node
+            )
+        )
+
+        # listen for driver ready event to reload the config entry
+        self.config_entry.async_on_unload(
+            driver.on(
+                "driver ready",
+                lambda _: self.hass.config_entries.async_schedule_reload(
+                    self.config_entry.entry_id
+                ),
             )
         )
 

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -201,7 +201,3 @@ COVER_TILT_PROPERTY_KEYS: set[str | int | None] = {
     WindowCoveringPropertyKey.VERTICAL_SLATS_ANGLE,
     WindowCoveringPropertyKey.VERTICAL_SLATS_ANGLE_NO_POSITION,
 }
-
-# Other constants
-
-DRIVER_READY_TIMEOUT = 60

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -613,7 +613,7 @@ def async_wait_for_driver_ready_event(
 
     @callback
     def driver_ready_received(event: dict) -> None:
-        "Receive the driver ready event."
+        """Receive the driver ready event."""
         driver_ready_event_received.set()
 
     unsubscribers.append(driver.once("driver ready", driver_ready_received))

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import astuple, dataclass
 import logging
 from typing import Any, cast
@@ -56,6 +56,7 @@ from .const import (
 )
 from .models import ZwaveJSConfigEntry
 
+DRIVER_READY_EVENT_TIMEOUT = 60
 SERVER_VERSION_TIMEOUT = 10
 
 
@@ -586,6 +587,58 @@ async def async_get_version_info(hass: HomeAssistant, ws_address: str) -> Versio
         raise CannotConnect from err
 
     return version_info
+
+
+@callback
+def async_wait_for_driver_ready_event(
+    config_entry: ZwaveJSConfigEntry,
+    driver: Driver,
+) -> Callable[[], Coroutine[Any, Any, None]]:
+    """Wait for the driver ready event and the config entry reload.
+
+    When the driver ready event is received
+    the config entry will be reloaded by the integration.
+    This function helps wait for that to happen
+    before proceeding with further actions.
+
+    If the config entry is reloaded for another reason,
+    this function will not wait for it to be reloaded again.
+
+    Raises TimeoutError if the driver ready event and reload
+    is not received within the specified timeout.
+    """
+    driver_ready_event_received = asyncio.Event()
+    config_entry_reloaded = asyncio.Event()
+    unsubscribers: list[Callable[[], None]] = []
+
+    @callback
+    def driver_ready_received(event: dict) -> None:
+        "Receive the driver ready event."
+        driver_ready_event_received.set()
+
+    unsubscribers.append(driver.once("driver ready", driver_ready_received))
+
+    @callback
+    def on_config_entry_state_change() -> None:
+        """Check config entry was loaded after driver ready event."""
+        if config_entry.state is ConfigEntryState.LOADED:
+            config_entry_reloaded.set()
+
+    unsubscribers.append(
+        config_entry.async_on_state_change(on_config_entry_state_change)
+    )
+
+    async def wait_for_events() -> None:
+        try:
+            async with asyncio.timeout(DRIVER_READY_EVENT_TIMEOUT):
+                await asyncio.gather(
+                    driver_ready_event_received.wait(), config_entry_reloaded.wait()
+                )
+        finally:
+            for unsubscribe in unsubscribers:
+                unsubscribe()
+
+    return wait_for_events
 
 
 class CannotConnect(HomeAssistantError):

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1,5 +1,6 @@
 """Test the Z-Wave JS Websocket API."""
 
+import asyncio
 from copy import deepcopy
 from http import HTTPStatus
 from io import BytesIO
@@ -5109,17 +5110,12 @@ async def test_hard_reset_controller(
     ws_client = await hass_ws_client(hass)
     assert entry.unique_id == "3245146787"
 
-    async def async_send_command_driver_ready(
-        message: dict[str, Any],
-        require_schema: int | None = None,
-    ) -> dict:
-        """Send a command and get a response."""
+    async def mock_driver_hard_reset() -> None:
         client.driver.emit(
             "driver ready", {"event": "driver ready", "source": "driver"}
         )
-        return {}
 
-    client.async_send_command.side_effect = async_send_command_driver_ready
+    client.driver.async_hard_reset = AsyncMock(side_effect=mock_driver_hard_reset)
 
     await ws_client.send_json_auto_id(
         {
@@ -5128,6 +5124,7 @@ async def test_hard_reset_controller(
         }
     )
     msg = await ws_client.receive_json()
+    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
@@ -5135,16 +5132,10 @@ async def test_hard_reset_controller(
     assert device is not None
     assert msg["result"] == device.id
     assert msg["success"]
-
-    assert client.async_send_command.call_count == 3
-    # The first call is the relevant hard reset command.
-    # 25 is the require_schema parameter.
-    assert client.async_send_command.call_args_list[0] == call(
-        {"command": "driver.hard_reset"}, 25
-    )
+    assert client.driver.async_hard_reset.call_count == 1
     assert entry.unique_id == "1234"
 
-    client.async_send_command.reset_mock()
+    client.driver.async_hard_reset.reset_mock()
 
     # Test client connect error when getting the server version.
 
@@ -5158,6 +5149,7 @@ async def test_hard_reset_controller(
     )
 
     msg = await ws_client.receive_json()
+    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
@@ -5165,33 +5157,24 @@ async def test_hard_reset_controller(
     assert device is not None
     assert msg["result"] == device.id
     assert msg["success"]
-
-    assert client.async_send_command.call_count == 3
-    # The first call is the relevant hard reset command.
-    # 25 is the require_schema parameter.
-    assert client.async_send_command.call_args_list[0] == call(
-        {"command": "driver.hard_reset"}, 25
-    )
+    assert client.driver.async_hard_reset.call_count == 1
     assert (
-        "Failed to get server version, cannot update config entry"
+        "Failed to get server version, cannot update config entry "
         "unique id with new home id, after controller reset"
     ) in caplog.text
 
-    client.async_send_command.reset_mock()
+    client.driver.async_hard_reset.reset_mock()
+    get_server_version.side_effect = None
 
     # Test sending command with driver not ready and timeout.
 
-    async def async_send_command_no_driver_ready(
-        message: dict[str, Any],
-        require_schema: int | None = None,
-    ) -> dict:
-        """Send a command and get a response."""
-        return {}
+    async def mock_driver_hard_reset_no_driver_ready() -> None:
+        pass
 
-    client.async_send_command.side_effect = async_send_command_no_driver_ready
+    client.driver.async_hard_reset.side_effect = mock_driver_hard_reset_no_driver_ready
 
     with patch(
-        "homeassistant.components.zwave_js.api.DRIVER_READY_TIMEOUT",
+        "homeassistant.components.zwave_js.helpers.DRIVER_READY_EVENT_TIMEOUT",
         new=0,
     ):
         await ws_client.send_json_auto_id(
@@ -5201,6 +5184,7 @@ async def test_hard_reset_controller(
             }
         )
         msg = await ws_client.receive_json()
+        await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
@@ -5208,32 +5192,29 @@ async def test_hard_reset_controller(
     assert device is not None
     assert msg["result"] == device.id
     assert msg["success"]
+    assert client.driver.async_hard_reset.call_count == 1
 
-    assert client.async_send_command.call_count == 3
-    # The first call is the relevant hard reset command.
-    # 25 is the require_schema parameter.
-    assert client.async_send_command.call_args_list[0] == call(
-        {"command": "driver.hard_reset"}, 25
-    )
-
-    client.async_send_command.reset_mock()
+    client.driver.async_hard_reset.reset_mock()
 
     # Test FailedZWaveCommand is caught
-    with patch(
-        "zwave_js_server.model.driver.Driver.async_hard_reset",
-        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
-    ):
-        await ws_client.send_json_auto_id(
-            {
-                TYPE: "zwave_js/hard_reset_controller",
-                ENTRY_ID: entry.entry_id,
-            }
-        )
-        msg = await ws_client.receive_json()
+    client.driver.async_hard_reset.side_effect = FailedZWaveCommand(
+        "failed_command", 1, "error message"
+    )
 
-        assert not msg["success"]
-        assert msg["error"]["code"] == "zwave_error"
-        assert msg["error"]["message"] == "zwave_error: Z-Wave error 1 - error message"
+    await ws_client.send_json_auto_id(
+        {
+            TYPE: "zwave_js/hard_reset_controller",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "zwave_error"
+    assert msg["error"]["message"] == "zwave_error: Z-Wave error 1 - error message"
+    assert client.driver.async_hard_reset.call_count == 1
+
+    client.driver.async_hard_reset.side_effect = None
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -5578,17 +5559,24 @@ async def test_restore_nvm(
     # Set up mocks for the controller events
     controller = client.driver.controller
 
-    async def async_send_command_driver_ready(
-        message: dict[str, Any],
-        require_schema: int | None = None,
-    ) -> dict:
-        """Send a command and get a response."""
+    async def mock_restore_nvm_base64(
+        self, base64_data: str, options: dict[str, bool] | None = None
+    ) -> None:
+        controller.emit(
+            "nvm convert progress",
+            {"event": "nvm convert progress", "bytesRead": 100, "total": 200},
+        )
+        await asyncio.sleep(0)
+        controller.emit(
+            "nvm restore progress",
+            {"event": "nvm restore progress", "bytesWritten": 150, "total": 200},
+        )
+        controller.data["homeId"] = 3245146787
         client.driver.emit(
             "driver ready", {"event": "driver ready", "source": "driver"}
         )
-        return {}
 
-    client.async_send_command.side_effect = async_send_command_driver_ready
+    controller.async_restore_nvm_base64 = AsyncMock(side_effect=mock_restore_nvm_base64)
 
     # Send the subscription request
     await ws_client.send_json_auto_id(
@@ -5599,7 +5587,19 @@ async def test_restore_nvm(
         }
     )
 
-    # Verify the finished event first
+    # Verify the convert progress event
+    msg = await ws_client.receive_json()
+    assert msg["event"]["event"] == "nvm convert progress"
+    assert msg["event"]["bytesRead"] == 100
+    assert msg["event"]["total"] == 200
+
+    # Verify the restore progress event
+    msg = await ws_client.receive_json()
+    assert msg["event"]["event"] == "nvm restore progress"
+    assert msg["event"]["bytesWritten"] == 150
+    assert msg["event"]["total"] == 200
+
+    # Verify the finished event
     msg = await ws_client.receive_json()
     assert msg["type"] == "event"
     assert msg["event"]["event"] == "finished"
@@ -5609,53 +5609,18 @@ async def test_restore_nvm(
     assert msg["type"] == "result"
     assert msg["success"] is True
 
-    # Simulate progress events
-    event = Event(
-        "nvm restore progress",
-        {
-            "source": "controller",
-            "event": "nvm restore progress",
-            "bytesWritten": 25,
-            "total": 100,
-        },
-    )
-    controller.receive_event(event)
-    msg = await ws_client.receive_json()
-    assert msg["event"]["event"] == "nvm restore progress"
-    assert msg["event"]["bytesWritten"] == 25
-    assert msg["event"]["total"] == 100
-
-    event = Event(
-        "nvm restore progress",
-        {
-            "source": "controller",
-            "event": "nvm restore progress",
-            "bytesWritten": 50,
-            "total": 100,
-        },
-    )
-    controller.receive_event(event)
-    msg = await ws_client.receive_json()
-    assert msg["event"]["event"] == "nvm restore progress"
-    assert msg["event"]["bytesWritten"] == 50
-    assert msg["event"]["total"] == 100
-
     await hass.async_block_till_done()
 
     # Verify the restore was called
     # The first call is the relevant one for nvm restore.
-    assert client.async_send_command.call_count == 3
-    assert client.async_send_command.call_args_list[0] == call(
-        {
-            "command": "controller.restore_nvm",
-            "nvmData": "dGVzdA==",
-            "migrateOptions": {"preserveRoutes": False},
-        },
-        require_schema=42,
+    assert controller.async_restore_nvm_base64.call_count == 1
+    assert controller.async_restore_nvm_base64.call_args == call(
+        "dGVzdA==",
+        {"preserveRoutes": False},
     )
     assert entry.unique_id == "1234"
 
-    client.async_send_command.reset_mock()
+    controller.async_restore_nvm_base64.reset_mock()
 
     # Test client connect error when getting the server version.
 
@@ -5670,7 +5635,19 @@ async def test_restore_nvm(
         }
     )
 
-    # Verify the finished event first
+    # Verify the convert progress event
+    msg = await ws_client.receive_json()
+    assert msg["event"]["event"] == "nvm convert progress"
+    assert msg["event"]["bytesRead"] == 100
+    assert msg["event"]["total"] == 200
+
+    # Verify the restore progress event
+    msg = await ws_client.receive_json()
+    assert msg["event"]["event"] == "nvm restore progress"
+    assert msg["event"]["bytesWritten"] == 150
+    assert msg["event"]["total"] == 200
+
+    # Verify the finished event
     msg = await ws_client.receive_json()
     assert msg["type"] == "event"
     assert msg["event"]["event"] == "finished"
@@ -5680,47 +5657,46 @@ async def test_restore_nvm(
     assert msg["type"] == "result"
     assert msg["success"] is True
 
-    assert client.async_send_command.call_count == 3
-    assert client.async_send_command.call_args_list[0] == call(
-        {
-            "command": "controller.restore_nvm",
-            "nvmData": "dGVzdA==",
-            "migrateOptions": {"preserveRoutes": False},
-        },
-        require_schema=42,
+    await hass.async_block_till_done()
+
+    assert controller.async_restore_nvm_base64.call_count == 1
+    assert controller.async_restore_nvm_base64.call_args == call(
+        "dGVzdA==",
+        {"preserveRoutes": False},
     )
     assert (
-        "Failed to get server version, cannot update config entry"
+        "Failed to get server version, cannot update config entry "
         "unique id with new home id, after controller NVM restore"
     ) in caplog.text
 
-    client.async_send_command.reset_mock()
+    controller.async_restore_nvm_base64.reset_mock()
+    get_server_version.side_effect = None
 
-    # Test sending command with driver not ready and timeout.
+    # Test sending command without driver ready event causing timeout.
 
-    async def async_send_command_no_driver_ready(
-        message: dict[str, Any],
-        require_schema: int | None = None,
-    ) -> dict:
-        """Send a command and get a response."""
-        return {}
+    async def mock_restore_nvm_without_driver_ready(
+        data: bytes, options: dict[str, bool] | None = None
+    ):
+        controller.data["homeId"] = 3245146787
 
-    client.async_send_command.side_effect = async_send_command_no_driver_ready
+    controller.async_restore_nvm_base64.side_effect = (
+        mock_restore_nvm_without_driver_ready
+    )
 
     with patch(
-        "homeassistant.components.zwave_js.api.DRIVER_READY_TIMEOUT",
+        "homeassistant.components.zwave_js.helpers.DRIVER_READY_EVENT_TIMEOUT",
         new=0,
     ):
         # Send the subscription request
         await ws_client.send_json_auto_id(
             {
                 "type": "zwave_js/restore_nvm",
-                "entry_id": integration.entry_id,
+                "entry_id": entry.entry_id,
                 "data": "dGVzdA==",  # base64 encoded "test"
             }
         )
 
-        # Verify the finished event first
+        # Verify the finished event
         msg = await ws_client.receive_json()
 
         assert msg["type"] == "event"
@@ -5734,37 +5710,41 @@ async def test_restore_nvm(
         await hass.async_block_till_done()
 
     # Verify the restore was called
-    # The first call is the relevant one for nvm restore.
-    assert client.async_send_command.call_count == 3
-    assert client.async_send_command.call_args_list[0] == call(
-        {
-            "command": "controller.restore_nvm",
-            "nvmData": "dGVzdA==",
-            "migrateOptions": {"preserveRoutes": False},
-        },
-        require_schema=42,
+    assert controller.async_restore_nvm_base64.call_count == 1
+    assert controller.async_restore_nvm_base64.call_args == call(
+        "dGVzdA==",
+        {"preserveRoutes": False},
     )
 
-    client.async_send_command.reset_mock()
+    controller.async_restore_nvm_base64.reset_mock()
 
     # Test restore failure
-    with patch(
-        f"{CONTROLLER_PATCH_PREFIX}.async_restore_nvm_base64",
-        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
-    ):
-        # Send the subscription request
-        await ws_client.send_json_auto_id(
-            {
-                "type": "zwave_js/restore_nvm",
-                "entry_id": integration.entry_id,
-                "data": "dGVzdA==",  # base64 encoded "test"
-            }
-        )
+    controller.async_restore_nvm_base64.side_effect = FailedZWaveCommand(
+        "failed_command", 1, "error message"
+    )
 
-        # Verify error response
-        msg = await ws_client.receive_json()
-        assert not msg["success"]
-        assert msg["error"]["code"] == "zwave_error"
+    # Send the subscription request
+    await ws_client.send_json_auto_id(
+        {
+            "type": "zwave_js/restore_nvm",
+            "entry_id": entry.entry_id,
+            "data": "dGVzdA==",  # base64 encoded "test"
+        }
+    )
+
+    # Verify error response
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "zwave_error"
+
+    await hass.async_block_till_done()
+
+    # Verify the restore was called
+    assert controller.async_restore_nvm_base64.call_count == 1
+    assert controller.async_restore_nvm_base64.call_args == call(
+        "dGVzdA==",
+        {"preserveRoutes": False},
+    )
 
     # Test entry_id not found
     await ws_client.send_json_auto_id(
@@ -5779,13 +5759,13 @@ async def test_restore_nvm(
     assert msg["error"]["code"] == "not_found"
 
     # Test config entry not loaded
-    await hass.config_entries.async_unload(integration.entry_id)
+    await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json_auto_id(
         {
             "type": "zwave_js/restore_nvm",
-            "entry_id": integration.entry_id,
+            "entry_id": entry.entry_id,
             "data": "dGVzdA==",  # base64 encoded "test"
         }
     )

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1101,7 +1101,7 @@ async def test_usb_discovery_migration_restore_driver_ready_timeout(
     assert restart_addon.call_args == call("core_zwave_js")
 
     with patch(
-        ("homeassistant.components.zwave_js.config_flow.DRIVER_READY_TIMEOUT"),
+        ("homeassistant.components.zwave_js.helpers.DRIVER_READY_EVENT_TIMEOUT"),
         new=0,
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -1111,7 +1111,7 @@ async def test_usb_discovery_migration_restore_driver_ready_timeout(
         assert client.connect.call_count == 2
 
         await hass.async_block_till_done()
-        assert client.connect.call_count == 4
+        assert client.connect.call_count == 3
         assert entry.state is config_entries.ConfigEntryState.LOADED
         assert client.driver.controller.async_restore_nvm.call_count == 1
         assert len(events) == 2
@@ -3897,7 +3897,7 @@ async def test_reconfigure_migrate_restore_driver_ready_timeout(
     assert restart_addon.call_args == call("core_zwave_js")
 
     with patch(
-        ("homeassistant.components.zwave_js.config_flow.DRIVER_READY_TIMEOUT"),
+        ("homeassistant.components.zwave_js.helpers.DRIVER_READY_EVENT_TIMEOUT"),
         new=0,
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -3907,7 +3907,7 @@ async def test_reconfigure_migrate_restore_driver_ready_timeout(
         assert client.connect.call_count == 2
 
         await hass.async_block_till_done()
-        assert client.connect.call_count == 4
+        assert client.connect.call_count == 3
         assert entry.state is config_entries.ConfigEntryState.LOADED
         assert client.driver.controller.async_restore_nvm.call_count == 1
         assert len(events) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Reload the config entry when receiving a driver ready event. A driver ready event is received, eg after updating the controller firmware, or restoring NVM to the controller.
- Reloading the config entry is needed to clean out and update the stored model state in the client.
- Before we only listened to the driver ready event when hard resetting the controller and when restoring controller NVM from inside Home Assistant. This isn't enough since the event can be triggered also from an outside source (like Z-Wave JS UI).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/75
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
