### PR TITLE
Pi_hole - Account for auth succeeding when it shouldn't

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -220,7 +220,8 @@ async def determine_api_version(
     else:
         # It seems that occasionally the auth can succeed unexpectedly when there is a valid session
         _LOGGER.warning(
-            "Authenticated with %s : succeeded with an incorrect password", holeV6.base_url
+            "Authenticated with %s : succeeded with an incorrect password", 
+            holeV6.base_url,
         )
         return 6
     holeV5 = api_by_version(hass, entry, 5, password="wrong_token")

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -220,7 +220,7 @@ async def determine_api_version(
     else:
         # It seems that occasionally the auth can succeed unexpectedly when there is a valid session
         _LOGGER.warning(
-            "Authenticated with %s : succeeded with an incorrect password", 
+            "Authenticated with %s through v6 API, but succeeded with an incorrect password. This is a known bug",
             holeV6.base_url,
         )
         return 6

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -220,7 +220,7 @@ async def determine_api_version(
     else:
         # It seems that occasionally the auth can succeed unexpectedly when there is a valid session
         _LOGGER.warning(
-            "Authenticated with %s : succeeded with an incorrect password.", holeV6.base_url
+            "Authenticated with %s : succeeded with an incorrect password", holeV6.base_url
         )
         return 6
     holeV5 = api_by_version(hass, entry, 5, password="wrong_token")

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -218,7 +218,7 @@ async def determine_api_version(
             "Connection to %s failed: %s, trying API version 5", holeV6.base_url, ex_v6
         )
     else:
-        # it seems occassionally the auth can succeed unexpectedly when there is a valid session
+        # It seems that occasionally the auth can succeed unexpectedly when there is a valid session
         _LOGGER.warning(
             "Authenticated with %s : succeeded with an incorrect password.", holeV6.base_url
         )

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -219,6 +219,9 @@ async def determine_api_version(
         )
     else:
         # it seems occassionally the auth can succeed unexpectedly when there is a valid session
+        _LOGGER.warning(
+            "Authenticated with %s : succeeded with an incorrect password.", holeV6.base_url
+        )
         return 6
     holeV5 = api_by_version(hass, entry, 5, password="wrong_token")
     try:

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -217,6 +217,9 @@ async def determine_api_version(
         _LOGGER.debug(
             "Connection to %s failed: %s, trying API version 5", holeV6.base_url, ex_v6
         )
+    else:
+        # it seems occassionally the auth can succeed unexpectedly when there is a valid session
+        return 6
     holeV5 = api_by_version(hass, entry, 5, password="wrong_token")
     try:
         await holeV5.get_data()

--- a/tests/components/pi_hole/__init__.py
+++ b/tests/components/pi_hole/__init__.py
@@ -221,12 +221,16 @@ def _create_mocked_hole(
             if wrong_host:
                 raise HoleConnectionError("Cannot authenticate with Pi-hole: err")
             password = getattr(mocked_hole, "password", None)
+
             if (
                 raise_exception
                 or incorrect_app_password
+                or api_version == 5
                 or (api_version == 6 and password not in ["newkey", "apikey"])
             ):
-                if api_version == 6:
+                if api_version == 6 and (
+                    incorrect_app_password or password not in ["newkey", "apikey"]
+                ):
                     raise HoleError("Authentication failed: Invalid password")
                 raise HoleConnectionError
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the new API in pihole we determine which API is running by differentiating their responses to an un-authenticated request. However, it seems that in some cases (although not clear which) the version 6 API will unexpectedly permit an invalid password when there is an active and valid session. This breaks our logic.

This could either be something to do with:
  - python_hole failing to log out before auth https://github.com/home-assistant-ecosystem/python-hole/blob/d5152f3af570b03bcc213b372014802f3598a6c9/hole/v6.py#L81
  - Something in pi-hole itself
  - some weird header caching or forwarding issue (I've only been able to re-create the bug on an install behind NGINX)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #149769, #150151
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
