### PR TITLE
Ensure Tuya humidifiers have at least one valid DPCode

### DIFF
--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -24,29 +24,29 @@ from .models import IntegerTypeData
 from .util import ActionDPCodeNotFoundError, get_dpcode
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class TuyaHumidifierEntityDescription(HumidifierEntityDescription):
     """Describe an Tuya (de)humidifier entity."""
 
     # DPCode, to use. If None, the key will be used as DPCode
     dpcode: DPCode | tuple[DPCode, ...] | None = None
 
-    current_humidity: DPCode | None = None
-    humidity: DPCode | None = None
+    current_humidity: DPCode
+    humidity: DPCode
 
 
 def _has_a_valid_dpcode(
     device: CustomerDevice, description: TuyaHumidifierEntityDescription
 ) -> bool:
     """Check if the device has at least one valid DP code."""
-    return any(
-        get_dpcode(device, code)
-        for code in (
-            *(description.dpcode or (DPCode(description.key),)),
-            description.current_humidity,
-            description.humidity,
-        )
+    codes_to_check = (
+        # Main control switch
+        *(description.dpcode or (DPCode(description.key),)),
+        # Other humidity properties
+        description.current_humidity,
+        description.humidity,
     )
+    return any(get_dpcode(device, code) for code in codes_to_check)
 
 
 HUMIDIFIERS: dict[str, TuyaHumidifierEntityDescription] = {

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -35,6 +35,20 @@ class TuyaHumidifierEntityDescription(HumidifierEntityDescription):
     humidity: DPCode | None = None
 
 
+def _has_a_valid_dpcode(
+    device: CustomerDevice, description: TuyaHumidifierEntityDescription
+) -> bool:
+    """Check if the device has at least one valid DP code."""
+    return any(
+        get_dpcode(device, code)
+        for code in (
+            *(description.dpcode or (DPCode(description.key),)),
+            description.current_humidity,
+            description.humidity,
+        )
+    )
+
+
 HUMIDIFIERS: dict[str, TuyaHumidifierEntityDescription] = {
     # Dehumidifier
     # https://developer.tuya.com/en/docs/iot/categorycs?id=Kaiuz1vcz4dha
@@ -71,7 +85,9 @@ async def async_setup_entry(
         entities: list[TuyaHumidifierEntity] = []
         for device_id in device_ids:
             device = hass_data.manager.device_map[device_id]
-            if description := HUMIDIFIERS.get(device.category):
+            if (
+                description := HUMIDIFIERS.get(device.category)
+            ) and _has_a_valid_dpcode(device, description):
                 entities.append(
                     TuyaHumidifierEntity(device, hass_data.manager, description)
                 )

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -24,29 +24,29 @@ from .models import IntegerTypeData
 from .util import ActionDPCodeNotFoundError, get_dpcode
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True)
 class TuyaHumidifierEntityDescription(HumidifierEntityDescription):
     """Describe an Tuya (de)humidifier entity."""
 
     # DPCode, to use. If None, the key will be used as DPCode
     dpcode: DPCode | tuple[DPCode, ...] | None = None
 
-    current_humidity: DPCode
-    humidity: DPCode
+    current_humidity: DPCode | None = None
+    humidity: DPCode | None = None
 
 
 def _has_a_valid_dpcode(
     device: CustomerDevice, description: TuyaHumidifierEntityDescription
 ) -> bool:
     """Check if the device has at least one valid DP code."""
-    codes_to_check = (
+    properties_to_check: list[DPCode | tuple[DPCode, ...] | None] = [
         # Main control switch
-        *(description.dpcode or (DPCode(description.key),)),
+        description.dpcode or DPCode(description.key),
         # Other humidity properties
         description.current_humidity,
         description.humidity,
-    )
-    return any(get_dpcode(device, code) for code in codes_to_check)
+    ]
+    return any(get_dpcode(device, code) for code in properties_to_check)
 
 
 HUMIDIFIERS: dict[str, TuyaHumidifierEntityDescription] = {

--- a/tests/components/tuya/snapshots/test_humidifier.ambr
+++ b/tests/components/tuya/snapshots/test_humidifier.ambr
@@ -60,61 +60,6 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'max_humidity': 100,
-      'min_humidity': 0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'humidifier',
-    'entity_category': None,
-    'entity_id': 'humidifier.dehumidifier',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <HumidifierDeviceClass.DEHUMIDIFIER: 'dehumidifier'>,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.ilms5pwjzzsxuxmvscswitch',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[humidifier.dehumidifier-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'dehumidifier',
-      'friendly_name': 'Dehumidifier ',
-      'max_humidity': 100,
-      'min_humidity': 0,
-      'supported_features': <HumidifierEntityFeature: 0>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'humidifier.dehumidifier',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_platform_setup_and_discovery[humidifier.dehumidifier_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
       'max_humidity': 70,
       'min_humidity': 35,
     }),
@@ -125,7 +70,7 @@
     'disabled_by': None,
     'domain': 'humidifier',
     'entity_category': None,
-    'entity_id': 'humidifier.dehumidifier_2',
+    'entity_id': 'humidifier.dehumidifier',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -147,7 +92,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[humidifier.dehumidifier_2-state]
+# name: test_platform_setup_and_discovery[humidifier.dehumidifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_humidity': 47,
@@ -159,65 +104,10 @@
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'humidifier.dehumidifier_2',
+    'entity_id': 'humidifier.dehumidifier',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
-  })
-# ---
-# name: test_platform_setup_and_discovery[humidifier.dryfix-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'max_humidity': 100,
-      'min_humidity': 0,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'humidifier',
-    'entity_category': None,
-    'entity_id': 'humidifier.dryfix',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <HumidifierDeviceClass.DEHUMIDIFIER: 'dehumidifier'>,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.hz4pau766eavmxhqscswitch',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_platform_setup_and_discovery[humidifier.dryfix-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'dehumidifier',
-      'friendly_name': 'DryFix',
-      'max_humidity': 100,
-      'min_humidity': 0,
-      'supported_features': <HumidifierEntityFeature: 0>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'humidifier.dryfix',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
   })
 # ---

--- a/tests/components/tuya/test_humidifier.py
+++ b/tests/components/tuya/test_humidifier.py
@@ -126,7 +126,7 @@ async def test_set_humidity(
 
 @pytest.mark.parametrize(
     "mock_device_code",
-    ["cs_vmxuxszzjwp5smli"],
+    ["cs_zibqa9dutqyaxym2"],
 )
 async def test_turn_on_unsupported(
     hass: HomeAssistant,
@@ -135,6 +135,11 @@ async def test_turn_on_unsupported(
     mock_device: CustomerDevice,
 ) -> None:
     """Test turn on service (not supported by this device)."""
+    # Remove switch control - but keep other functionality
+    mock_device.status.pop("switch")
+    mock_device.function.pop("switch")
+    mock_device.status_range.pop("switch")
+
     entity_id = "humidifier.dehumidifier"
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
@@ -150,13 +155,13 @@ async def test_turn_on_unsupported(
     assert err.value.translation_key == "action_dpcode_not_found"
     assert err.value.translation_placeholders == {
         "expected": "['switch', 'switch_spray']",
-        "available": ("[]"),
+        "available": ("['child_lock', 'countdown_set', 'dehumidify_set_value']"),
     }
 
 
 @pytest.mark.parametrize(
     "mock_device_code",
-    ["cs_vmxuxszzjwp5smli"],
+    ["cs_zibqa9dutqyaxym2"],
 )
 async def test_turn_off_unsupported(
     hass: HomeAssistant,
@@ -165,6 +170,11 @@ async def test_turn_off_unsupported(
     mock_device: CustomerDevice,
 ) -> None:
     """Test turn off service (not supported by this device)."""
+    # Remove switch control - but keep other functionality
+    mock_device.status.pop("switch")
+    mock_device.function.pop("switch")
+    mock_device.status_range.pop("switch")
+
     entity_id = "humidifier.dehumidifier"
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
@@ -180,13 +190,13 @@ async def test_turn_off_unsupported(
     assert err.value.translation_key == "action_dpcode_not_found"
     assert err.value.translation_placeholders == {
         "expected": "['switch', 'switch_spray']",
-        "available": ("[]"),
+        "available": ("['child_lock', 'countdown_set', 'dehumidify_set_value']"),
     }
 
 
 @pytest.mark.parametrize(
     "mock_device_code",
-    ["cs_vmxuxszzjwp5smli"],
+    ["cs_zibqa9dutqyaxym2"],
 )
 async def test_set_humidity_unsupported(
     hass: HomeAssistant,
@@ -195,6 +205,11 @@ async def test_set_humidity_unsupported(
     mock_device: CustomerDevice,
 ) -> None:
     """Test set humidity service (not supported by this device)."""
+    # Remove set humidity control - but keep other functionality
+    mock_device.status.pop("dehumidify_set_value")
+    mock_device.function.pop("dehumidify_set_value")
+    mock_device.status_range.pop("dehumidify_set_value")
+
     entity_id = "humidifier.dehumidifier"
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
@@ -213,5 +228,5 @@ async def test_set_humidity_unsupported(
     assert err.value.translation_key == "action_dpcode_not_found"
     assert err.value.translation_placeholders == {
         "expected": "['dehumidify_set_value']",
-        "available": ("[]"),
+        "available": ("['child_lock', 'countdown_set', 'switch']"),
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently Tuya (de-)humidifiers get created only based on the category (`cs` or `jsq`), regardless of whether sensors and controls are available.

This ensures that at least one of the sensors or controls is available.

Related to #148726

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
