### PR TITLE
Add raw advertisement data to Bluetooth WebSocket API

### DIFF
--- a/homeassistant/components/bluetooth/websocket_api.py
+++ b/homeassistant/components/bluetooth/websocket_api.py
@@ -39,7 +39,13 @@ def async_setup(hass: HomeAssistant) -> None:
 def serialize_service_info(
     service_info: BluetoothServiceInfoBleak, time_diff: float
 ) -> dict[str, Any]:
-    """Serialize a BluetoothServiceInfoBleak object."""
+    """Serialize a BluetoothServiceInfoBleak object.
+
+    The raw field is included for:
+    1. Debugging - to see the actual advertisement packet
+    2. Data freshness - manufacturer_data and service_data are aggregated
+       across multiple advertisements, raw shows the latest packet only
+    """
     return {
         "name": service_info.name,
         "address": service_info.address,
@@ -57,6 +63,7 @@ def serialize_service_info(
         "connectable": service_info.connectable,
         "time": service_info.time + time_diff,
         "tx_power": service_info.tx_power,
+        "raw": service_info.raw.hex() if service_info.raw else None,
     }
 
 

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -145,6 +145,7 @@ def inject_advertisement_with_time_and_source_connectable(
     time: float,
     source: str,
     connectable: bool,
+    raw: bytes | None = None,
 ) -> None:
     """Inject an advertisement into the manager from a specific source at a time and connectable status."""
     async_get_advertisement_callback(hass)(
@@ -161,6 +162,7 @@ def inject_advertisement_with_time_and_source_connectable(
             connectable=connectable,
             time=time,
             tx_power=adv.tx_power,
+            raw=raw,
         )
     )
 

--- a/tests/components/bluetooth/test_websocket_api.py
+++ b/tests/components/bluetooth/test_websocket_api.py
@@ -22,6 +22,7 @@ from . import (
     generate_advertisement_data,
     generate_ble_device,
     inject_advertisement_with_source,
+    inject_advertisement_with_time_and_source_connectable,
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -72,6 +73,7 @@ async def test_subscribe_advertisements(
                 "source": HCI0_SOURCE_ADDRESS,
                 "time": ANY,
                 "tx_power": -127,
+                "raw": None,
             }
         ]
     }
@@ -83,8 +85,15 @@ async def test_subscribe_advertisements(
         service_uuids=[],
         rssi=-80,
     )
-    inject_advertisement_with_source(
-        hass, switchbot_device_signal_100, switchbot_adv_signal_100, HCI1_SOURCE_ADDRESS
+    # Inject with raw bytes data
+    inject_advertisement_with_time_and_source_connectable(
+        hass,
+        switchbot_device_signal_100,
+        switchbot_adv_signal_100,
+        time.monotonic(),
+        HCI1_SOURCE_ADDRESS,
+        True,
+        raw=b"\x02\x01\x06\x03\x03\x0f\x18",
     )
     async with asyncio.timeout(1):
         response = await client.receive_json()
@@ -101,6 +110,7 @@ async def test_subscribe_advertisements(
                 "source": HCI1_SOURCE_ADDRESS,
                 "time": ANY,
                 "tx_power": -127,
+                "raw": "02010603030f18",
             }
         ]
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the `raw` field to the Bluetooth WebSocket API's advertisement data response. The raw field contains the latest BLE advertisement packet as a hex-encoded string.

This addition is important for two key use cases:
1. **Debugging** - Developers can see the actual BLE advertisement packet as received, which is invaluable for troubleshooting Bluetooth issues. The frontend will already preserve this in the `Copy to clipboard` in the UI which will improve issue reporting.
2. **Data freshness** - Since `manufacturer_data` and `service_data` are aggregated across multiple advertisement packets over time, the raw field provides a way to see only the data from the most recent advertisement packet, helping identify which data is newest

The field returns `null` when no raw data is available, maintaining backward compatibility.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr****