### PR TITLE
Add support for multi-tap action in Lutron Caseta integration

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -8,7 +8,7 @@ import logging
 import ssl
 from typing import Any, cast
 
-from pylutron_caseta import BUTTON_STATUS_PRESSED
+from pylutron_caseta import BUTTON_STATUS_MULTITAP, BUTTON_STATUS_PRESSED
 from pylutron_caseta.smartbridge import Smartbridge
 import voluptuous as vol
 
@@ -25,6 +25,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    ACTION_MULTITAP,
     ACTION_PRESS,
     ACTION_RELEASE,
     ATTR_ACTION,
@@ -448,6 +449,8 @@ def _async_subscribe_keypad_events(
 
         if event_type == BUTTON_STATUS_PRESSED:
             action = ACTION_PRESS
+        elif event_type == BUTTON_STATUS_MULTITAP:
+            action = ACTION_MULTITAP
         else:
             action = ACTION_RELEASE
 

--- a/homeassistant/components/lutron_caseta/const.py
+++ b/homeassistant/components/lutron_caseta/const.py
@@ -29,6 +29,7 @@ ATTR_DEVICE_NAME = "device_name"
 ATTR_AREA_NAME = "area_name"
 ATTR_ACTION = "action"
 
+ACTION_MULTITAP = "multi_tap"
 ACTION_PRESS = "press"
 ACTION_RELEASE = "release"
 

--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    ACTION_MULTITAP,
     ACTION_PRESS,
     ACTION_RELEASE,
     ATTR_ACTION,
@@ -39,7 +40,7 @@ def _reverse_dict(forward_dict: dict) -> dict:
     return {v: k for k, v in forward_dict.items()}
 
 
-SUPPORTED_INPUTS_EVENTS_TYPES = [ACTION_PRESS, ACTION_RELEASE]
+SUPPORTED_INPUTS_EVENTS_TYPES = [ACTION_PRESS, ACTION_MULTITAP, ACTION_RELEASE]
 
 LUTRON_BUTTON_TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {

--- a/homeassistant/components/lutron_caseta/manifest.json
+++ b/homeassistant/components/lutron_caseta/manifest.json
@@ -9,7 +9,7 @@
   },
   "iot_class": "local_push",
   "loggers": ["pylutron_caseta"],
-  "requirements": ["pylutron-caseta==0.24.0"],
+  "requirements": ["pylutron-caseta==0.25.0"],
   "zeroconf": [
     {
       "type": "_lutron._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2135,7 +2135,7 @@ pylitejet==0.6.3
 pylitterbot==2024.2.4
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.24.0
+pylutron-caseta==0.25.0
 
 # homeassistant.components.lutron
 pylutron==0.2.18

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1783,7 +1783,7 @@ pylitejet==0.6.3
 pylitterbot==2024.2.4
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.24.0
+pylutron-caseta==0.25.0
 
 # homeassistant.components.lutron
 pylutron==0.2.18

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -148,6 +148,17 @@ async def test_get_triggers(hass: HomeAssistant) -> None:
         }
         for subtype in ("on", "stop", "off", "raise", "lower")
     ]
+    expected_triggers += [
+        {
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_PLATFORM: "device",
+            CONF_SUBTYPE: subtype,
+            CONF_TYPE: "multi_tap",
+            "metadata": {},
+        }
+        for subtype in ("on", "stop", "off", "raise", "lower")
+    ]
 
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_id
@@ -439,7 +450,7 @@ async def test_validate_trigger_invalid_triggers(
         },
     )
 
-    assert "value must be one of ['press', 'release']" in caplog.text
+    assert "value must be one of ['multi_tap', 'press', 'release']" in caplog.text
 
 
 async def test_if_fires_on_button_event_late_setup(


### PR DESCRIPTION
## Proposed change
Add support for multi-tap action in Lutron Caseta integration to detect double press events sent by some keypads -e.g. Alisse.

Dependency Information:

Upgraded: pylutron-caseta==0.25.0
Changelog: https://github.com/gurumitts/pylutron-caseta/compare/v0.24.0...v0.25.0
Usage: Adds a new button status to detect double press events sent by some keypads -e.g. Alisse 

## Type of change

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
