### PR TITLE
Fix brightness command not sent when in white color mode

### DIFF
--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -663,11 +663,11 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
                 },
             ]
 
-        elif (ATTR_BRIGHTNESS in kwargs or ATTR_WHITE in kwargs) and self._brightness:
-            brightness_attr = (
-                ATTR_BRIGHTNESS if ATTR_BRIGHTNESS in kwargs else ATTR_WHITE
-            )
-            brightness = kwargs[brightness_attr]
+        elif self._brightness and (ATTR_BRIGHTNESS in kwargs or ATTR_WHITE in kwargs):
+            if ATTR_BRIGHTNESS in kwargs:
+                brightness = kwargs[ATTR_BRIGHTNESS]
+            else:
+                brightness = kwargs[ATTR_WHITE]
 
             # If there is a min/max value, the brightness is actually limited.
             # Meaning it is actually not on a 0-255 scale.

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -663,8 +663,11 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
                 },
             ]
 
-        elif ATTR_BRIGHTNESS in kwargs and self._brightness:
-            brightness = kwargs[ATTR_BRIGHTNESS]
+        elif (ATTR_BRIGHTNESS in kwargs or ATTR_WHITE in kwargs) and self._brightness:
+            brightness_attr = (
+                ATTR_BRIGHTNESS if ATTR_BRIGHTNESS in kwargs else ATTR_WHITE
+            )
+            brightness = kwargs[brightness_attr]
 
             # If there is a min/max value, the brightness is actually limited.
             # Meaning it is actually not on a 0-255 scale.

--- a/tests/components/tuya/test_light.py
+++ b/tests/components/tuya/test_light.py
@@ -39,11 +39,10 @@ async def test_platform_setup_and_discovery(
 
 
 @pytest.mark.parametrize(
-    ("mock_device_code", "entity_id", "turn_on_input", "expected_commands"),
+    ("mock_device_code", "turn_on_input", "expected_commands"),
     [
         (
             "dj_mki13ie507rlry4r",
-            "light.garage_light",
             {"entity_id": "light.garage_light", "white": True},
             [
                 {"code": "switch_led", "value": True},
@@ -53,7 +52,6 @@ async def test_platform_setup_and_discovery(
         ),
         (
             "dj_mki13ie507rlry4r",
-            "light.garage_light",
             {
                 "entity_id": "light.garage_light",
                 "brightness": 150,
@@ -65,7 +63,6 @@ async def test_platform_setup_and_discovery(
         ),
         (
             "dj_mki13ie507rlry4r",
-            "light.garage_light",
             {
                 "entity_id": "light.garage_light",
                 "white": True,
@@ -79,7 +76,6 @@ async def test_platform_setup_and_discovery(
         ),
         (
             "dj_mki13ie507rlry4r",
-            "light.garage_light",
             {
                 "entity_id": "light.garage_light",
                 "white": 150,
@@ -97,13 +93,13 @@ async def test_turn_on(
     mock_manager: ManagerCompat,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    entity_id: str,
     turn_on_input: dict,
     expected_commands: list[dict],
 ) -> None:
     """Test turn_on service."""
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
+    entity_id = turn_on_input["entity_id"]
     state = hass.states.get(entity_id)
     assert state is not None, f"{entity_id} does not exist"
     await hass.services.async_call(

--- a/tests/components/tuya/test_light.py
+++ b/tests/components/tuya/test_light.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -39,11 +40,14 @@ async def test_platform_setup_and_discovery(
 
 
 @pytest.mark.parametrize(
-    ("mock_device_code", "turn_on_input", "expected_commands"),
+    "mock_device_code",
+    ["dj_mki13ie507rlry4r"],
+)
+@pytest.mark.parametrize(
+    ("turn_on_input", "expected_commands"),
     [
         (
-            "dj_mki13ie507rlry4r",
-            {"entity_id": "light.garage_light", "white": True},
+            {"white": True},
             [
                 {"code": "switch_led", "value": True},
                 {"code": "work_mode", "value": "white"},
@@ -51,9 +55,7 @@ async def test_platform_setup_and_discovery(
             ],
         ),
         (
-            "dj_mki13ie507rlry4r",
             {
-                "entity_id": "light.garage_light",
                 "brightness": 150,
             },
             [
@@ -62,9 +64,7 @@ async def test_platform_setup_and_discovery(
             ],
         ),
         (
-            "dj_mki13ie507rlry4r",
             {
-                "entity_id": "light.garage_light",
                 "white": True,
                 "brightness": 150,
             },
@@ -75,9 +75,7 @@ async def test_platform_setup_and_discovery(
             ],
         ),
         (
-            "dj_mki13ie507rlry4r",
             {
-                "entity_id": "light.garage_light",
                 "white": 150,
             },
             [
@@ -88,24 +86,27 @@ async def test_platform_setup_and_discovery(
         ),
     ],
 )
-async def test_turn_on(
+async def test_turn_on_white(
     hass: HomeAssistant,
     mock_manager: ManagerCompat,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
-    turn_on_input: dict,
-    expected_commands: list[dict],
+    turn_on_input: dict[str, Any],
+    expected_commands: list[dict[str, Any]],
 ) -> None:
     """Test turn_on service."""
+    entity_id = "light.garage_light"
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
-    entity_id = turn_on_input["entity_id"]
     state = hass.states.get(entity_id)
     assert state is not None, f"{entity_id} does not exist"
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        turn_on_input,
+        {
+            "entity_id": entity_id,
+            **turn_on_input,
+        },
     )
     await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(

--- a/tests/components/tuya/test_light.py
+++ b/tests/components/tuya/test_light.py
@@ -39,17 +39,69 @@ async def test_platform_setup_and_discovery(
 
 
 @pytest.mark.parametrize(
-    "mock_device_code",
-    ["dj_mki13ie507rlry4r"],
+    ("mock_device_code", "entity_id", "turn_on_input", "expected_commands"),
+    [
+        (
+            "dj_mki13ie507rlry4r",
+            "light.garage_light",
+            {"entity_id": "light.garage_light", "white": True},
+            [
+                {"code": "switch_led", "value": True},
+                {"code": "work_mode", "value": "white"},
+                {"code": "bright_value_v2", "value": 546},
+            ],
+        ),
+        (
+            "dj_mki13ie507rlry4r",
+            "light.garage_light",
+            {
+                "entity_id": "light.garage_light",
+                "brightness": 150,
+            },
+            [
+                {"code": "switch_led", "value": True},
+                {"code": "bright_value_v2", "value": 592},
+            ],
+        ),
+        (
+            "dj_mki13ie507rlry4r",
+            "light.garage_light",
+            {
+                "entity_id": "light.garage_light",
+                "white": True,
+                "brightness": 150,
+            },
+            [
+                {"code": "switch_led", "value": True},
+                {"code": "work_mode", "value": "white"},
+                {"code": "bright_value_v2", "value": 592},
+            ],
+        ),
+        (
+            "dj_mki13ie507rlry4r",
+            "light.garage_light",
+            {
+                "entity_id": "light.garage_light",
+                "white": 150,
+            },
+            [
+                {"code": "switch_led", "value": True},
+                {"code": "work_mode", "value": "white"},
+                {"code": "bright_value_v2", "value": 592},
+            ],
+        ),
+    ],
 )
-async def test_turn_on_white(
+async def test_turn_on(
     hass: HomeAssistant,
     mock_manager: ManagerCompat,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
+    entity_id: str,
+    turn_on_input: dict,
+    expected_commands: list[dict],
 ) -> None:
     """Test turn_on service."""
-    entity_id = "light.garage_light"
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
     state = hass.states.get(entity_id)
@@ -57,124 +109,12 @@ async def test_turn_on_white(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {
-            "entity_id": entity_id,
-            "white": True,
-        },
+        turn_on_input,
     )
     await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id,
-        [
-            {"code": "switch_led", "value": True},
-            {"code": "work_mode", "value": "white"},
-            {"code": "bright_value_v2", "value": 546},
-        ],
-    )
-
-
-@pytest.mark.parametrize(
-    "mock_device_code",
-    ["dj_mki13ie507rlry4r"],
-)
-async def test_turn_on_brightness(
-    hass: HomeAssistant,
-    mock_manager: ManagerCompat,
-    mock_config_entry: MockConfigEntry,
-    mock_device: CustomerDevice,
-) -> None:
-    """Test turn_on service."""
-    entity_id = "light.garage_light"
-    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-
-    state = hass.states.get(entity_id)
-    assert state is not None, f"{entity_id} does not exist"
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {
-            "entity_id": entity_id,
-            "brightness": 150,
-        },
-    )
-    await hass.async_block_till_done()
-    mock_manager.send_commands.assert_called_once_with(
-        mock_device.id,
-        [
-            {"code": "switch_led", "value": True},
-            {"code": "bright_value_v2", "value": 592},
-        ],
-    )
-
-
-@pytest.mark.parametrize(
-    "mock_device_code",
-    ["dj_mki13ie507rlry4r"],
-)
-async def test_turn_on_white_and_brightness_1(
-    hass: HomeAssistant,
-    mock_manager: ManagerCompat,
-    mock_config_entry: MockConfigEntry,
-    mock_device: CustomerDevice,
-) -> None:
-    """Test turn_on service."""
-    entity_id = "light.garage_light"
-    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-
-    state = hass.states.get(entity_id)
-    assert state is not None, f"{entity_id} does not exist"
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {
-            "entity_id": entity_id,
-            "white": True,
-            "brightness": 150,
-        },
-    )
-    await hass.async_block_till_done()
-    mock_manager.send_commands.assert_called_once_with(
-        mock_device.id,
-        [
-            {"code": "switch_led", "value": True},
-            {"code": "work_mode", "value": "white"},
-            {"code": "bright_value_v2", "value": 592},
-        ],
-    )
-
-
-@pytest.mark.parametrize(
-    "mock_device_code",
-    ["dj_mki13ie507rlry4r"],
-)
-async def test_turn_on_white_and_brightness_2(
-    hass: HomeAssistant,
-    mock_manager: ManagerCompat,
-    mock_config_entry: MockConfigEntry,
-    mock_device: CustomerDevice,
-) -> None:
-    """Test turn_on service."""
-    entity_id = "light.garage_light"
-    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-
-    state = hass.states.get(entity_id)
-    assert state is not None, f"{entity_id} does not exist"
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {
-            "entity_id": entity_id,
-            "white": 150,
-        },
-    )
-    await hass.async_block_till_done()
-    mock_manager.send_commands.assert_called_once_with(
-        mock_device.id,
-        [
-            {"code": "switch_led", "value": True},
-            {"code": "work_mode", "value": "white"},
-            {"code": "bright_value_v2", "value": 592},
-        ],
+        expected_commands,
     )
 
 

--- a/tests/components/tuya/test_light.py
+++ b/tests/components/tuya/test_light.py
@@ -47,7 +47,9 @@ async def test_platform_setup_and_discovery(
     ("turn_on_input", "expected_commands"),
     [
         (
-            {"white": True},
+            {
+                "white": True,
+            },
             [
                 {"code": "switch_led", "value": True},
                 {"code": "work_mode", "value": "white"},

--- a/tests/components/tuya/test_light.py
+++ b/tests/components/tuya/test_light.py
@@ -59,6 +59,111 @@ async def test_turn_on_white(
         SERVICE_TURN_ON,
         {
             "entity_id": entity_id,
+            "white": True,
+        },
+    )
+    await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "switch_led", "value": True},
+            {"code": "work_mode", "value": "white"},
+            {"code": "bright_value_v2", "value": 546},
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["dj_mki13ie507rlry4r"],
+)
+async def test_turn_on_brightness(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test turn_on service."""
+    entity_id = "light.garage_light"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            "entity_id": entity_id,
+            "brightness": 150,
+        },
+    )
+    await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "switch_led", "value": True},
+            {"code": "bright_value_v2", "value": 592},
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["dj_mki13ie507rlry4r"],
+)
+async def test_turn_on_white_and_brightness_1(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test turn_on service."""
+    entity_id = "light.garage_light"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            "entity_id": entity_id,
+            "white": True,
+            "brightness": 150,
+        },
+    )
+    await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "switch_led", "value": True},
+            {"code": "work_mode", "value": "white"},
+            {"code": "bright_value_v2", "value": 592},
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["dj_mki13ie507rlry4r"],
+)
+async def test_turn_on_white_and_brightness_2(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test turn_on service."""
+    entity_id = "light.garage_light"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            "entity_id": entity_id,
             "white": 150,
         },
     )
@@ -68,6 +173,7 @@ async def test_turn_on_white(
         [
             {"code": "switch_led", "value": True},
             {"code": "work_mode", "value": "white"},
+            {"code": "bright_value_v2", "value": 592},
         ],
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #150269 where the brightness value is not set when both white color mode and brightness sent in the same action.

This is caused by the fact that the brightness value is put as the value for "white" arg, not the "brightness" arg when both "white" and "brightness" are provided in the action. 

The change now checks for both arguments, and will get the value from whichever is available.

Also added additional tests related to this change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #150269
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
