### PR TITLE
Add jitter sensor to Ping integration

### DIFF
--- a/homeassistant/components/ping/helpers.py
+++ b/homeassistant/components/ping/helpers.py
@@ -79,6 +79,7 @@ class PingDataICMPLib(PingData):
             "min": data.min_rtt,
             "max": data.max_rtt,
             "avg": data.avg_rtt,
+            "jitter": data.jitter,
         }
 
 

--- a/homeassistant/components/ping/sensor.py
+++ b/homeassistant/components/ping/sensor.py
@@ -72,8 +72,8 @@ SENSORS: tuple[PingSensorEntityDescription, ...] = (
         has_fn=lambda result: "min" in result.data,
     ),
     PingSensorEntityDescription(
-        key="round_trip_time_jitter",
-        translation_key="round_trip_time_jitter",
+        key="jitter",
+        translation_key="jitter",
         native_unit_of_measurement=UnitOfTime.MILLISECONDS,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DURATION,

--- a/homeassistant/components/ping/sensor.py
+++ b/homeassistant/components/ping/sensor.py
@@ -71,6 +71,17 @@ SENSORS: tuple[PingSensorEntityDescription, ...] = (
         value_fn=lambda result: result.data.get("min"),
         has_fn=lambda result: "min" in result.data,
     ),
+    PingSensorEntityDescription(
+        key="round_trip_time_jitter",
+        translation_key="round_trip_time_jitter",
+        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.DURATION,
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda result: result.data.get("jitter"),
+        has_fn=lambda result: "jitter" in result.data,
+    ),
 )
 
 

--- a/homeassistant/components/ping/strings.json
+++ b/homeassistant/components/ping/strings.json
@@ -12,6 +12,9 @@
       },
       "round_trip_time_min": {
         "name": "Round-trip time minimum"
+      },
+      "round_trip_time_jitter": {
+        "name": "Round-trip time jitter"
       }
     }
   },

--- a/homeassistant/components/ping/strings.json
+++ b/homeassistant/components/ping/strings.json
@@ -13,8 +13,8 @@
       "round_trip_time_min": {
         "name": "Round-trip time minimum"
       },
-      "round_trip_time_jitter": {
-        "name": "Round-trip time jitter"
+      "jitter": {
+        "name": "Jitter"
       }
     }
   },

--- a/tests/components/ping/snapshots/test_sensor.ambr
+++ b/tests/components/ping/snapshots/test_sensor.ambr
@@ -1,4 +1,59 @@
 # serializer version: 1
+# name: test_setup_and_update[jitter]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.10_10_10_10_jitter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Jitter',
+    'platform': 'ping',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'jitter',
+    'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+  })
+# ---
+# name: test_setup_and_update[jitter].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': '10.10.10.10 Jitter',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.10_10_10_10_jitter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.5',
+  })
+# ---
 # name: test_setup_and_update[round_trip_time_average]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/ping/snapshots/test_sensor.ambr
+++ b/tests/components/ping/snapshots/test_sensor.ambr
@@ -109,61 +109,6 @@
     'state': '4.8',
   })
 # ---
-# name: test_setup_and_update[round_trip_time_jitter]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.10_10_10_10_round_trip_time_jitter',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
-    'original_icon': None,
-    'original_name': 'Round-trip time jitter',
-    'platform': 'ping',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'round_trip_time_jitter',
-    'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
-  })
-# ---
-# name: test_setup_and_update[round_trip_time_jitter].1
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': '10.10.10.10 Round-trip time jitter',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.10_10_10_10_round_trip_time_jitter',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '3.5',
-  })
-# ---
 # name: test_setup_and_update[round_trip_time_maximum]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/ping/snapshots/test_sensor.ambr
+++ b/tests/components/ping/snapshots/test_sensor.ambr
@@ -54,6 +54,61 @@
     'state': '4.8',
   })
 # ---
+# name: test_setup_and_update[round_trip_time_jitter]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.10_10_10_10_round_trip_time_jitter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Round-trip time jitter',
+    'platform': 'ping',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'round_trip_time_jitter',
+    'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+  })
+# ---
+# name: test_setup_and_update[round_trip_time_jitter].1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': '10.10.10.10 Round-trip time jitter',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.10_10_10_10_round_trip_time_jitter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.5',
+  })
+# ---
 # name: test_setup_and_update[round_trip_time_maximum]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/ping/test_sensor.py
+++ b/tests/components/ping/test_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import entity_registry as er
         "round_trip_time_maximum",
         "round_trip_time_mean_deviation",  # should be None in the snapshot
         "round_trip_time_minimum",
+        "round_trip_time_jitter",
     ],
 )
 async def test_setup_and_update(

--- a/tests/components/ping/test_sensor.py
+++ b/tests/components/ping/test_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import entity_registry as er
         "round_trip_time_maximum",
         "round_trip_time_mean_deviation",  # should be None in the snapshot
         "round_trip_time_minimum",
-        "round_trip_time_jitter",
+        "jitter",
     ],
 )
 async def test_setup_and_update(


### PR DESCRIPTION
## Proposed change
Make the RTT jitter available as sensor in Ping integration. This solves a feature request https://github.com/orgs/home-assistant/discussions/485

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40259
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
