### PR TITLE
Split test_config_flow_duplicate tests into two separate ones for APCUPSD

### DIFF
--- a/homeassistant/components/apcupsd/quality_scale.yaml
+++ b/homeassistant/components/apcupsd/quality_scale.yaml
@@ -12,7 +12,6 @@ rules:
     comment: |
       Consider looking into making a `mock_setup_entry` fixture that just automatically do this.
       `test_config_flow_cannot_connect`: Needs to end in CREATE_ENTRY to test that its able to recover.
-      `test_config_flow_duplicate`: this test should be split in 2, one for testing duplicate host/port and one for duplicate serial number.
   config-flow: done
   dependency-transparency: done
   docs-actions:

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_config_flow_cannot_connect(hass: HomeAssistant) -> None:
 
 
 async def test_config_flow_duplicate_host_port(hass: HomeAssistant) -> None:
-    """Test duplicate config flow setup with the same host / port but different serial number."""
+    """Test duplicate config flow setup with the same host / port."""
     # First add an existing config entry to hass.
     mock_entry = MockConfigEntry(
         version=1,

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -59,19 +59,19 @@ async def test_config_flow_duplicate_host_port(hass: HomeAssistant) -> None:
         ) as mock_request_status,
         _patch_setup(),
     ):
-        # Assign a different serial number, but we should still reject the creation since the
-        # host and port are the same as the existing entry.
-        mock_request_status.return_value = MOCK_STATUS | {
-            "SERIALNO": MOCK_STATUS["SERIALNO"] + "ZZZ"
-        }
+        # Assign the same host and port, which we should reject since the entry already exists.
+        mock_request_status.return_value = MOCK_STATUS
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
-        # Now we change the host and add it again. This should be successful.
+        # Now we change the host with a different serial number and add it again. This should be successful.
         another_host = CONF_DATA | {CONF_HOST: "another_host"}
+        mock_request_status.return_value = MOCK_STATUS | {
+            "SERIALNO": MOCK_STATUS["SERIALNO"] + "ZZZ"
+        }
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -100,7 +100,7 @@ async def test_config_flow_duplicate_serial_number(hass: HomeAssistant) -> None:
         ) as mock_request_status,
         _patch_setup(),
     ):
-        # Assign the same host and port, but we should still reject the creation since the
+        # Assign the different host and port, but we should still reject the creation since the
         # serial number is the same as the existing entry.
         mock_request_status.return_value = MOCK_STATUS
         another_host = CONF_DATA | {CONF_HOST: "another_host"}

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import copy
 from unittest.mock import patch
 
 import pytest
@@ -41,9 +40,9 @@ async def test_config_flow_cannot_connect(hass: HomeAssistant) -> None:
         assert result["errors"]["base"] == "cannot_connect"
 
 
-async def test_config_flow_duplicate(hass: HomeAssistant) -> None:
-    """Test duplicate config flow setup."""
-    # First add an exiting config entry to hass.
+async def test_config_flow_duplicate_host_port(hass: HomeAssistant) -> None:
+    """Test duplicate config flow setup with the same host / port but different serial number."""
+    # First add an existing config entry to hass.
     mock_entry = MockConfigEntry(
         version=1,
         domain=DOMAIN,
@@ -60,25 +59,51 @@ async def test_config_flow_duplicate(hass: HomeAssistant) -> None:
         ) as mock_request_status,
         _patch_setup(),
     ):
-        mock_request_status.return_value = MOCK_STATUS
-
-        # Now, create the integration again using the same config data, we should reject
-        # the creation due same host / port.
+        # Assign a different serial number, but we should still reject the creation since the
+        # host and port are the same as the existing entry.
+        mock_request_status.return_value = MOCK_STATUS | {
+            "SERIALNO": MOCK_STATUS["SERIALNO"] + "ZZZ"
+        }
         result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-            data=CONF_DATA,
+            DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
-        # Then, we create the integration once again using a different port. However,
-        # the apcaccess patch is kept to report the same serial number, we should
-        # reject the creation as well.
-        another_host = {
-            CONF_HOST: CONF_DATA[CONF_HOST],
-            CONF_PORT: CONF_DATA[CONF_PORT] + 1,
-        }
+        # Now we change the host and add it again. This should be successful.
+        another_host = CONF_DATA | {CONF_HOST: "another_host"}
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=another_host,
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["data"] == another_host
+
+
+async def test_config_flow_duplicate_serial_number(hass: HomeAssistant) -> None:
+    """Test duplicate config flow setup with different host but the same serial number."""
+    # First add an existing config entry to hass.
+    mock_entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title="APCUPSd",
+        data=CONF_DATA,
+        unique_id=MOCK_STATUS["SERIALNO"],
+        source=SOURCE_USER,
+    )
+    mock_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
+        ) as mock_request_status,
+        _patch_setup(),
+    ):
+        # Assign the same host and port, but we should still reject the creation since the
+        # serial number is the same as the existing entry.
+        mock_request_status.return_value = MOCK_STATUS
+        another_host = CONF_DATA | {CONF_HOST: "another_host"}
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -88,14 +113,11 @@ async def test_config_flow_duplicate(hass: HomeAssistant) -> None:
         assert result["reason"] == "already_configured"
 
         # Now we change the serial number and add it again. This should be successful.
-        another_device_status = copy(MOCK_STATUS)
-        another_device_status["SERIALNO"] = MOCK_STATUS["SERIALNO"] + "ZZZ"
-        mock_request_status.return_value = another_device_status
-
+        mock_request_status.return_value = MOCK_STATUS | {
+            "SERIALNO": MOCK_STATUS["SERIALNO"] + "ZZZ"
+        }
         result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-            data=another_host,
+            DOMAIN, context={"source": SOURCE_USER}, data=another_host
         )
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"] == another_host


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR splits the `test_config_flow_duplicate` test for APCUPSD into two separate ones: 

(1) tests the abort logic when the configuration has the same host and port but different serial number
(2) tests the abort logic when the configuration has different host and port but same serial number.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
