### PR TITLE
Specify learn frequency for Broadlink devices

### DIFF
--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -47,6 +47,7 @@ ATTR_DELAY_SECS = "delay_secs"
 ATTR_HOLD_SECS = "hold_secs"
 ATTR_ALTERNATIVE = "alternative"
 ATTR_TIMEOUT = "timeout"
+ATTR_FREQUENCY = "frequency"
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
@@ -58,7 +59,6 @@ SERVICE_SYNC = "sync"
 DEFAULT_NUM_REPEATS = 1
 DEFAULT_DELAY_SECS = 0.4
 DEFAULT_HOLD_SECS = 0
-
 
 class RemoteEntityFeature(IntFlag):
     """Supported features of the remote entity."""
@@ -118,6 +118,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             vol.Optional(ATTR_DEVICE): cv.string,
             vol.Optional(ATTR_COMMAND): vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(ATTR_COMMAND_TYPE): cv.string,
+            vol.Optional(ATTR_FREQUENCY): vol.Coerce(float),
             vol.Optional(ATTR_ALTERNATIVE): cv.boolean,
             vol.Optional(ATTR_TIMEOUT): cv.positive_int,
         },

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -80,6 +80,14 @@ learn_command:
           options:
             - "ir"
             - "rf"
+    frequency:
+      default: 315
+      selector:
+        number:
+          min: 300
+          max: 500
+          step: 1
+          unit_of_measurement: MHz
     alternative:
       selector:
         boolean:

--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -86,6 +86,10 @@
           "name": "Command type",
           "description": "The type of command to be learned."
         },
+        "frequency": {
+          "name": "Frequency",
+          "description": "Only for RF command type. Specify the frequency of the command to learn. When disabled, a frequency sweep will attempt to detect the command frequency."
+        },
         "alternative": {
           "name": "Alternative",
           "description": "If code must be stored as an alternative. This is useful for discrete codes. Discrete codes are used for toggles that only perform one function. For example, a code to only turn a device on. If it is on already, sending the code won't change the state."


### PR DESCRIPTION
## Proposed change
- Include optional `frequency` field for `Learn command`.
- Allows specifying an RF frequency when learning a command using a Broadlink device.
- Previous behavior would attempt a frequency sweep to obtain the command frequency before learning a command. If the remote/device does not continuously send commands while the sweep is taking place the sweep will not detect the frequency and fail to learn the command.
- Specifying the frequency skips the sweep.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #149100 #66685
- This PR is related to issue: 77321
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
