### PR TITLE
Lower Z-Wave firmware check delay

### DIFF
--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -42,7 +42,7 @@ from .models import ZwaveJSConfigEntry
 PARALLEL_UPDATES = 1
 
 UPDATE_DELAY_STRING = "delay"
-UPDATE_DELAY_INTERVAL = 5  # In minutes
+UPDATE_DELAY_INTERVAL = 15  # In seconds
 ATTR_LATEST_VERSION_FIRMWARE = "latest_version_firmware"
 
 
@@ -129,11 +129,11 @@ async def async_setup_entry(
     @callback
     def async_add_firmware_update_entity(node: ZwaveNode) -> None:
         """Add firmware update entity."""
-        # We need to delay the first update of each entity to avoid flooding the network
-        # so we maintain a counter to schedule first update in UPDATE_DELAY_INTERVAL
-        # minute increments.
+        # Delay the first update of each entity to avoid spamming the firmware server.
+        # Maintain a counter to schedule first update in UPDATE_DELAY_INTERVAL
+        # second increments.
         cnt[UPDATE_DELAY_STRING] += 1
-        delay = timedelta(minutes=(cnt[UPDATE_DELAY_STRING] * UPDATE_DELAY_INTERVAL))
+        delay = timedelta(seconds=(cnt[UPDATE_DELAY_STRING] * UPDATE_DELAY_INTERVAL))
         driver = client.driver
         assert driver is not None  # Driver is ready before platforms are loaded.
         if node.is_controller_node:
@@ -413,7 +413,8 @@ class ZWaveFirmwareUpdateEntity(UpdateEntity):
         ):
             self._attr_latest_version = self._attr_installed_version
 
-        # Spread updates out in 5 minute increments to avoid flooding the network
+        # Spread updates out in 15 second increments
+        # to avoid spamming the firmware server
         self.async_on_remove(
             async_call_later(self.hass, self._delay, self._async_update)
         )

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -28,7 +28,13 @@ from homeassistant.components.zwave_js.discovery_data_template import (
     DynamicCurrentTempClimateDataTemplate,
 )
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_UNKNOWN, EntityCategory
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_OFF,
+    STATE_UNKNOWN,
+    EntityCategory,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
@@ -253,6 +259,7 @@ async def test_merten_507801_disabled_enitites(
         assert updated_entry.disabled is False
 
 
+@pytest.mark.parametrize("platforms", [[Platform.BUTTON, Platform.NUMBER]])
 async def test_zooz_zen72(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -324,6 +331,9 @@ async def test_zooz_zen72(
     assert args["value"] is True
 
 
+@pytest.mark.parametrize(
+    "platforms", [[Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]]
+)
 async def test_indicator_test(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -167,7 +167,7 @@ async def test_update_entity_states(
 
     client.async_send_command.return_value = {"updates": []}
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -186,7 +186,7 @@ async def test_update_entity_states(
 
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=2))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=2))
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -224,7 +224,7 @@ async def test_update_entity_states(
 
     client.async_send_command.return_value = {"updates": []}
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=3))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=3))
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -246,7 +246,7 @@ async def test_update_entity_install_raises(
     """Test update entity install raises exception."""
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=1))
     await hass.async_block_till_done()
 
     # Test failed installation by driver
@@ -279,7 +279,7 @@ async def test_update_entity_sleep(
 
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=1))
     await hass.async_block_till_done()
 
     # Two nodes in total, the controller node and the zen_31 node.
@@ -308,7 +308,7 @@ async def test_update_entity_dead(
 
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=1))
     await hass.async_block_till_done()
 
     # Two nodes in total, the controller node and the zen_31 node.
@@ -352,14 +352,14 @@ async def test_update_entity_ha_not_running(
     # Update should be delayed by a day because Home Assistant is not running
     hass.set_state(CoreState.starting)
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15))
     await hass.async_block_till_done()
 
     assert client.async_send_command.call_count == 0
 
     hass.set_state(CoreState.running)
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=1))
     await hass.async_block_till_done()
 
     # Two nodes in total, the controller node and the zen_31 node.
@@ -385,7 +385,7 @@ async def test_update_entity_update_failure(
     assert client.async_send_command.call_count == 0
     client.async_send_command.side_effect = FailedZWaveCommand("test", 260, "test")
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=1))
     await hass.async_block_till_done()
 
     entity_ids = (CONTROLLER_UPDATE_ENTITY, NODE_UPDATE_ENTITY)
@@ -493,7 +493,7 @@ async def test_update_entity_progress(
     client.async_send_command.return_value = FIRMWARE_UPDATES
     driver = client.driver
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -641,7 +641,7 @@ async def test_update_entity_install_failed(
     driver = client.driver
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -717,7 +717,7 @@ async def test_update_entity_reload(
 
     client.async_send_command.return_value = {"updates": []}
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -726,7 +726,7 @@ async def test_update_entity_reload(
 
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=2))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=2))
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -758,7 +758,7 @@ async def test_update_entity_reload(
     await hass.async_block_till_done()
 
     # Trigger another update and make sure the skipped version is still skipped
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=4))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15, days=4))
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -793,7 +793,7 @@ async def test_update_entity_delay(
 
     assert client.async_send_command.call_count == 0
 
-    update_interval = timedelta(minutes=5)
+    update_interval = timedelta(seconds=15)
     freezer.tick(update_interval)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Lower the delay of the firmware check when loading the config entry and Home Assistant is started to 15 seconds between each device.
- We used to have a delay of 5 minutes, as at the time, the Z-Wave network would be impacted during a firmware check. This is no longer the case.
- Currently we only need to consider the impact on the cloud server that hosts the firmware and Home Assistant itself when deciding how to spread update checks.
- Log details confirming the delay with three devices: https://paste.ubuntu.com/p/6nGW7qwRR5/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
