### PR TITLE
Fix Z-Wave duplicate provisioned device

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -648,29 +648,37 @@ class ControllerEvents:
             provisioning_entry
             and provisioning_entry.additional_properties
             and "device_id" in provisioning_entry.additional_properties
-        ):
-            preprovisioned_device = self.dev_reg.async_get(
-                provisioning_entry.additional_properties["device_id"]
+            and (
+                preprovisioned_device := self.dev_reg.async_get(
+                    provisioning_entry.additional_properties["device_id"]
+                )
             )
+            and (dsk_identifier := (DOMAIN, f"provision_{provisioning_entry.dsk}"))
+            in preprovisioned_device.identifiers
+        ):
+            driver = self.driver_events.driver
+            device_id = get_device_id(driver, node)
+            device_id_ext = get_device_id_ext(driver, node)
+            new_identifiers = preprovisioned_device.identifiers.copy()
+            new_identifiers.remove(dsk_identifier)
+            new_identifiers.add(device_id)
+            if device_id_ext:
+                new_identifiers.add(device_id_ext)
 
-            if preprovisioned_device:
-                dsk = provisioning_entry.dsk
-                dsk_identifier = (DOMAIN, f"provision_{dsk}")
-
-                # If the pre-provisioned device has the DSK identifier, remove it
-                if dsk_identifier in preprovisioned_device.identifiers:
-                    driver = self.driver_events.driver
-                    device_id = get_device_id(driver, node)
-                    device_id_ext = get_device_id_ext(driver, node)
-                    new_identifiers = preprovisioned_device.identifiers.copy()
-                    new_identifiers.remove(dsk_identifier)
-                    new_identifiers.add(device_id)
-                    if device_id_ext:
-                        new_identifiers.add(device_id_ext)
-                    self.dev_reg.async_update_device(
-                        preprovisioned_device.id,
-                        new_identifiers=new_identifiers,
-                    )
+            if self.dev_reg.async_get_device(identifiers=new_identifiers):
+                # If a device entry is registered with the node ID based identifiers,
+                # just remove the device entry with the DSK identifier.
+                self.dev_reg.async_update_device(
+                    preprovisioned_device.id,
+                    remove_config_entry_id=self.config_entry.entry_id,
+                )
+            else:
+                # Add the node ID based identifiers to the device entry
+                # with the DSK identifier and remove the DSK identifier.
+                self.dev_reg.async_update_device(
+                    preprovisioned_device.id,
+                    new_identifiers=new_identifiers,
+                )
 
     async def async_register_node_in_dev_reg(self, node: ZwaveNode) -> dr.DeviceEntry:
         """Register node in dev reg."""

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -509,7 +509,7 @@ class ControllerEvents:
             )
         )
 
-        await self.async_check_preprovisioned_device(node)
+        await self.async_check_pre_provisioned_device(node)
 
         if node.is_controller_node:
             # Create a controller status sensor for each device
@@ -637,8 +637,8 @@ class ControllerEvents:
             f"{DOMAIN}.identify_controller.{dev_id[1]}",
         )
 
-    async def async_check_preprovisioned_device(self, node: ZwaveNode) -> None:
-        """Check if the node was preprovisioned and update the device registry."""
+    async def async_check_pre_provisioned_device(self, node: ZwaveNode) -> None:
+        """Check if the node was pre-provisioned and update the device registry."""
         provisioning_entry = (
             await self.driver_events.driver.controller.async_get_provisioning_entry(
                 node.node_id
@@ -649,17 +649,17 @@ class ControllerEvents:
             and provisioning_entry.additional_properties
             and "device_id" in provisioning_entry.additional_properties
             and (
-                preprovisioned_device := self.dev_reg.async_get(
+                pre_provisioned_device := self.dev_reg.async_get(
                     provisioning_entry.additional_properties["device_id"]
                 )
             )
             and (dsk_identifier := (DOMAIN, f"provision_{provisioning_entry.dsk}"))
-            in preprovisioned_device.identifiers
+            in pre_provisioned_device.identifiers
         ):
             driver = self.driver_events.driver
             device_id = get_device_id(driver, node)
             device_id_ext = get_device_id_ext(driver, node)
-            new_identifiers = preprovisioned_device.identifiers.copy()
+            new_identifiers = pre_provisioned_device.identifiers.copy()
             new_identifiers.remove(dsk_identifier)
             new_identifiers.add(device_id)
             if device_id_ext:
@@ -669,14 +669,14 @@ class ControllerEvents:
                 # If a device entry is registered with the node ID based identifiers,
                 # just remove the device entry with the DSK identifier.
                 self.dev_reg.async_update_device(
-                    preprovisioned_device.id,
+                    pre_provisioned_device.id,
                     remove_config_entry_id=self.config_entry.entry_id,
                 )
             else:
                 # Add the node ID based identifiers to the device entry
                 # with the DSK identifier and remove the DSK identifier.
                 self.dev_reg.async_update_device(
-                    preprovisioned_device.id,
+                    pre_provisioned_device.id,
                     new_identifiers=new_identifiers,
                 )
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -497,17 +497,17 @@ async def test_on_node_added_ready(
     )
 
 
-async def test_on_node_added_preprovisioned(
+async def test_on_node_added_pre_provisioned(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     multisensor_6_state,
     client,
     integration,
 ) -> None:
-    """Test node added event with a preprovisioned device."""
+    """Test node added event with a pre-provisioned device."""
     dsk = "test"
     node = Node(client, deepcopy(multisensor_6_state))
-    device = device_registry.async_get_or_create(
+    pre_provisioned_device = device_registry.async_get_or_create(
         config_entry_id=integration.entry_id,
         identifiers={(DOMAIN, f"provision_{dsk}")},
     )
@@ -515,7 +515,7 @@ async def test_on_node_added_preprovisioned(
         {
             "dsk": dsk,
             "securityClasses": [SecurityClass.S2_UNAUTHENTICATED],
-            "device_id": device.id,
+            "device_id": pre_provisioned_device.id,
         }
     )
     with patch(
@@ -526,14 +526,14 @@ async def test_on_node_added_preprovisioned(
         client.driver.controller.emit("node added", event)
         await hass.async_block_till_done()
 
-        device = device_registry.async_get(device.id)
+        device = device_registry.async_get(pre_provisioned_device.id)
         assert device
         assert device.identifiers == {
             get_device_id(client.driver, node),
             get_device_id_ext(client.driver, node),
         }
         assert device.sw_version == node.firmware_version
-        # There should only be the controller and the preprovisioned device
+        # There should only be the controller and the pre-provisioned device
         assert len(device_registry.devices) == 2
 
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -497,14 +497,14 @@ async def test_on_node_added_ready(
     )
 
 
-async def test_on_node_added_pre_provisioned(
+async def test_check_pre_provisioned_device_update_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    multisensor_6_state,
-    client,
-    integration,
+    multisensor_6_state: NodeDataType,
+    client: MagicMock,
+    integration: MockConfigEntry,
 ) -> None:
-    """Test node added event with a pre-provisioned device."""
+    """Test check pre-provisioned device that should update the device."""
     dsk = "test"
     node = Node(client, deepcopy(multisensor_6_state))
     pre_provisioned_device = device_registry.async_get_or_create(
@@ -534,6 +534,52 @@ async def test_on_node_added_pre_provisioned(
         }
         assert device.sw_version == node.firmware_version
         # There should only be the controller and the pre-provisioned device
+        assert len(device_registry.devices) == 2
+
+
+async def test_check_pre_provisioned_device_remove_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    multisensor_6_state: NodeDataType,
+    client: MagicMock,
+    integration: MockConfigEntry,
+) -> None:
+    """Test check pre-provisioned device that should remove the device."""
+    dsk = "test"
+    driver = client.driver
+    node = Node(client, deepcopy(multisensor_6_state))
+    pre_provisioned_device = device_registry.async_get_or_create(
+        config_entry_id=integration.entry_id,
+        identifiers={(DOMAIN, f"provision_{dsk}")},
+    )
+    extended_identifier = get_device_id_ext(driver, node)
+    assert extended_identifier
+    existing_device = device_registry.async_get_or_create(
+        config_entry_id=integration.entry_id,
+        identifiers={
+            get_device_id(driver, node),
+            extended_identifier,
+        },
+    )
+    provisioning_entry = ProvisioningEntry.from_dict(
+        {
+            "dsk": dsk,
+            "securityClasses": [SecurityClass.S2_UNAUTHENTICATED],
+            "device_id": pre_provisioned_device.id,
+        }
+    )
+    with patch(
+        f"{CONTROLLER_PATCH_PREFIX}.async_get_provisioning_entry",
+        side_effect=lambda id: provisioning_entry if id == node.node_id else None,
+    ):
+        event = {"node": node}
+        client.driver.controller.emit("node added", event)
+        await hass.async_block_till_done()
+
+        assert not device_registry.async_get(pre_provisioned_device.id)
+        assert device_registry.async_get(existing_device.id)
+
+        # There should only be the controller and the existing device
         assert len(device_registry.devices) == 2
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- It's possible to get into a state where there's a pre-provisioned device entry and another device entry with node ID based identifiers corresponding to the same device/node. Most likely, the user has tried to add an existing device again and ended up with duplicate device entries.
- If we encounter this state we remove the device entry that only has the pre-provisioning DSK identifier, as this is a temporary identifier.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146970
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
