### PR TITLE
Add preview to sql config flow

### DIFF
--- a/tests/components/sql/conftest.py
+++ b/tests/components/sql/conftest.py
@@ -3,9 +3,19 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config):
+    """Configure pytest."""
+    logger = logging.getLogger("sqlalchemy.engine")
+    logger.setLevel(logging.CRITICAL)
+    logger2 = logging.getLogger("homeassistant.components.recorder")
+    logger2.setLevel(logging.CRITICAL)
 
 
 @pytest.fixture

--- a/tests/components/sql/snapshots/test_config_flow.ambr
+++ b/tests/components/sql/snapshots/test_config_flow.ambr
@@ -1,0 +1,80 @@
+# serializer version: 1
+# name: test_config_flow_preview[incorrect_column]
+  dict({
+    'attributes': dict({
+      'device_class': 'data_size',
+      'friendly_name': 'Get Value',
+      'state_class': 'total',
+      'unit_of_measurement': 'MiB',
+    }),
+    'state': 'unknown',
+  })
+# ---
+# name: test_config_flow_preview[missing_column]
+  dict({
+    'attributes': dict({
+      'friendly_name': 'Get Value',
+    }),
+    'state': 'unknown',
+  })
+# ---
+# name: test_config_flow_preview[success]
+  dict({
+    'attributes': dict({
+      'device_class': 'data_size',
+      'friendly_name': 'Get Value',
+      'state_class': 'total',
+      'unit_of_measurement': 'MiB',
+      'value': 5,
+    }),
+    'state': '5',
+  })
+# ---
+# name: test_config_flow_preview[with_value_template]
+  dict({
+    'attributes': dict({
+      'device_class': 'data_size',
+      'friendly_name': 'Get Value',
+      'state_class': 'total',
+      'unit_of_measurement': 'MiB',
+      'value': 5,
+    }),
+    'state': '5',
+  })
+# ---
+# name: test_config_flow_preview[with_value_template_invalid]
+  dict({
+    'attributes': dict({
+      'device_class': 'data_size',
+      'friendly_name': 'Get Value',
+      'state_class': 'total',
+      'unit_of_measurement': 'MiB',
+      'value': 5,
+    }),
+    'state': '5',
+  })
+# ---
+# name: test_config_flow_preview_no_database
+  dict({
+    'attributes': dict({
+      'device_class': 'data_size',
+      'friendly_name': 'Get Value',
+      'state_class': 'total',
+      'unit_of_measurement': 'MiB',
+      'value': 5,
+    }),
+    'state': '5',
+  })
+# ---
+# name: test_options_flow_preview
+  dict({
+    'attributes': dict({
+      'device_class': 'data_size',
+      'friendly_name': 'Get Value',
+      'state_class': 'total',
+      'unit_of_measurement': 'MiB',
+      'value': 6,
+    }),
+    'state': '6',
+  })
+# ---

--- a/tests/components/sql/snapshots/test_config_flow.ambr
+++ b/tests/components/sql/snapshots/test_config_flow.ambr
@@ -70,7 +70,7 @@
   dict({
     'attributes': dict({
       'device_class': 'data_size',
-      'friendly_name': 'Get Value',
+      'friendly_name': 'Select value SQL query',
       'state_class': 'total',
       'unit_of_measurement': 'MiB',
       'value': 6,

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant import config_entries
 from homeassistant.components.recorder import CONF_DB_URL, Recorder
@@ -56,6 +57,7 @@ from . import (
 )
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry", "recorder_mock")
 
@@ -880,4 +882,250 @@ async def test_device_state_class(hass: HomeAssistant) -> None:
         CONF_ADVANCED_OPTIONS: {
             CONF_UNIT_OF_MEASUREMENT: "MiB",
         },
+    }
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    [
+        (
+            {
+                CONF_NAME: "Get Value",
+                CONF_QUERY: "SELECT 5 as value",
+                CONF_COLUMN_NAME: "value",
+                CONF_UNIT_OF_MEASUREMENT: "MiB",
+                CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+                CONF_STATE_CLASS: SensorStateClass.TOTAL,
+            }
+        ),
+        (
+            {
+                CONF_NAME: "Get Value",
+                CONF_QUERY: "SELECT 5 as value",
+                CONF_COLUMN_NAME: "state",
+                CONF_UNIT_OF_MEASUREMENT: "MiB",
+                CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+                CONF_STATE_CLASS: SensorStateClass.TOTAL,
+            }
+        ),
+        (
+            {
+                CONF_NAME: "Get Value",
+                CONF_QUERY: "SELECT 5 as value",
+            }
+        ),
+        (
+            {
+                CONF_NAME: "Get Value",
+                CONF_QUERY: "SELECT 5 as value",
+                CONF_COLUMN_NAME: "value",
+                CONF_VALUE_TEMPLATE: "{{ value }}",
+                CONF_UNIT_OF_MEASUREMENT: "MiB",
+                CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+                CONF_STATE_CLASS: SensorStateClass.TOTAL,
+            }
+        ),
+        (
+            {
+                CONF_NAME: "Get Value",
+                CONF_QUERY: "SELECT 5 as value",
+                CONF_COLUMN_NAME: "value",
+                CONF_VALUE_TEMPLATE: "{{ value",
+                CONF_UNIT_OF_MEASUREMENT: "MiB",
+                CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+                CONF_STATE_CLASS: SensorStateClass.TOTAL,
+            }
+        ),
+    ],
+    ids=(
+        "success",
+        "incorrect_column",
+        "missing_column",
+        "with_value_template",
+        "with_value_template_invalid",
+    ),
+)
+async def test_config_flow_preview(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    user_input: str,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the config flow preview."""
+    client = await hass_ws_client(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+    assert result["preview"] == "sql"
+
+    await client.send_json_auto_id(
+        {
+            "type": "sql/start_preview",
+            "flow_id": result["flow_id"],
+            "flow_type": "config_flow",
+            "user_input": user_input,
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] is None
+
+    msg = await client.receive_json()
+    assert msg["event"] == snapshot
+    assert len(hass.states.async_all()) == 0
+
+
+async def test_config_flow_preview_no_database(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the config flow preview with no database."""
+    client = await hass_ws_client(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+    assert result["preview"] == "sql"
+
+    await client.send_json_auto_id(
+        {
+            "type": "sql/start_preview",
+            "flow_id": result["flow_id"],
+            "flow_type": "config_flow",
+            "user_input": {
+                CONF_DB_URL: "sqlite://homeassistant.local",
+                CONF_NAME: "Get Value",
+                CONF_QUERY: "SELECT 5 as value",
+                CONF_COLUMN_NAME: "value",
+                CONF_UNIT_OF_MEASUREMENT: "MiB",
+                CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+                CONF_STATE_CLASS: SensorStateClass.TOTAL,
+            },
+        }
+    )
+    # msg = await client.receive_json()
+    # assert msg["success"]
+    # assert msg["result"] is None
+
+    # msg = await client.receive_json()
+    # assert msg["event"] == snapshot
+    # assert len(hass.states.async_all()) == 0
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert False
+
+
+async def test_options_flow_preview(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the options flow preview."""
+    client = await hass_ws_client(hass)
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_NAME: "Get Value",
+            CONF_QUERY: "SELECT 5 as value",
+            CONF_COLUMN_NAME: "value",
+            CONF_UNIT_OF_MEASUREMENT: "MiB",
+            CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+            CONF_STATE_CLASS: SensorStateClass.TOTAL,
+        },
+        title="Get Value",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["preview"] == "sql"
+
+    await client.send_json_auto_id(
+        {
+            "type": "sql/start_preview",
+            "flow_id": result["flow_id"],
+            "flow_type": "options_flow",
+            "user_input": {
+                CONF_QUERY: "SELECT 6 as value",
+                CONF_COLUMN_NAME: "value",
+                CONF_UNIT_OF_MEASUREMENT: "MiB",
+                CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+                CONF_STATE_CLASS: SensorStateClass.TOTAL,
+            },
+        }
+    )
+
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] is None
+
+    msg = await client.receive_json()
+    assert msg["event"] == snapshot
+    assert len(hass.states.async_all()) == 1
+
+
+async def test_options_flow_sensor_preview_config_entry_removed(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test the option flow preview where the config entry is removed."""
+    client = await hass_ws_client(hass)
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_NAME: "Get Value",
+            CONF_QUERY: "SELECT 5 as value",
+            CONF_COLUMN_NAME: "value",
+            CONF_UNIT_OF_MEASUREMENT: "MiB",
+            CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+            CONF_STATE_CLASS: SensorStateClass.TOTAL,
+        },
+        title="Get Value",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["preview"] == "sql"
+
+    await hass.config_entries.async_remove(config_entry.entry_id)
+
+    await client.send_json_auto_id(
+        {
+            "type": "sql/start_preview",
+            "flow_id": result["flow_id"],
+            "flow_type": "options_flow",
+            "user_input": {
+                CONF_QUERY: "SELECT 6 as value",
+                CONF_COLUMN_NAME: "value",
+                CONF_UNIT_OF_MEASUREMENT: "MiB",
+                CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+                CONF_STATE_CLASS: SensorStateClass.TOTAL,
+            },
+        }
+    )
+    msg = await client.receive_json()
+    assert not msg["success"]
+    assert msg["error"] == {
+        "code": "home_assistant_error",
+        "message": "Config entry not found",
     }

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -54,6 +54,7 @@ from . import (
     ENTRY_CONFIG_WITH_BROKEN_QUERY_TEMPLATE_OPT,
     ENTRY_CONFIG_WITH_QUERY_TEMPLATE,
     ENTRY_CONFIG_WITH_VALUE_TEMPLATE,
+    init_integration,
 )
 
 from tests.common import MockConfigEntry
@@ -1021,7 +1022,6 @@ async def test_config_flow_preview_no_database(
     # assert msg["event"] == snapshot
     # assert len(hass.states.async_all()) == 0
     await hass.async_block_till_done(wait_background_tasks=True)
-    assert False
 
 
 async def test_options_flow_preview(
@@ -1034,22 +1034,7 @@ async def test_options_flow_preview(
     client = await hass_ws_client(hass)
 
     # Setup the config entry
-    config_entry = MockConfigEntry(
-        data={},
-        domain=DOMAIN,
-        options={
-            CONF_NAME: "Get Value",
-            CONF_QUERY: "SELECT 5 as value",
-            CONF_COLUMN_NAME: "value",
-            CONF_UNIT_OF_MEASUREMENT: "MiB",
-            CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
-            CONF_STATE_CLASS: SensorStateClass.TOTAL,
-        },
-        title="Get Value",
-    )
-    config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    config_entry = await init_integration(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] == FlowResultType.FORM


### PR DESCRIPTION
## Breaking change


## Proposed change
Adds preview to SQL integration config/options flow

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 