### PR TITLE
Update pystiebeleltron to 0.2.3

### DIFF
--- a/homeassistant/components/stiebel_eltron/manifest.json
+++ b/homeassistant/components/stiebel_eltron/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/stiebel_eltron",
   "iot_class": "local_polling",
   "loggers": ["pymodbus", "pystiebeleltron"],
-  "requirements": ["pystiebeleltron==0.1.0"]
+  "requirements": ["pystiebeleltron==0.2.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2382,7 +2382,7 @@ pyspeex-noise==1.0.2
 pysqueezebox==0.12.1
 
 # homeassistant.components.stiebel_eltron
-pystiebeleltron==0.1.0
+pystiebeleltron==0.2.3
 
 # homeassistant.components.suez_water
 pysuezV2==2.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1985,7 +1985,7 @@ pyspeex-noise==1.0.2
 pysqueezebox==0.12.1
 
 # homeassistant.components.stiebel_eltron
-pystiebeleltron==0.1.0
+pystiebeleltron==0.2.3
 
 # homeassistant.components.suez_water
 pysuezV2==2.0.7


### PR DESCRIPTION
## Proposed change
Update dependency of stiebel-eltron integration.
The new pystiebeleltron is compatible with pymodbus >= 3.10

Changes:
https://github.com/ThyMYthOS/python-stiebel-eltron/compare/v0.1.0...ThyMYthOS:python-stiebel-eltron:v0.2.3

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #150261

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
