### PR TITLE
Add fuzzy matching to default agent

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -115,9 +115,10 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Optional("intents"): vol.Schema(
                     {cv.string: vol.All(cv.ensure_list, [cv.string])}
-                )
+                ),
+                vol.Optional("fuzzy_matching"): bool,
             }
-        )
+        ),
     },
     extra=vol.ALLOW_EXTRA,
 )
@@ -268,8 +269,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     entity_component = EntityComponent[ConversationEntity](_LOGGER, DOMAIN, hass)
     hass.data[DATA_COMPONENT] = entity_component
 
+    agent_config = config.get(DOMAIN, {})
     await async_setup_default_agent(
-        hass, entity_component, config.get(DOMAIN, {}).get("intents", {})
+        hass,
+        entity_component,
+        config_intents=agent_config.get("intents", {}),
+        fuzzy_matching=agent_config.get("fuzzy_matching", True),
     )
 
     async def handle_process(service: ServiceCall) -> ServiceResponse:

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -271,10 +271,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     agent_config = config.get(DOMAIN, {})
     await async_setup_default_agent(
-        hass,
-        entity_component,
-        config_intents=agent_config.get("intents", {}),
-        fuzzy_matching=agent_config.get("fuzzy_matching", True),
+        hass, entity_component, config_intents=agent_config.get("intents", {})
     )
 
     async def handle_process(service: ServiceCall) -> ServiceResponse:

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -115,8 +115,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Optional("intents"): vol.Schema(
                     {cv.string: vol.All(cv.ensure_list, [cv.string])}
-                ),
-                vol.Optional("fuzzy_matching"): bool,
+                )
             }
         ),
     },

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -207,10 +207,9 @@ async def async_setup_default_agent(
     hass: core.HomeAssistant,
     entity_component: EntityComponent[ConversationEntity],
     config_intents: dict[str, Any],
-    fuzzy_matching: bool,
 ) -> None:
     """Set up entity registry listener for the default agent."""
-    entity = DefaultAgent(hass, config_intents, fuzzy_matching)
+    entity = DefaultAgent(hass, config_intents)
     await entity_component.async_add_entities([entity])
     hass.data[DATA_DEFAULT_ENTITY] = entity
 
@@ -238,10 +237,7 @@ class DefaultAgent(ConversationEntity):
     _attr_supported_features = ConversationEntityFeature.CONTROL
 
     def __init__(
-        self,
-        hass: core.HomeAssistant,
-        config_intents: dict[str, Any],
-        fuzzy_matching: bool,
+        self, hass: core.HomeAssistant, config_intents: dict[str, Any]
     ) -> None:
         """Initialize the default agent."""
         self.hass = hass
@@ -265,7 +261,7 @@ class DefaultAgent(ConversationEntity):
         self._intent_cache = IntentCache(capacity=128)
 
         # Shared configuration for fuzzy matching
-        self.fuzzy_matching = fuzzy_matching
+        self.fuzzy_matching = True
         self._fuzzy_config: FuzzyConfig | None = None
 
     @property

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -15,13 +15,18 @@ import time
 from typing import IO, Any, cast
 
 from hassil.expression import Expression, Group, ListReference, TextChunk
+from hassil.fuzzy import FuzzyNgramMatcher, SlotCombinationInfo
 from hassil.intents import (
+    Intent,
+    IntentData,
     Intents,
     SlotList,
     TextSlotList,
     TextSlotValue,
     WildcardSlotList,
 )
+from hassil.models import MatchEntity
+from hassil.ngram import Sqlite3NgramModel
 from hassil.recognize import (
     MISSING_ENTITY,
     RecognizeResult,
@@ -31,7 +36,15 @@ from hassil.recognize import (
 from hassil.string_matcher import UnmatchedRangeEntity, UnmatchedTextEntity
 from hassil.trie import Trie
 from hassil.util import merge_dict
-from home_assistant_intents import ErrorKey, get_intents, get_languages
+from home_assistant_intents import (
+    ErrorKey,
+    FuzzyConfig,
+    FuzzyLanguageResponses,
+    get_fuzzy_config,
+    get_fuzzy_language,
+    get_intents,
+    get_languages,
+)
 import yaml
 
 from homeassistant import core
@@ -76,6 +89,7 @@ TRIGGER_CALLBACK_TYPE = Callable[
 ]
 METADATA_CUSTOM_SENTENCE = "hass_custom_sentence"
 METADATA_CUSTOM_FILE = "hass_custom_file"
+METADATA_FUZZY_MATCH = "hass_fuzzy_match"
 
 ERROR_SENTINEL = object()
 
@@ -94,6 +108,8 @@ class LanguageIntents:
     intent_responses: dict[str, Any]
     error_responses: dict[str, Any]
     language_variant: str | None
+    fuzzy_matcher: FuzzyNgramMatcher | None = None
+    fuzzy_responses: FuzzyLanguageResponses | None = None
 
 
 @dataclass(slots=True)
@@ -119,10 +135,13 @@ class IntentMatchingStage(Enum):
     EXPOSED_ENTITIES_ONLY = auto()
     """Match against exposed entities only."""
 
+    FUZZY = auto()
+    """Use fuzzy matching to guess intent."""
+
     UNEXPOSED_ENTITIES = auto()
     """Match against unexposed entities in Home Assistant."""
 
-    FUZZY = auto()
+    UNKNOWN_NAMES = auto()
     """Capture names that are not known to Home Assistant."""
 
 
@@ -241,6 +260,9 @@ class DefaultAgent(ConversationEntity):
         # LRU cache to avoid unnecessary intent matching
         self._intent_cache = IntentCache(capacity=128)
 
+        # Shared configuration for fuzzy matching
+        self._fuzzy_config: FuzzyConfig | None = None
+
     @property
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""
@@ -299,7 +321,7 @@ class DefaultAgent(ConversationEntity):
             _LOGGER.warning("No intents were loaded for language: %s", language)
             return None
 
-        slot_lists = self._make_slot_lists()
+        slot_lists = await self._make_slot_lists()
         intent_context = self._make_intent_context(user_input)
 
         if self._exposed_names_trie is not None:
@@ -556,6 +578,68 @@ class DefaultAgent(ConversationEntity):
             # Don't try matching against all entities or doing a fuzzy match
             return None
 
+        # Use fuzzy matching
+        skip_fuzzy_match = False
+        if cache_value is not None:
+            if (cache_value.result is not None) and (
+                cache_value.stage == IntentMatchingStage.FUZZY
+            ):
+                _LOGGER.debug("Got cached result for fuzzy match")
+                return cache_value.result
+
+            # Continue with matching, but we know we won't succeed for fuzzy
+            # match.
+            skip_fuzzy_match = True
+
+        if (not skip_fuzzy_match) and (lang_intents.fuzzy_matcher is not None):
+            start_time = time.monotonic()
+            fuzzy_result = lang_intents.fuzzy_matcher.match(user_input.text)
+            if fuzzy_result is not None:
+                response = "default"
+                if lang_intents.fuzzy_responses:
+                    domain = ""  # no domain
+                    if "name" in fuzzy_result.slots:
+                        domain = fuzzy_result.name_domain
+                    elif "domain" in fuzzy_result.slots:
+                        domain = fuzzy_result.slots["domain"].value
+
+                    slot_combo = tuple(sorted(fuzzy_result.slots))
+                    if (
+                        intent_responses := lang_intents.fuzzy_responses.get(
+                            fuzzy_result.intent_name
+                        )
+                    ) and (combo_responses := intent_responses.get(slot_combo)):
+                        response = combo_responses.get(domain, response)
+
+                entities = [
+                    MatchEntity(
+                        name=slot_name, value=slot_value.value, text=slot_value.text
+                    )
+                    for slot_name, slot_value in fuzzy_result.slots.items()
+                ]
+
+                fuzzy_result = RecognizeResult(
+                    intent=Intent(name=fuzzy_result.intent_name),
+                    intent_data=IntentData(sentence_texts=[]),
+                    intent_metadata={METADATA_FUZZY_MATCH: True},
+                    entities={entity.name: entity for entity in entities},
+                    entities_list=entities,
+                    response=response,
+                )
+
+            # Update cache
+            self._intent_cache.put(
+                cache_key,
+                IntentCacheValue(result=fuzzy_result, stage=IntentMatchingStage.FUZZY),
+            )
+
+            _LOGGER.debug(
+                "Did fuzzy match in %s second(s)", time.monotonic() - start_time
+            )
+
+            if fuzzy_result is not None:
+                return fuzzy_result
+
         # Try again with all entities (including unexposed)
         skip_unexposed_entities_match = False
         if cache_value is not None:
@@ -601,20 +685,19 @@ class DefaultAgent(ConversationEntity):
                 # This should fail the intent handling phase (async_match_targets).
                 return strict_result
 
-        # Try again with missing entities enabled
-        skip_fuzzy_match = False
+        # Check unknown names
+        skip_unknown_names = False
         if cache_value is not None:
             if (cache_value.result is not None) and (
-                cache_value.stage == IntentMatchingStage.FUZZY
+                cache_value.stage == IntentMatchingStage.UNKNOWN_NAMES
             ):
-                _LOGGER.debug("Got cached result for fuzzy match")
+                _LOGGER.debug("Got cached result for unknown names")
                 return cache_value.result
 
-            # We know we won't succeed for fuzzy matching.
-            skip_fuzzy_match = True
+            skip_unknown_names = True
 
         maybe_result: RecognizeResult | None = None
-        if not skip_fuzzy_match:
+        if not skip_unknown_names:
             start_time = time.monotonic()
             best_num_matched_entities = 0
             best_num_unmatched_entities = 0
@@ -688,11 +771,13 @@ class DefaultAgent(ConversationEntity):
             # Update cache
             self._intent_cache.put(
                 cache_key,
-                IntentCacheValue(result=maybe_result, stage=IntentMatchingStage.FUZZY),
+                IntentCacheValue(
+                    result=maybe_result, stage=IntentMatchingStage.UNKNOWN_NAMES
+                ),
             )
 
             _LOGGER.debug(
-                "Did fuzzy match in %s second(s)", time.monotonic() - start_time
+                "Did unknown names match in %s second(s)", time.monotonic() - start_time
             )
 
         return maybe_result
@@ -851,7 +936,7 @@ class DefaultAgent(ConversationEntity):
         if lang_intents is None:
             return
 
-        self._make_slot_lists()
+        await self._make_slot_lists()
 
     async def async_get_or_load_intents(self, language: str) -> LanguageIntents | None:
         """Load all intents of a language with lock."""
@@ -1002,12 +1087,66 @@ class DefaultAgent(ConversationEntity):
         intent_responses = responses_dict.get("intents", {})
         error_responses = responses_dict.get("errors", {})
 
+        # Load fuzzy
+        if self._fuzzy_config is None:
+            # Load shared config
+            self._fuzzy_config = get_fuzzy_config(json_load=json_load)
+            _LOGGER.debug("Loaded shared fuzzy matching config")
+
+        assert self._fuzzy_config is not None
+
+        fuzzy_matcher: FuzzyNgramMatcher | None = None
+        fuzzy_responses: FuzzyLanguageResponses | None = None
+        if fuzzy_info := get_fuzzy_language(language_variant, json_load=json_load):
+            start_time = time.monotonic()
+            fuzzy_responses = fuzzy_info.responses
+            fuzzy_matcher = FuzzyNgramMatcher(
+                intents=intents,
+                intent_models={
+                    intent_name: Sqlite3NgramModel(
+                        order=fuzzy_model.order,
+                        words={
+                            word: str(word_id)
+                            for word, word_id in fuzzy_model.words.items()
+                        },
+                        database_path=fuzzy_model.database_path,
+                    )
+                    for intent_name, fuzzy_model in fuzzy_info.ngram_models.items()
+                },
+                intent_slot_list_names=self._fuzzy_config.slot_list_names,
+                slot_combinations={
+                    intent_name: {
+                        combo_key: [
+                            SlotCombinationInfo(
+                                name_domains=set(name_domains) if name_domains else None
+                            )
+                        ]
+                        for combo_key, name_domains in intent_combos.items()
+                    }
+                    for intent_name, intent_combos in self._fuzzy_config.slot_combinations.items()
+                },
+                domain_keywords=fuzzy_info.domain_keywords,
+                stop_words=fuzzy_info.stop_words,
+            )
+            _LOGGER.debug(
+                "Loaded fuzzy matcher in %s second(s): language=%s, intents=%s",
+                time.monotonic() - start_time,
+                language_variant,
+                sorted(fuzzy_matcher.intent_models.keys()),
+            )
+        else:
+            _LOGGER.debug(
+                "Fuzzy matching not available for language: %s", language_variant
+            )
+
         return LanguageIntents(
             intents,
             intents_dict,
             intent_responses,
             error_responses,
             language_variant,
+            fuzzy_matcher=fuzzy_matcher,
+            fuzzy_responses=fuzzy_responses,
         )
 
     @core.callback
@@ -1028,7 +1167,7 @@ class DefaultAgent(ConversationEntity):
         self._intent_cache.clear()
 
     @core.callback
-    def _make_slot_lists(self) -> dict[str, SlotList]:
+    async def _make_slot_lists(self) -> dict[str, SlotList]:
         """Create slot lists with areas and entity names/aliases."""
         if self._slot_lists is not None:
             return self._slot_lists
@@ -1089,6 +1228,10 @@ class DefaultAgent(ConversationEntity):
             "floor": TextSlotList.from_tuples(floor_names, allow_template=False),
         }
 
+        # Reload fuzzy matchers with new slot lists
+        # await self.hass.async_add_executor_job(self._load_fuzzy_matchers)
+        self._load_fuzzy_matchers()
+
         self._listen_clear_slot_list()
 
         _LOGGER.debug(
@@ -1097,6 +1240,22 @@ class DefaultAgent(ConversationEntity):
         )
 
         return self._slot_lists
+
+    def _load_fuzzy_matchers(self) -> None:
+        """Reload fuzzy matchers for all loaded languages."""
+        for lang_intents in self._lang_intents.values():
+            if (lang_matcher := lang_intents.fuzzy_matcher) is None:
+                continue
+
+            lang_intents.fuzzy_matcher = FuzzyNgramMatcher(
+                intents=lang_matcher.intents,
+                intent_models=lang_matcher.intent_models,
+                intent_slot_list_names=lang_matcher.intent_slot_list_names,
+                slot_combinations=lang_matcher.slot_combinations,
+                domain_keywords=lang_matcher.domain_keywords,
+                stop_words=lang_matcher.stop_words,
+                slot_lists=self._slot_lists,
+            )
 
     def _make_intent_context(
         self, user_input: ConversationInput

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -735,11 +735,13 @@ class DefaultAgent(ConversationEntity):
                     (maybe_result is None)  # first result
                     or (
                         # More literal text matched
-                        result.text_chunks_matched > maybe_result.text_chunks_matched
+                        result.text_chunks_matched
+                        > maybe_result.text_chunks_matched
                     )
                     or (
                         # More entities matched
-                        num_matched_entities > best_num_matched_entities
+                        num_matched_entities
+                        > best_num_matched_entities
                     )
                     or (
                         # Fewer unmatched entities
@@ -1229,8 +1231,7 @@ class DefaultAgent(ConversationEntity):
         }
 
         # Reload fuzzy matchers with new slot lists
-        # await self.hass.async_add_executor_job(self._load_fuzzy_matchers)
-        self._load_fuzzy_matchers()
+        await self.hass.async_add_executor_job(self._load_fuzzy_matchers)
 
         self._listen_clear_slot_list()
 
@@ -1244,9 +1245,12 @@ class DefaultAgent(ConversationEntity):
     def _load_fuzzy_matchers(self) -> None:
         """Reload fuzzy matchers for all loaded languages."""
         for lang_intents in self._lang_intents.values():
-            if (lang_matcher := lang_intents.fuzzy_matcher) is None:
+            if (not isinstance(lang_intents, LanguageIntents)) or (
+                lang_intents.fuzzy_matcher is None
+            ):
                 continue
 
+            lang_matcher = lang_intents.fuzzy_matcher
             lang_intents.fuzzy_matcher = FuzzyNgramMatcher(
                 intents=lang_matcher.intents,
                 intent_models=lang_matcher.intent_models,

--- a/homeassistant/components/conversation/http.py
+++ b/homeassistant/components/conversation/http.py
@@ -26,7 +26,11 @@ from .agent_manager import (
     get_agent_manager,
 )
 from .const import DATA_COMPONENT, DATA_DEFAULT_ENTITY
-from .default_agent import METADATA_CUSTOM_FILE, METADATA_CUSTOM_SENTENCE
+from .default_agent import (
+    METADATA_CUSTOM_FILE,
+    METADATA_CUSTOM_SENTENCE,
+    METADATA_FUZZY_MATCH,
+)
 from .entity import ConversationEntity
 from .models import ConversationInput
 
@@ -240,6 +244,8 @@ async def websocket_hass_agent_debug(
                 "sentence_template": "",
                 # When match is incomplete, this will contain the best slot guesses
                 "unmatched_slots": _get_unmatched_slots(intent_result),
+                # True if match was not exact
+                "fuzzy_match": False,
             }
 
             if successful_match:
@@ -251,16 +257,19 @@ async def websocket_hass_agent_debug(
             if intent_result.intent_sentence is not None:
                 result_dict["sentence_template"] = intent_result.intent_sentence.text
 
-            # Inspect metadata to determine if this matched a custom sentence
-            if intent_result.intent_metadata and intent_result.intent_metadata.get(
-                METADATA_CUSTOM_SENTENCE
-            ):
-                result_dict["source"] = "custom"
-                result_dict["file"] = intent_result.intent_metadata.get(
-                    METADATA_CUSTOM_FILE
+            if intent_result.intent_metadata:
+                # Inspect metadata to determine if this matched a custom sentence
+                if intent_result.intent_metadata.get(METADATA_CUSTOM_SENTENCE):
+                    result_dict["source"] = "custom"
+                    result_dict["file"] = intent_result.intent_metadata.get(
+                        METADATA_CUSTOM_FILE
+                    )
+                else:
+                    result_dict["source"] = "builtin"
+
+                result_dict["fuzzy_match"] = intent_result.intent_metadata.get(
+                    METADATA_FUZZY_MATCH, False
                 )
-            else:
-                result_dict["source"] = "builtin"
 
         result_dicts.append(result_dict)
 

--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -295,6 +295,9 @@ async def init_supporting_components(
     assert await async_setup_component(hass, tts.DOMAIN, {"tts": {"platform": "test"}})
     assert await async_setup_component(hass, stt.DOMAIN, {"stt": {"platform": "test"}})
     assert await async_setup_component(hass, "media_source", {})
+    assert await async_setup_component(
+        hass, "conversation", {"conversation": {"fuzzy_matching": False}}
+    )
 
     config_entry = MockConfigEntry(domain="test")
     config_entry.add_to_hass(hass)

--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components import stt, tts, wake_word
+from homeassistant.components import conversation, stt, tts, wake_word
 from homeassistant.components.assist_pipeline import DOMAIN, select as assist_select
 from homeassistant.components.assist_pipeline.const import (
     BYTES_PER_CHUNK,
@@ -295,9 +295,11 @@ async def init_supporting_components(
     assert await async_setup_component(hass, tts.DOMAIN, {"tts": {"platform": "test"}})
     assert await async_setup_component(hass, stt.DOMAIN, {"stt": {"platform": "test"}})
     assert await async_setup_component(hass, "media_source", {})
-    assert await async_setup_component(
-        hass, "conversation", {"conversation": {"fuzzy_matching": False}}
-    )
+    assert await async_setup_component(hass, "conversation", {"conversation": {}})
+
+    # Disable fuzzy matching by default for tests
+    agent = hass.data[conversation.DATA_DEFAULT_ENTITY]
+    agent.fuzzy_matching = False
 
     config_entry = MockConfigEntry(domain="test")
     config_entry.add_to_hass(hass)

--- a/tests/components/conversation/conftest.py
+++ b/tests/components/conversation/conftest.py
@@ -73,4 +73,6 @@ async def sl_setup(hass: HomeAssistant):
 async def init_components(hass: HomeAssistant):
     """Initialize relevant components with empty configs."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(
+        hass, "conversation", {conversation.DOMAIN: {"fuzzy_matching": False}}
+    )

--- a/tests/components/conversation/conftest.py
+++ b/tests/components/conversation/conftest.py
@@ -73,6 +73,8 @@ async def sl_setup(hass: HomeAssistant):
 async def init_components(hass: HomeAssistant):
     """Initialize relevant components with empty configs."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(
-        hass, "conversation", {conversation.DOMAIN: {"fuzzy_matching": False}}
-    )
+    assert await async_setup_component(hass, "conversation", {conversation.DOMAIN: {}})
+
+    # Disable fuzzy matching by default for tests
+    agent = hass.data[conversation.DATA_DEFAULT_ENTITY]
+    agent.fuzzy_matching = False

--- a/tests/components/conversation/snapshots/test_http.ambr
+++ b/tests/components/conversation/snapshots/test_http.ambr
@@ -590,6 +590,7 @@
           }),
         }),
         'file': 'en/beer.yaml',
+        'fuzzy_match': False,
         'intent': dict({
           'name': 'OrderBeer',
         }),

--- a/tests/components/conversation/snapshots/test_http.ambr
+++ b/tests/components/conversation/snapshots/test_http.ambr
@@ -464,6 +464,7 @@
             'value': 'my cool light',
           }),
         }),
+        'fuzzy_match': False,
         'intent': dict({
           'name': 'HassTurnOn',
         }),
@@ -472,7 +473,6 @@
         'slots': dict({
           'name': 'my cool light',
         }),
-        'source': 'builtin',
         'targets': dict({
           'light.kitchen': dict({
             'matched': True,
@@ -489,6 +489,7 @@
             'value': 'my cool light',
           }),
         }),
+        'fuzzy_match': False,
         'intent': dict({
           'name': 'HassTurnOff',
         }),
@@ -497,7 +498,6 @@
         'slots': dict({
           'name': 'my cool light',
         }),
-        'source': 'builtin',
         'targets': dict({
           'light.kitchen': dict({
             'matched': True,
@@ -519,6 +519,7 @@
             'value': 'light',
           }),
         }),
+        'fuzzy_match': False,
         'intent': dict({
           'name': 'HassTurnOn',
         }),
@@ -528,7 +529,6 @@
           'area': 'kitchen',
           'domain': 'light',
         }),
-        'source': 'builtin',
         'targets': dict({
           'light.kitchen': dict({
             'matched': True,
@@ -555,6 +555,7 @@
             'value': 'on',
           }),
         }),
+        'fuzzy_match': False,
         'intent': dict({
           'name': 'HassGetState',
         }),
@@ -565,7 +566,6 @@
           'domain': 'lights',
           'state': 'on',
         }),
-        'source': 'builtin',
         'targets': dict({
           'light.kitchen': dict({
             'matched': False,
@@ -631,6 +631,7 @@
             'value': 'test light',
           }),
         }),
+        'fuzzy_match': False,
         'intent': dict({
           'name': 'HassLightSet',
         }),
@@ -640,7 +641,6 @@
           'brightness': '100',
           'name': 'test light',
         }),
-        'source': 'builtin',
         'targets': dict({
           'light.demo_1234': dict({
             'matched': True,
@@ -663,6 +663,7 @@
             'value': 'test light',
           }),
         }),
+        'fuzzy_match': False,
         'intent': dict({
           'name': 'HassLightSet',
         }),
@@ -671,7 +672,6 @@
         'slots': dict({
           'name': 'test light',
         }),
-        'source': 'builtin',
         'targets': dict({
         }),
         'unmatched_slots': dict({

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -3332,6 +3332,9 @@ async def test_fuzzy_matching(
     assert await async_setup_component(hass, "intent", {})
     await light_intent.async_setup_intents(hass)
 
+    agent = hass.data[DATA_DEFAULT_ENTITY]
+    agent.fuzzy_matching = fuzzy_matching
+
     area_office = area_registry.async_get_or_create("office_id")
     area_office = area_registry.async_update(area_office.id, name="office")
 

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -12,7 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 import yaml
 
 from homeassistant.components import conversation, cover, media_player, weather
-from homeassistant.components.conversation import default_agent
+from homeassistant.components.conversation import DOMAIN, default_agent
 from homeassistant.components.conversation.const import DATA_DEFAULT_ENTITY
 from homeassistant.components.conversation.default_agent import METADATA_CUSTOM_SENTENCE
 from homeassistant.components.conversation.models import ConversationInput
@@ -25,7 +25,12 @@ from homeassistant.components.intent import (
     TimerInfo,
     async_register_timer_handler,
 )
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.light import (
+    ATTR_SUPPORTED_COLOR_MODES,
+    DOMAIN as LIGHT_DOMAIN,
+    ColorMode,
+    intent as light_intent,
+)
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
@@ -78,7 +83,9 @@ class OrderBeerIntentHandler(intent.IntentHandler):
 async def init_components(hass: HomeAssistant) -> None:
     """Initialize relevant components with empty configs."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(
+        hass, "conversation", {DOMAIN: {"fuzzy_matching": False}}
+    )
     assert await async_setup_component(hass, "intent", {})
 
 
@@ -3287,3 +3294,96 @@ async def test_language_with_alternative_code(
         assert call.domain == LIGHT_DOMAIN
         assert call.service == "turn_on"
         assert call.data == {"entity_id": [entity_id]}
+
+
+@pytest.mark.parametrize("fuzzy_matching", [True, False])
+@pytest.mark.parametrize(
+    ("sentence", "intent_type", "slots"),
+    [
+        ("time", "HassGetCurrentTime", {}),
+        ("how about my timers", "HassTimerStatus", {}),
+        (
+            "the office needs more blue",
+            "HassLightSet",
+            {"area": "office", "color": "blue"},
+        ),
+        (
+            "50% office light",
+            "HassLightSet",
+            {"name": "office light", "brightness": "50%"},
+        ),
+    ],
+)
+async def test_fuzzy_matching(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fuzzy_matching: bool,
+    sentence: str,
+    intent_type: str,
+    slots: dict[str, Any],
+) -> None:
+    """Test fuzzy vs. non-fuzzy matching on some English sentences."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(
+        hass, "conversation", {DOMAIN: {"fuzzy_matching": fuzzy_matching}}
+    )
+    assert await async_setup_component(hass, "intent", {})
+    await light_intent.async_setup_intents(hass)
+
+    area_office = area_registry.async_get_or_create("office_id")
+    area_office = area_registry.async_update(area_office.id, name="office")
+
+    entry = MockConfigEntry()
+    entry.add_to_hass(hass)
+    office_satellite = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections=set(),
+        identifiers={("demo", "id-1234")},
+    )
+    device_registry.async_update_device(office_satellite.id, area_id=area_office.id)
+
+    office_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    office_light = entity_registry.async_update_entity(
+        office_light.entity_id, area_id=area_office.id
+    )
+    hass.states.async_set(
+        office_light.entity_id,
+        "on",
+        attributes={
+            ATTR_FRIENDLY_NAME: "office light",
+            ATTR_SUPPORTED_COLOR_MODES: [ColorMode.BRIGHTNESS, ColorMode.RGB],
+        },
+    )
+    _on_calls = async_mock_service(hass, LIGHT_DOMAIN, "turn_on")
+
+    result = await conversation.async_converse(
+        hass,
+        sentence,
+        None,
+        Context(),
+        language="en",
+        device_id=office_satellite.id,
+    )
+    response = result.response
+
+    if not fuzzy_matching:
+        # Should not match
+        assert response.response_type == intent.IntentResponseType.ERROR
+        return
+
+    assert response.response_type in (
+        intent.IntentResponseType.ACTION_DONE,
+        intent.IntentResponseType.QUERY_ANSWER,
+    )
+    assert response.intent is not None
+    assert response.intent.intent_type == intent_type
+
+    # Verify slot texts match
+    actual_slots = {
+        slot_name: slot_value["text"]
+        for slot_name, slot_value in response.intent.slots.items()
+        if slot_name != "preferred_area_id"  # context area
+    }
+    assert actual_slots == slots

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -12,7 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 import yaml
 
 from homeassistant.components import conversation, cover, media_player, weather
-from homeassistant.components.conversation import DOMAIN, default_agent
+from homeassistant.components.conversation import default_agent
 from homeassistant.components.conversation.const import DATA_DEFAULT_ENTITY
 from homeassistant.components.conversation.default_agent import METADATA_CUSTOM_SENTENCE
 from homeassistant.components.conversation.models import ConversationInput
@@ -83,10 +83,12 @@ class OrderBeerIntentHandler(intent.IntentHandler):
 async def init_components(hass: HomeAssistant) -> None:
     """Initialize relevant components with empty configs."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(
-        hass, "conversation", {DOMAIN: {"fuzzy_matching": False}}
-    )
+    assert await async_setup_component(hass, "conversation", {})
     assert await async_setup_component(hass, "intent", {})
+
+    # Disable fuzzy matching by default for tests
+    agent = hass.data[DATA_DEFAULT_ENTITY]
+    agent.fuzzy_matching = False
 
 
 @pytest.mark.parametrize(
@@ -3326,9 +3328,7 @@ async def test_fuzzy_matching(
 ) -> None:
     """Test fuzzy vs. non-fuzzy matching on some English sentences."""
     assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(
-        hass, "conversation", {DOMAIN: {"fuzzy_matching": fuzzy_matching}}
-    )
+    assert await async_setup_component(hass, "conversation", {})
     assert await async_setup_component(hass, "intent", {})
     await light_intent.async_setup_intents(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds fuzzy matching to the default agent: https://github.com/OHF-Voice/hassil/blob/main/docs/fuzzy_matching.md
This allows **non-LLM** voice pipelines to recognize many more sentences that are outside the [existing intents](https://github.com/OHF-Voice/intents).

With fuzzy matching, a new stage is added to the default agent (non-LLM only):

1. Check sentence triggers
2. If failed, check hassil intents (strict)
3. **If failed, check hassil intents (fuzzy)**
4. If failed, try to guess intent and missing slots

A new `fuzzy_match` boolean has been added to the Assist developer tool so it's easy to tell when a sentence was recognized due to a strict or fuzzy match.

**Only English is supported for now** due to the size of the data files that need to be included in the `home-assistant-intents` package. The English resources add approximately 2MB of compressed data, so with 57 supported languages this would likely exceed [PyPI's file size limit of 100MB](https://docs.pypi.org/project-management/storage-limits/). We need to determine how best to distribute the language-specific data files before including other languages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
