### PR TITLE
Handle non-streaming TTS case correctly

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -977,8 +977,7 @@ class SpeechManager:
             raise HomeAssistantError("TTS engine name is not set.")
 
         if isinstance(engine_instance, Provider) or (
-            isinstance(engine_instance, TextToSpeechEntity)
-            and (not engine_instance.async_supports_streaming_input())
+            not engine_instance.async_supports_streaming_input()
         ):
             # Non-streaming
             if isinstance(message_or_stream, str):

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -986,15 +986,9 @@ class SpeechManager:
             else:
                 message = "".join([chunk async for chunk in message_or_stream])
 
-            if isinstance(engine_instance, Provider):
-                # Legacy API
-                extension, data = await engine_instance.async_internal_get_tts_audio(
-                    message, language, options
-                )
-            else:
-                extension, data = await engine_instance.async_get_tts_audio(
-                    message, language, options
-                )
+            extension, data = await engine_instance.async_internal_get_tts_audio(
+                message, language, options
+            )
 
             if data is None or extension is None:
                 raise HomeAssistantError(

--- a/homeassistant/components/tts/entity.py
+++ b/homeassistant/components/tts/entity.py
@@ -198,6 +198,8 @@ class TextToSpeechEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH
 
         Return a tuple of file extension and data as bytes.
         """
+        self.__last_tts_loaded = dt_util.utcnow().isoformat()
+        self.async_write_ha_state()
         return await self.hass.async_add_executor_job(
             partial(self.get_tts_audio, message, language, options=options)
         )

--- a/homeassistant/components/tts/entity.py
+++ b/homeassistant/components/tts/entity.py
@@ -191,6 +191,18 @@ class TextToSpeechEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH
         """Load tts audio file from the engine."""
         raise NotImplementedError
 
+    @final
+    async def async_internal_get_tts_audio(
+        self, message: str, language: str, options: dict[str, Any]
+    ) -> TtsAudioType:
+        """Load tts audio file from the engine and update state.
+
+        Return a tuple of file extension and data as bytes.
+        """
+        self.__last_tts_loaded = dt_util.utcnow().isoformat()
+        self.async_write_ha_state()
+        return await self.async_get_tts_audio(message, language, options=options)
+
     async def async_get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]
     ) -> TtsAudioType:
@@ -198,8 +210,6 @@ class TextToSpeechEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH
 
         Return a tuple of file extension and data as bytes.
         """
-        self.__last_tts_loaded = dt_util.utcnow().isoformat()
-        self.async_write_ha_state()
         return await self.hass.async_add_executor_job(
             partial(self.get_tts_audio, message, language, options=options)
         )

--- a/tests/components/tts/test_entity.py
+++ b/tests/components/tts/test_entity.py
@@ -175,3 +175,31 @@ def test_streaming_supported() -> None:
 
     sync_non_streaming_entity = SyncNonStreamingEntity()
     assert sync_non_streaming_entity.async_supports_streaming_input() is False
+
+
+async def test_internal_get_tts_audio_writes_state(
+    hass: HomeAssistant,
+    mock_tts_entity: MockTTSEntity,
+) -> None:
+    """Test that only async_internal_get_tts_audio updates and writes the state."""
+
+    entity_id = f"{tts.DOMAIN}.{TEST_DOMAIN}"
+
+    config_entry = await mock_config_entry_setup(hass, mock_tts_entity)
+    assert config_entry.state is ConfigEntryState.LOADED
+    state1 = hass.states.get(entity_id)
+    assert state1 is not None
+
+    # State should *not* change with external method
+    await mock_tts_entity.async_get_tts_audio("test message", hass.config.language, {})
+    state2 = hass.states.get(entity_id)
+    assert state2 is not None
+    assert state1.state == state2.state
+
+    # State *should* change with internal method
+    await mock_tts_entity.async_internal_get_tts_audio(
+        "test message", hass.config.language, {}
+    )
+    state3 = hass.states.get(entity_id)
+    assert state3 is not None
+    assert state1.state != state3.state

--- a/tests/components/wyoming/snapshots/test_tts.ambr
+++ b/tests/components/wyoming/snapshots/test_tts.ambr
@@ -3,29 +3,10 @@
   list([
     dict({
       'data': dict({
-      }),
-      'payload': None,
-      'type': 'synthesize-start',
-    }),
-    dict({
-      'data': dict({
-        'text': 'Hello world',
-      }),
-      'payload': None,
-      'type': 'synthesize-chunk',
-    }),
-    dict({
-      'data': dict({
         'text': 'Hello world',
       }),
       'payload': None,
       'type': 'synthesize',
-    }),
-    dict({
-      'data': dict({
-      }),
-      'payload': None,
-      'type': 'synthesize-stop',
     }),
   ])
 # ---
@@ -33,29 +14,10 @@
   list([
     dict({
       'data': dict({
-      }),
-      'payload': None,
-      'type': 'synthesize-start',
-    }),
-    dict({
-      'data': dict({
-        'text': 'Hello world',
-      }),
-      'payload': None,
-      'type': 'synthesize-chunk',
-    }),
-    dict({
-      'data': dict({
         'text': 'Hello world',
       }),
       'payload': None,
       'type': 'synthesize',
-    }),
-    dict({
-      'data': dict({
-      }),
-      'payload': None,
-      'type': 'synthesize-stop',
     }),
   ])
 # ---
@@ -63,29 +25,10 @@
   list([
     dict({
       'data': dict({
-      }),
-      'payload': None,
-      'type': 'synthesize-start',
-    }),
-    dict({
-      'data': dict({
-        'text': 'Hello world',
-      }),
-      'payload': None,
-      'type': 'synthesize-chunk',
-    }),
-    dict({
-      'data': dict({
         'text': 'Hello world',
       }),
       'payload': None,
       'type': 'synthesize',
-    }),
-    dict({
-      'data': dict({
-      }),
-      'payload': None,
-      'type': 'synthesize-stop',
     }),
   ])
 # ---
@@ -130,23 +73,6 @@
   list([
     dict({
       'data': dict({
-        'voice': dict({
-          'name': 'voice1',
-          'speaker': 'speaker1',
-        }),
-      }),
-      'payload': None,
-      'type': 'synthesize-start',
-    }),
-    dict({
-      'data': dict({
-        'text': 'Hello world',
-      }),
-      'payload': None,
-      'type': 'synthesize-chunk',
-    }),
-    dict({
-      'data': dict({
         'text': 'Hello world',
         'voice': dict({
           'name': 'voice1',
@@ -155,12 +81,6 @@
       }),
       'payload': None,
       'type': 'synthesize',
-    }),
-    dict({
-      'data': dict({
-      }),
-      'payload': None,
-      'type': 'synthesize-stop',
     }),
   ])
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes: https://github.com/roryeckel/wyoming_openai/issues/19

This PR checks if a TTS entity supports streaming in the `SpeechManager` instead of assuming that the underlying TTS entity does the same thing whether or not its streaming.

Explanation:

When streaming TTS was added to the `tts` integration, an important case was not handled correctly. If a TTS entity did not support streaming (i.e., `async_supports_streaming_input()` is `False`), the internal streaming function was still being called. By default, this has no effect as it simply mimics the streaming API while calling the original code underneath. With `wyoming` however, the streaming and non-streaming cases are very different. This caused non-streaming TTS services to incorrectly receive events intended only for streaming, breaking them entirely.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
