### PR TITLE
Improve downloader service

### DIFF
--- a/homeassistant/components/downloader/__init__.py
+++ b/homeassistant/components/downloader/__init__.py
@@ -18,6 +18,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # If path is relative, we assume relative to Home Assistant config dir
     if not os.path.isabs(download_path):
         download_path = hass.config.path(download_path)
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_DOWNLOAD_DIR: download_path}
+        )
 
     if not await hass.async_add_executor_job(os.path.isdir, download_path):
         _LOGGER.error(

--- a/homeassistant/components/downloader/services.py
+++ b/homeassistant/components/downloader/services.py
@@ -46,14 +46,12 @@ def download_file(service: ServiceCall) -> None:
             raise_if_invalid_path(subdir)
         except ValueError as err:
             raise ServiceValidationError(
-                f"Invalid subdirectory, got: {subdir}",
                 translation_domain=DOMAIN,
                 translation_key="subdir_invalid",
                 translation_placeholders={"subdir": subdir},
             ) from err
         if os.path.isabs(subdir):
             raise ServiceValidationError(
-                f"Subdirectory must be relative, got: {subdir}",
                 translation_domain=DOMAIN,
                 translation_key="subdir_not_relative",
                 translation_placeholders={"subdir": subdir},

--- a/homeassistant/components/downloader/services.py
+++ b/homeassistant/components/downloader/services.py
@@ -11,6 +11,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.util import raise_if_invalid_filename, raise_if_invalid_path
@@ -34,24 +35,35 @@ def download_file(service: ServiceCall) -> None:
 
     entry = service.hass.config_entries.async_loaded_entries(DOMAIN)[0]
     download_path = entry.data[CONF_DOWNLOAD_DIR]
+    url = service.data[ATTR_URL]
+    subdir = service.data.get(ATTR_SUBDIR)
+    filename = service.data.get(ATTR_FILENAME)
+    overwrite = service.data.get(ATTR_OVERWRITE)
+
+    if subdir:
+        # Check the path
+        try:
+            raise_if_invalid_path(subdir)
+        except ValueError as err:
+            raise ServiceValidationError(
+                f"Invalid subdirectory, got: {subdir}",
+                translation_domain=DOMAIN,
+                translation_key="subdir_invalid",
+                translation_placeholders={"subdir": subdir},
+            ) from err
+        if os.path.isabs(subdir):
+            raise ServiceValidationError(
+                f"Subdirectory must be relative, got: {subdir}",
+                translation_domain=DOMAIN,
+                translation_key="subdir_not_relative",
+                translation_placeholders={"subdir": subdir},
+            )
 
     def do_download() -> None:
         """Download the file."""
+        final_path = None
+        nonlocal filename
         try:
-            url = service.data[ATTR_URL]
-
-            subdir = service.data.get(ATTR_SUBDIR)
-
-            filename = service.data.get(ATTR_FILENAME)
-
-            overwrite = service.data.get(ATTR_OVERWRITE)
-
-            if subdir:
-                # Check the path
-                raise_if_invalid_path(subdir)
-
-            final_path = None
-
             req = requests.get(url, stream=True, timeout=10)
 
             if req.status_code != HTTPStatus.OK:

--- a/homeassistant/components/downloader/services.py
+++ b/homeassistant/components/downloader/services.py
@@ -35,10 +35,10 @@ def download_file(service: ServiceCall) -> None:
 
     entry = service.hass.config_entries.async_loaded_entries(DOMAIN)[0]
     download_path = entry.data[CONF_DOWNLOAD_DIR]
-    url = service.data[ATTR_URL]
-    subdir = service.data.get(ATTR_SUBDIR)
-    filename = service.data.get(ATTR_FILENAME)
-    overwrite = service.data.get(ATTR_OVERWRITE)
+    url: str = service.data[ATTR_URL]
+    subdir: str | None = service.data.get(ATTR_SUBDIR)
+    target_filename: str | None = service.data.get(ATTR_FILENAME)
+    overwrite: bool = service.data[ATTR_OVERWRITE]
 
     if subdir:
         # Check the path
@@ -62,7 +62,7 @@ def download_file(service: ServiceCall) -> None:
     def do_download() -> None:
         """Download the file."""
         final_path = None
-        nonlocal filename
+        filename = target_filename
         try:
             req = requests.get(url, stream=True, timeout=10)
 

--- a/homeassistant/components/downloader/strings.json
+++ b/homeassistant/components/downloader/strings.json
@@ -12,6 +12,14 @@
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
+  "exceptions": {
+    "subdir_invalid": {
+      "message": "Invalid subdirectory, got: {subdir}"
+    },
+    "subdir_not_relative": {
+      "message": "Subdirectory must be relative, got: {subdir}"
+    }
+  },
   "services": {
     "download_file": {
       "name": "Download file",

--- a/tests/components/downloader/conftest.py
+++ b/tests/components/downloader/conftest.py
@@ -1,0 +1,94 @@
+"""Provide common fixtures for downloader tests."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from requests_mock import Mocker
+
+from homeassistant.components.downloader.const import (
+    CONF_DOWNLOAD_DIR,
+    DOMAIN,
+    DOWNLOAD_COMPLETED_EVENT,
+    DOWNLOAD_FAILED_EVENT,
+)
+from homeassistant.core import Event, HomeAssistant, callback
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+async def setup_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> MockConfigEntry:
+    """Set up the downloader integration for testing."""
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry
+
+
+@pytest.fixture
+def mock_config_entry(
+    hass: HomeAssistant,
+    download_dir: Path,
+) -> MockConfigEntry:
+    """Return a mocked config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DOWNLOAD_DIR: str(download_dir)},
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
+@pytest.fixture
+def download_dir(tmp_path: Path) -> Path:
+    """Return a download directory."""
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def mock_download_request(
+    requests_mock: Mocker,
+    download_url: str,
+) -> None:
+    """Mock the download request."""
+    requests_mock.get(download_url, text="{'one': 1}")
+
+
+@pytest.fixture
+def download_url() -> str:
+    """Return a mock download URL."""
+    return "http://example.com/file.txt"
+
+
+@pytest.fixture
+def download_completed(hass: HomeAssistant) -> asyncio.Event:
+    """Return an asyncio event to wait for download completion."""
+    download_event = asyncio.Event()
+
+    @callback
+    def download_set(event: Event[dict[str, str]]) -> None:
+        """Set the event when download is completed."""
+        download_event.set()
+
+    hass.bus.async_listen_once(f"{DOMAIN}_{DOWNLOAD_COMPLETED_EVENT}", download_set)
+
+    return download_event
+
+
+@pytest.fixture
+def download_failed(hass: HomeAssistant) -> asyncio.Event:
+    """Return an asyncio event to wait for download failure."""
+    download_event = asyncio.Event()
+
+    @callback
+    def download_set(event: Event[dict[str, str]]) -> None:
+        """Set the event when download has failed."""
+        download_event.set()
+
+    hass.bus.async_listen_once(f"{DOMAIN}_{DOWNLOAD_FAILED_EVENT}", download_set)
+
+    return download_event

--- a/tests/components/downloader/test_init.py
+++ b/tests/components/downloader/test_init.py
@@ -1,6 +1,8 @@
 """Tests for the downloader component init."""
 
-from unittest.mock import patch
+from pathlib import Path
+
+import pytest
 
 from homeassistant.components.downloader.const import (
     CONF_DOWNLOAD_DIR,
@@ -13,17 +15,57 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-async def test_initialization(hass: HomeAssistant) -> None:
-    """Test the initialization of the downloader component."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_DOWNLOAD_DIR: "/test_dir",
-        },
-    )
-    config_entry.add_to_hass(hass)
-    with patch("os.path.isdir", return_value=True):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
+@pytest.fixture
+def download_dir(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
+    """Return a download directory."""
+    if hasattr(request, "param"):
+        return tmp_path / request.param
+    return tmp_path
+
+
+async def test_config_entry_setup(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+) -> None:
+    """Test config entry setup."""
+    config_entry = setup_integration
 
     assert hass.services.has_service(DOMAIN, SERVICE_DOWNLOAD_FILE)
     assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_config_entry_setup_relative_directory(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test config entry setup with a relative download directory."""
+    relative_directory = "downloads"
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        data={**mock_config_entry.data, CONF_DOWNLOAD_DIR: relative_directory},
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    # The config entry will fail to set up since the directory does not exist.
+    # This is not relevant for this test.
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.data[CONF_DOWNLOAD_DIR] == hass.config.path(
+        relative_directory
+    )
+
+
+@pytest.mark.parametrize(
+    "download_dir",
+    [
+        "not_existing_path",
+    ],
+    indirect=True,
+)
+async def test_config_entry_setup_not_existing_directory(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test config entry setup without existing download directory."""
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert not hass.services.has_service(DOMAIN, SERVICE_DOWNLOAD_FILE)
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/components/downloader/test_services.py
+++ b/tests/components/downloader/test_services.py
@@ -1,0 +1,54 @@
+"""Test downloader services."""
+
+import asyncio
+from contextlib import AbstractContextManager, nullcontext as does_not_raise
+
+import pytest
+
+from homeassistant.components.downloader.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.parametrize(
+    ("subdir", "expected_result"),
+    [
+        ("test", does_not_raise()),
+        ("test/path", does_not_raise()),
+        ("~test/path", pytest.raises(ServiceValidationError)),
+        ("~/../test/path", pytest.raises(ServiceValidationError)),
+        ("../test/path", pytest.raises(ServiceValidationError)),
+        (".../test/path", pytest.raises(ServiceValidationError)),
+        ("/test/path", pytest.raises(ServiceValidationError)),
+    ],
+)
+async def test_download_invalid_subdir(
+    hass: HomeAssistant,
+    download_completed: asyncio.Event,
+    download_failed: asyncio.Event,
+    download_url: str,
+    subdir: str,
+    expected_result: AbstractContextManager,
+) -> None:
+    """Test service invalid subdirectory."""
+
+    async def call_service() -> None:
+        """Call the download service."""
+        completed = hass.async_create_task(download_completed.wait())
+        failed = hass.async_create_task(download_failed.wait())
+        await hass.services.async_call(
+            DOMAIN,
+            "download_file",
+            {
+                "url": download_url,
+                "subdir": subdir,
+                "filename": "file.txt",
+                "overwrite": True,
+            },
+            blocking=True,
+        )
+        await asyncio.wait((completed, failed), return_when=asyncio.FIRST_COMPLETED)
+
+    with expected_result:
+        await call_service()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Make sure to update the download directory in the config entry data, if the original download directory is relative.
- Raise ServiceValidationError if the subdirectory path is invalid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
