### PR TITLE
ruuvitag_ble: add new sensors

### DIFF
--- a/homeassistant/components/ruuvitag_ble/sensor.py
+++ b/homeassistant/components/ruuvitag_ble/sensor.py
@@ -104,6 +104,35 @@ SENSOR_DESCRIPTIONS = {
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
+    # Keys exported for dataformat 06 sensors in newer versions of ruuvitag-ble
+    "pm25": SensorEntityDescription(
+        key=f"{SSDSensorDeviceClass.PM25}_{Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER}",
+        device_class=SensorDeviceClass.PM25,
+        native_unit_of_measurement=Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "carbon_dioxide": SensorEntityDescription(
+        key=f"{SSDSensorDeviceClass.CO2}_{Units.CONCENTRATION_PARTS_PER_MILLION}",
+        device_class=SensorDeviceClass.CO2,
+        native_unit_of_measurement=Units.CONCENTRATION_PARTS_PER_MILLION,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "illuminance": SensorEntityDescription(
+        key=f"{SSDSensorDeviceClass.ILLUMINANCE}_{Units.LIGHT_LUX}",
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        native_unit_of_measurement=Units.LIGHT_LUX,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "voc_index": SensorEntityDescription(
+        key="voc_index",
+        translation_key="voc_index",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "nox_index": SensorEntityDescription(
+        key="nox_index",
+        translation_key="nox_index",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 }
 
 

--- a/homeassistant/components/ruuvitag_ble/sensor.py
+++ b/homeassistant/components/ruuvitag_ble/sensor.py
@@ -62,6 +62,7 @@ SENSOR_DESCRIPTIONS = {
     ): SensorEntityDescription(
         key=f"{SSDSensorDeviceClass.VOLTAGE}_{Units.ELECTRIC_POTENTIAL_MILLIVOLT}",
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     (
@@ -76,6 +77,7 @@ SENSOR_DESCRIPTIONS = {
     ),
     (SSDSensorDeviceClass.COUNT, None): SensorEntityDescription(
         key="movement_counter",
+        translation_key="movement_counter",
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
     ),
@@ -116,10 +118,7 @@ def sensor_update_to_bluetooth_data_update(
             _device_key_to_bluetooth_entity_key(device_key): sensor_values.native_value
             for device_key, sensor_values in sensor_update.entity_values.items()
         },
-        entity_names={
-            _device_key_to_bluetooth_entity_key(device_key): sensor_values.name
-            for device_key, sensor_values in sensor_update.entity_values.items()
-        },
+        entity_names={},
     )
 
 

--- a/homeassistant/components/ruuvitag_ble/sensor.py
+++ b/homeassistant/components/ruuvitag_ble/sensor.py
@@ -75,6 +75,35 @@ SENSOR_DESCRIPTIONS = {
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
     ),
+    # Acceleration keys exported in newer versions of ruuvitag-ble
+    "acceleration_x": SensorEntityDescription(
+        key=f"acceleration_x_{Units.ACCELERATION_METERS_PER_SQUARE_SECOND}",
+        translation_key="acceleration_x",
+        native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    "acceleration_y": SensorEntityDescription(
+        key=f"acceleration_y_{Units.ACCELERATION_METERS_PER_SQUARE_SECOND}",
+        translation_key="acceleration_y",
+        native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    "acceleration_z": SensorEntityDescription(
+        key=f"acceleration_z_{Units.ACCELERATION_METERS_PER_SQUARE_SECOND}",
+        translation_key="acceleration_z",
+        native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    "acceleration_total": SensorEntityDescription(
+        key=f"acceleration_total_{Units.ACCELERATION_METERS_PER_SQUARE_SECOND}",
+        translation_key="acceleration_total",
+        native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
 }
 
 

--- a/homeassistant/components/ruuvitag_ble/strings.json
+++ b/homeassistant/components/ruuvitag_ble/strings.json
@@ -18,5 +18,12 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "entity": {
+    "sensor": {
+      "movement_counter": {
+        "name": "Movement counter"
+      }
+    }
   }
 }

--- a/homeassistant/components/ruuvitag_ble/strings.json
+++ b/homeassistant/components/ruuvitag_ble/strings.json
@@ -35,6 +35,12 @@
       },
       "movement_counter": {
         "name": "Movement counter"
+      },
+      "nox_index": {
+        "name": "NOx index"
+      },
+      "voc_index": {
+        "name": "VOC index"
       }
     }
   }

--- a/homeassistant/components/ruuvitag_ble/strings.json
+++ b/homeassistant/components/ruuvitag_ble/strings.json
@@ -21,6 +21,18 @@
   },
   "entity": {
     "sensor": {
+      "acceleration_total": {
+        "name": "Acceleration total"
+      },
+      "acceleration_x": {
+        "name": "Acceleration X"
+      },
+      "acceleration_y": {
+        "name": "Acceleration Y"
+      },
+      "acceleration_z": {
+        "name": "Acceleration Z"
+      },
       "movement_counter": {
         "name": "Movement counter"
       }

--- a/tests/components/ruuvitag_ble/fixtures.py
+++ b/tests/components/ruuvitag_ble/fixtures.py
@@ -12,12 +12,23 @@ NOT_RUUVITAG_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
-RUUVITAG_SERVICE_INFO = BluetoothServiceInfo(
+RUUVI_V5_SERVICE_INFO = BluetoothServiceInfo(
     name="RuuviTag 0911",
     address="01:03:05:07:09:11",  # Ignored (the payload encodes the correct MAC)
     rssi=-60,
     manufacturer_data={
         1177: b"\x05\x05\xa0`\xa0\xc8\x9a\xfd4\x02\x8c\xff\x00cvriv\xde\xad{?\xef\xaf"
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+RUUVI_V6_SERVICE_INFO = BluetoothServiceInfo(
+    name="Ruuvi 1234",
+    address="01:03:05:07:12:34",  # Ignored (the payload encodes the correct MAC)
+    rssi=-60,
+    manufacturer_data={
+        1177: b"\x06\x17\x0cVh\xc7\x9e\x00p\x00\xc9\x05\x01\xd9J\xcd\x00L\x88O",
     },
     service_data={},
     service_uuids=[],

--- a/tests/components/ruuvitag_ble/snapshots/test_sensor.ambr
+++ b/tests/components/ruuvitag_ble/snapshots/test_sensor.ambr
@@ -79,12 +79,12 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Movement Counter',
+    'original_name': 'Movement counter',
     'platform': 'ruuvitag_ble',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'movement_counter',
     'unique_id': '01:03:05:07:09:11-movement_counter',
     'unit_of_measurement': None,
   })
@@ -92,7 +92,7 @@
 # name: test_sensors[v5][sensor.ruuvitag_efaf_movement_counter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'RuuviTag EFAF Movement Counter',
+      'friendly_name': 'RuuviTag EFAF Movement counter',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
@@ -186,7 +186,7 @@
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
     'original_icon': None,
-    'original_name': 'Signal Strength',
+    'original_name': 'Signal strength',
     'platform': 'ruuvitag_ble',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -200,7 +200,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'RuuviTag EFAF Signal Strength',
+      'friendly_name': 'RuuviTag EFAF Signal strength',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
     }),
@@ -292,8 +292,11 @@
     }),
     'name': None,
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
     'original_icon': None,
     'original_name': 'Voltage',
     'platform': 'ruuvitag_ble',
@@ -308,6 +311,7 @@
 # name: test_sensors[v5][sensor.ruuvitag_efaf_voltage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
       'friendly_name': 'RuuviTag EFAF Voltage',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfElectricPotential.MILLIVOLT: 'mV'>,

--- a/tests/components/ruuvitag_ble/snapshots/test_sensor.ambr
+++ b/tests/components/ruuvitag_ble/snapshots/test_sensor.ambr
@@ -532,3 +532,482 @@
     'state': '2395',
   })
 # ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_carbon_dioxide-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_884f_carbon_dioxide',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.CO2: 'carbon_dioxide'>,
+    'original_icon': None,
+    'original_name': 'Carbon dioxide',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:12:34-carbon_dioxide',
+    'unit_of_measurement': <Units.CONCENTRATION_PARTS_PER_MILLION: 'ppm'>,
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_carbon_dioxide-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'carbon_dioxide',
+      'friendly_name': 'RuuviTag 884F Carbon dioxide',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <Units.CONCENTRATION_PARTS_PER_MILLION: 'ppm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_884f_carbon_dioxide',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '201',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_884f_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:12:34-humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'friendly_name': 'RuuviTag 884F Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_884f_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '55.3',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_illuminance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_884f_illuminance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ILLUMINANCE: 'illuminance'>,
+    'original_icon': None,
+    'original_name': 'Illuminance',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:12:34-illuminance',
+    'unit_of_measurement': <Units.LIGHT_LUX: 'lx'>,
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_illuminance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'illuminance',
+      'friendly_name': 'RuuviTag 884F Illuminance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <Units.LIGHT_LUX: 'lx'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_884f_illuminance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '13027',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_nox_index-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_884f_nox_index',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'NOx index',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'nox_index',
+    'unique_id': '01:03:05:07:12:34-nox_index',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_nox_index-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'RuuviTag 884F NOx index',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_884f_nox_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_pm2_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_884f_pm2_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PM25: 'pm25'>,
+    'original_icon': None,
+    'original_name': 'PM2.5',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:12:34-pm25',
+    'unit_of_measurement': <Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: 'µg/m³'>,
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_pm2_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pm25',
+      'friendly_name': 'RuuviTag 884F PM2.5',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: 'µg/m³'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_884f_pm2_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11.2',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_884f_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Pressure',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:12:34-pressure',
+    'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'RuuviTag 884F Pressure',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_884f_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1011.02',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_signal_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_884f_signal_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Signal strength',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:12:34-signal_strength',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_signal_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'signal_strength',
+      'friendly_name': 'RuuviTag 884F Signal strength',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_884f_signal_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-60',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_884f_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:12:34-temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'RuuviTag 884F Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_884f_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '29.5',
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_voc_index-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_884f_voc_index',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'VOC index',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'voc_index',
+    'unique_id': '01:03:05:07:12:34-voc_index',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[v6][sensor.ruuvitag_884f_voc_index-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'RuuviTag 884F VOC index',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_884f_voc_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---

--- a/tests/components/ruuvitag_ble/snapshots/test_sensor.ambr
+++ b/tests/components/ruuvitag_ble/snapshots/test_sensor.ambr
@@ -1,0 +1,322 @@
+# serializer version: 1
+# name: test_sensors[v5][sensor.ruuvitag_efaf_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:09:11-humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'friendly_name': 'RuuviTag EFAF Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '61.84',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_movement_counter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_movement_counter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Movement Counter',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:09:11-movement_counter',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_movement_counter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'RuuviTag EFAF Movement Counter',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_movement_counter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '114',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Pressure',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:09:11-pressure',
+    'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'RuuviTag EFAF Pressure',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1013.54',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_signal_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_signal_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Signal Strength',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:09:11-signal_strength',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_signal_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'signal_strength',
+      'friendly_name': 'RuuviTag EFAF Signal Strength',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_signal_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-60',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:09:11-temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'RuuviTag EFAF Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '7.2',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Voltage',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01:03:05:07:09:11-voltage',
+    'unit_of_measurement': <UnitOfElectricPotential.MILLIVOLT: 'mV'>,
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'RuuviTag EFAF Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.MILLIVOLT: 'mV'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2395',
+  })
+# ---

--- a/tests/components/ruuvitag_ble/snapshots/test_sensor.ambr
+++ b/tests/components/ruuvitag_ble/snapshots/test_sensor.ambr
@@ -1,4 +1,212 @@
 # serializer version: 1
+# name: test_sensors[v5][sensor.ruuvitag_efaf_acceleration_total-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_acceleration_total',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Acceleration total',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'acceleration_total',
+    'unique_id': '01:03:05:07:09:11-acceleration_total',
+    'unit_of_measurement': <Units.ACCELERATION_METERS_PER_SQUARE_SECOND: 'm/s²'>,
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_acceleration_total-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'RuuviTag EFAF Acceleration total',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <Units.ACCELERATION_METERS_PER_SQUARE_SECOND: 'm/s²'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_acceleration_total',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '9.82',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_acceleration_x-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_acceleration_x',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Acceleration X',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'acceleration_x',
+    'unique_id': '01:03:05:07:09:11-acceleration_x',
+    'unit_of_measurement': <Units.ACCELERATION_METERS_PER_SQUARE_SECOND: 'm/s²'>,
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_acceleration_x-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'RuuviTag EFAF Acceleration X',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <Units.ACCELERATION_METERS_PER_SQUARE_SECOND: 'm/s²'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_acceleration_x',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-7.02',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_acceleration_y-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_acceleration_y',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Acceleration Y',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'acceleration_y',
+    'unique_id': '01:03:05:07:09:11-acceleration_y',
+    'unit_of_measurement': <Units.ACCELERATION_METERS_PER_SQUARE_SECOND: 'm/s²'>,
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_acceleration_y-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'RuuviTag EFAF Acceleration Y',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <Units.ACCELERATION_METERS_PER_SQUARE_SECOND: 'm/s²'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_acceleration_y',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6.39',
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_acceleration_z-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ruuvitag_efaf_acceleration_z',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Acceleration Z',
+    'platform': 'ruuvitag_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'acceleration_z',
+    'unique_id': '01:03:05:07:09:11-acceleration_z',
+    'unit_of_measurement': <Units.ACCELERATION_METERS_PER_SQUARE_SECOND: 'm/s²'>,
+  })
+# ---
+# name: test_sensors[v5][sensor.ruuvitag_efaf_acceleration_z-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'RuuviTag EFAF Acceleration Z',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <Units.ACCELERATION_METERS_PER_SQUARE_SECOND: 'm/s²'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ruuvitag_efaf_acceleration_z',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-2.51',
+  })
+# ---
 # name: test_sensors[v5][sensor.ruuvitag_efaf_humidity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/ruuvitag_ble/test_config_flow.py
+++ b/tests/components/ruuvitag_ble/test_config_flow.py
@@ -9,7 +9,7 @@ from homeassistant.components.ruuvitag_ble.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .fixtures import CONFIGURED_NAME, NOT_RUUVITAG_SERVICE_INFO, RUUVITAG_SERVICE_INFO
+from .fixtures import CONFIGURED_NAME, NOT_RUUVITAG_SERVICE_INFO, RUUVI_V5_SERVICE_INFO
 
 from tests.common import MockConfigEntry
 
@@ -24,7 +24,7 @@ async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=RUUVITAG_SERVICE_INFO,
+        data=RUUVI_V5_SERVICE_INFO,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
@@ -36,7 +36,7 @@ async def test_async_step_bluetooth_valid_device(hass: HomeAssistant) -> None:
         )
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == CONFIGURED_NAME
-    assert result2["result"].unique_id == RUUVITAG_SERVICE_INFO.address
+    assert result2["result"].unique_id == RUUVI_V5_SERVICE_INFO.address
 
 
 async def test_async_step_bluetooth_not_ruuvitag(hass: HomeAssistant) -> None:
@@ -64,7 +64,7 @@ async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     """Test setup from service info cache with devices found."""
     with patch(
         "homeassistant.components.ruuvitag_ble.config_flow.async_discovered_service_info",
-        return_value=[RUUVITAG_SERVICE_INFO],
+        return_value=[RUUVI_V5_SERVICE_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -77,18 +77,18 @@ async def test_async_step_user_with_found_devices(hass: HomeAssistant) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"address": RUUVITAG_SERVICE_INFO.address},
+            user_input={"address": RUUVI_V5_SERVICE_INFO.address},
         )
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == CONFIGURED_NAME
-    assert result2["result"].unique_id == RUUVITAG_SERVICE_INFO.address
+    assert result2["result"].unique_id == RUUVI_V5_SERVICE_INFO.address
 
 
 async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -> None:
     """Test the device gets added via another flow between steps."""
     with patch(
         "homeassistant.components.ruuvitag_ble.config_flow.async_discovered_service_info",
-        return_value=[RUUVITAG_SERVICE_INFO],
+        return_value=[RUUVI_V5_SERVICE_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -99,7 +99,7 @@ async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=RUUVITAG_SERVICE_INFO.address,
+        unique_id=RUUVI_V5_SERVICE_INFO.address,
     )
     entry.add_to_hass(hass)
 
@@ -108,7 +108,7 @@ async def test_async_step_user_device_added_between_steps(hass: HomeAssistant) -
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"address": RUUVITAG_SERVICE_INFO.address},
+            user_input={"address": RUUVI_V5_SERVICE_INFO.address},
         )
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
@@ -120,13 +120,13 @@ async def test_async_step_user_with_found_devices_already_setup(
     """Test setup from service info cache with devices found."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=RUUVITAG_SERVICE_INFO.address,
+        unique_id=RUUVI_V5_SERVICE_INFO.address,
     )
     entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.ruuvitag_ble.config_flow.async_discovered_service_info",
-        return_value=[RUUVITAG_SERVICE_INFO],
+        return_value=[RUUVI_V5_SERVICE_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -140,14 +140,14 @@ async def test_async_step_bluetooth_devices_already_setup(hass: HomeAssistant) -
     """Test we can't start a flow if there is already a config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=RUUVITAG_SERVICE_INFO.address,
+        unique_id=RUUVI_V5_SERVICE_INFO.address,
     )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=RUUVITAG_SERVICE_INFO,
+        data=RUUVI_V5_SERVICE_INFO,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -158,7 +158,7 @@ async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=RUUVITAG_SERVICE_INFO,
+        data=RUUVI_V5_SERVICE_INFO,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
@@ -166,7 +166,7 @@ async def test_async_step_bluetooth_already_in_progress(hass: HomeAssistant) -> 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=RUUVITAG_SERVICE_INFO,
+        data=RUUVI_V5_SERVICE_INFO,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_in_progress"
@@ -179,14 +179,14 @@ async def test_async_step_user_takes_precedence_over_discovery(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=RUUVITAG_SERVICE_INFO,
+        data=RUUVI_V5_SERVICE_INFO,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
 
     with patch(
         "homeassistant.components.ruuvitag_ble.config_flow.async_discovered_service_info",
-        return_value=[RUUVITAG_SERVICE_INFO],
+        return_value=[RUUVI_V5_SERVICE_INFO],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -199,9 +199,9 @@ async def test_async_step_user_takes_precedence_over_discovery(
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"address": RUUVITAG_SERVICE_INFO.address},
+            user_input={"address": RUUVI_V5_SERVICE_INFO.address},
         )
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == CONFIGURED_NAME
     assert result2["data"] == {}
-    assert result2["result"].unique_id == RUUVITAG_SERVICE_INFO.address
+    assert result2["result"].unique_id == RUUVI_V5_SERVICE_INFO.address

--- a/tests/components/ruuvitag_ble/test_sensor.py
+++ b/tests/components/ruuvitag_ble/test_sensor.py
@@ -2,22 +2,24 @@
 
 from __future__ import annotations
 
-from habluetooth import BluetoothServiceInfo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.ruuvitag_ble.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
-from .fixtures import RUUVITAG_SERVICE_INFO
+from .fixtures import RUUVI_V5_SERVICE_INFO, RUUVI_V6_SERVICE_INFO
 
 from tests.common import MockConfigEntry, snapshot_platform
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 @pytest.mark.usefixtures("enable_bluetooth", "entity_registry_enabled_by_default")
-@pytest.mark.parametrize("service_info", [RUUVITAG_SERVICE_INFO], ids=("v5",))
+@pytest.mark.parametrize(
+    "service_info", [RUUVI_V5_SERVICE_INFO, RUUVI_V6_SERVICE_INFO], ids=("v5", "v6")
+)
 async def test_sensors(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,

--- a/tests/components/ruuvitag_ble/test_sensor.py
+++ b/tests/components/ruuvitag_ble/test_sensor.py
@@ -2,48 +2,36 @@
 
 from __future__ import annotations
 
+from habluetooth import BluetoothServiceInfo
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.ruuvitag_ble.const import DOMAIN
-from homeassistant.components.sensor import ATTR_STATE_CLASS
-from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import EntityRegistry
 
-from .fixtures import CONFIGURED_NAME, CONFIGURED_PREFIX, RUUVITAG_SERVICE_INFO
+from .fixtures import RUUVITAG_SERVICE_INFO
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-@pytest.mark.usefixtures("enable_bluetooth")
-async def test_sensors(hass: HomeAssistant) -> None:
+@pytest.mark.usefixtures("enable_bluetooth", "entity_registry_enabled_by_default")
+@pytest.mark.parametrize("service_info", [RUUVITAG_SERVICE_INFO], ids=("v5",))
+async def test_sensors(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    snapshot: SnapshotAssertion,
+    service_info: BluetoothServiceInfo,
+) -> None:
     """Test the RuuviTag BLE sensors."""
-    entry = MockConfigEntry(domain=DOMAIN, unique_id=RUUVITAG_SERVICE_INFO.address)
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=service_info.address)
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 0
-    inject_bluetooth_service_info(
-        hass,
-        RUUVITAG_SERVICE_INFO,
-    )
+    inject_bluetooth_service_info(hass, service_info)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) >= 4
-
-    for sensor, value, unit, state_class in (
-        ("temperature", "7.2", "°C", "measurement"),
-        ("humidity", "61.84", "%", "measurement"),
-        ("pressure", "1013.54", "hPa", "measurement"),
-        ("voltage", "2395", "mV", "measurement"),
-    ):
-        state = hass.states.get(f"sensor.{CONFIGURED_PREFIX}_{sensor}")
-        assert state is not None
-        assert state.state == value
-        name_lower = state.attributes[ATTR_FRIENDLY_NAME].lower()
-        assert name_lower == f"{CONFIGURED_NAME} {sensor}".lower()
-        assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == unit
-        assert state.attributes[ATTR_STATE_CLASS] == state_class
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change

With #150436 having bumped [ruuvitag-ble](https://github.com/Bluetooth-Devices/ruuvitag-ble) [from 0.1.2 to 0.2.1](https://github.com/Bluetooth-Devices/ruuvitag-ble/compare/v0.1.2...v0.2.1), this PR adds support for the new sensors exported in that version of the parser library: acceleration sensors (not enabled by default so as not to clutter installations for users with static Ruuvitags), and those exposed by data format 6.

The conversion code between the parser library and HA got simplified and optimized a bit, too, as I couldn't make much heads or tails of the code I'd copy-pasted in 3 years ago 😄 

## Relations

* Closes #150483 (includes the same changes)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
