### PR TITLE
Add support for Media player Mute/Unmute intents

### DIFF
--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
     SERVICE_MEDIA_PREVIOUS_TRACK,
+    SERVICE_VOLUME_MUTE,
     SERVICE_VOLUME_SET,
     STATE_PLAYING,
 )
@@ -27,6 +28,7 @@ from .browse_media import SearchMedia
 from .const import (
     ATTR_MEDIA_FILTER_CLASSES,
     ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
     DOMAIN,
     SERVICE_PLAY_MEDIA,
     SERVICE_SEARCH_MEDIA,
@@ -39,6 +41,8 @@ INTENT_MEDIA_PAUSE = "HassMediaPause"
 INTENT_MEDIA_UNPAUSE = "HassMediaUnpause"
 INTENT_MEDIA_NEXT = "HassMediaNext"
 INTENT_MEDIA_PREVIOUS = "HassMediaPrevious"
+INTENT_PLAYER_MUTE = "HassMediaPlayerMute"
+INTENT_PLAYER_UNMUTE = "HassMediaPlayerUnmute"
 INTENT_SET_VOLUME = "HassSetVolume"
 INTENT_SET_VOLUME_RELATIVE = "HassSetVolumeRelative"
 INTENT_MEDIA_SEARCH_AND_PLAY = "HassMediaSearchAndPlay"
@@ -130,6 +134,8 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
         ),
     )
     intent.async_register(hass, MediaSetVolumeRelativeHandler())
+    intent.async_register(hass, MediaPlayerMuteUnmuteHandler(True))
+    intent.async_register(hass, MediaPlayerMuteUnmuteHandler(False))
     intent.async_register(hass, MediaSearchAndPlayHandler())
 
 
@@ -229,6 +235,42 @@ class MediaUnpauseHandler(intent.ServiceIntentHandler):
         return await super().async_handle_states(
             intent_obj, match_result, match_constraints
         )
+
+
+class MediaPlayerMuteUnmuteHandler(intent.ServiceIntentHandler):
+    """Handle Mute/Unmute intents."""
+
+    def __init__(self, is_volume_muted: bool) -> None:
+        """Initialize the mute/unmute handler objects."""
+
+        super().__init__(
+            (INTENT_PLAYER_MUTE if is_volume_muted else INTENT_PLAYER_UNMUTE),
+            DOMAIN,
+            SERVICE_VOLUME_MUTE,
+            required_domains={DOMAIN},
+            required_features=MediaPlayerEntityFeature.VOLUME_MUTE,
+            optional_slots={
+                ATTR_MEDIA_VOLUME_MUTED: intent.IntentSlotInfo(
+                    description="Whether the media player should be muted or unmuted",
+                    value_schema=vol.Boolean(),
+                ),
+            },
+            description=(
+                "Mutes a media player" if is_volume_muted else "Unmutes a media player"
+            ),
+            platforms={DOMAIN},
+            device_classes={MediaPlayerDeviceClass},
+        )
+        self.is_volume_muted = is_volume_muted
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        """Handle the intent."""
+
+        intent_obj.slots["is_volume_muted"] = {
+            "value": self.is_volume_muted,
+            "text": str(self.is_volume_muted),
+        }
+        return await super().async_handle(intent_obj)
 
 
 class MediaSearchAndPlayHandler(intent.IntentHandler):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Proposed change
*Add support for Media player Mute/Unmute intents.*

The assist pipeline has support for the set_volume operation; but not for the mute/unmute operation. This change adds this support.

I tested this functionality with assist pipeline using a local assist pipeline and with google generative ai assist pipeline.

Other than this change, we also need a change in the [sentences list][sentences-list] so that HA can identify the intents from the sentences.
PR: https://github.com/OHF-Voice/intents/pull/3334

I have tested it locally by modifying the json.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: NA
- This PR is related to issue: NA
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40405
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user-exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]


If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[sentences-list]:https://github.com/OHF-Voice/intents