### PR TITLE
Ignore errors when PlayStation Network group fetch is blocked by parental controls

### DIFF
--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -194,8 +194,6 @@ class PlaystationNetworkGroupsUpdateCoordinator(
             )
             await self.async_shutdown()
             return {}
-        except PSNAWPError:
-            raise
 
 
 class PlaystationNetworkFriendDataCoordinator(

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -173,7 +173,10 @@ class PlaystationNetworkGroupsUpdateCoordinator(
                 }
             )
         except PSNAWPForbiddenError as e:
-            error = json.loads(e.args[0])
+            try:
+                error = json.loads(e.args[0])
+            except json.JSONDecodeError as err:
+                raise PSNAWPServerError from err
             _LOGGER.info(
                 "Unable to retrieve group chats for %s from PlayStation Network "
                 "due to permissions: %s. This does not affect other integration features",

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -174,8 +174,9 @@ class PlaystationNetworkGroupsUpdateCoordinator(
             )
         except PSNAWPForbiddenError as e:
             error = json.loads(e.args[0])
-            _LOGGER.warning(
-                "Failed to retrieve DM and group chats for %s from PlayStation Network: %s",
+            _LOGGER.info(
+                "Unable to retrieve group chats for %s from PlayStation Network "
+                "due to permissions: %s. This does not affect other integration features",
                 self.config_entry.title,
                 error["error"]["message"],
             )

--- a/homeassistant/components/playstation_network/strings.json
+++ b/homeassistant/components/playstation_network/strings.json
@@ -164,5 +164,11 @@
         "name": "Direct message: {name}"
       }
     }
+  },
+  "issues": {
+    "group_chat_forbidden": {
+      "title": "Failed to retrieve group chats for {name}",
+      "description": "The PlayStation Network integration was unable to retrieve group chats for **{name}**.\n\nThis is likely due to insufficient permissions (Error: `{error_message}`).\n\nTo resolve this issue, please ensure the account's chat and messaging feature is not restricted by parental controls or other privacy settings.\n\nIf the restriction is intentional, you can safely ignore this message."
+    }
   }
 }

--- a/tests/components/playstation_network/test_notify.py
+++ b/tests/components/playstation_network/test_notify.py
@@ -137,7 +137,7 @@ async def test_send_message_exceptions(
     mock_psnawpapi.group.return_value.send_message.assert_called_once_with("henlo fren")
 
 
-async def test_notify_skip_fobidden(
+async def test_notify_skip_forbidden(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_psnawpapi: MagicMock,


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Ignores errors when fetching groups is blocked by parental controls or other privacy settings. When the endpoint is queried, if access is forbidden, the coordinator shuts down to stop polling. A message is logged that it is forbidden by parental controls (or other privacy settings if applicable)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #149738
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
