### PR TITLE
Bump to ruuvitag-ble==0.2.1

### DIFF
--- a/homeassistant/components/ruuvitag_ble/manifest.json
+++ b/homeassistant/components/ruuvitag_ble/manifest.json
@@ -16,5 +16,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/ruuvitag_ble",
   "iot_class": "local_push",
-  "requirements": ["ruuvitag-ble==0.1.2"]
+  "requirements": ["ruuvitag-ble==0.2.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2702,7 +2702,7 @@ rpi-bad-power==0.1.0
 russound==0.2.0
 
 # homeassistant.components.ruuvitag_ble
-ruuvitag-ble==0.1.2
+ruuvitag-ble==0.2.1
 
 # homeassistant.components.yamaha
 rxv==0.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2233,7 +2233,7 @@ rova==0.4.1
 rpi-bad-power==0.1.0
 
 # homeassistant.components.ruuvitag_ble
-ruuvitag-ble==0.1.2
+ruuvitag-ble==0.2.1
 
 # homeassistant.components.yamaha
 rxv==0.7.0


### PR DESCRIPTION
## Proposed change

This PR upgrades [ruuvitag-ble](https://github.com/Bluetooth-Devices/ruuvitag-ble) [from 0.1.2 to 0.2.1](https://github.com/Bluetooth-Devices/ruuvitag-ble/compare/v0.1.2...v0.2.1). The major changes in the new version of the parser library are:

* acceleration sensor values
* support for the legacy data format version 3
* support for the new data format version 6

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to PR: #150435 (split out from it)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no <del>commented out</del> code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
