### PR TITLE
Use `mock_setup_entry` fixture for APCUPSD

### DIFF
--- a/tests/components/apcupsd/conftest.py
+++ b/tests/components/apcupsd/conftest.py
@@ -1,0 +1,15 @@
+"""Common fixtures for the APC UPS Daemon (APCUPSD) tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.apcupsd.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -15,13 +15,6 @@ from homeassistant.data_entry_flow import FlowResultType
 from . import CONF_DATA, MOCK_MINIMAL_STATUS, MOCK_STATUS
 
 from tests.common import MockConfigEntry
-
-
-def _patch_setup():
-    return patch(
-        "homeassistant.components.apcupsd.async_setup_entry",
-        return_value=True,
-    )
 
 
 async def test_config_flow_cannot_connect(hass: HomeAssistant) -> None:
@@ -40,7 +33,9 @@ async def test_config_flow_cannot_connect(hass: HomeAssistant) -> None:
         assert result["errors"]["base"] == "cannot_connect"
 
 
-async def test_config_flow_duplicate_host_port(hass: HomeAssistant) -> None:
+async def test_config_flow_duplicate_host_port(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test duplicate config flow setup with the same host / port."""
     # First add an existing config entry to hass.
     mock_entry = MockConfigEntry(
@@ -53,12 +48,9 @@ async def test_config_flow_duplicate_host_port(hass: HomeAssistant) -> None:
     )
     mock_entry.add_to_hass(hass)
 
-    with (
-        patch(
-            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
-        ) as mock_request_status,
-        _patch_setup(),
-    ):
+    with patch(
+        "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
+    ) as mock_request_status:
         # Assign the same host and port, which we should reject since the entry already exists.
         mock_request_status.return_value = MOCK_STATUS
         result = await hass.config_entries.flow.async_init(
@@ -81,7 +73,9 @@ async def test_config_flow_duplicate_host_port(hass: HomeAssistant) -> None:
         assert result["data"] == another_host
 
 
-async def test_config_flow_duplicate_serial_number(hass: HomeAssistant) -> None:
+async def test_config_flow_duplicate_serial_number(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test duplicate config flow setup with different host but the same serial number."""
     # First add an existing config entry to hass.
     mock_entry = MockConfigEntry(
@@ -94,12 +88,9 @@ async def test_config_flow_duplicate_serial_number(hass: HomeAssistant) -> None:
     )
     mock_entry.add_to_hass(hass)
 
-    with (
-        patch(
-            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
-        ) as mock_request_status,
-        _patch_setup(),
-    ):
+    with patch(
+        "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
+    ) as mock_request_status:
         # Assign the different host and port, but we should still reject the creation since the
         # serial number is the same as the existing entry.
         mock_request_status.return_value = MOCK_STATUS
@@ -123,14 +114,11 @@ async def test_config_flow_duplicate_serial_number(hass: HomeAssistant) -> None:
         assert result["data"] == another_host
 
 
-async def test_flow_works(hass: HomeAssistant) -> None:
+async def test_flow_works(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     """Test successful creation of config entries via user configuration."""
-    with (
-        patch(
-            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
-            return_value=MOCK_STATUS,
-        ),
-        _patch_setup() as mock_setup,
+    with patch(
+        "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
+        return_value=MOCK_STATUS,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -147,7 +135,7 @@ async def test_flow_works(hass: HomeAssistant) -> None:
         assert result["data"] == CONF_DATA
         assert result["result"].unique_id == MOCK_STATUS["SERIALNO"]
 
-        mock_setup.assert_called_once()
+        mock_setup_entry.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -162,19 +150,19 @@ async def test_flow_works(hass: HomeAssistant) -> None:
     ],
 )
 async def test_flow_minimal_status(
-    hass: HomeAssistant, extra_status: dict[str, str], expected_title: str
+    hass: HomeAssistant,
+    extra_status: dict[str, str],
+    expected_title: str,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test successful creation of config entries via user configuration when minimal status is reported.
 
     We test different combinations of minimal statuses, where the title of the
     integration will vary.
     """
-    with (
-        patch(
-            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
-        ) as mock_request_status,
-        _patch_setup() as mock_setup,
-    ):
+    with patch(
+        "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status"
+    ) as mock_request_status:
         status = MOCK_MINIMAL_STATUS | extra_status
         mock_request_status.return_value = status
 
@@ -185,10 +173,12 @@ async def test_flow_minimal_status(
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"] == CONF_DATA
         assert result["title"] == expected_title
-        mock_setup.assert_called_once()
+        mock_setup_entry.assert_called_once()
 
 
-async def test_reconfigure_flow_works(hass: HomeAssistant) -> None:
+async def test_reconfigure_flow_works(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test successful reconfiguration of an existing entry."""
     mock_entry = MockConfigEntry(
         version=1,
@@ -207,18 +197,15 @@ async def test_reconfigure_flow_works(hass: HomeAssistant) -> None:
     # New configuration data with different host/port.
     new_conf_data = {CONF_HOST: "new_host", CONF_PORT: 4321}
 
-    with (
-        patch(
-            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
-            return_value=MOCK_STATUS,
-        ),
-        _patch_setup() as mock_setup,
+    with patch(
+        "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
+        return_value=MOCK_STATUS,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=new_conf_data
         )
         await hass.async_block_till_done()
-        mock_setup.assert_called_once()
+        mock_setup_entry.assert_called_once()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
@@ -228,7 +215,9 @@ async def test_reconfigure_flow_works(hass: HomeAssistant) -> None:
     assert mock_entry.data[CONF_PORT] == new_conf_data[CONF_PORT]
 
 
-async def test_reconfigure_flow_cannot_connect(hass: HomeAssistant) -> None:
+async def test_reconfigure_flow_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
     """Test reconfiguration with connection error and recovery."""
     mock_entry = MockConfigEntry(
         version=1,
@@ -258,12 +247,9 @@ async def test_reconfigure_flow_cannot_connect(hass: HomeAssistant) -> None:
     assert result["errors"]["base"] == "cannot_connect"
 
     # Test recovery by fixing the connection issue.
-    with (
-        patch(
-            "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
-            return_value=MOCK_STATUS,
-        ),
-        _patch_setup(),
+    with patch(
+        "homeassistant.components.apcupsd.coordinator.aioapcaccess.request_status",
+        return_value=MOCK_STATUS,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=new_conf_data


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR uses `mock_setup_entry` fixture for APCUPSD to simplify the codebase.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
