### PR TITLE
Remove deprecated json helper constants and function

### DIFF
--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -12,39 +12,7 @@ from typing import TYPE_CHECKING, Any, Final
 import orjson
 
 from homeassistant.util.file import write_utf8_file, write_utf8_file_atomic
-from homeassistant.util.json import (
-    JSON_DECODE_EXCEPTIONS as _JSON_DECODE_EXCEPTIONS,
-    JSON_ENCODE_EXCEPTIONS as _JSON_ENCODE_EXCEPTIONS,
-    SerializationError,
-    format_unserializable_data,
-    json_loads as _json_loads,
-)
-
-from .deprecation import (
-    DeprecatedConstant,
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    deprecated_function,
-    dir_with_deprecated_constants,
-)
-
-_DEPRECATED_JSON_DECODE_EXCEPTIONS = DeprecatedConstant(
-    _JSON_DECODE_EXCEPTIONS, "homeassistant.util.json.JSON_DECODE_EXCEPTIONS", "2025.8"
-)
-_DEPRECATED_JSON_ENCODE_EXCEPTIONS = DeprecatedConstant(
-    _JSON_ENCODE_EXCEPTIONS, "homeassistant.util.json.JSON_ENCODE_EXCEPTIONS", "2025.8"
-)
-json_loads = deprecated_function(
-    "homeassistant.util.json.json_loads", breaks_in_ha_version="2025.8"
-)(_json_loads)
-
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())
-
+from homeassistant.util.json import SerializationError, format_unserializable_data
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/helpers/test_discovery_flow.py
+++ b/tests/helpers/test_discovery_flow.py
@@ -10,6 +10,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import discovery_flow, json as json_helper
 from homeassistant.helpers.discovery_flow import DiscoveryKey
+from homeassistant.util import json as json_util
 
 
 @pytest.fixture
@@ -151,6 +152,6 @@ def test_discovery_key_serialize_deserialize(key: str | tuple[str]) -> None:
     )
     serialized = json_helper.json_dumps(discovery_key_1)
     assert (
-        discovery_flow.DiscoveryKey.from_json_dict(json_helper.json_loads(serialized))
+        discovery_flow.DiscoveryKey.from_json_dict(json_util.json_loads(serialized))
         == discovery_key_1
     )

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -13,7 +13,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.core import Event, HomeAssistant, State
-from homeassistant.helpers import json as json_helper
 from homeassistant.helpers.json import (
     ExtendedJSONEncoder,
     JSONEncoder as DefaultHASSJSONEncoder,
@@ -27,14 +26,9 @@ from homeassistant.helpers.json import (
 )
 from homeassistant.util import dt as dt_util
 from homeassistant.util.color import RGBColor
-from homeassistant.util.json import (
-    JSON_DECODE_EXCEPTIONS,
-    JSON_ENCODE_EXCEPTIONS,
-    SerializationError,
-    load_json,
-)
+from homeassistant.util.json import SerializationError, load_json
 
-from tests.common import import_and_test_deprecated_constant, json_round_trip
+from tests.common import json_round_trip
 
 # Test data that can be saved as JSON
 TEST_JSON_A = {"a": 1, "B": "two"}
@@ -350,50 +344,3 @@ def test_find_unserializable_data() -> None:
         BadData(),
         dump=partial(json.dumps, cls=MockJSONEncoder),
     ) == {"$(BadData).bla": bad_data}
-
-
-def test_deprecated_json_loads(caplog: pytest.LogCaptureFixture) -> None:
-    """Test deprecated json_loads function.
-
-    It was moved from helpers to util in #88099
-    """
-    json_helper.json_loads("{}")
-    assert (
-        "The deprecated function json_loads was called. It will be removed "
-        "in HA Core 2025.8. Use homeassistant.util.json.json_loads instead"
-    ) in caplog.text
-
-
-@pytest.mark.parametrize(
-    ("constant_name", "replacement_name", "replacement"),
-    [
-        (
-            "JSON_DECODE_EXCEPTIONS",
-            "homeassistant.util.json.JSON_DECODE_EXCEPTIONS",
-            JSON_DECODE_EXCEPTIONS,
-        ),
-        (
-            "JSON_ENCODE_EXCEPTIONS",
-            "homeassistant.util.json.JSON_ENCODE_EXCEPTIONS",
-            JSON_ENCODE_EXCEPTIONS,
-        ),
-    ],
-)
-def test_deprecated_aliases(
-    caplog: pytest.LogCaptureFixture,
-    constant_name: str,
-    replacement_name: str,
-    replacement: Any,
-) -> None:
-    """Test deprecated JSON_DECODE_EXCEPTIONS and JSON_ENCODE_EXCEPTIONS constants.
-
-    They were moved from helpers to util in #88099
-    """
-    import_and_test_deprecated_constant(
-        caplog,
-        json_helper,
-        constant_name,
-        replacement_name,
-        replacement,
-        "2025.8",
-    )


### PR DESCRIPTION
## Breaking change
Previously deprecated (moved) constants and function from json helper has now been removed.

## Proposed change
Removed constants and function that has moved to `homeassistant.util.json`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 