### PR TITLE
Add select platform to LetPot integration

### DIFF
--- a/homeassistant/components/letpot/__init__.py
+++ b/homeassistant/components/letpot/__init__.py
@@ -25,6 +25,7 @@ from .coordinator import LetPotConfigEntry, LetPotDeviceCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.TIME,

--- a/homeassistant/components/letpot/icons.json
+++ b/homeassistant/components/letpot/icons.json
@@ -20,6 +20,23 @@
         }
       }
     },
+    "select": {
+      "display_temperature_unit": {
+        "default": "mdi:thermometer-lines"
+      },
+      "light_brightness": {
+        "default": "mdi:brightness-6",
+        "state": {
+          "high": "mdi:brightness-7"
+        }
+      },
+      "light_mode": {
+        "default": "mdi:sprout",
+        "state": {
+          "flower": "mdi:flower"
+        }
+      }
+    },
     "sensor": {
       "water_level": {
         "default": "mdi:water-percent"

--- a/homeassistant/components/letpot/select.py
+++ b/homeassistant/components/letpot/select.py
@@ -1,0 +1,166 @@
+"""Support for LetPot select entities."""
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from letpot.deviceclient import LetPotDeviceClient
+from letpot.models import DeviceFeature, LightMode, TemperatureUnit
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import LetPotConfigEntry, LetPotDeviceCoordinator
+from .entity import LetPotEntity, LetPotEntityDescription, exception_handler
+
+# Each change pushes a 'full' device status with the change. The library will cache
+# pending changes to avoid overwriting, but try to avoid a lot of parallelism.
+PARALLEL_UPDATES = 1
+
+
+class LightBrightnessLowHigh(StrEnum):
+    """Light brightness low/high model."""
+
+    LOW = "low"
+    HIGH = "high"
+
+
+def _get_brightness_low_high_value(coordinator: LetPotDeviceCoordinator) -> str | None:
+    """Return brightness as low/high for a device which only has a low and high value."""
+    brightness = coordinator.data.light_brightness
+    levels = coordinator.device_client.get_light_brightness_levels(
+        coordinator.device.serial_number
+    )
+    return (
+        LightBrightnessLowHigh.LOW.value
+        if levels[0] == brightness
+        else LightBrightnessLowHigh.HIGH.value
+    )
+
+
+async def _set_brightness_low_high_value(
+    device_client: LetPotDeviceClient, serial: str, option: str
+) -> None:
+    """Set brightness from low/high for a device which only has a low and high value."""
+    levels = device_client.get_light_brightness_levels(serial)
+    await device_client.set_light_brightness(
+        serial, levels[0] if option == LightBrightnessLowHigh.LOW.value else levels[1]
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class LetPotSelectEntityDescription(LetPotEntityDescription, SelectEntityDescription):
+    """Describes a LetPot select entity."""
+
+    options_fn: Callable[[LetPotDeviceCoordinator], list[str]]
+    value_fn: Callable[[LetPotDeviceCoordinator], str | None]
+    set_value_fn: Callable[[LetPotDeviceClient, str, str], Coroutine[Any, Any, None]]
+
+
+SELECTORS: tuple[LetPotSelectEntityDescription, ...] = (
+    LetPotSelectEntityDescription(
+        key="display_temperature_unit",
+        translation_key="display_temperature_unit",
+        options_fn=lambda _: [x.name.lower() for x in TemperatureUnit],
+        value_fn=(
+            lambda coordinator: coordinator.data.temperature_unit.name.lower()
+            if coordinator.data.temperature_unit is not None
+            else None
+        ),
+        set_value_fn=(
+            lambda device_client, serial, option: device_client.set_temperature_unit(
+                serial, TemperatureUnit[option.upper()]
+            )
+        ),
+        supported_fn=(
+            lambda coordinator: DeviceFeature.TEMPERATURE_SET_UNIT
+            in coordinator.device_client.device_info(
+                coordinator.device.serial_number
+            ).features
+        ),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    LetPotSelectEntityDescription(
+        key="light_brightness_low_high",
+        translation_key="light_brightness",
+        options_fn=lambda _: [
+            LightBrightnessLowHigh.LOW.value,
+            LightBrightnessLowHigh.HIGH.value,
+        ],
+        value_fn=_get_brightness_low_high_value,
+        set_value_fn=_set_brightness_low_high_value,
+        supported_fn=(
+            lambda coordinator: DeviceFeature.LIGHT_BRIGHTNESS_LOW_HIGH
+            in coordinator.device_client.device_info(
+                coordinator.device.serial_number
+            ).features
+        ),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    LetPotSelectEntityDescription(
+        key="light_mode",
+        translation_key="light_mode",
+        options_fn=lambda _: [x.name.lower() for x in LightMode],
+        value_fn=(
+            lambda coordinator: coordinator.data.light_mode.name.lower()
+            if coordinator.data.light_mode is not None
+            else None
+        ),
+        set_value_fn=(
+            lambda device_client, serial, option: device_client.set_light_mode(
+                serial, LightMode[option.upper()]
+            )
+        ),
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: LetPotConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up LetPot select entities based on a config entry and device status/features."""
+    coordinators = entry.runtime_data
+    entities: list[SelectEntity] = [
+        LetPotSelectEntity(coordinator, description)
+        for description in SELECTORS
+        for coordinator in coordinators
+        if description.supported_fn(coordinator)
+    ]
+    async_add_entities(entities)
+
+
+class LetPotSelectEntity(LetPotEntity, SelectEntity):
+    """Defines a LetPot select entity."""
+
+    entity_description: LetPotSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: LetPotDeviceCoordinator,
+        description: LetPotSelectEntityDescription,
+    ) -> None:
+        """Initialize LetPot select entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{coordinator.device.serial_number}_{description.key}"
+        self._attr_options = self.entity_description.options_fn(coordinator)
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option."""
+        return self.entity_description.value_fn(self.coordinator)
+
+    @exception_handler
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        return await self.entity_description.set_value_fn(
+            self.coordinator.device_client,
+            self.coordinator.device.serial_number,
+            option,
+        )

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -49,6 +49,29 @@
         "name": "Refill error"
       }
     },
+    "select": {
+      "display_temperature_unit": {
+        "name": "Display temperature unit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "light_brightness": {
+        "name": "Light brightness",
+        "state": {
+          "low": "[%key:common::state::low%]",
+          "high": "[%key:common::state::high%]"
+        }
+      },
+      "light_mode": {
+        "name": "Light mode",
+        "state": {
+          "flower": "Fruits / flowers",
+          "vegetable": "Veggie / herbs"
+        }
+      }
+    },
     "sensor": {
       "water_level": {
         "name": "Water level"

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -51,7 +51,7 @@
     },
     "select": {
       "display_temperature_unit": {
-        "name": "Display temperature unit",
+        "name": "Temperature unit on display",
         "state": {
           "celsius": "Celsius",
           "fahrenheit": "Fahrenheit"

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -68,7 +68,7 @@
         "name": "Light mode",
         "state": {
           "flower": "Fruits/Flowers",
-          "vegetable": "Veggie/Herbs"
+          "vegetable": "Veggies/Herbs"
         }
       }
     },

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -67,8 +67,8 @@
       "light_mode": {
         "name": "Light mode",
         "state": {
-          "flower": "Fruits / flowers",
-          "vegetable": "Veggie / herbs"
+          "flower": "Fruits/Flowers",
+          "vegetable": "Veggie/Herbs"
         }
       }
     },

--- a/tests/components/letpot/__init__.py
+++ b/tests/components/letpot/__init__.py
@@ -33,7 +33,7 @@ AUTHENTICATION = AuthenticationInfo(
 
 MAX_STATUS = LetPotDeviceStatus(
     errors=LetPotDeviceErrors(low_water=True, low_nutrients=False, refill_error=False),
-    light_brightness=500,
+    light_brightness=750,
     light_mode=LightMode.VEGETABLE,
     light_schedule_end=datetime.time(18, 0),
     light_schedule_start=datetime.time(8, 0),

--- a/tests/components/letpot/conftest.py
+++ b/tests/components/letpot/conftest.py
@@ -49,6 +49,16 @@ def _mock_device_features(device_type: str) -> DeviceFeature:
             | DeviceFeature.LIGHT_BRIGHTNESS_LOW_HIGH
             | DeviceFeature.PUMP_STATUS
         )
+    if device_type == "LPH62":
+        return (
+            DeviceFeature.CATEGORY_HYDROPONIC_GARDEN
+            | DeviceFeature.LIGHT_BRIGHTNESS_LEVELS
+            | DeviceFeature.NUTRIENT_BUTTON
+            | DeviceFeature.PUMP_AUTO
+            | DeviceFeature.TEMPERATURE
+            | DeviceFeature.TEMPERATURE_SET_UNIT
+            | DeviceFeature.WATER_LEVEL
+        )
     if device_type == "LPH63":
         return (
             DeviceFeature.CATEGORY_HYDROPONIC_GARDEN
@@ -66,8 +76,17 @@ def _mock_device_status(device_type: str) -> LetPotDeviceStatus:
     """Return mock device status for the given type."""
     if device_type == "LPH31":
         return SE_STATUS
-    if device_type == "LPH63":
+    if device_type in {"LPH62", "LPH63"}:
         return MAX_STATUS
+    raise ValueError(f"No mock data for device type {device_type}")
+
+
+def _mock_light_brightness_levels(device_type: str) -> list[int]:
+    """Return mock brightness levels for the given type."""
+    if device_type == "LPH31":
+        return [500, 1000]
+    if device_type in {"LPH62", "LPH63"}:
+        return [125, 250, 375, 500, 625, 750, 875, 1000]
     raise ValueError(f"No mock data for device type {device_type}")
 
 
@@ -133,6 +152,9 @@ def mock_device_client() -> Generator[AsyncMock]:
 
         device_client.device_info.side_effect = lambda serial: _mock_device_info(
             serial[:5]
+        )
+        device_client.get_light_brightness_levels.side_effect = (
+            lambda serial: _mock_light_brightness_levels(serial[:5])
         )
         device_client.get_current_status.side_effect = get_current_status_side_effect
         device_client.request_status_update.side_effect = request_status_side_effect

--- a/tests/components/letpot/snapshots/test_select.ambr
+++ b/tests/components/letpot/snapshots/test_select.ambr
@@ -113,63 +113,6 @@
     'state': 'vegetable',
   })
 # ---
-# name: test_all_entities[LPH62][select.garden_display_temperature_unit-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'options': list([
-        'fahrenheit',
-        'celsius',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'select',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.garden_display_temperature_unit',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Display temperature unit',
-    'platform': 'letpot',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'display_temperature_unit',
-    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH62ABCD_display_temperature_unit',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[LPH62][select.garden_display_temperature_unit-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Garden Display temperature unit',
-      'options': list([
-        'fahrenheit',
-        'celsius',
-      ]),
-    }),
-    'context': <ANY>,
-    'entity_id': 'select.garden_display_temperature_unit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'celsius',
-  })
-# ---
 # name: test_all_entities[LPH62][select.garden_light_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -225,5 +168,62 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'vegetable',
+  })
+# ---
+# name: test_all_entities[LPH62][select.garden_temperature_unit_on_display-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'fahrenheit',
+        'celsius',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.garden_temperature_unit_on_display',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Temperature unit on display',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'display_temperature_unit',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH62ABCD_display_temperature_unit',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[LPH62][select.garden_temperature_unit_on_display-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Garden Temperature unit on display',
+      'options': list([
+        'fahrenheit',
+        'celsius',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.garden_temperature_unit_on_display',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'celsius',
   })
 # ---

--- a/tests/components/letpot/snapshots/test_select.ambr
+++ b/tests/components/letpot/snapshots/test_select.ambr
@@ -1,0 +1,229 @@
+# serializer version: 1
+# name: test_all_entities[LPH31][select.garden_light_brightness-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'low',
+        'high',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.garden_light_brightness',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Light brightness',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'light_brightness',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH31ABCD_light_brightness_low_high',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[LPH31][select.garden_light_brightness-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Garden Light brightness',
+      'options': list([
+        'low',
+        'high',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.garden_light_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'low',
+  })
+# ---
+# name: test_all_entities[LPH31][select.garden_light_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'flower',
+        'vegetable',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.garden_light_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Light mode',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'light_mode',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH31ABCD_light_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[LPH31][select.garden_light_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Garden Light mode',
+      'options': list([
+        'flower',
+        'vegetable',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.garden_light_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'vegetable',
+  })
+# ---
+# name: test_all_entities[LPH62][select.garden_display_temperature_unit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'fahrenheit',
+        'celsius',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.garden_display_temperature_unit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Display temperature unit',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'display_temperature_unit',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH62ABCD_display_temperature_unit',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[LPH62][select.garden_display_temperature_unit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Garden Display temperature unit',
+      'options': list([
+        'fahrenheit',
+        'celsius',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.garden_display_temperature_unit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'celsius',
+  })
+# ---
+# name: test_all_entities[LPH62][select.garden_light_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'flower',
+        'vegetable',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.garden_light_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Light mode',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'light_mode',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH62ABCD_light_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[LPH62][select.garden_light_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Garden Light mode',
+      'options': list([
+        'flower',
+        'vegetable',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.garden_light_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'vegetable',
+  })
+# ---

--- a/tests/components/letpot/test_select.py
+++ b/tests/components/letpot/test_select.py
@@ -1,0 +1,102 @@
+"""Test select entities for the LetPot integration."""
+
+from unittest.mock import MagicMock, patch
+
+from letpot.exceptions import LetPotConnectionException, LetPotException
+from letpot.models import LightMode
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.parametrize("device_type", ["LPH62", "LPH31"])
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_type: str,
+) -> None:
+    """Test switch entities."""
+    with patch("homeassistant.components.letpot.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize("device_type", ["LPH62"])
+async def test_set_select(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+    device_type: str,
+) -> None:
+    """Test select entity set to value."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.garden_light_mode",
+            ATTR_OPTION: LightMode.FLOWER.name.lower(),
+        },
+        blocking=True,
+    )
+
+    mock_device_client.set_light_mode.assert_awaited_once_with(
+        f"{device_type}ABCD", LightMode.FLOWER
+    )
+
+
+@pytest.mark.parametrize(
+    ("exception", "user_error"),
+    [
+        (
+            LetPotConnectionException("Connection failed"),
+            "An error occurred while communicating with the LetPot device: Connection failed",
+        ),
+        (
+            LetPotException("Random thing failed"),
+            "An unknown error occurred while communicating with the LetPot device: Random thing failed",
+        ),
+    ],
+)
+async def test_select_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+    exception: Exception,
+    user_error: str,
+) -> None:
+    """Test select entity exception handling."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_device_client.set_light_mode.side_effect = exception
+
+    with pytest.raises(HomeAssistantError, match=user_error):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.garden_light_mode",
+                ATTR_OPTION: LightMode.FLOWER.name.lower(),
+            },
+            blocking=True,
+        )

--- a/tests/components/letpot/test_select.py
+++ b/tests/components/letpot/test_select.py
@@ -38,7 +38,7 @@ async def test_all_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.parametrize("device_type", ["LPH62"])
+@pytest.mark.parametrize("device_type", ["LPH31"])
 async def test_set_select(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -53,14 +53,14 @@ async def test_set_select(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {
-            ATTR_ENTITY_ID: "select.garden_light_mode",
-            ATTR_OPTION: LightMode.FLOWER.name.lower(),
+            ATTR_ENTITY_ID: "select.garden_light_brightness",
+            ATTR_OPTION: "high",
         },
         blocking=True,
     )
 
-    mock_device_client.set_light_mode.assert_awaited_once_with(
-        f"{device_type}ABCD", LightMode.FLOWER
+    mock_device_client.set_light_brightness.assert_awaited_once_with(
+        f"{device_type}ABCD", 1000
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the select platform to the LetPot integration, providing 1 or 2 selects depending on device support.

All available selects and options:

|![](https://github.com/user-attachments/assets/82416d9a-72d2-4c1e-a184-3278ce241b05)|![](https://github.com/user-attachments/assets/72ba98f3-a839-4866-94b9-ce4154117234)|
|---|---|

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#40323
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
