### PR TITLE
Enable disabled Anthropic config entries after entry migration

### DIFF
--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -81,11 +81,15 @@ async def async_update_options(
 async def async_migrate_integration(hass: HomeAssistant) -> None:
     """Migrate integration entry structure."""
 
-    entries = hass.config_entries.async_entries(DOMAIN)
+    # Make sure we get enabled config entries first
+    entries = sorted(
+        hass.config_entries.async_entries(DOMAIN),
+        key=lambda e: e.disabled_by is not None,
+    )
     if not any(entry.version == 1 for entry in entries):
         return
 
-    api_keys_entries: dict[str, ConfigEntry] = {}
+    api_keys_entries: dict[str, tuple[ConfigEntry, bool]] = {}
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
 
@@ -99,30 +103,61 @@ async def async_migrate_integration(hass: HomeAssistant) -> None:
         )
         if entry.data[CONF_API_KEY] not in api_keys_entries:
             use_existing = True
-            api_keys_entries[entry.data[CONF_API_KEY]] = entry
+            all_disabled = all(
+                e.disabled_by is not None
+                for e in entries
+                if e.data[CONF_API_KEY] == entry.data[CONF_API_KEY]
+            )
+            api_keys_entries[entry.data[CONF_API_KEY]] = (entry, all_disabled)
 
-        parent_entry = api_keys_entries[entry.data[CONF_API_KEY]]
+        parent_entry, all_disabled = api_keys_entries[entry.data[CONF_API_KEY]]
 
         hass.config_entries.async_add_subentry(parent_entry, subentry)
-        conversation_entity = entity_registry.async_get_entity_id(
+        conversation_entity_id = entity_registry.async_get_entity_id(
             "conversation",
             DOMAIN,
             entry.entry_id,
         )
-        if conversation_entity is not None:
-            entity_registry.async_update_entity(
-                conversation_entity,
-                config_entry_id=parent_entry.entry_id,
-                config_subentry_id=subentry.subentry_id,
-                new_unique_id=subentry.subentry_id,
-            )
-
         device = device_registry.async_get_device(
             identifiers={(DOMAIN, entry.entry_id)}
         )
+
+        if conversation_entity_id is not None:
+            conversation_entity_entry = entity_registry.entities[conversation_entity_id]
+            entity_disabled_by = conversation_entity_entry.disabled_by
+            if (
+                entity_disabled_by is er.RegistryEntryDisabler.CONFIG_ENTRY
+                and not all_disabled
+            ):
+                # Device and entity registries don't update the disabled_by flag
+                # when moving a device or entity from one config entry to another,
+                # so we need to do it manually.
+                entity_disabled_by = (
+                    er.RegistryEntryDisabler.DEVICE
+                    if device
+                    else er.RegistryEntryDisabler.USER
+                )
+            entity_registry.async_update_entity(
+                conversation_entity_id,
+                config_entry_id=parent_entry.entry_id,
+                config_subentry_id=subentry.subentry_id,
+                disabled_by=entity_disabled_by,
+                new_unique_id=subentry.subentry_id,
+            )
+
         if device is not None:
+            # Device and entity registries don't update the disabled_by flag when
+            # moving a device or entity from one config entry to another, so we
+            # need to do it manually.
+            device_disabled_by = device.disabled_by
+            if (
+                device.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+                and not all_disabled
+            ):
+                device_disabled_by = dr.DeviceEntryDisabler.USER
             device_registry.async_update_device(
                 device.id,
+                disabled_by=device_disabled_by,
                 new_identifiers={(DOMAIN, subentry.subentry_id)},
                 add_config_subentry_id=subentry.subentry_id,
                 add_config_entry_id=parent_entry.entry_id,
@@ -147,7 +182,7 @@ async def async_migrate_integration(hass: HomeAssistant) -> None:
                 title=DEFAULT_CONVERSATION_NAME,
                 options={},
                 version=2,
-                minor_version=2,
+                minor_version=3,
             )
 
 
@@ -172,6 +207,38 @@ async def async_migrate_entry(hass: HomeAssistant, entry: AnthropicConfigEntry) 
             )
 
         hass.config_entries.async_update_entry(entry, minor_version=2)
+
+    if entry.version == 2 and entry.minor_version == 2:
+        # Fix migration where the disabled_by flag was not set correctly.
+        # We can currently only correct this for enabled config entries,
+        # because migration does not run for disabled config entries. This
+        # is asserted in tests, and if that behavior is changed, we should
+        # correct also disabled config entries.
+        device_registry = dr.async_get(hass)
+        entity_registry = er.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        entity_entries = er.async_entries_for_config_entry(
+            entity_registry, entry.entry_id
+        )
+        if entry.disabled_by is None:
+            # If the config entry is not disabled, we need to set the disabled_by
+            # flag on devices to USER, and on entities to DEVICE, if they are set
+            # to CONFIG_ENTRY.
+            for device in devices:
+                if device.disabled_by is not dr.DeviceEntryDisabler.CONFIG_ENTRY:
+                    continue
+                device_registry.async_update_device(
+                    device.id,
+                    disabled_by=dr.DeviceEntryDisabler.USER,
+                )
+            for entity in entity_entries:
+                if entity.disabled_by is not er.RegistryEntryDisabler.CONFIG_ENTRY:
+                    continue
+                entity_registry.async_update_entity(
+                    entity.entity_id,
+                    disabled_by=er.RegistryEntryDisabler.DEVICE,
+                )
+        hass.config_entries.async_update_entry(entry, minor_version=3)
 
     LOGGER.debug(
         "Migration to version %s:%s successful", entry.version, entry.minor_version

--- a/homeassistant/components/anthropic/config_flow.py
+++ b/homeassistant/components/anthropic/config_flow.py
@@ -75,7 +75,7 @@ class AnthropicConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Anthropic."""
 
     VERSION = 2
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the Anthropic integration."""
 
+from typing import Any
 from unittest.mock import patch
 
 from anthropic import (
@@ -12,9 +13,12 @@ from httpx import URL, Request, Response
 import pytest
 
 from homeassistant.components.anthropic.const import DOMAIN
-from homeassistant.config_entries import ConfigSubentryData
+from homeassistant.config_entries import ConfigEntryDisabler, ConfigSubentryData
+from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.device_registry import DeviceEntryDisabler
+from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -114,7 +118,7 @@ async def test_migration_from_v1_to_v2(
         await hass.async_block_till_done()
 
     assert mock_config_entry.version == 2
-    assert mock_config_entry.minor_version == 2
+    assert mock_config_entry.minor_version == 3
     assert mock_config_entry.data == {"api_key": "1234"}
     assert mock_config_entry.options == {}
 
@@ -147,6 +151,207 @@ async def test_migration_from_v1_to_v2(
     assert migrated_device.config_entries_subentries == {
         mock_config_entry.entry_id: {subentry.subentry_id}
     }
+
+
+@pytest.mark.parametrize(
+    (
+        "config_entry_disabled_by",
+        "merged_config_entry_disabled_by",
+        "conversation_subentry_data",
+        "main_config_entry",
+    ),
+    [
+        (
+            [ConfigEntryDisabler.USER, None],
+            None,
+            [
+                {
+                    "conversation_entity_id": "conversation.claude_2",
+                    "device_disabled_by": None,
+                    "entity_disabled_by": None,
+                    "device": 1,
+                },
+                {
+                    "conversation_entity_id": "conversation.claude",
+                    "device_disabled_by": DeviceEntryDisabler.USER,
+                    "entity_disabled_by": RegistryEntryDisabler.DEVICE,
+                    "device": 0,
+                },
+            ],
+            1,
+        ),
+        (
+            [None, ConfigEntryDisabler.USER],
+            None,
+            [
+                {
+                    "conversation_entity_id": "conversation.claude",
+                    "device_disabled_by": DeviceEntryDisabler.USER,
+                    "entity_disabled_by": RegistryEntryDisabler.DEVICE,
+                    "device": 0,
+                },
+                {
+                    "conversation_entity_id": "conversation.claude_2",
+                    "device_disabled_by": None,
+                    "entity_disabled_by": None,
+                    "device": 1,
+                },
+            ],
+            0,
+        ),
+        (
+            [ConfigEntryDisabler.USER, ConfigEntryDisabler.USER],
+            ConfigEntryDisabler.USER,
+            [
+                {
+                    "conversation_entity_id": "conversation.claude",
+                    "device_disabled_by": DeviceEntryDisabler.CONFIG_ENTRY,
+                    "entity_disabled_by": RegistryEntryDisabler.CONFIG_ENTRY,
+                    "device": 0,
+                },
+                {
+                    "conversation_entity_id": "conversation.claude_2",
+                    "device_disabled_by": None,
+                    "entity_disabled_by": None,
+                    "device": 1,
+                },
+            ],
+            0,
+        ),
+    ],
+)
+async def test_migration_from_v1_disabled(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    config_entry_disabled_by: list[ConfigEntryDisabler | None],
+    merged_config_entry_disabled_by: ConfigEntryDisabler | None,
+    conversation_subentry_data: list[dict[str, Any]],
+    main_config_entry: int,
+) -> None:
+    """Test migration where the config entries are disabled."""
+    # Create a v1 config entry with conversation options and an entity
+    options = {
+        "recommended": True,
+        "llm_hass_api": ["assist"],
+        "prompt": "You are a helpful assistant",
+        "chat_model": "claude-3-haiku-20240307",
+    }
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "1234"},
+        options=options,
+        version=1,
+        title="Claude",
+        disabled_by=config_entry_disabled_by[0],
+    )
+    mock_config_entry.add_to_hass(hass)
+    mock_config_entry_2 = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "1234"},
+        options=options,
+        version=1,
+        title="Claude 2",
+        disabled_by=config_entry_disabled_by[1],
+    )
+    mock_config_entry_2.add_to_hass(hass)
+    mock_config_entries = [mock_config_entry, mock_config_entry_2]
+
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, mock_config_entry.entry_id)},
+        name=mock_config_entry.title,
+        manufacturer="Anthropic",
+        model="Claude",
+        entry_type=dr.DeviceEntryType.SERVICE,
+        disabled_by=DeviceEntryDisabler.CONFIG_ENTRY,
+    )
+    entity_registry.async_get_or_create(
+        "conversation",
+        DOMAIN,
+        mock_config_entry.entry_id,
+        config_entry=mock_config_entry,
+        device_id=device_1.id,
+        suggested_object_id="claude",
+        disabled_by=RegistryEntryDisabler.CONFIG_ENTRY,
+    )
+
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry_2.entry_id,
+        identifiers={(DOMAIN, mock_config_entry_2.entry_id)},
+        name=mock_config_entry_2.title,
+        manufacturer="Anthropic",
+        model="Claude",
+        entry_type=dr.DeviceEntryType.SERVICE,
+    )
+    entity_registry.async_get_or_create(
+        "conversation",
+        DOMAIN,
+        mock_config_entry_2.entry_id,
+        config_entry=mock_config_entry_2,
+        device_id=device_2.id,
+        suggested_object_id="claude",
+    )
+
+    devices = [device_1, device_2]
+
+    # Run migration
+    with patch(
+        "homeassistant.components.anthropic.async_setup_entry",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.disabled_by is merged_config_entry_disabled_by
+    assert entry.version == 2
+    assert entry.minor_version == 3
+    assert not entry.options
+    assert entry.title == "Claude conversation"
+    assert len(entry.subentries) == 2
+    conversation_subentries = [
+        subentry
+        for subentry in entry.subentries.values()
+        if subentry.subentry_type == "conversation"
+    ]
+    assert len(conversation_subentries) == 2
+    for subentry in conversation_subentries:
+        assert subentry.subentry_type == "conversation"
+        assert subentry.data == options
+        assert "Claude" in subentry.title
+
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    )
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
+    )
+
+    for idx, subentry in enumerate(conversation_subentries):
+        subentry_data = conversation_subentry_data[idx]
+        entity = entity_registry.async_get(subentry_data["conversation_entity_id"])
+        assert entity.unique_id == subentry.subentry_id
+        assert entity.config_subentry_id == subentry.subentry_id
+        assert entity.config_entry_id == entry.entry_id
+        assert entity.disabled_by is subentry_data["entity_disabled_by"]
+
+        assert (
+            device := device_registry.async_get_device(
+                identifiers={(DOMAIN, subentry.subentry_id)}
+            )
+        )
+        assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
+        assert device.id == devices[subentry_data["device"]].id
+        assert device.config_entries == {
+            mock_config_entries[main_config_entry].entry_id
+        }
+        assert device.config_entries_subentries == {
+            mock_config_entries[main_config_entry].entry_id: {subentry.subentry_id}
+        }
+        assert device.disabled_by is subentry_data["device_disabled_by"]
 
 
 async def test_migration_from_v1_to_v2_with_multiple_keys(
@@ -226,7 +431,7 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
 
     for idx, entry in enumerate(entries):
         assert entry.version == 2
-        assert entry.minor_version == 2
+        assert entry.minor_version == 3
         assert not entry.options
         assert len(entry.subentries) == 1
         subentry = list(entry.subentries.values())[0]
@@ -320,7 +525,7 @@ async def test_migration_from_v1_to_v2_with_same_keys(
 
     entry = entries[0]
     assert entry.version == 2
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
     assert not entry.options
     assert len(entry.subentries) == 2  # Two subentries from the two original entries
 
@@ -443,7 +648,7 @@ async def test_migration_from_v2_1_to_v2_2(
     assert len(entries) == 1
     entry = entries[0]
     assert entry.version == 2
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
     assert not entry.options
     assert entry.title == "Claude"
     assert len(entry.subentries) == 2
@@ -500,3 +705,193 @@ async def test_migration_from_v2_1_to_v2_2(
     assert device.config_entries_subentries == {
         mock_config_entry.entry_id: {subentry.subentry_id}
     }
+
+
+@pytest.mark.parametrize(
+    (
+        "config_entry_disabled_by",
+        "device_disabled_by",
+        "entity_disabled_by",
+        "setup_result",
+        "minor_version_after_migration",
+        "config_entry_disabled_by_after_migration",
+        "device_disabled_by_after_migration",
+        "entity_disabled_by_after_migration",
+    ),
+    [
+        # Config entry not disabled, update device and entity disabled by config entry
+        (
+            None,
+            DeviceEntryDisabler.CONFIG_ENTRY,
+            RegistryEntryDisabler.CONFIG_ENTRY,
+            True,
+            3,
+            None,
+            DeviceEntryDisabler.USER,
+            RegistryEntryDisabler.DEVICE,
+        ),
+        (
+            None,
+            DeviceEntryDisabler.USER,
+            RegistryEntryDisabler.DEVICE,
+            True,
+            3,
+            None,
+            DeviceEntryDisabler.USER,
+            RegistryEntryDisabler.DEVICE,
+        ),
+        (
+            None,
+            DeviceEntryDisabler.USER,
+            RegistryEntryDisabler.USER,
+            True,
+            3,
+            None,
+            DeviceEntryDisabler.USER,
+            RegistryEntryDisabler.USER,
+        ),
+        (
+            None,
+            None,
+            None,
+            True,
+            3,
+            None,
+            None,
+            None,
+        ),
+        # Config entry disabled, migration does not run
+        (
+            ConfigEntryDisabler.USER,
+            DeviceEntryDisabler.CONFIG_ENTRY,
+            RegistryEntryDisabler.CONFIG_ENTRY,
+            False,
+            2,
+            ConfigEntryDisabler.USER,
+            DeviceEntryDisabler.CONFIG_ENTRY,
+            RegistryEntryDisabler.CONFIG_ENTRY,
+        ),
+        (
+            ConfigEntryDisabler.USER,
+            DeviceEntryDisabler.USER,
+            RegistryEntryDisabler.DEVICE,
+            False,
+            2,
+            ConfigEntryDisabler.USER,
+            DeviceEntryDisabler.USER,
+            RegistryEntryDisabler.DEVICE,
+        ),
+        (
+            ConfigEntryDisabler.USER,
+            DeviceEntryDisabler.USER,
+            RegistryEntryDisabler.USER,
+            False,
+            2,
+            ConfigEntryDisabler.USER,
+            DeviceEntryDisabler.USER,
+            RegistryEntryDisabler.USER,
+        ),
+        (
+            ConfigEntryDisabler.USER,
+            None,
+            None,
+            False,
+            2,
+            ConfigEntryDisabler.USER,
+            None,
+            None,
+        ),
+    ],
+)
+async def test_migrate_entry_to_v2_3(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    config_entry_disabled_by: ConfigEntryDisabler | None,
+    device_disabled_by: DeviceEntryDisabler | None,
+    entity_disabled_by: RegistryEntryDisabler | None,
+    setup_result: bool,
+    minor_version_after_migration: int,
+    config_entry_disabled_by_after_migration: ConfigEntryDisabler | None,
+    device_disabled_by_after_migration: ConfigEntryDisabler | None,
+    entity_disabled_by_after_migration: RegistryEntryDisabler | None,
+) -> None:
+    """Test migration from version 2.3."""
+    # Create a v2.3 config entry with conversation subentries
+    conversation_subentry_id = "blabla"
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "test-api-key"},
+        disabled_by=config_entry_disabled_by,
+        version=2,
+        minor_version=2,
+        subentries_data=[
+            {
+                "data": {
+                    "recommended": True,
+                    "llm_hass_api": ["assist"],
+                    "prompt": "You are a helpful assistant",
+                    "chat_model": "claude-3-haiku-20240307",
+                },
+                "subentry_id": conversation_subentry_id,
+                "subentry_type": "conversation",
+                "title": "Claude haiku",
+                "unique_id": None,
+            },
+        ],
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    conversation_device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        config_subentry_id=conversation_subentry_id,
+        disabled_by=device_disabled_by,
+        identifiers={(DOMAIN, mock_config_entry.entry_id)},
+        name=mock_config_entry.title,
+        manufacturer="Anthropic",
+        model="Claude",
+        entry_type=dr.DeviceEntryType.SERVICE,
+    )
+    conversation_entity = entity_registry.async_get_or_create(
+        "conversation",
+        DOMAIN,
+        mock_config_entry.entry_id,
+        config_entry=mock_config_entry,
+        config_subentry_id=conversation_subentry_id,
+        disabled_by=entity_disabled_by,
+        device_id=conversation_device.id,
+        suggested_object_id="claude",
+    )
+
+    # Verify initial state
+    assert mock_config_entry.version == 2
+    assert mock_config_entry.minor_version == 2
+    assert len(mock_config_entry.subentries) == 1
+    assert mock_config_entry.disabled_by == config_entry_disabled_by
+    assert conversation_device.disabled_by == device_disabled_by
+    assert conversation_entity.disabled_by == entity_disabled_by
+
+    # Run setup to trigger migration
+    with patch(
+        "homeassistant.components.anthropic.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        assert result is setup_result
+        await hass.async_block_till_done()
+
+    # Verify migration completed
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    entry = entries[0]
+
+    # Check version and subversion were updated
+    assert entry.version == 2
+    assert entry.minor_version == minor_version_after_migration
+
+    # Check the disabled_by flag on config entry, device and entity are as expected
+    conversation_device = device_registry.async_get(conversation_device.id)
+    conversation_entity = entity_registry.async_get(conversation_entity.entity_id)
+    assert mock_config_entry.disabled_by == config_entry_disabled_by_after_migration
+    assert conversation_device.disabled_by == device_disabled_by_after_migration
+    assert conversation_entity.disabled_by == entity_disabled_by_after_migration

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -816,8 +816,8 @@ async def test_migrate_entry_to_v2_3(
     device_disabled_by_after_migration: ConfigEntryDisabler | None,
     entity_disabled_by_after_migration: RegistryEntryDisabler | None,
 ) -> None:
-    """Test migration from version 2.3."""
-    # Create a v2.3 config entry with conversation subentries
+    """Test migration to version 2.3."""
+    # Create a v2.2 config entry with conversation subentries
     conversation_subentry_id = "blabla"
     mock_config_entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enable disabled Anthropic config entries after entry migration as after the migration, This migration moved multiple config entries to a single config entry with every config entry that connected to the same service as a sub entry. The downside was that if the first config entry was disabled, the rest would be disabled as well, and if the first was enabled, everything would be enabled. With this change, we move the disabled reason of those devices and entities from being disabled by the config entry to being disabled by the device, which is recoverable by the user

Similar to #148161

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
