### PR TITLE
Always expose Twitch channel_picture attr regardless of channel status

### DIFF
--- a/homeassistant/components/twitch/sensor.py
+++ b/homeassistant/components/twitch/sensor.py
@@ -22,6 +22,7 @@ ATTR_FOLLOW_SINCE = "following_since"
 ATTR_FOLLOWING = "followers"
 ATTR_VIEWERS = "viewers"
 ATTR_STARTED_AT = "started_at"
+ATTR_CHANNEL_PICTURE = "channel_picture"
 
 STATE_OFFLINE = "offline"
 STATE_STREAMING = "streaming"
@@ -82,6 +83,7 @@ class TwitchSensor(CoordinatorEntity[TwitchCoordinator], SensorEntity):
             ATTR_STARTED_AT: channel.started_at,
             ATTR_VIEWERS: channel.viewers,
             ATTR_SUBSCRIPTION: False,
+            ATTR_CHANNEL_PICTURE: channel.picture,
         }
         if channel.subscribed is not None:
             resp[ATTR_SUBSCRIPTION] = channel.subscribed

--- a/tests/components/twitch/test_sensor.py
+++ b/tests/components/twitch/test_sensor.py
@@ -29,6 +29,7 @@ async def test_offline(
     sensor_state = hass.states.get(ENTITY_ID)
     assert sensor_state.state == "offline"
     assert sensor_state.attributes["entity_picture"] == "logo.png"
+    assert sensor_state.attributes["channel_picture"] == "logo.png"
 
 
 async def test_streaming(
@@ -40,6 +41,7 @@ async def test_streaming(
     sensor_state = hass.states.get(ENTITY_ID)
     assert sensor_state.state == "streaming"
     assert sensor_state.attributes["entity_picture"] == "stream-medium.png"
+    assert sensor_state.attributes["channel_picture"] == "logo.png"
     assert sensor_state.attributes["game"] == "Good game"
     assert sensor_state.attributes["title"] == "Title"
     assert sensor_state.attributes["started_at"] == datetime(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
The existing logic exposes (via entity_picture attribute) *either* a url to a streamer's icon (when they're offline) {small}, or screengrab of their livestream (if they're live) {large}. 

The small icon url is currently unavailable if the streamer is live. This change ensures that regardless of the streamers current status, the channel icon is always exposed as an entity attribute (as channel_picture).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository. (i reviewed two issues)

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
