### PR TITLE
Add Linea Research amplifier integration

### DIFF
--- a/homeassistant/components/linea_research/__init__.py
+++ b/homeassistant/components/linea_research/__init__.py
@@ -1,0 +1,52 @@
+"""The Linea Research integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .coordinator import LineaResearchConfigEntry, LineaResearchDataUpdateCoordinator
+from .tipi_client import TIPIClient, TIPIConnectionError
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: LineaResearchConfigEntry) -> bool:
+    """Set up Linea Research from a config entry."""
+    host = entry.data[CONF_HOST]
+    port = entry.data[CONF_PORT]
+    
+    client = TIPIClient(host, port)
+    coordinator = LineaResearchDataUpdateCoordinator(hass, entry, client)
+    
+    try:
+        await coordinator.async_setup()
+        await coordinator.async_config_entry_first_refresh()
+    except TIPIConnectionError as err:
+        await client.disconnect()
+        raise ConfigEntryNotReady(f"Unable to connect to {host}:{port}") from err
+    
+    entry.runtime_data = coordinator
+    
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: LineaResearchConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        coordinator = entry.runtime_data
+        await coordinator.async_shutdown()
+    
+    return unload_ok

--- a/homeassistant/components/linea_research/binary_sensor.py
+++ b/homeassistant/components/linea_research/binary_sensor.py
@@ -1,0 +1,77 @@
+"""Binary sensor platform for Linea Research integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import LineaResearchConfigEntry
+from .entity import LineaResearchEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LineaResearchConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Linea Research binary sensors from a config entry."""
+    coordinator = config_entry.runtime_data
+    
+    async_add_entities([
+        LineaResearchSleepStateSensor(coordinator),
+        LineaResearchMuteASensor(coordinator),
+        LineaResearchMuteBSensor(coordinator),
+    ])
+
+
+class LineaResearchSleepStateSensor(LineaResearchEntity, BinarySensorEntity):
+    """Representation of a Linea Research amplifier sleep state sensor."""
+
+    def __init__(self, coordinator: LineaResearchConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, "sleep_state")
+        self._attr_name = "Sleep state"
+        self._attr_device_class = BinarySensorDeviceClass.RUNNING
+        self._attr_icon = "mdi:sleep"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the amplifier is in sleep/standby mode."""
+        # standby=True means the device is sleeping/off
+        return self.coordinator.data.get("standby", True)
+
+
+class LineaResearchMuteASensor(LineaResearchEntity, BinarySensorEntity):
+    """Representation of a Linea Research amplifier mute state for channel A."""
+
+    def __init__(self, coordinator: LineaResearchConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, "mute_a")
+        self._attr_name = "Channel A mute"
+        self._attr_device_class = BinarySensorDeviceClass.SOUND
+        self._attr_icon = "mdi:volume-off"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if channel A is muted."""
+        return self.coordinator.data.get("mute_a", False)
+
+
+class LineaResearchMuteBSensor(LineaResearchEntity, BinarySensorEntity):
+    """Representation of a Linea Research amplifier mute state for channel B."""
+
+    def __init__(self, coordinator: LineaResearchConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, "mute_b")
+        self._attr_name = "Channel B mute"
+        self._attr_device_class = BinarySensorDeviceClass.SOUND
+        self._attr_icon = "mdi:volume-off"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if channel B is muted."""
+        return self.coordinator.data.get("mute_b", False)

--- a/homeassistant/components/linea_research/config_flow.py
+++ b/homeassistant/components/linea_research/config_flow.py
@@ -1,0 +1,92 @@
+"""Config flow for Linea Research integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+
+from .const import DEFAULT_PORT, DOMAIN, NAME
+from .tipi_client import TIPIClient, TIPIConnectionError, TIPIProtocolError
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    }
+)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect."""
+    client = TIPIClient(data[CONF_HOST], data[CONF_PORT])
+    
+    try:
+        await client.connect()
+        info = await client.get_device_info()
+        await client.disconnect()
+        
+        return {
+            "title": f"{NAME} {info.get('model', 'Amplifier')}",
+            "unique_id": info.get("serial", f"{data[CONF_HOST]}:{data[CONF_PORT]}"),
+        }
+    except TIPIConnectionError as err:
+        _LOGGER.error("Failed to connect: %s", err)
+        raise CannotConnect from err
+    except TIPIProtocolError as err:
+        _LOGGER.error("Protocol error: %s", err)
+        raise CannotConnect from err
+    except Exception as err:
+        _LOGGER.exception("Unexpected error: %s", err)
+        raise CannotConnect from err
+    finally:
+        await client.disconnect()
+
+
+class LineaResearchConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Linea Research."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                # Set unique ID to prevent duplicate entries
+                await self.async_set_unique_id(info["unique_id"])
+                self._abort_if_unique_id_configured()
+                
+                return self.async_create_entry(
+                    title=info["title"],
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="user", 
+            data_schema=STEP_USER_DATA_SCHEMA, 
+            errors=errors,
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/linea_research/const.py
+++ b/homeassistant/components/linea_research/const.py
@@ -1,0 +1,9 @@
+"""Constants for the Linea Research integration."""
+
+from typing import Final
+
+DOMAIN: Final = "linea_research"
+NAME: Final = "Linea Research"
+MANUFACTURER: Final = "Linea Research"
+
+DEFAULT_PORT: Final = 10001

--- a/homeassistant/components/linea_research/coordinator.py
+++ b/homeassistant/components/linea_research/coordinator.py
@@ -1,0 +1,76 @@
+"""Data update coordinator for Linea Research integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, NAME
+from .tipi_client import TIPIClient, TIPIConnectionError, TIPIProtocolError
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=10)
+
+type LineaResearchConfigEntry = ConfigEntry[LineaResearchDataUpdateCoordinator]
+
+
+class LineaResearchDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Data update coordinator for Linea Research amplifiers."""
+
+    config_entry: LineaResearchConfigEntry
+
+    def __init__(
+        self, 
+        hass: HomeAssistant, 
+        config_entry: LineaResearchConfigEntry,
+        client: TIPIClient,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass=hass,
+            logger=_LOGGER,
+            name=NAME,
+            update_interval=SCAN_INTERVAL,
+            config_entry=config_entry,
+        )
+        
+        self.client = client
+        self.device_info: dict[str, Any] = {}
+
+    async def async_setup(self) -> None:
+        """Set up the coordinator."""
+        try:
+            await self.client.connect()
+            self.device_info = await self.client.get_device_info()
+            _LOGGER.debug("Device info: %s", self.device_info)
+        except TIPIConnectionError as err:
+            raise ConfigEntryNotReady(
+                f"Unable to connect to {self.config_entry.data[CONF_HOST]}"
+            ) from err
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from the amplifier."""
+        try:
+            if not self.client._connected:
+                await self.client.connect()
+                
+            status = await self.client.get_status()
+            _LOGGER.debug("Status update: %s", status)
+            return status
+            
+        except TIPIConnectionError as err:
+            raise UpdateFailed(f"Failed to connect: {err}") from err
+        except TIPIProtocolError as err:
+            raise UpdateFailed(f"Protocol error: {err}") from err
+
+    async def async_shutdown(self) -> None:
+        """Shutdown the coordinator."""
+        await self.client.disconnect()

--- a/homeassistant/components/linea_research/entity.py
+++ b/homeassistant/components/linea_research/entity.py
@@ -1,0 +1,37 @@
+"""Base entity for Linea Research integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER, NAME
+from .coordinator import LineaResearchDataUpdateCoordinator
+
+
+class LineaResearchEntity(CoordinatorEntity[LineaResearchDataUpdateCoordinator]):
+    """Base entity for Linea Research amplifiers."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: LineaResearchDataUpdateCoordinator,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        
+        device_serial = coordinator.device_info.get(
+            "serial", 
+            f"{coordinator.config_entry.data['host']}:{coordinator.config_entry.data['port']}"
+        )
+        
+        self._attr_unique_id = f"{device_serial}_{unique_id_suffix}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_serial)},
+            name=f"{NAME} {coordinator.device_info.get('model', 'Amplifier')}",
+            manufacturer=MANUFACTURER,
+            model=coordinator.device_info.get("model", "Unknown"),
+            sw_version=coordinator.device_info.get("firmware", "Unknown"),
+        )

--- a/homeassistant/components/linea_research/manifest.json
+++ b/homeassistant/components/linea_research/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "linea_research",
+  "name": "Linea Research",
+  "codeowners": ["@yourusername"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/linea_research",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "requirements": []
+}

--- a/homeassistant/components/linea_research/sensor.py
+++ b/homeassistant/components/linea_research/sensor.py
@@ -1,0 +1,65 @@
+"""Sensor platform for Linea Research integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.const import SIGNAL_STRENGTH_DECIBELS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import LineaResearchConfigEntry
+from .entity import LineaResearchEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LineaResearchConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Linea Research sensors from a config entry."""
+    coordinator = config_entry.runtime_data
+    
+    async_add_entities([
+        LineaResearchGainASensor(coordinator),
+        LineaResearchGainBSensor(coordinator),
+    ])
+
+
+class LineaResearchGainASensor(LineaResearchEntity, SensorEntity):
+    """Representation of a Linea Research amplifier gain for channel A."""
+
+    def __init__(self, coordinator: LineaResearchConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, "gain_a")
+        self._attr_name = "Channel A gain"
+        self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS
+        self._attr_icon = "mdi:volume-high"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the gain value for channel A."""
+        return self.coordinator.data.get("gain_a")
+
+
+class LineaResearchGainBSensor(LineaResearchEntity, SensorEntity):
+    """Representation of a Linea Research amplifier gain for channel B."""
+
+    def __init__(self, coordinator: LineaResearchConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, "gain_b")
+        self._attr_name = "Channel B gain"
+        self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS
+        self._attr_icon = "mdi:volume-high"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the gain value for channel B."""
+        return self.coordinator.data.get("gain_b")

--- a/homeassistant/components/linea_research/strings.json
+++ b/homeassistant/components/linea_research/strings.json
@@ -1,0 +1,51 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Linea Research amplifier",
+        "description": "Set up your Linea Research amplifier to integrate with Home Assistant.",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        },
+        "data_description": {
+          "host": "IP address or hostname of your Linea Research amplifier",
+          "port": "TIPI protocol port (default: 10001)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the amplifier. Please check the IP address and port.",
+      "unknown": "Unexpected error occurred."
+    },
+    "abort": {
+      "already_configured": "This amplifier is already configured."
+    }
+  },
+  "entity": {
+    "switch": {
+      "power": {
+        "name": "Power"
+      }
+    },
+    "binary_sensor": {
+      "sleep_state": {
+        "name": "Sleep state"
+      },
+      "mute_a": {
+        "name": "Channel A mute"
+      },
+      "mute_b": {
+        "name": "Channel B mute"
+      }
+    },
+    "sensor": {
+      "gain_a": {
+        "name": "Channel A gain"
+      },
+      "gain_b": {
+        "name": "Channel B gain"
+      }
+    }
+  }
+}

--- a/homeassistant/components/linea_research/switch.py
+++ b/homeassistant/components/linea_research/switch.py
@@ -1,0 +1,60 @@
+"""Switch platform for Linea Research integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import LineaResearchConfigEntry
+from .entity import LineaResearchEntity
+from .tipi_client import TIPIConnectionError, TIPIProtocolError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LineaResearchConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Linea Research switch from a config entry."""
+    coordinator = config_entry.runtime_data
+    
+    async_add_entities([LineaResearchPowerSwitch(coordinator)])
+
+
+class LineaResearchPowerSwitch(LineaResearchEntity, SwitchEntity):
+    """Representation of a Linea Research amplifier power switch."""
+
+    def __init__(self, coordinator: LineaResearchConfigEntry) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, "power")
+        self._attr_name = "Power"
+        self._attr_icon = "mdi:amplifier"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the amplifier is on."""
+        return self.coordinator.data.get("power", False)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the amplifier on."""
+        try:
+            await self.coordinator.client.set_power_on()
+            await self.coordinator.async_request_refresh()
+        except (TIPIConnectionError, TIPIProtocolError) as err:
+            _LOGGER.error("Failed to turn on amplifier: %s", err)
+            raise
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the amplifier off."""
+        try:
+            await self.coordinator.client.set_power_off()
+            await self.coordinator.async_request_refresh()
+        except (TIPIConnectionError, TIPIProtocolError) as err:
+            _LOGGER.error("Failed to turn off amplifier: %s", err)
+            raise

--- a/homeassistant/components/linea_research/tipi_client.py
+++ b/homeassistant/components/linea_research/tipi_client.py
@@ -1,0 +1,187 @@
+"""TIPI Protocol client for Linea Research amplifiers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PORT = 10001
+CONNECTION_TIMEOUT = 10
+RESPONSE_TIMEOUT = 5
+
+
+class TIPIProtocolError(Exception):
+    """Base exception for TIPI protocol errors."""
+
+
+class TIPIConnectionError(TIPIProtocolError):
+    """Exception for connection errors."""
+
+
+class TIPIClient:
+    """Client for TIPI protocol communication with Linea Research amplifiers."""
+
+    def __init__(self, host: str, port: int = DEFAULT_PORT) -> None:
+        """Initialize the TIPI client."""
+        self.host = host
+        self.port = port
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._lock = asyncio.Lock()
+        self._connected = False
+
+    async def connect(self) -> None:
+        """Connect to the amplifier."""
+        if self._connected:
+            return
+
+        try:
+            self._reader, self._writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, self.port),
+                timeout=CONNECTION_TIMEOUT,
+            )
+            self._connected = True
+            _LOGGER.debug("Connected to Linea Research amplifier at %s:%s", self.host, self.port)
+        except (asyncio.TimeoutError, OSError) as err:
+            raise TIPIConnectionError(f"Failed to connect to {self.host}:{self.port}") from err
+
+    async def disconnect(self) -> None:
+        """Disconnect from the amplifier."""
+        if self._writer:
+            self._writer.close()
+            await self._writer.wait_closed()
+            self._writer = None
+            self._reader = None
+            self._connected = False
+            _LOGGER.debug("Disconnected from Linea Research amplifier")
+
+    async def _send_command(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Send a TIPI command and return the response."""
+        if not self._connected:
+            await self.connect()
+
+        async with self._lock:
+            command = {
+                "jsonrpc": "2.0",
+                "method": method,
+                "id": 1,
+            }
+            if params:
+                command["params"] = params
+
+            # Send command
+            json_command = json.dumps(command) + "\n"
+            _LOGGER.debug("Sending TIPI command: %s", json_command.strip())
+            
+            try:
+                self._writer.write(json_command.encode())
+                await self._writer.drain()
+
+                # Read response
+                response_data = await asyncio.wait_for(
+                    self._reader.readline(),
+                    timeout=RESPONSE_TIMEOUT,
+                )
+                
+                response_str = response_data.decode().strip()
+                _LOGGER.debug("Received TIPI response: %s", response_str)
+                
+                response = json.loads(response_str)
+                
+                if "error" in response:
+                    raise TIPIProtocolError(f"TIPI error: {response['error']}")
+                
+                return response.get("result", {})
+                
+            except (asyncio.TimeoutError, ConnectionError, OSError) as err:
+                self._connected = False
+                raise TIPIConnectionError(f"Communication error: {err}") from err
+            except json.JSONDecodeError as err:
+                raise TIPIProtocolError(f"Invalid JSON response: {err}") from err
+
+    async def get_power_state(self) -> bool:
+        """Get the power state of the amplifier."""
+        # Using System::GetStandby to check if in standby (sleep) mode
+        result = await self._send_command("System::GetStandby")
+        # Returns true if in standby, so power is on when NOT in standby
+        return not result.get("value", True)
+
+    async def set_power_on(self) -> None:
+        """Turn the amplifier on (exit standby)."""
+        # Set standby to false to turn on
+        await self._send_command("System::SetStandby", {"value": False})
+
+    async def set_power_off(self) -> None:
+        """Turn the amplifier off (enter standby)."""
+        # Set standby to true to turn off
+        await self._send_command("System::SetStandby", {"value": True})
+
+    async def get_sleep_state(self) -> bool:
+        """Get the sleep state of the amplifier."""
+        # Using System::GetStandby to check sleep state
+        result = await self._send_command("System::GetStandby")
+        return result.get("value", False)
+
+    async def get_device_info(self) -> dict[str, Any]:
+        """Get device information."""
+        info = {}
+        
+        try:
+            # Get various device info using available TIPI methods
+            frame_info = await self._send_command("System::GetFrameInfo")
+            info["model"] = frame_info.get("value", {}).get("model", "Unknown")
+            info["serial"] = frame_info.get("value", {}).get("serial", "Unknown")
+            
+            # Get firmware version
+            firmware = await self._send_command("System::GetFirmwareInfo")
+            info["firmware"] = firmware.get("value", {}).get("version", "Unknown")
+            
+        except TIPIProtocolError:
+            _LOGGER.warning("Failed to get complete device info")
+            
+        return info
+
+    async def get_status(self) -> dict[str, Any]:
+        """Get current status of the amplifier."""
+        status = {}
+        
+        try:
+            # Get power/standby state
+            standby_result = await self._send_command("System::GetStandby")
+            status["standby"] = standby_result.get("value", True)
+            status["power"] = not status["standby"]
+            
+            # Get mute states for channels
+            try:
+                mute_a = await self._send_command("Amplifier::GetMuteA")
+                status["mute_a"] = mute_a.get("value", False)
+            except TIPIProtocolError:
+                pass
+                
+            try:
+                mute_b = await self._send_command("Amplifier::GetMuteB")
+                status["mute_b"] = mute_b.get("value", False)
+            except TIPIProtocolError:
+                pass
+                
+            # Get gain settings
+            try:
+                gain_a = await self._send_command("Amplifier::GetGainA")
+                status["gain_a"] = gain_a.get("value", 0)
+            except TIPIProtocolError:
+                pass
+                
+            try:
+                gain_b = await self._send_command("Amplifier::GetGainB")
+                status["gain_b"] = gain_b.get("value", 0)
+            except TIPIProtocolError:
+                pass
+                
+        except TIPIProtocolError as err:
+            _LOGGER.error("Failed to get amplifier status: %s", err)
+            
+        return status


### PR DESCRIPTION
## Summary
- Adds new integration for Linea Research amplifiers (M and C series)
- Implements TIPI protocol communication over TCP/telnet
- Provides power control and monitoring capabilities

## Features
This integration enables control and monitoring of Linea Research amplifiers via their TIPI protocol interface:

### Entities
- **Switch**: Power on/off control (manages standby mode)
- **Binary Sensors**: 
  - Sleep state monitoring
  - Channel A/B mute status
- **Sensors**: 
  - Channel A/B gain levels (in dB)

### Technical Details
- **Protocol**: TIPI (JSON-RPC over TCP socket)
- **Default Port**: 10001
- **Polling Interval**: 10 seconds
- **IoT Class**: Local polling
- **Integration Type**: Device

### Configuration
The integration is configured via the UI:
1. Enter the amplifier's IP address
2. Enter the port (default: 10001)
3. The integration auto-detects model and serial number

### Protocol Documentation
Implementation based on:
- [TIPI Protocol V1.03](https://linea-research.co.uk/wp-content/uploads/2020/07/Tipi%20Protocol%20V1_03.pdf)
- [TIPI Method Names - M and C Series V1.24](https://linea-research.co.uk/wp-content/uploads/2020/08/Tipi%20MethodNames%20-%20M%20and%20C%20Series%20Amplifiers%20-%20V1_24.pdf)

## Test Plan
- [ ] Config flow creates entry successfully
- [ ] Connection to amplifier established
- [ ] Power switch turns amplifier on/off
- [ ] Sleep state sensor reflects standby status
- [ ] Mute sensors show channel mute states
- [ ] Gain sensors display current gain levels
- [ ] Integration handles connection errors gracefully
- [ ] Integration reconnects after network interruption

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>