### PR TITLE
Do not create Tuya fan entities without control

### DIFF
--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -45,6 +45,8 @@ TUYA_SUPPORT_TYPE = {
     "ks",
 }
 
+_SWITCH_DP_CODES = (DPCode.SWITCH_FAN, DPCode.FAN_SWITCH, DPCode.SWITCH)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -60,7 +62,9 @@ async def async_setup_entry(
         entities: list[TuyaFanEntity] = []
         for device_id in device_ids:
             device = hass_data.manager.device_map[device_id]
-            if device and device.category in TUYA_SUPPORT_TYPE:
+            if device.category in TUYA_SUPPORT_TYPE and any(
+                code in device.status for code in _SWITCH_DP_CODES
+            ):
                 entities.append(TuyaFanEntity(device, hass_data.manager))
         async_add_entities(entities)
 
@@ -90,9 +94,7 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
         """Init Tuya Fan Device."""
         super().__init__(device, device_manager)
 
-        self._switch = self.find_dpcode(
-            (DPCode.SWITCH_FAN, DPCode.FAN_SWITCH, DPCode.SWITCH), prefer_function=True
-        )
+        self._switch = self.find_dpcode(_SWITCH_DP_CODES, prefer_function=True)
 
         self._attr_preset_modes = []
         if enum_type := self.find_dpcode(

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -43,8 +43,8 @@ DEVICE_MOCKS = {
     ],
     "cs_vmxuxszzjwp5smli": [
         # https://github.com/home-assistant/core/issues/119865
-        Platform.FAN,
-        Platform.HUMIDIFIER,
+        # Platform.FAN, missing DPCodes in device status
+        Platform.HUMIDIFIER
     ],
     "cs_zibqa9dutqyaxym2": [
         Platform.BINARY_SENSOR,
@@ -213,6 +213,10 @@ DEVICE_MOCKS = {
     "dlq_kxdr6su0c55p7bbo": [
         # https://github.com/home-assistant/core/issues/143499
         Platform.SENSOR,
+    ],
+    "fs_ibytpo6fpnugft1c": [
+        # https://github.com/home-assistant/core/issues/135541
+        # Platform.FAN, missing DPCodes in device status
     ],
     "gyd_lgekqfxdabipm3tn": [
         # https://github.com/home-assistant/core/issues/133173

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -44,7 +44,7 @@ DEVICE_MOCKS = {
     "cs_vmxuxszzjwp5smli": [
         # https://github.com/home-assistant/core/issues/119865
         # Platform.FAN, missing DPCodes in device status
-        Platform.HUMIDIFIER
+        Platform.HUMIDIFIER,
     ],
     "cs_zibqa9dutqyaxym2": [
         Platform.BINARY_SENSOR,

--- a/tests/components/tuya/fixtures/fs_ibytpo6fpnugft1c.json
+++ b/tests/components/tuya/fixtures/fs_ibytpo6fpnugft1c.json
@@ -1,0 +1,23 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "terminal_id": "REDACTED",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "id": "10706550a4e57c88b93a",
+  "name": "Ventilador Cama",
+  "category": "fs",
+  "product_id": "ibytpo6fpnugft1c",
+  "product_name": "Tower bladeless fan ",
+  "online": true,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2025-01-10T18:47:46+00:00",
+  "create_time": "2025-01-10T18:47:46+00:00",
+  "update_time": "2025-01-10T18:47:46+00:00",
+  "function": {},
+  "status_range": {},
+  "status": {},
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_fan.ambr
+++ b/tests/components/tuya/snapshots/test_fan.ambr
@@ -53,56 +53,6 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_platform_setup_and_discovery[cs_vmxuxszzjwp5smli][fan.dehumidifier-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'fan',
-    'entity_category': None,
-    'entity_id': 'fan.dehumidifier',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.mock_device_id',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[cs_vmxuxszzjwp5smli][fan.dehumidifier-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Dehumidifier ',
-      'supported_features': <FanEntityFeature: 0>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'fan.dehumidifier',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_platform_setup_and_discovery[cs_zibqa9dutqyaxym2][fan.dehumidifier-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on issue #135541 (and #119865)

If the control switch DPCode is missing from status, we should not be creating the Fan entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
