### PR TITLE
Set sensors to unknown when no next alarm is set in Sleep as Android

### DIFF
--- a/homeassistant/components/sleep_as_android/sensor.py
+++ b/homeassistant/components/sleep_as_android/sensor.py
@@ -85,6 +85,12 @@ class SleepAsAndroidSensorEntity(SleepAsAndroidEntity, RestoreSensor):
             ):
                 self._attr_native_value = label
 
+            if data[ATTR_EVENT] in (
+                "alarm_rescheduled",
+                "alarm_alert_dismiss",
+            ) and data.get(ATTR_VALUE1) in (None, "null"):
+                self._attr_native_value = None
+
             self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/sleep_as_android/sensor.py
+++ b/homeassistant/components/sleep_as_android/sensor.py
@@ -85,10 +85,10 @@ class SleepAsAndroidSensorEntity(SleepAsAndroidEntity, RestoreSensor):
             ):
                 self._attr_native_value = label
 
-            if data[ATTR_EVENT] in (
-                "alarm_rescheduled",
-                "alarm_alert_dismiss",
-            ) and data.get(ATTR_VALUE1) in (None, "null"):
+            if (
+                data[ATTR_EVENT] == "alarm_rescheduled"
+                and data.get(ATTR_VALUE1) is None
+            ):
                 self._attr_native_value = None
 
             self.async_write_ha_state()

--- a/tests/components/sleep_as_android/test_sensor.py
+++ b/tests/components/sleep_as_android/test_sensor.py
@@ -122,3 +122,53 @@ async def test_webhook_sensor(
 
     assert (state := hass.states.get("sensor.sleep_as_android_alarm_label"))
     assert state.state == "label"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        "alarm_alert_dismiss",
+        "alarm_rescheduled",
+    ],
+)
+async def test_webhook_sensor_alarm_unset(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+    event: str,
+) -> None:
+    """Test unsetting sensors if there is no next alarm."""
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    client = await hass_client_no_auth()
+
+    response = await client.post(
+        "/api/webhook/webhook_id",
+        json={
+            "event": event,
+            "value1": "1582719660934",
+            "value2": "label",
+        },
+    )
+    assert response.status == HTTPStatus.NO_CONTENT
+
+    assert (state := hass.states.get("sensor.sleep_as_android_next_alarm"))
+    assert state.state == "2020-02-26T12:21:00+00:00"
+
+    assert (state := hass.states.get("sensor.sleep_as_android_alarm_label"))
+    assert state.state == "label"
+
+    response = await client.post(
+        "/api/webhook/webhook_id",
+        json={"event": event},
+    )
+    assert (state := hass.states.get("sensor.sleep_as_android_next_alarm"))
+    assert state.state == STATE_UNKNOWN
+
+    assert (state := hass.states.get("sensor.sleep_as_android_alarm_label"))
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/sleep_as_android/test_sensor.py
+++ b/tests/components/sleep_as_android/test_sensor.py
@@ -124,18 +124,10 @@ async def test_webhook_sensor(
     assert state.state == "label"
 
 
-@pytest.mark.parametrize(
-    "event",
-    [
-        "alarm_alert_dismiss",
-        "alarm_rescheduled",
-    ],
-)
 async def test_webhook_sensor_alarm_unset(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     hass_client_no_auth: ClientSessionGenerator,
-    event: str,
 ) -> None:
     """Test unsetting sensors if there is no next alarm."""
 
@@ -150,7 +142,7 @@ async def test_webhook_sensor_alarm_unset(
     response = await client.post(
         "/api/webhook/webhook_id",
         json={
-            "event": event,
+            "event": "alarm_rescheduled",
             "value1": "1582719660934",
             "value2": "label",
         },
@@ -165,7 +157,7 @@ async def test_webhook_sensor_alarm_unset(
 
     response = await client.post(
         "/api/webhook/webhook_id",
-        json={"event": event},
+        json={"event": "alarm_rescheduled"},
     )
     assert (state := hass.states.get("sensor.sleep_as_android_next_alarm"))
     assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When an alarm is deleted and there is no other scheduled alarm, the webhook is called without a timestamp. In that case we set the next alarm and label sensors to `unknown` state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
