### PR TITLE
Use OptionsFlowWithReload in mqtt

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -246,14 +246,6 @@ MQTT_PUBLISH_SCHEMA = vol.Schema(
 )
 
 
-async def _async_config_entry_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle signals of config entry being updated.
-
-    Causes for this is config entry options changing.
-    """
-    await hass.config_entries.async_reload(entry.entry_id)
-
-
 @callback
 def _async_remove_mqtt_issues(hass: HomeAssistant, mqtt_data: MqttData) -> None:
     """Unregister open config issues."""
@@ -435,9 +427,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 mqtt_data.subscriptions_to_restore
             )
             mqtt_data.subscriptions_to_restore = set()
-        mqtt_data.reload_dispatchers.append(
-            entry.add_update_listener(_async_config_entry_updated)
-        )
 
         return (mqtt_data, conf)
 

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -4184,7 +4184,7 @@ class MQTTSubentryFlowHandler(ConfigSubentryFlow):
             full_entity_name = device_name
 
         self._async_update_component_data_defaults()
-        return self.async_create_entry(
+        result = self.async_create_entry(
             data=self._subentry_data,
             title=self._subentry_data[CONF_DEVICE][CONF_NAME],
             description_placeholders={
@@ -4192,6 +4192,8 @@ class MQTTSubentryFlowHandler(ConfigSubentryFlow):
                 CONF_PLATFORM: platform,
             },
         )
+        self.hass.config_entries.async_schedule_reload(self._get_entry().entry_id)
+        return result
 
     async def async_step_availability(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -60,7 +60,7 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
     ConfigSubentryFlow,
-    OptionsFlow,
+    OptionsFlowWithReload,
     SubentryFlowResult,
 )
 from homeassistant.const import (
@@ -3671,7 +3671,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         )
 
 
-class MQTTOptionsFlowHandler(OptionsFlow):
+class MQTTOptionsFlowHandler(OptionsFlowWithReload):
     """Handle MQTT options."""
 
     async def async_step_init(self, user_input: None = None) -> ConfigFlowResult:
@@ -4289,7 +4289,7 @@ class MQTTSubentryFlowHandler(ConfigSubentryFlow):
             ):
                 entity_registry.async_remove(entity_id)
 
-        return self.async_update_and_abort(
+        return self.async_update_reload_and_abort(
             entry,
             subentry,
             data=self._subentry_data,
@@ -4491,7 +4491,7 @@ def _validate_pki_file(
 
 
 async def async_get_broker_settings(  # noqa: C901
-    flow: ConfigFlow | OptionsFlow,
+    flow: ConfigFlow | OptionsFlowWithReload,
     fields: OrderedDict[Any, Any],
     entry_config: MappingProxyType[str, Any] | None,
     user_input: dict[str, Any] | None,

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -17,7 +17,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import mqtt
 from homeassistant.components.hassio import AddonError
-from homeassistant.components.mqtt.config_flow import PWD_NOT_CHANGED
+from homeassistant.components.mqtt.config_flow import (
+    PWD_NOT_CHANGED,
+    MQTTOptionsFlowHandler,
+)
 from homeassistant.components.mqtt.util import learn_more_url
 from homeassistant.config_entries import ConfigSubentry, ConfigSubentryData
 from homeassistant.const import (
@@ -202,8 +205,8 @@ def mock_ssl_context(mock_context_client_key: bytes) -> Generator[dict[str, Magi
 @pytest.fixture
 def mock_reload_after_entry_update() -> Generator[MagicMock]:
     """Mock out the reload after updating the entry."""
-    with patch(
-        "homeassistant.components.mqtt._async_config_entry_updated"
+    with patch.object(
+        MQTTOptionsFlowHandler, "automatic_reload", return_value=False
     ) as mock_reload:
         yield mock_reload
 
@@ -1339,11 +1342,11 @@ async def test_keepalive_validation(
     assert result["reason"] == "reconfigure_successful"
 
 
+@pytest.mark.usefixtures("mock_reload_after_entry_update")
 async def test_disable_birth_will(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
     mock_try_connection: MagicMock,
-    mock_reload_after_entry_update: MagicMock,
 ) -> None:
     """Test disabling birth and will."""
     await mqtt_mock_entry()
@@ -1357,7 +1360,6 @@ async def test_disable_birth_will(
         },
     )
     await hass.async_block_till_done()
-    mock_reload_after_entry_update.reset_mock()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] is FlowResultType.FORM
@@ -1396,10 +1398,6 @@ async def test_disable_birth_will(
         mqtt.CONF_WILL_MESSAGE: {},
     }
 
-    await hass.async_block_till_done()
-    # assert that the entry was reloaded with the new config
-    assert mock_reload_after_entry_update.call_count == 1
-
 
 async def test_invalid_discovery_prefix(
     hass: HomeAssistant,
@@ -1423,7 +1421,6 @@ async def test_invalid_discovery_prefix(
         },
     )
     await hass.async_block_till_done()
-    mock_reload_after_entry_update.reset_mock()
     mqtt_mock.async_connect.reset_mock()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
@@ -1451,10 +1448,6 @@ async def test_invalid_discovery_prefix(
         mqtt.CONF_DISCOVERY: True,
         mqtt.CONF_DISCOVERY_PREFIX: "homeassistant",
     }
-
-    await hass.async_block_till_done()
-    # assert that the entry was not reloaded with the new config
-    assert mock_reload_after_entry_update.call_count == 0
 
 
 def get_default(schema: vol.Schema, key: str) -> Any | None:


### PR DESCRIPTION
## Breaking change


## Proposed change
Use OptionsFlowWithReload in mqtt

Replaces #149092 which was reverted (did not reload for subentries which is now fixed with the new helper in this PR)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 