### PR TITLE
Silence vacuum battery deprecation for built in integrations

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -333,7 +333,7 @@ class StateVacuumEntity(
                 f"is setting the {property} which has been deprecated."
                 f" Integration {self.platform.platform_name} should implement a sensor"
                 " instead with a correct device class and link it to the same device",
-                core_integration_behavior=ReportBehavior.LOG,
+                core_integration_behavior=ReportBehavior.IGNORE,
                 custom_integration_behavior=ReportBehavior.LOG,
                 breaks_in_ha_version="2026.8",
                 integration_domain=self.platform.platform_name,
@@ -358,7 +358,7 @@ class StateVacuumEntity(
                 f" Integration {self.platform.platform_name} should remove this as part of migrating"
                 " the battery level and icon to a sensor",
                 core_behavior=ReportBehavior.LOG,
-                core_integration_behavior=ReportBehavior.LOG,
+                core_integration_behavior=ReportBehavior.IGNORE,
                 custom_integration_behavior=ReportBehavior.LOG,
                 breaks_in_ha_version="2026.8",
                 integration_domain=self.platform.platform_name,

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
+import logging
 from types import ModuleType
 from typing import Any
 
@@ -437,11 +438,13 @@ async def test_vacuum_deprecated_state_does_not_break_state(
     assert state.state == "cleaning"
 
 
-@pytest.mark.usefixtures("mock_as_custom_component")
-async def test_vacuum_log_deprecated_battery_properties(
+@pytest.mark.parametrize(("is_built_in", "log_warnings"), [(True, 0), (False, 3)])
+async def test_vacuum_log_deprecated_battery_using_properties(
     hass: HomeAssistant,
     config_flow_fixture: None,
     caplog: pytest.LogCaptureFixture,
+    is_built_in: bool,
+    log_warnings: int,
 ) -> None:
     """Test incorrectly using battery properties logs warning."""
 
@@ -449,7 +452,7 @@ async def test_vacuum_log_deprecated_battery_properties(
         """Mocked vacuum entity."""
 
         @property
-        def activity(self) -> str:
+        def activity(self) -> VacuumActivity:
             """Return the state of the entity."""
             return VacuumActivity.CLEANING
 
@@ -477,7 +480,7 @@ async def test_vacuum_log_deprecated_battery_properties(
             async_setup_entry=help_async_setup_entry_init,
             async_unload_entry=help_async_unload_entry,
         ),
-        built_in=False,
+        built_in=is_built_in,
     )
     setup_test_component_platform(hass, DOMAIN, [entity], from_config_entry=True)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -486,26 +489,27 @@ async def test_vacuum_log_deprecated_battery_properties(
     assert state is not None
 
     assert (
-        "Detected that custom integration 'test' is setting the battery_icon which has been deprecated."
-        " Integration test should implement a sensor instead with a correct device class and link it"
-        " to the same device. This will stop working in Home Assistant 2026.8,"
-        " please report it to the author of the 'test' custom integration"
-        in caplog.text
+        len([record for record in caplog.records if record.levelno >= logging.WARNING])
+        == log_warnings
     )
+
     assert (
-        "Detected that custom integration 'test' is setting the battery_level which has been deprecated."
-        " Integration test should implement a sensor instead with a correct device class and link it"
-        " to the same device. This will stop working in Home Assistant 2026.8,"
-        " please report it to the author of the 'test' custom integration"
+        "integration 'test' is setting the battery_icon which has been deprecated."
         in caplog.text
-    )
+    ) != is_built_in
+    assert (
+        "integration 'test' is setting the battery_level which has been deprecated."
+        in caplog.text
+    ) != is_built_in
 
 
-@pytest.mark.usefixtures("mock_as_custom_component")
-async def test_vacuum_log_deprecated_battery_properties_using_attr(
+@pytest.mark.parametrize(("is_built_in", "log_warnings"), [(True, 0), (False, 3)])
+async def test_vacuum_log_deprecated_battery_using_attr(
     hass: HomeAssistant,
     config_flow_fixture: None,
     caplog: pytest.LogCaptureFixture,
+    is_built_in: bool,
+    log_warnings: int,
 ) -> None:
     """Test incorrectly using _attr_battery_* attribute does log issue and raise repair."""
 
@@ -531,7 +535,7 @@ async def test_vacuum_log_deprecated_battery_properties_using_attr(
             async_setup_entry=help_async_setup_entry_init,
             async_unload_entry=help_async_unload_entry,
         ),
-        built_in=False,
+        built_in=is_built_in,
     )
     setup_test_component_platform(hass, DOMAIN, [entity], from_config_entry=True)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -541,47 +545,51 @@ async def test_vacuum_log_deprecated_battery_properties_using_attr(
     entity.start()
 
     assert (
-        "Detected that custom integration 'test' is setting the battery_level which has been deprecated."
-        " Integration test should implement a sensor instead with a correct device class and link it to"
-        " the same device. This will stop working in Home Assistant 2026.8,"
-        " please report it to the author of the 'test' custom integration"
-        in caplog.text
+        len([record for record in caplog.records if record.levelno >= logging.WARNING])
+        == log_warnings
     )
+
     assert (
-        "Detected that custom integration 'test' is setting the battery_icon which has been deprecated."
-        " Integration test should implement a sensor instead with a correct device class and link it to"
-        " the same device. This will stop working in Home Assistant 2026.8,"
-        " please report it to the author of the 'test' custom integration"
+        "integration 'test' is setting the battery_level which has been deprecated."
         in caplog.text
-    )
+    ) != is_built_in
+    assert (
+        "integration 'test' is setting the battery_icon which has been deprecated."
+        in caplog.text
+    ) != is_built_in
 
     await async_start(hass, entity.entity_id)
 
     caplog.clear()
+
     await async_start(hass, entity.entity_id)
+
     # Test we only log once
     assert (
-        "Detected that custom integration 'test' is setting the battery_level which has been deprecated."
-        not in caplog.text
-    )
-    assert (
-        "Detected that custom integration 'test' is setting the battery_icon which has been deprecated."
-        not in caplog.text
+        len([record for record in caplog.records if record.levelno >= logging.WARNING])
+        == 0
     )
 
 
-@pytest.mark.usefixtures("mock_as_custom_component")
+@pytest.mark.parametrize(("is_built_in", "log_warnings"), [(True, 0), (False, 1)])
 async def test_vacuum_log_deprecated_battery_supported_feature(
     hass: HomeAssistant,
     config_flow_fixture: None,
     caplog: pytest.LogCaptureFixture,
+    is_built_in: bool,
+    log_warnings: int,
 ) -> None:
     """Test incorrectly setting battery supported feature logs warning."""
 
-    entity = MockVacuum(
-        name="Testing",
-        entity_id="vacuum.test",
-    )
+    class MockVacuum(StateVacuumEntity):
+        """Mock vacuum class."""
+
+        _attr_supported_features = (
+            VacuumEntityFeature.STATE | VacuumEntityFeature.BATTERY
+        )
+        _attr_name = "Testing"
+
+    entity = MockVacuum()
     config_entry = MockConfigEntry(domain="test")
     config_entry.add_to_hass(hass)
 
@@ -592,7 +600,7 @@ async def test_vacuum_log_deprecated_battery_supported_feature(
             async_setup_entry=help_async_setup_entry_init,
             async_unload_entry=help_async_unload_entry,
         ),
-        built_in=False,
+        built_in=is_built_in,
     )
     setup_test_component_platform(hass, DOMAIN, [entity], from_config_entry=True)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -601,12 +609,13 @@ async def test_vacuum_log_deprecated_battery_supported_feature(
     assert state is not None
 
     assert (
-        "Detected that custom integration 'test' is setting the battery supported feature"
-        " which has been deprecated. Integration test should remove this as part of migrating"
-        " the battery level and icon to a sensor. This will stop working in Home Assistant 2026.8"
-        ", please report it to the author of the 'test' custom integration"
-        in caplog.text
+        len([record for record in caplog.records if record.levelno >= logging.WARNING])
+        == log_warnings
     )
+
+    assert (
+        "integration 'test' is setting the battery supported feature" in caplog.text
+    ) != is_built_in
 
 
 async def test_vacuum_not_log_deprecated_battery_properties_during_init(
@@ -624,7 +633,7 @@ async def test_vacuum_not_log_deprecated_battery_properties_during_init(
             self._attr_battery_level = 50
 
         @property
-        def activity(self) -> str:
+        def activity(self) -> VacuumActivity:
             """Return the state of the entity."""
             return VacuumActivity.CLEANING
 
@@ -635,6 +644,6 @@ async def test_vacuum_not_log_deprecated_battery_properties_during_init(
     assert entity.battery_level == 50
 
     assert (
-        "Detected that custom integration 'test' is setting the battery_level which has been deprecated."
-        not in caplog.text
+        len([record for record in caplog.records if record.levelno >= logging.WARNING])
+        == 0
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We haven't migrated all built in integrations with a vacuum platform to not set battery attributes yet.
- Silence the warning log for now, until all built in integrations are migrated.
- Custom integrations will still log a warning.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
