### PR TITLE
Add protected call for data retrieval in BSB lan

### DIFF
--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -29,7 +29,7 @@ from homeassistant.exceptions import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_PASSKEY
+from .const import CONF_PASSKEY, DOMAIN
 from .coordinator import BSBLanUpdateCoordinator
 
 PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.WATER_HEATER]
@@ -75,15 +75,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
         static = await bsblan.static_values()
     except BSBLANConnectionError as err:
         raise ConfigEntryNotReady(
-            f"Failed to retrieve static device data from BSB-Lan device at {entry.data[CONF_HOST]}"
+            translation_domain=DOMAIN,
+            translation_key="setup_connection_error",
+            translation_placeholders={"host": entry.data[CONF_HOST]},
         ) from err
     except BSBLANAuthError as err:
         raise ConfigEntryAuthFailed(
-            "Authentication failed while retrieving static device data"
+            translation_domain=DOMAIN,
+            translation_key="setup_auth_error",
         ) from err
     except BSBLANError as err:
         raise ConfigEntryError(
-            "An unknown error occurred while retrieving static device data"
+            translation_domain=DOMAIN,
+            translation_key="setup_general_error",
         ) from err
 
     entry.runtime_data = BSBLanData(

--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -2,7 +2,16 @@
 
 import dataclasses
 
-from bsblan import BSBLAN, BSBLANConfig, Device, Info, StaticState
+from bsblan import (
+    BSBLAN,
+    BSBLANAuthError,
+    BSBLANConfig,
+    BSBLANConnectionError,
+    BSBLANError,
+    Device,
+    Info,
+    StaticState,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -13,6 +22,11 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_PASSKEY
@@ -54,10 +68,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
     coordinator = BSBLanUpdateCoordinator(hass, entry, bsblan)
     await coordinator.async_config_entry_first_refresh()
 
-    # Fetch all required data concurrently
-    device = await bsblan.device()
-    info = await bsblan.info()
-    static = await bsblan.static_values()
+    try:
+        # Fetch all required data sequentially
+        device = await bsblan.device()
+        info = await bsblan.info()
+        static = await bsblan.static_values()
+    except BSBLANConnectionError as err:
+        raise ConfigEntryNotReady(
+            f"Failed to retrieve static device data from BSB-Lan device at {entry.data[CONF_HOST]}"
+        ) from err
+    except BSBLANAuthError as err:
+        raise ConfigEntryAuthFailed(
+            "Authentication failed while retrieving static device data"
+        ) from err
+    except BSBLANError as err:
+        raise ConfigEntryError(
+            "An unknown error occurred while retrieving static device data"
+        ) from err
 
     entry.runtime_data = BSBLanData(
         client=bsblan,

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -41,6 +41,11 @@
           "passkey": "[%key:component::bsblan::config::step::user::data::passkey%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "passkey": "[%key:component::bsblan::config::step::user::data_description::passkey%]",
+          "username": "[%key:component::bsblan::config::step::user::data_description::username%]",
+          "password": "[%key:component::bsblan::config::step::user::data_description::password%]"
         }
       }
     },

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -71,6 +71,15 @@
     },
     "set_operation_mode_error": {
       "message": "An error occurred while setting the operation mode"
+    },
+    "setup_connection_error": {
+      "message": "Failed to retrieve static device data from BSB-Lan device at {host}"
+    },
+    "setup_auth_error": {
+      "message": "Authentication failed while retrieving static device data"
+    },
+    "setup_general_error": {
+      "message": "An unknown error occurred while retrieving static device data"
     }
   },
   "entity": {

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from bsblan import BSBLANAuthError, BSBLANConnectionError
+from bsblan import BSBLANAuthError, BSBLANConnectionError, BSBLANError
 from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.components.bsblan.const import DOMAIN
@@ -75,3 +75,51 @@ async def test_config_entry_auth_failed_triggers_reauth(
     assert len(flows) == 1
     assert flows[0]["context"]["source"] == "reauth"
     assert flows[0]["context"]["entry_id"] == mock_config_entry.entry_id
+
+
+async def test_config_entry_static_data_connection_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test BSBLANConnectionError during static data fetching triggers ConfigEntryNotReady."""
+    # Mock connection error during device() call
+    mock_bsblan.device.side_effect = BSBLANConnectionError("Connection failed")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_config_entry_static_data_auth_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test BSBLANAuthError during static data fetching triggers ConfigEntryAuthFailed."""
+    # Mock auth error during info() call
+    mock_bsblan.info.side_effect = BSBLANAuthError("Authentication failed")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_config_entry_static_data_general_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test BSBLANError during static data fetching triggers ConfigEntryError."""
+    # Mock general error during static_values() call
+    mock_bsblan.static_values.side_effect = BSBLANError("General error")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
To fully comply with the rule 'test-before-setup', all network calls made during async_setup_entry must be protected. We should wrap the additional API calls in a try...except block to catch potential communication errors and raise the appropriate Home Assistant exception.

Also added some missing translation strings. If needed I could make a separate PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
