### PR TITLE
Check for Z-Wave firmware updates of sleeping devices

### DIFF
--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -10,7 +10,6 @@ from datetime import datetime, timedelta
 from typing import Any, Final, cast
 
 from awesomeversion import AwesomeVersion
-from zwave_js_server.const import NodeStatus
 from zwave_js_server.exceptions import BaseZwaveJSServerError, FailedZWaveCommand
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.firmware import (
@@ -192,7 +191,6 @@ class ZWaveFirmwareUpdateEntity(UpdateEntity):
         self.entity_description = entity_description
         self.node = node
         self._latest_version_firmware: FirmwareUpdateInfo | None = None
-        self._status_unsub: Callable[[], None] | None = None
         self._poll_unsub: Callable[[], None] | None = None
         self._progress_unsub: Callable[[], None] | None = None
         self._finished_unsub: Callable[[], None] | None = None
@@ -212,12 +210,6 @@ class ZWaveFirmwareUpdateEntity(UpdateEntity):
     def extra_restore_state_data(self) -> ZWaveFirmwareUpdateExtraStoredData:
         """Return ZWave Node Firmware Update specific state data to be restored."""
         return ZWaveFirmwareUpdateExtraStoredData(self._latest_version_firmware)
-
-    @callback
-    def _update_on_status_change(self, _: dict[str, Any]) -> None:
-        """Update the entity when node is awake."""
-        self._status_unsub = None
-        self.hass.async_create_task(self._async_update())
 
     @callback
     def update_progress(self, event: dict[str, Any]) -> None:
@@ -268,14 +260,6 @@ class ZWaveFirmwareUpdateEntity(UpdateEntity):
             self._poll_unsub = async_call_later(
                 self.hass, timedelta(days=1), self._async_update
             )
-            return
-
-        # If device is asleep, wait for it to wake up before attempting an update
-        if self.node.status == NodeStatus.ASLEEP:
-            if not self._status_unsub:
-                self._status_unsub = self.node.once(
-                    "wake up", self._update_on_status_change
-                )
             return
 
         try:
@@ -436,10 +420,6 @@ class ZWaveFirmwareUpdateEntity(UpdateEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed."""
-        if self._status_unsub:
-            self._status_unsub()
-            self._status_unsub = None
-
         if self._poll_unsub:
             self._poll_unsub()
             self._poll_unsub = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Z-Wave integration used to wait for sleeping devices to wake up before checking if there is a firmware update available. This used to be necessary, because Z-Wave JS would first ensure that its cached information is up to date, and then use that for firmware update checks.

This order is now reversed, Z-Wave JS checks for updates first and then validates when the update should be performed.

Therefore we no longer need to wait for the wakeup (which may take days or may never happen automatically), before checking for firmware updates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been **updated** to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
