### PR TITLE
Simplify DPCode lookup in Tuya

### DIFF
--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -22,6 +22,7 @@ from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DPCode, DPType
 from .entity import TuyaEntity
 from .models import EnumTypeData
+from .util import get_dpcode
 
 
 @dataclass(frozen=True)
@@ -140,7 +141,7 @@ class TuyaAlarmEntity(TuyaEntity, AlarmControlPanelEntity):
             self._master_state = enum_type
 
         # Determine alarm message
-        if dp_code := self.find_dpcode(description.alarm_msg, prefer_function=True):
+        if dp_code := get_dpcode(self.device, description.alarm_msg):
             self._alarm_msg_dpcode = dp_code
 
     @property

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -27,6 +27,7 @@ from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DPCode, DPType
 from .entity import TuyaEntity
 from .models import IntegerTypeData
+from .util import get_dpcode
 
 TUYA_HVAC_TO_HA = {
     "auto": HVACMode.HEAT_COOL,
@@ -229,7 +230,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
                 self._attr_hvac_modes.append(description.switch_only_hvac_mode)
                 self._attr_preset_modes = unknown_hvac_modes
                 self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
-        elif self.find_dpcode(DPCode.SWITCH, prefer_function=True):
+        elif get_dpcode(self.device, DPCode.SWITCH):
             self._attr_hvac_modes = [
                 HVACMode.OFF,
                 description.switch_only_hvac_mode,
@@ -261,24 +262,24 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
             self._fan_mode_dp_code = enum_type.dpcode
 
         # Determine swing modes
-        if self.find_dpcode(
+        if get_dpcode(
+            self.device,
             (
                 DPCode.SHAKE,
                 DPCode.SWING,
                 DPCode.SWITCH_HORIZONTAL,
                 DPCode.SWITCH_VERTICAL,
             ),
-            prefer_function=True,
         ):
             self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
             self._attr_swing_modes = [SWING_OFF]
-            if self.find_dpcode((DPCode.SHAKE, DPCode.SWING), prefer_function=True):
+            if get_dpcode(self.device, (DPCode.SHAKE, DPCode.SWING)):
                 self._attr_swing_modes.append(SWING_ON)
 
-            if self.find_dpcode(DPCode.SWITCH_HORIZONTAL, prefer_function=True):
+            if get_dpcode(self.device, DPCode.SWITCH_HORIZONTAL):
                 self._attr_swing_modes.append(SWING_HORIZONTAL)
 
-            if self.find_dpcode(DPCode.SWITCH_VERTICAL, prefer_function=True):
+            if get_dpcode(self.device, DPCode.SWITCH_VERTICAL):
                 self._attr_swing_modes.append(SWING_VERTICAL)
 
         if DPCode.SWITCH in self.device.function:

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -23,6 +23,7 @@ from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DPCode, DPType
 from .entity import TuyaEntity
 from .models import IntegerTypeData
+from .util import get_dpcode
 
 
 @dataclass(frozen=True)
@@ -202,7 +203,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         self._attr_supported_features = CoverEntityFeature(0)
 
         # Check if this cover is based on a switch or has controls
-        if self.find_dpcode(description.key, prefer_function=True):
+        if get_dpcode(self.device, description.key):
             if device.function[description.key].type == "Boolean":
                 self._attr_supported_features |= (
                     CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE

--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -80,6 +80,9 @@ class TuyaEntity(Entity):
         dptype: DPType,
     ) -> EnumTypeData | IntegerTypeData | None:
         """Find a matching DP code available on for this device."""
+        if dptype not in (DPType.ENUM, DPType.INTEGER):
+            raise NotImplementedError("Only ENUM and INTEGER types are supported")
+
         if dpcodes is None:
             return None
 

--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -79,7 +79,7 @@ class TuyaEntity(Entity):
         prefer_function: bool = False,
         dptype: DPType,
     ) -> EnumTypeData | IntegerTypeData | None:
-        """Find a matching DP code available on for this device."""
+        """Find type information for a matching DP code available for this device."""
         if dptype not in (DPType.ENUM, DPType.INTEGER):
             raise NotImplementedError("Only ENUM and INTEGER types are supported")
 

--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -72,21 +72,13 @@ class TuyaEntity(Entity):
         dptype: Literal[DPType.INTEGER],
     ) -> IntegerTypeData | None: ...
 
-    @overload
     def find_dpcode(
         self,
         dpcodes: str | DPCode | tuple[DPCode, ...] | None,
         *,
         prefer_function: bool = False,
-    ) -> DPCode | None: ...
-
-    def find_dpcode(
-        self,
-        dpcodes: str | DPCode | tuple[DPCode, ...] | None,
-        *,
-        prefer_function: bool = False,
-        dptype: DPType | None = None,
-    ) -> DPCode | EnumTypeData | IntegerTypeData | None:
+        dptype: DPType,
+    ) -> EnumTypeData | IntegerTypeData | None:
         """Find a matching DP code available on for this device."""
         if dpcodes is None:
             return None
@@ -99,11 +91,6 @@ class TuyaEntity(Entity):
         order = ["status_range", "function"]
         if prefer_function:
             order = ["function", "status_range"]
-
-        # When we are not looking for a specific datatype, we can append status for
-        # searching
-        if not dptype:
-            order.append("status")
 
         for dpcode in dpcodes:
             for key in order:
@@ -132,9 +119,6 @@ class TuyaEntity(Entity):
                     ):
                         continue
                     return integer_type
-
-                if dptype not in (DPType.ENUM, DPType.INTEGER):
-                    return dpcode
 
         return None
 

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -24,6 +24,7 @@ from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DPCode, DPType
 from .entity import TuyaEntity
 from .models import EnumTypeData, IntegerTypeData
+from .util import get_dpcode
 
 TUYA_SUPPORT_TYPE = {
     # Dehumidifier
@@ -90,8 +91,8 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
         """Init Tuya Fan Device."""
         super().__init__(device, device_manager)
 
-        self._switch = self.find_dpcode(
-            (DPCode.SWITCH_FAN, DPCode.FAN_SWITCH, DPCode.SWITCH), prefer_function=True
+        self._switch = get_dpcode(
+            self.device, (DPCode.SWITCH_FAN, DPCode.FAN_SWITCH, DPCode.SWITCH)
         )
 
         self._attr_preset_modes = []
@@ -120,8 +121,8 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
             self._attr_supported_features |= FanEntityFeature.SET_SPEED
             self._speeds = enum_type
 
-        if dpcode := self.find_dpcode(
-            (DPCode.SWITCH_HORIZONTAL, DPCode.SWITCH_VERTICAL), prefer_function=True
+        if dpcode := get_dpcode(
+            self.device, (DPCode.SWITCH_HORIZONTAL, DPCode.SWITCH_VERTICAL)
         ):
             self._oscillate = dpcode
             self._attr_supported_features |= FanEntityFeature.OSCILLATE

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -21,7 +21,7 @@ from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DPCode, DPType
 from .entity import TuyaEntity
 from .models import IntegerTypeData
-from .util import ActionDPCodeNotFoundError
+from .util import ActionDPCodeNotFoundError, get_dpcode
 
 
 @dataclass(frozen=True)
@@ -105,8 +105,8 @@ class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
         self._attr_unique_id = f"{super().unique_id}{description.key}"
 
         # Determine main switch DPCode
-        self._switch_dpcode = self.find_dpcode(
-            description.dpcode or DPCode(description.key), prefer_function=True
+        self._switch_dpcode = get_dpcode(
+            self.device, description.dpcode or DPCode(description.key)
         )
 
         # Determine humidity parameters

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -29,7 +29,7 @@ from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DPCode, DPType, WorkMode
 from .entity import TuyaEntity
 from .models import IntegerTypeData
-from .util import remap_value
+from .util import get_dpcode, remap_value
 
 
 @dataclass
@@ -515,9 +515,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         color_modes: set[ColorMode] = {ColorMode.ONOFF}
 
         # Determine DPCodes
-        self._color_mode_dpcode = self.find_dpcode(
-            description.color_mode, prefer_function=True
-        )
+        self._color_mode_dpcode = get_dpcode(self.device, description.color_mode)
 
         if int_type := self.find_dpcode(
             description.brightness, dptype=DPType.INTEGER, prefer_function=True
@@ -532,7 +530,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
             )
 
         if (
-            dpcode := self.find_dpcode(description.color_data, prefer_function=True)
+            dpcode := get_dpcode(self.device, description.color_data)
         ) and self.get_dptype(dpcode) == DPType.JSON:
             self._color_data_dpcode = dpcode
             color_modes.add(ColorMode.HS)

--- a/homeassistant/components/tuya/util.py
+++ b/homeassistant/components/tuya/util.py
@@ -9,6 +9,29 @@ from homeassistant.exceptions import ServiceValidationError
 from .const import DOMAIN, DPCode
 
 
+def get_dpcode(
+    device: CustomerDevice, dpcodes: str | DPCode | tuple[DPCode, ...] | None
+) -> DPCode | None:
+    """Get the DPCode from the device or return None."""
+    if dpcodes is None:
+        return None
+
+    if isinstance(dpcodes, DPCode):
+        dpcodes = (dpcodes,)
+    elif isinstance(dpcodes, str):
+        dpcodes = (DPCode(dpcodes),)
+
+    for dpcode in dpcodes:
+        if (
+            dpcode in device.function
+            or dpcode in device.status
+            or dpcode in device.status_range
+        ):
+            return dpcode
+
+    return None
+
+
 def remap_value(
     value: float,
     from_min: float = 0,

--- a/homeassistant/components/tuya/util.py
+++ b/homeassistant/components/tuya/util.py
@@ -12,7 +12,7 @@ from .const import DOMAIN, DPCode
 def get_dpcode(
     device: CustomerDevice, dpcodes: str | DPCode | tuple[DPCode, ...] | None
 ) -> DPCode | None:
-    """Get the DPCode from the device or return None."""
+    """Get the first matching DPCode from the device or return None."""
     if dpcodes is None:
         return None
 

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -19,6 +19,7 @@ from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DPCode, DPType
 from .entity import TuyaEntity
 from .models import EnumTypeData
+from .util import get_dpcode
 
 TUYA_MODE_RETURN_HOME = "chargego"
 TUYA_STATUS_TO_HA = {
@@ -88,11 +89,11 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         self._attr_supported_features = (
             VacuumEntityFeature.SEND_COMMAND | VacuumEntityFeature.STATE
         )
-        if self.find_dpcode(DPCode.PAUSE, prefer_function=True):
+        if get_dpcode(self.device, DPCode.PAUSE):
             self._attr_supported_features |= VacuumEntityFeature.PAUSE
 
         self._return_home_use_switch_charge = False
-        if self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True):
+        if get_dpcode(self.device, DPCode.SWITCH_CHARGE):
             self._attr_supported_features |= VacuumEntityFeature.RETURN_HOME
             self._return_home_use_switch_charge = True
         elif (
@@ -102,10 +103,10 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         ) and TUYA_MODE_RETURN_HOME in enum_type.range:
             self._attr_supported_features |= VacuumEntityFeature.RETURN_HOME
 
-        if self.find_dpcode(DPCode.SEEK, prefer_function=True):
+        if get_dpcode(self.device, DPCode.SEEK):
             self._attr_supported_features |= VacuumEntityFeature.LOCATE
 
-        if self.find_dpcode(DPCode.POWER_GO, prefer_function=True):
+        if get_dpcode(self.device, DPCode.POWER_GO):
             self._attr_supported_features |= (
                 VacuumEntityFeature.STOP | VacuumEntityFeature.START
             )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alternative to #150040

When we are not interested in the `DPType` (ie. leave `DPType` argument as default `None`), the logic behind `TuyaEntity.find_dpcode` is unnecessarily complicated and hard to read, and passing `prefer_function= True` has absolutely no impact.

Having it as a `TuyaEntity` method also prevents us from using it before building the object, so this moves the new function out to `util.py`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
