### PR TITLE
Use "device_id" instead of "slave" in modbus integration

### DIFF
--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -104,10 +104,9 @@ UDP = "udp"
 
 # service call attributes
 ATTR_ADDRESS = CONF_ADDRESS
-ATTR_DEVICE_ID = "device_id"
 ATTR_HUB = "hub"
 ATTR_UNIT = "unit"
-ATTR_SLAVE = "slave"
+ATTR_SLAVE = "device_id"
 ATTR_VALUE = "value"
 
 

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -104,6 +104,7 @@ UDP = "udp"
 
 # service call attributes
 ATTR_ADDRESS = CONF_ADDRESS
+ATTR_DEVICE_ID = "device_id"
 ATTR_HUB = "hub"
 ATTR_UNIT = "unit"
 ATTR_SLAVE = "slave"

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -96,6 +96,7 @@ CONF_VIRTUAL_COUNT = "virtual_count"
 CONF_WRITE_TYPE = "write_type"
 CONF_ZERO_SUPPRESS = "zero_suppress"
 
+DEVICE_ID = "device_id"
 RTUOVERTCP = "rtuovertcp"
 SERIAL = "serial"
 TCP = "tcp"
@@ -106,7 +107,7 @@ UDP = "udp"
 ATTR_ADDRESS = CONF_ADDRESS
 ATTR_HUB = "hub"
 ATTR_UNIT = "unit"
-ATTR_SLAVE = "device_id"
+ATTR_SLAVE = "slave"
 ATTR_VALUE = "value"
 
 

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -57,6 +57,7 @@ from .const import (
     CONF_PARITY,
     CONF_STOPBITS,
     DEFAULT_HUB,
+    DEVICE_ID,
     MODBUS_DOMAIN as DOMAIN,
     PLATFORMS,
     RTUOVERTCP,
@@ -381,7 +382,7 @@ class ModbusHub:
     ) -> ModbusPDU | None:
         """Call sync. pymodbus."""
         kwargs: dict[str, Any] = (
-            {ATTR_SLAVE: slave} if slave is not None else {ATTR_SLAVE: 1}
+            {DEVICE_ID: slave} if slave is not None else {DEVICE_ID: 1}
         )
         entry = self._pb_request[use_call]
 

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -39,7 +39,6 @@ from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     ATTR_ADDRESS,
-    ATTR_DEVICE_ID,
     ATTR_HUB,
     ATTR_SLAVE,
     ATTR_UNIT,
@@ -378,13 +377,11 @@ class ModbusHub:
                 _LOGGER.info(message)
 
     async def low_level_pb_call(
-        self, device_id: int | None, address: int, value: int | list[int], use_call: str
+        self, slave: int | None, address: int, value: int | list[int], use_call: str
     ) -> ModbusPDU | None:
         """Call sync. pymodbus."""
         kwargs: dict[str, Any] = (
-            {ATTR_DEVICE_ID: device_id}
-            if device_id is not None
-            else {ATTR_DEVICE_ID: 1}
+            {ATTR_SLAVE: slave} if slave is not None else {ATTR_SLAVE: 1}
         )
         entry = self._pb_request[use_call]
 
@@ -396,21 +393,21 @@ class ModbusHub:
         try:
             result: ModbusPDU = await entry.func(address, **kwargs)
         except ModbusException as exception_error:
-            error = (
-                f"Error: device: {device_id} address: {address} -> {exception_error!s}"
-            )
+            error = f"Error: device: {slave} address: {address} -> {exception_error!s}"
             self._log_error(error)
             return None
         if not result:
-            error = f"Error: device: {device_id} address: {address} -> pymodbus returned None"
+            error = (
+                f"Error: device: {slave} address: {address} -> pymodbus returned None"
+            )
             self._log_error(error)
             return None
         if not hasattr(result, entry.attr):
-            error = f"Error: device: {device_id} address: {address} -> {result!s}"
+            error = f"Error: device: {slave} address: {address} -> {result!s}"
             self._log_error(error)
             return None
         if result.isError():
-            error = f"Error: device: {device_id} address: {address} -> pymodbus returned isError True"
+            error = f"Error: device: {slave} address: {address} -> pymodbus returned isError True"
             self._log_error(error)
             return None
         self._in_error = False

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -39,6 +39,7 @@ from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     ATTR_ADDRESS,
+    ATTR_DEVICE_ID,
     ATTR_HUB,
     ATTR_SLAVE,
     ATTR_UNIT,
@@ -381,7 +382,7 @@ class ModbusHub:
     ) -> ModbusPDU | None:
         """Call sync. pymodbus."""
         kwargs: dict[str, Any] = (
-            {ATTR_SLAVE: slave} if slave is not None else {ATTR_SLAVE: 1}
+            {ATTR_DEVICE_ID: slave} if slave is not None else {ATTR_DEVICE_ID: 1}
         )
         entry = self._pb_request[use_call]
 

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -467,7 +467,7 @@ async def test_hvac_onoff_values(hass: HomeAssistant, mock_modbus) -> None:
     )
     await hass.async_block_till_done()
 
-    mock_modbus.write_register.assert_called_with(11, value=0xAA, slave=10)
+    mock_modbus.write_register.assert_called_with(11, value=0xAA, device_id=10)
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -477,7 +477,7 @@ async def test_hvac_onoff_values(hass: HomeAssistant, mock_modbus) -> None:
     )
     await hass.async_block_till_done()
 
-    mock_modbus.write_register.assert_called_with(11, value=0xFF, slave=10)
+    mock_modbus.write_register.assert_called_with(11, value=0xFF, device_id=10)
 
 
 @pytest.mark.parametrize(
@@ -506,7 +506,7 @@ async def test_hvac_onoff_coil(hass: HomeAssistant, mock_modbus) -> None:
     )
     await hass.async_block_till_done()
 
-    mock_modbus.write_coil.assert_called_with(11, value=1, slave=10)
+    mock_modbus.write_coil.assert_called_with(11, value=1, device_id=10)
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -516,7 +516,7 @@ async def test_hvac_onoff_coil(hass: HomeAssistant, mock_modbus) -> None:
     )
     await hass.async_block_till_done()
 
-    mock_modbus.write_coil.assert_called_with(11, value=0, slave=10)
+    mock_modbus.write_coil.assert_called_with(11, value=0, device_id=10)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -1413,3 +1413,65 @@ async def test_pb_service_write_no_slave(
 
     if do_return[DATA]:
         assert any(message.startswith("Pymodbus:") for message in caplog.messages)
+
+
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_NAME: TEST_MODBUS_NAME,
+            CONF_TYPE: SERIAL,
+            CONF_BAUDRATE: 9600,
+            CONF_BYTESIZE: 8,
+            CONF_METHOD: "rtu",
+            CONF_PORT: TEST_PORT_SERIAL,
+            CONF_PARITY: "E",
+            CONF_STOPBITS: 1,
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: "dummy_noslave",
+                    CONF_ADDRESS: 8888,
+                }
+            ],
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    "do_write",
+    [
+        {
+            DATA: ATTR_VALUE,
+            VALUE: 15,
+            SERVICE: SERVICE_WRITE_REGISTER,
+            FUNC: CALL_TYPE_WRITE_REGISTER,
+        },
+        {
+            DATA: ATTR_STATE,
+            VALUE: False,
+            SERVICE: SERVICE_WRITE_COIL,
+            FUNC: CALL_TYPE_WRITE_COIL,
+        },
+    ],
+)
+async def test_pb_service_return_None(
+    hass: HomeAssistant,
+    do_write,
+    caplog: pytest.LogCaptureFixture,
+    mock_modbus_with_pymodbus,
+) -> None:
+    """Run test when pymodbus returns None."""
+    func_name = {
+        CALL_TYPE_WRITE_COIL: mock_modbus_with_pymodbus.write_coil,
+        CALL_TYPE_WRITE_REGISTER: mock_modbus_with_pymodbus.write_register,
+    }
+    data = {
+        ATTR_HUB: TEST_MODBUS_NAME,
+        ATTR_ADDRESS: 16,
+        do_write[DATA]: do_write[VALUE],
+    }
+    mock_modbus_with_pymodbus.reset_mock()
+    caplog.clear()
+    caplog.set_level(logging.DEBUG)
+    func_name[do_write[FUNC]].return_value = None
+    await hass.services.async_call(DOMAIN, do_write[SERVICE], data, blocking=True)
+    assert any("None" in message for message in caplog.messages)

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -867,7 +867,7 @@ async def test_pb_service_write(
     assert func_name[do_write[FUNC]].called
     assert func_name[do_write[FUNC]].call_args.args == (data[ATTR_ADDRESS],)
     assert func_name[do_write[FUNC]].call_args.kwargs == {
-        "slave": 17,
+        "device_id": 17,
         value_arg_name[do_write[FUNC]]: data[do_write[DATA]],
     }
 
@@ -1326,7 +1326,7 @@ async def test_check_default_slave(
     """Test default slave."""
     assert mock_modbus.read_holding_registers.mock_calls
     first_call = mock_modbus.read_holding_registers.mock_calls[0]
-    assert first_call.kwargs["slave"] == expected_slave_value
+    assert first_call.kwargs["device_id"] == expected_slave_value
 
 
 @pytest.mark.parametrize(
@@ -1407,7 +1407,7 @@ async def test_pb_service_write_no_slave(
     assert func_name[do_write[FUNC]].called
     assert func_name[do_write[FUNC]].call_args.args == (data[ATTR_ADDRESS],)
     assert func_name[do_write[FUNC]].call_args.kwargs == {
-        "slave": 1,
+        "device_id": 1,
         value_arg_name[do_write[FUNC]]: data[do_write[DATA]],
     }
 

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -63,6 +63,7 @@ from homeassistant.components.modbus.const import (
     CONF_SWING_MODE_VALUES,
     CONF_VIRTUAL_COUNT,
     DEFAULT_SCAN_INTERVAL,
+    DEVICE_ID,
     MODBUS_DOMAIN as DOMAIN,
     RTUOVERTCP,
     SERIAL,
@@ -867,7 +868,7 @@ async def test_pb_service_write(
     assert func_name[do_write[FUNC]].called
     assert func_name[do_write[FUNC]].call_args.args == (data[ATTR_ADDRESS],)
     assert func_name[do_write[FUNC]].call_args.kwargs == {
-        ATTR_SLAVE: 17,
+        DEVICE_ID: 17,
         value_arg_name[do_write[FUNC]]: data[do_write[DATA]],
     }
 
@@ -1326,7 +1327,7 @@ async def test_check_default_slave(
     """Test default slave."""
     assert mock_modbus.read_holding_registers.mock_calls
     first_call = mock_modbus.read_holding_registers.mock_calls[0]
-    assert first_call.kwargs[ATTR_SLAVE] == expected_slave_value
+    assert first_call.kwargs[DEVICE_ID] == expected_slave_value
 
 
 @pytest.mark.parametrize(
@@ -1407,7 +1408,7 @@ async def test_pb_service_write_no_slave(
     assert func_name[do_write[FUNC]].called
     assert func_name[do_write[FUNC]].call_args.args == (data[ATTR_ADDRESS],)
     assert func_name[do_write[FUNC]].call_args.kwargs == {
-        ATTR_SLAVE: 1,
+        DEVICE_ID: 1,
         value_arg_name[do_write[FUNC]]: data[do_write[DATA]],
     }
 

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -27,6 +27,7 @@ from homeassistant import config as hass_config
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.modbus.const import (
     ATTR_ADDRESS,
+    ATTR_DEVICE_ID,
     ATTR_HUB,
     ATTR_SLAVE,
     ATTR_UNIT,
@@ -867,7 +868,7 @@ async def test_pb_service_write(
     assert func_name[do_write[FUNC]].called
     assert func_name[do_write[FUNC]].call_args.args == (data[ATTR_ADDRESS],)
     assert func_name[do_write[FUNC]].call_args.kwargs == {
-        "device_id": 17,
+        ATTR_DEVICE_ID: 17,
         value_arg_name[do_write[FUNC]]: data[do_write[DATA]],
     }
 
@@ -1326,7 +1327,7 @@ async def test_check_default_slave(
     """Test default slave."""
     assert mock_modbus.read_holding_registers.mock_calls
     first_call = mock_modbus.read_holding_registers.mock_calls[0]
-    assert first_call.kwargs["device_id"] == expected_slave_value
+    assert first_call.kwargs[ATTR_DEVICE_ID] == expected_slave_value
 
 
 @pytest.mark.parametrize(
@@ -1407,7 +1408,7 @@ async def test_pb_service_write_no_slave(
     assert func_name[do_write[FUNC]].called
     assert func_name[do_write[FUNC]].call_args.args == (data[ATTR_ADDRESS],)
     assert func_name[do_write[FUNC]].call_args.kwargs == {
-        "device_id": 1,
+        ATTR_DEVICE_ID: 1,
         value_arg_name[do_write[FUNC]]: data[do_write[DATA]],
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
As pymodbus version has been bumped to 3.11.0, slave is not accepted as a argument and has to be replaced ,by device_id

see https://github.com/pymodbus-dev/pymodbus/blob/dev/API_changes.rst


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
