### PR TITLE
Revert "Do not allow overriding users when uuid is duplicate"

### DIFF
--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -120,9 +120,6 @@ class AuthStore:
 
         new_user = models.User(**kwargs)
 
-        while new_user.id in self._users:
-            new_user = models.User(**kwargs)
-
         self._users[new_user.id] = new_user
 
         if credentials is None:

--- a/tests/auth/test_auth_store.py
+++ b/tests/auth/test_auth_store.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from typing import Any
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -298,20 +298,6 @@ async def test_loading_does_not_write_right_away(
     # Once for the task
     await hass.async_block_till_done()
     assert hass_storage[auth_store.STORAGE_KEY] != {}
-
-
-async def test_duplicate_uuid(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
-) -> None:
-    """Test we don't override user if we have a duplicate user ID."""
-    hass_storage[auth_store.STORAGE_KEY] = MOCK_STORAGE_DATA
-    store = auth_store.AuthStore(hass)
-    await store.async_load()
-    with patch("uuid.UUID.hex", new_callable=PropertyMock) as hex_mock:
-        hex_mock.side_effect = ["user-id", "new-id"]
-        user = await store.async_create_user("Test User")
-    assert len(hex_mock.mock_calls) == 2
-    assert user.id == "new-id"
 
 
 async def test_add_remove_user_affects_tokens(


### PR DESCRIPTION
Reverts home-assistant/core#149408

Related failed CI tests:

https://github.com/home-assistant/core/actions/runs/16768725900/job/47479325952?pr=149877