### PR TITLE
Allow template in query in sql

### DIFF
--- a/homeassistant/components/sql/__init__.py
+++ b/homeassistant/components/sql/__init__.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, discovery
-from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     CONF_AVAILABILITY,
     CONF_PICTURE,
@@ -41,7 +40,7 @@ from .const import (
     PLATFORMS,
 )
 from .services import async_setup_services
-from .util import check_and_render_sql_query, redact_credentials, validate_sql_select
+from .util import redact_credentials, validate_sql_select
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sql/__init__.py
+++ b/homeassistant/components/sql/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant.helpers.template import Template
 from homeassistant.helpers.trigger_template_entity import (
     CONF_AVAILABILITY,
     CONF_PICTURE,
@@ -40,7 +41,7 @@ from .const import (
     PLATFORMS,
 )
 from .services import async_setup_services
-from .util import redact_credentials, validate_sql_select
+from .util import check_and_render_sql_query, redact_credentials, validate_sql_select
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,7 +50,9 @@ QUERY_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_COLUMN_NAME): cv.string,
         vol.Required(CONF_NAME): cv.template,
-        vol.Required(CONF_QUERY): vol.All(cv.string, validate_sql_select),
+        vol.Required(CONF_QUERY): vol.All(
+            cv.template, ValueTemplate.from_template, validate_sql_select
+        ),
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): vol.All(
             cv.template, ValueTemplate.from_template

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -6,11 +6,11 @@ import logging
 from typing import Any
 
 import sqlalchemy
-import voluptuous as vol
 from sqlalchemy.engine import Engine, Result
 from sqlalchemy.exc import MultipleResultsFound, NoSuchColumnError, SQLAlchemyError
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from sqlparse.exceptions import SQLParseError
+import voluptuous as vol
 
 from homeassistant.components.recorder import CONF_DB_URL, get_instance
 from homeassistant.components.sensor import (

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -6,12 +6,11 @@ import logging
 from typing import Any
 
 import sqlalchemy
+import voluptuous as vol
 from sqlalchemy.engine import Engine, Result
 from sqlalchemy.exc import MultipleResultsFound, NoSuchColumnError, SQLAlchemyError
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
-import sqlparse
 from sqlparse.exceptions import SQLParseError
-import voluptuous as vol
 
 from homeassistant.components.recorder import CONF_DB_URL, get_instance
 from homeassistant.components.sensor import (
@@ -31,12 +30,12 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_TEMPLATE,
 )
-from homeassistant.core import callback
+from homeassistant.core import async_get_hass, callback
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers import selector
 
 from .const import CONF_ADVANCED_OPTIONS, CONF_COLUMN_NAME, CONF_QUERY, DOMAIN
-from .util import resolve_db_url
+from .util import check_and_render_sql_query, resolve_db_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -89,14 +88,20 @@ CONFIG_SCHEMA: vol.Schema = vol.Schema(
 
 def validate_sql_select(value: str) -> str:
     """Validate that value is a SQL SELECT query."""
-    if len(query := sqlparse.parse(value.lstrip().lstrip(";"))) > 1:
-        raise MultipleResultsFound
-    if len(query) == 0 or (query_type := query[0].get_type()) == "UNKNOWN":
-        raise ValueError
-    if query_type != "SELECT":
-        _LOGGER.debug("The SQL query %s is of type %s", query, query_type)
-        raise SQLParseError
-    return str(query[0])
+    hass = async_get_hass()
+    try:
+        return check_and_render_sql_query(hass, value)
+    except ValueError as err:
+        err_text = err.args[0]
+        _LOGGER.debug("Invalid query '%s' results in '%s'", value, err_text)
+        if err_text == "Multiple SQL statements are not allowed":
+            raise MultipleResultsFound from err
+        if err_text in (
+            "SQL query must be of type SELECT",
+            "SQL query must start with SELECT",
+        ):
+            raise SQLParseError from err
+        raise
 
 
 def validate_db_connection(db_url: str) -> bool:

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -42,9 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 
 OPTIONS_SCHEMA: vol.Schema = vol.Schema(
     {
-        vol.Required(CONF_QUERY): selector.TextSelector(
-            selector.TextSelectorConfig(multiline=True)
-        ),
+        vol.Required(CONF_QUERY): selector.TemplateSelector(),
         vol.Required(CONF_COLUMN_NAME): selector.TextSelector(),
         vol.Required(CONF_ADVANCED_OPTIONS): section(
             vol.Schema(

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -174,7 +174,7 @@ async def async_setup_sensor(
     ) = await async_create_sessionmaker(hass, db_url)
     if sessmaker is None:
         return
-    validate_query(hass, query_str, uses_recorder_db, unique_id)
+    validate_query(hass, query_template, uses_recorder_db, unique_id)
 
     query_str = check_and_render_sql_query(hass, query_template)
     upper_query = query_str.upper()
@@ -225,7 +225,6 @@ class SQLSensor(ManualTriggerSensorEntity):
         self.sessionmaker = sessmaker
         self._attr_extra_state_attributes = {}
         self._use_database_executor = use_database_executor
-        self._lambda_stmt = generate_lambda_stmt(query)
         if not yaml and (unique_id := trigger_entity_config.get(CONF_UNIQUE_ID)):
             self._attr_name = None
             self._attr_has_entity_name = True
@@ -267,7 +266,7 @@ class SQLSensor(ManualTriggerSensorEntity):
         sess: scoped_session = self.sessionmaker()
         try:
             rendered_query = check_and_render_sql_query(self.hass, self._query)
-            _lambda_stmt = _generate_lambda_stmt(rendered_query)
+            _lambda_stmt = generate_lambda_stmt(rendered_query)
             result: Result = sess.execute(_lambda_stmt)
         except ValueError as err:
             _LOGGER.error(

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -40,6 +40,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import CONF_ADVANCED_OPTIONS, CONF_COLUMN_NAME, CONF_QUERY, DOMAIN
 from .util import (
+    InvalidSqlQuery,
     async_create_sessionmaker,
     check_and_render_sql_query,
     convert_value,
@@ -268,7 +269,7 @@ class SQLSensor(ManualTriggerSensorEntity):
             rendered_query = check_and_render_sql_query(self.hass, self._query)
             _lambda_stmt = generate_lambda_stmt(rendered_query)
             result: Result = sess.execute(_lambda_stmt)
-        except ValueError as err:
+        except (TemplateError, InvalidSqlQuery) as err:
             _LOGGER.error(
                 "Error rendering query %s: %s",
                 redact_credentials(self._query.template),

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -180,15 +180,12 @@ async def async_setup_sensor(
     upper_query = query_str.upper()
     # MSSQL uses TOP and not LIMIT
     mod_query_template = query_template
-    if "LIMIT" not in upper_query and not upper_query.startswith("SELECT TOP"):
+    if not ("LIMIT" in upper_query or "SELECT TOP" in upper_query):
         if "mssql" in db_url:
-            mod_query_template = ValueTemplate(
-                f"SELECT TOP 1{query_template.template[6:]}", hass
-            )
+            _query = query_template.template.replace("SELECT", "SELECT TOP 1")
         else:
-            mod_query_template = ValueTemplate(
-                f"{query_template.template.replace(';', '')} LIMIT 1;", hass
-            )
+            _query = query_template.template.replace(";", "") + " LIMIT 1;"
+        mod_query_template = ValueTemplate(_query, hass)
 
     async_add_entities(
         [
@@ -272,7 +269,7 @@ class SQLSensor(ManualTriggerSensorEntity):
             rendered_query = check_and_render_sql_query(self.hass, self._query)
             _lambda_stmt = _generate_lambda_stmt(rendered_query)
             result: Result = sess.execute(_lambda_stmt)
-        except TemplateError as err:
+        except ValueError as err:
             _LOGGER.error(
                 "Error rendering query %s: %s",
                 redact_credentials(self._query.template),

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -180,7 +180,7 @@ async def async_setup_sensor(
     upper_query = query_str.upper()
     # MSSQL uses TOP and not LIMIT
     mod_query_template = query_template
-    if not ("LIMIT" in upper_query or upper_query.startswith("SELECT TOP")):
+    if "LIMIT" not in upper_query and not upper_query.startswith("SELECT TOP"):
         if "mssql" in db_url:
             mod_query_template = ValueTemplate(
                 f"SELECT TOP 1{query_template.template[6:]}", hass

--- a/homeassistant/components/sql/services.py
+++ b/homeassistant/components/sql/services.py
@@ -19,11 +19,13 @@ from homeassistant.core import (
 )
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.trigger_template_entity import ValueTemplate
 from homeassistant.util.json import JsonValueType
 
 from .const import CONF_QUERY, DOMAIN
 from .util import (
     async_create_sessionmaker,
+    check_and_render_sql_query,
     convert_value,
     generate_lambda_stmt,
     redact_credentials,
@@ -37,7 +39,9 @@ _LOGGER = logging.getLogger(__name__)
 SERVICE_QUERY = "query"
 SERVICE_QUERY_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_QUERY): vol.All(cv.string, validate_sql_select),
+        vol.Required(CONF_QUERY): vol.All(
+            cv.template, ValueTemplate.from_template, validate_sql_select
+        ),
         vol.Optional(CONF_DB_URL): cv.string,
     }
 )
@@ -72,8 +76,9 @@ async def _async_query_service(
     def _execute_and_convert_query() -> list[JsonValueType]:
         """Execute the query and return the results with converted types."""
         sess: Session = sessmaker()
+        rendered_query = check_and_render_sql_query(call.hass, query_str)
         try:
-            result: Result = sess.execute(generate_lambda_stmt(query_str))
+            result: Result = sess.execute(generate_lambda_stmt(rendered_query))
         except SQLAlchemyError as err:
             _LOGGER.debug(
                 "Error executing query %s: %s",

--- a/homeassistant/components/sql/strings.json
+++ b/homeassistant/components/sql/strings.json
@@ -8,7 +8,7 @@
       "db_url_invalid": "Database URL invalid",
       "multiple_queries": "Multiple SQL queries are not supported",
       "query_invalid": "SQL query invalid",
-      "query_no_read_only": "SQL query must be read-only"
+      "query_no_read_only": "SQL query is not a read-only SELECT query or it's of an unknown type"
     },
     "step": {
       "options": {

--- a/homeassistant/components/sql/util.py
+++ b/homeassistant/components/sql/util.py
@@ -266,4 +266,5 @@ def check_and_render_sql_query(hass: HomeAssistant, query: Template | str) -> st
     if query_type != "SELECT":
         _LOGGER.debug("The SQL query %s is of type %s", rendered_query, query_type)
         raise ValueError("SQL query must be of type SELECT")
+
     return str(rendered_queries[0])

--- a/tests/components/sql/__init__.py
+++ b/tests/components/sql/__init__.py
@@ -44,6 +44,15 @@ ENTRY_CONFIG = {
     },
 }
 
+ENTRY_CONFIG_BLANK_QUERY = {
+    CONF_NAME: "Get Value",
+    CONF_QUERY: "  ",
+    CONF_COLUMN_NAME: "value",
+    CONF_UNIT_OF_MEASUREMENT: "MiB",
+    CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+    CONF_STATE_CLASS: SensorStateClass.TOTAL,
+}
+
 ENTRY_CONFIG_WITH_VALUE_TEMPLATE = {
     CONF_QUERY: "SELECT 5 as value",
     CONF_COLUMN_NAME: "value",

--- a/tests/components/sql/__init__.py
+++ b/tests/components/sql/__init__.py
@@ -53,6 +53,29 @@ ENTRY_CONFIG_WITH_VALUE_TEMPLATE = {
     },
 }
 
+ENTRY_CONFIG_WITH_QUERY_TEMPLATE = {
+    CONF_NAME: "Get Value",
+    CONF_QUERY: "SELECT {% if states('sensor.input1')=='on' %} 5 {% else %} 6 {% endif %} as value",
+    CONF_COLUMN_NAME: "value",
+    CONF_UNIT_OF_MEASUREMENT: "MiB",
+    CONF_VALUE_TEMPLATE: "{{ value }}",
+}
+
+ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE = {
+    CONF_NAME: "Get Value",
+    CONF_QUERY: "SELECT {{ 5 as value",
+    CONF_COLUMN_NAME: "value",
+    CONF_UNIT_OF_MEASUREMENT: "MiB",
+    CONF_VALUE_TEMPLATE: "{{ value }}",
+}
+
+ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE_OPT = {
+    CONF_QUERY: "SELECT {{ 5 as value",
+    CONF_COLUMN_NAME: "value",
+    CONF_UNIT_OF_MEASUREMENT: "MiB",
+    CONF_VALUE_TEMPLATE: "{{ value }}",
+}
+
 ENTRY_CONFIG_INVALID_QUERY = {
     CONF_QUERY: "SELECT 5 FROM as value",
     CONF_COLUMN_NAME: "size",

--- a/tests/components/sql/__init__.py
+++ b/tests/components/sql/__init__.py
@@ -48,9 +48,11 @@ ENTRY_CONFIG_BLANK_QUERY = {
     CONF_NAME: "Get Value",
     CONF_QUERY: "  ",
     CONF_COLUMN_NAME: "value",
-    CONF_UNIT_OF_MEASUREMENT: "MiB",
-    CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
-    CONF_STATE_CLASS: SensorStateClass.TOTAL,
+    CONF_ADVANCED_OPTIONS: {
+        CONF_UNIT_OF_MEASUREMENT: "MiB",
+        CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+        CONF_STATE_CLASS: SensorStateClass.TOTAL,
+    },
 }
 
 ENTRY_CONFIG_WITH_VALUE_TEMPLATE = {
@@ -63,26 +65,30 @@ ENTRY_CONFIG_WITH_VALUE_TEMPLATE = {
 }
 
 ENTRY_CONFIG_WITH_QUERY_TEMPLATE = {
-    CONF_NAME: "Get Value",
     CONF_QUERY: "SELECT {% if states('sensor.input1')=='on' %} 5 {% else %} 6 {% endif %} as value",
     CONF_COLUMN_NAME: "value",
-    CONF_UNIT_OF_MEASUREMENT: "MiB",
-    CONF_VALUE_TEMPLATE: "{{ value }}",
+    CONF_ADVANCED_OPTIONS: {
+        CONF_UNIT_OF_MEASUREMENT: "MiB",
+        CONF_VALUE_TEMPLATE: "{{ value }}",
+    },
 }
 
 ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE = {
-    CONF_NAME: "Get Value",
     CONF_QUERY: "SELECT {{ 5 as value",
     CONF_COLUMN_NAME: "value",
-    CONF_UNIT_OF_MEASUREMENT: "MiB",
-    CONF_VALUE_TEMPLATE: "{{ value }}",
+    CONF_ADVANCED_OPTIONS: {
+        CONF_UNIT_OF_MEASUREMENT: "MiB",
+        CONF_VALUE_TEMPLATE: "{{ value }}",
+    },
 }
 
 ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE_OPT = {
     CONF_QUERY: "SELECT {{ 5 as value",
     CONF_COLUMN_NAME: "value",
-    CONF_UNIT_OF_MEASUREMENT: "MiB",
-    CONF_VALUE_TEMPLATE: "{{ value }}",
+    CONF_ADVANCED_OPTIONS: {
+        CONF_UNIT_OF_MEASUREMENT: "MiB",
+        CONF_VALUE_TEMPLATE: "{{ value }}",
+    },
 }
 
 ENTRY_CONFIG_INVALID_QUERY = {

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -30,7 +30,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType, InvalidData
-from tests.common import MockConfigEntry
 
 from . import (
     ENTRY_CONFIG,
@@ -54,6 +53,8 @@ from . import (
     ENTRY_CONFIG_WITH_QUERY_TEMPLATE,
     ENTRY_CONFIG_WITH_VALUE_TEMPLATE,
 )
+
+from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry", "recorder_mock")
 

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     CONF_VALUE_TEMPLATE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.data_entry_flow import FlowResultType, InvalidData
 from tests.common import MockConfigEntry
 
 from . import (
@@ -152,13 +152,14 @@ async def test_form_with_broken_query_template(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE,
-    )
+    with pytest.raises(InvalidData):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE,
+        )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"query": "query_invalid"}
+    assert result["errors"] == {}
 
     with patch(
         "homeassistant.components.sql.async_setup_entry",
@@ -603,10 +604,11 @@ async def test_options_flow_fails_invalid_query(hass: HomeAssistant) -> None:
         CONF_QUERY: "multiple_queries",
     }
 
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input=ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE_OPT,
-    )
+    with pytest.raises(InvalidData):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input=ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE_OPT,
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     CONF_VALUE_TEMPLATE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType, InvalidData
+from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
     ENTRY_CONFIG,
@@ -163,14 +163,13 @@ async def test_form_with_broken_query_template(
         DATA_CONFIG,
     )
 
-    with pytest.raises(InvalidData):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE,
-        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE,
+    )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {}
+    assert result["errors"] == {"query": "query_invalid"}
 
     with patch(
         "homeassistant.components.sql.async_setup_entry",
@@ -616,11 +615,10 @@ async def test_options_flow_fails_invalid_query(hass: HomeAssistant) -> None:
         CONF_QUERY: "multiple_queries",
     }
 
-    with pytest.raises(InvalidData):
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input=ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE_OPT,
-        )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input=ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE_OPT,
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -280,7 +280,7 @@ async def test_flow_fails_invalid_query(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {
-        CONF_QUERY: "query_invalid",
+        CONF_QUERY: "query_no_read_only",
     }
 
     result = await hass.config_entries.flow.async_configure(
@@ -290,7 +290,7 @@ async def test_flow_fails_invalid_query(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {
-        CONF_QUERY: "query_invalid",
+        CONF_QUERY: "query_no_read_only",
     }
 
     result = await hass.config_entries.flow.async_configure(
@@ -572,7 +572,7 @@ async def test_options_flow_fails_invalid_query(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {
-        CONF_QUERY: "query_invalid",
+        CONF_QUERY: "query_no_read_only",
     }
 
     result = await hass.config_entries.options.async_configure(
@@ -582,7 +582,7 @@ async def test_options_flow_fails_invalid_query(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {
-        CONF_QUERY: "query_invalid",
+        CONF_QUERY: "query_no_read_only",
     }
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+import voluptuous as vol
+
 from homeassistant.components.recorder import CONF_DB_URL, Recorder
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
@@ -16,6 +19,7 @@ from homeassistant.components.sql.const import (
     CONF_QUERY,
     DOMAIN,
 )
+from homeassistant.components.sql.util import validate_sql_select
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import (
     CONF_DEVICE_CLASS,

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     CONF_VALUE_TEMPLATE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.template import Template
 from homeassistant.setup import async_setup_component
 
 from . import YAML_CONFIG_INVALID, YAML_CONFIG_NO_DB, init_integration
@@ -65,6 +66,45 @@ async def test_setup_invalid_config(
     ):
         assert not await async_setup_component(hass, DOMAIN, YAML_CONFIG_INVALID)
         await hass.async_block_till_done()
+
+
+async def test_invalid_query(hass: HomeAssistant) -> None:
+    """Test invalid query."""
+    with pytest.raises(vol.Invalid, match="SQL query must be of type SELECT"):
+        validate_sql_select(Template("DROP TABLE *", hass))
+
+    with pytest.raises(vol.Invalid, match="SQL query is empty or unknown type"):
+        validate_sql_select(Template("SELECT5 as value", hass))
+
+    with pytest.raises(vol.Invalid, match="SQL query is empty or unknown type"):
+        validate_sql_select(Template(";;", hass))
+
+
+async def test_query_no_read_only(hass: HomeAssistant) -> None:
+    """Test query no read only."""
+    with pytest.raises(vol.Invalid, match="SQL query must be of type SELECT"):
+        validate_sql_select(
+            Template("UPDATE states SET state = 999999 WHERE state_id = 11125", hass)
+        )
+
+
+async def test_query_no_read_only_cte(hass: HomeAssistant) -> None:
+    """Test query no read only CTE."""
+    with pytest.raises(vol.Invalid, match="SQL query must be of type SELECT"):
+        validate_sql_select(
+            Template(
+                "WITH test AS (SELECT state FROM states) UPDATE states SET states.state = test.state;",
+                hass,
+            )
+        )
+
+
+async def test_multiple_queries(hass: HomeAssistant) -> None:
+    """Test multiple queries."""
+    with pytest.raises(vol.Invalid, match="Multiple SQL statements are not allowed"):
+        validate_sql_select(
+            Template("SELECT 5 as value; UPDATE states SET state = 10;", hass)
+        )
 
 
 async def test_migration_from_future(

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -196,8 +196,10 @@ async def test_broken_template_query_2(
     state = hass.states.get("sensor.count_tables")
     assert state.state == "0.005"
     assert (
-        "Error rendering query SELECT {{ states.sensor.input1.state"
-        " | int / 1000}} as value LIMIT 1;: Invalid template" in caplog.text
+        "Error rendering query SELECT {{ states.sensor.input1.state | int / 1000}} as value"
+        " LIMIT 1;: ValueError: Template error: int got invalid input 'on' when rendering"
+        " template 'SELECT {{ states.sensor.input1.state | int / 1000}} as value LIMIT 1;'"
+        " but no default was specified" in caplog.text
     )
 
 

--- a/tests/components/sql/test_services.py
+++ b/tests/components/sql/test_services.py
@@ -153,7 +153,7 @@ async def test_query_service_invalid_query_not_select(
     await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
-    with pytest.raises(vol.Invalid, match="Only SELECT queries allowed"):
+    with pytest.raises(vol.Invalid, match="SQL query must be of type SELECT"):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_QUERY,
@@ -171,7 +171,7 @@ async def test_query_service_sqlalchemy_error(
     await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
-    with pytest.raises(MultipleInvalid, match="Invalid SQL query"):
+    with pytest.raises(MultipleInvalid, match="SQL query is empty or unknown type"):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_QUERY,

--- a/tests/components/sql/test_util.py
+++ b/tests/components/sql/test_util.py
@@ -13,6 +13,7 @@ from homeassistant.components.sql.util import (
     validate_sql_select,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.template import Template
 
 
 async def test_resolve_db_url_when_none_configured(
@@ -39,27 +40,27 @@ async def test_resolve_db_url_when_configured(hass: HomeAssistant) -> None:
     [
         (
             "DROP TABLE *",
-            "Only SELECT queries allowed",
+            "SQL query must be of type SELECT",
         ),
         (
             "SELECT5 as value",
-            "Invalid SQL query",
+            "SQL query is empty or unknown type",
         ),
         (
             ";;",
-            "Invalid SQL query",
+            "SQL query is empty or unknown type",
         ),
         (
             "UPDATE states SET state = 999999 WHERE state_id = 11125",
-            "Only SELECT queries allowed",
+            "SQL query must be of type SELECT",
         ),
         (
             "WITH test AS (SELECT state FROM states) UPDATE states SET states.state = test.state;",
-            "Only SELECT queries allowed",
+            "SQL query must be of type SELECT",
         ),
         (
             "SELECT 5 as value; UPDATE states SET state = 10;",
-            "Multiple SQL queries are not supported",
+            "Multiple SQL statements are not allowed",
         ),
     ],
 )
@@ -70,7 +71,7 @@ async def test_invalid_sql_queries(
 ) -> None:
     """Test that various invalid or disallowed SQL queries raise the correct exception."""
     with pytest.raises(vol.Invalid, match=expected_error_message):
-        validate_sql_select(sql_query)
+        validate_sql_select(Template(sql_query, hass))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
Allow using templates in sql query in SQL integration.

Possible use cases
- Most proposals are around dynamically setting a datetime in the query
- Some seems to use it for external db's to collect information and present it in sensors
- Get history for some sensor based on another sensors value (quite generic but that's what people are asking for)
Some is mentioned here https://community.home-assistant.io/t/add-support-for-query-template-to-sql-integration/188760

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40345
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 