### PR TITLE
Add downloading and seeding counts to Deluge

### DIFF
--- a/homeassistant/components/deluge/const.py
+++ b/homeassistant/components/deluge/const.py
@@ -43,3 +43,5 @@ class DelugeSensorType(enum.StrEnum):
     UPLOAD_SPEED_SENSOR = "upload_speed"
     PROTOCOL_TRAFFIC_UPLOAD_SPEED_SENSOR = "protocol_traffic_upload_speed"
     PROTOCOL_TRAFFIC_DOWNLOAD_SPEED_SENSOR = "protocol_traffic_download_speed"
+    DOWNLOADING_COUNT_SENSOR = "downloading_count"
+    SEEDING_COUNT_SENSOR = "seeding_count"

--- a/homeassistant/components/deluge/coordinator.py
+++ b/homeassistant/components/deluge/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from datetime import timedelta
 from ssl import SSLError
 from typing import Any
@@ -21,20 +22,12 @@ type DelugeConfigEntry = ConfigEntry[DelugeDataUpdateCoordinator]
 
 def count_states(data: dict[str, Any]) -> dict[str, int]:
     """Count the states of the provided torrents."""
-    downloading_count = 0
-    seeding_count = 0
 
-    for torrent in data.values():
-        state = torrent[b"state"].decode()
-
-        if state == "Downloading":
-            downloading_count += 1
-        elif state == "Seeding":
-            seeding_count += 1
+    counts = Counter(torrent[b"state"].decode() for torrent in data.values())
 
     return {
-        DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value: downloading_count,
-        DelugeSensorType.SEEDING_COUNT_SENSOR.value: seeding_count,
+        DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value: counts.get("Downloading", 0),
+        DelugeSensorType.SEEDING_COUNT_SENSOR.value: counts.get("Seeding", 0),
     }
 
 

--- a/homeassistant/components/deluge/coordinator.py
+++ b/homeassistant/components/deluge/coordinator.py
@@ -48,7 +48,16 @@ class DelugeDataUpdateCoordinator(
                 "core.get_session_status",
                 [iter_member.value for iter_member in list(DelugeGetSessionStatusKeys)],
             )
+
+            _states = await self.hass.async_add_executor_job(
+                self.api.call, "core.get_torrents_status", {}, ["state"]
+            )
+
             data[Platform.SENSOR] = {k.decode(): v for k, v in _data.items()}
+            data[Platform.SENSOR]["states"] = {
+                k.decode(): v for k, v in _states.items()
+            }
+
             data[Platform.SWITCH] = await self.hass.async_add_executor_job(
                 self.api.call, "core.get_torrents_status", {}, ["paused"]
             )

--- a/homeassistant/components/deluge/icons.json
+++ b/homeassistant/components/deluge/icons.json
@@ -1,0 +1,12 @@
+{
+  "entity": {
+    "sensor": {
+      "downloading_count": {
+        "default": "mdi:download"
+      },
+      "seeding_count": {
+        "default": "mdi:upload"
+      }
+    }
+  }
+}

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -22,7 +22,7 @@ from .coordinator import DelugeConfigEntry, DelugeDataUpdateCoordinator
 from .entity import DelugeEntity
 
 
-def get_count(data: dict[str, Any], key: str) -> float:
+def get_count(data: dict[str, Any], key: str) -> int:
     """Get current count of torrents by state."""
 
     downloading_count = 0

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -22,6 +22,30 @@ from .coordinator import DelugeConfigEntry, DelugeDataUpdateCoordinator
 from .entity import DelugeEntity
 
 
+def get_count(data: dict[str, Any], key: str) -> float:
+    """Get current count of torrents by state."""
+
+    downloading_count = 0
+    seeding_count = 0
+
+    for torrent in data["states"].values():
+        torrent = {k.decode(): v for k, v in torrent.items()}
+        state = torrent["state"].decode()
+
+        if state == "Downloading":
+            downloading_count += 1
+        elif state == "Seeding":
+            seeding_count += 1
+
+    count = 0
+    if key == DelugeSensorType.DOWNLOADING_COUNT_SENSOR:
+        count = downloading_count
+    elif key == DelugeSensorType.SEEDING_COUNT_SENSOR:
+        count = seeding_count
+
+    return count
+
+
 def get_state(data: dict[str, float], key: str) -> str | float:
     """Get current download/upload state."""
     upload = data[DelugeGetSessionStatusKeys.UPLOAD_RATE.value]
@@ -109,6 +133,22 @@ SENSOR_TYPES: tuple[DelugeSensorEntityDescription, ...] = (
         value=lambda data: get_state(
             data, DelugeSensorType.PROTOCOL_TRAFFIC_DOWNLOAD_SPEED_SENSOR.value
         ),
+    ),
+    DelugeSensorEntityDescription(
+        key=DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value,
+        translation_key=DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:download",
+        value=lambda data: get_count(
+            data, DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value
+        ),
+    ),
+    DelugeSensorEntityDescription(
+        key=DelugeSensorType.SEEDING_COUNT_SENSOR.value,
+        translation_key=DelugeSensorType.SEEDING_COUNT_SENSOR.value,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:upload",
+        value=lambda data: get_count(data, DelugeSensorType.SEEDING_COUNT_SENSOR.value),
     ),
 )
 

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -22,30 +22,6 @@ from .coordinator import DelugeConfigEntry, DelugeDataUpdateCoordinator
 from .entity import DelugeEntity
 
 
-def get_count(data: dict[str, Any], key: str) -> int:
-    """Get current count of torrents by state."""
-
-    downloading_count = 0
-    seeding_count = 0
-
-    for torrent in data["states"].values():
-        torrent = {k.decode(): v for k, v in torrent.items()}
-        state = torrent["state"].decode()
-
-        if state == "Downloading":
-            downloading_count += 1
-        elif state == "Seeding":
-            seeding_count += 1
-
-    count = 0
-    if key == DelugeSensorType.DOWNLOADING_COUNT_SENSOR:
-        count = downloading_count
-    elif key == DelugeSensorType.SEEDING_COUNT_SENSOR:
-        count = seeding_count
-
-    return count
-
-
 def get_state(data: dict[str, float], key: str) -> str | float:
     """Get current download/upload state."""
     upload = data[DelugeGetSessionStatusKeys.UPLOAD_RATE.value]
@@ -139,16 +115,14 @@ SENSOR_TYPES: tuple[DelugeSensorEntityDescription, ...] = (
         translation_key=DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:download",
-        value=lambda data: get_count(
-            data, DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value
-        ),
+        value=lambda data: data[DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value],
     ),
     DelugeSensorEntityDescription(
         key=DelugeSensorType.SEEDING_COUNT_SENSOR.value,
         translation_key=DelugeSensorType.SEEDING_COUNT_SENSOR.value,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:upload",
-        value=lambda data: get_count(data, DelugeSensorType.SEEDING_COUNT_SENSOR.value),
+        value=lambda data: data[DelugeSensorType.SEEDING_COUNT_SENSOR.value],
     ),
 )
 

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -114,14 +114,12 @@ SENSOR_TYPES: tuple[DelugeSensorEntityDescription, ...] = (
         key=DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value,
         translation_key=DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:download",
         value=lambda data: data[DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value],
     ),
     DelugeSensorEntityDescription(
         key=DelugeSensorType.SEEDING_COUNT_SENSOR.value,
         translation_key=DelugeSensorType.SEEDING_COUNT_SENSOR.value,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:upload",
         value=lambda data: data[DelugeSensorType.SEEDING_COUNT_SENSOR.value],
     ),
 )

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -113,13 +113,13 @@ SENSOR_TYPES: tuple[DelugeSensorEntityDescription, ...] = (
     DelugeSensorEntityDescription(
         key=DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value,
         translation_key=DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL,
         value=lambda data: data[DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value],
     ),
     DelugeSensorEntityDescription(
         key=DelugeSensorType.SEEDING_COUNT_SENSOR.value,
         translation_key=DelugeSensorType.SEEDING_COUNT_SENSOR.value,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL,
         value=lambda data: data[DelugeSensorType.SEEDING_COUNT_SENSOR.value],
     ),
 )

--- a/homeassistant/components/deluge/strings.json
+++ b/homeassistant/components/deluge/strings.json
@@ -36,6 +36,9 @@
           "idle": "[%key:common::state::idle%]"
         }
       },
+      "downloading_count": {
+        "name": "Downloading count"
+      },
       "download_speed": {
         "name": "Download speed"
       },
@@ -44,6 +47,9 @@
       },
       "protocol_traffic_upload_speed": {
         "name": "Protocol traffic upload speed"
+      },
+      "seeding_count": {
+        "name": "Seeding count"
       },
       "upload_speed": {
         "name": "Upload speed"

--- a/homeassistant/components/deluge/strings.json
+++ b/homeassistant/components/deluge/strings.json
@@ -37,7 +37,8 @@
         }
       },
       "downloading_count": {
-        "name": "Downloading count"
+        "name": "Downloading count",
+        "unit_of_measurement": "torrents"
       },
       "download_speed": {
         "name": "Download speed"
@@ -49,7 +50,8 @@
         "name": "Protocol traffic upload speed"
       },
       "seeding_count": {
-        "name": "Seeding count"
+        "name": "Seeding count",
+        "unit_of_measurement": "[%key:component::deluge::entity::sensor::downloading_count::unit_of_measurement%]"
       },
       "upload_speed": {
         "name": "Upload speed"

--- a/tests/components/deluge/__init__.py
+++ b/tests/components/deluge/__init__.py
@@ -23,9 +23,7 @@ GET_TORRENT_STATUS_RESPONSE = {
 }
 
 GET_TORRENT_STATES_RESPONSE = {
-    "states": {
-        "6dcd3f46d09547b62bf07ba9b2943c95d53ddae3": {b"state": b"Seeding"},
-        "1c56ea49918b9baed94cf4bc0ee9f324efc8841a": {b"state": b"Downloading"},
-        "fbf4dab701189a344fa5ab06d7b87c11a74e3da0": {b"state": b"Seeding"},
-    }
+    "6dcd3f46d09547b62bf07ba9b2943c95d53ddae3": {b"state": b"Seeding"},
+    "1c56ea49918b9baed94cf4bc0ee9f324efc8841a": {b"state": b"Downloading"},
+    "fbf4dab701189a344fa5ab06d7b87c11a74e3da0": {b"state": b"Seeding"},
 }

--- a/tests/components/deluge/__init__.py
+++ b/tests/components/deluge/__init__.py
@@ -21,3 +21,11 @@ GET_TORRENT_STATUS_RESPONSE = {
     "dht_upload_rate": 7818.0,
     "dht_download_rate": 2658.0,
 }
+
+GET_TORRENT_STATES_RESPONSE = {
+    "states": {
+        "6dcd3f46d09547b62bf07ba9b2943c95d53ddae3": {b"state": b"Seeding"},
+        "1c56ea49918b9baed94cf4bc0ee9f324efc8841a": {b"state": b"Downloading"},
+        "fbf4dab701189a344fa5ab06d7b87c11a74e3da0": {b"state": b"Seeding"},
+    }
+}

--- a/tests/components/deluge/test_coordinator.py
+++ b/tests/components/deluge/test_coordinator.py
@@ -1,0 +1,15 @@
+"""Test Deluge coordinator.py methods."""
+
+from homeassistant.components.deluge.const import DelugeSensorType
+from homeassistant.components.deluge.coordinator import count_states
+
+from . import GET_TORRENT_STATES_RESPONSE
+
+
+def test_get_count() -> None:
+    """Tests count_states()."""
+
+    states = count_states(GET_TORRENT_STATES_RESPONSE)
+
+    assert states[DelugeSensorType.DOWNLOADING_COUNT_SENSOR.value] == 1
+    assert states[DelugeSensorType.SEEDING_COUNT_SENSOR.value] == 2

--- a/tests/components/deluge/test_sensor.py
+++ b/tests/components/deluge/test_sensor.py
@@ -1,23 +1,9 @@
 """Test Deluge sensor.py methods."""
 
 from homeassistant.components.deluge.const import DelugeSensorType
-from homeassistant.components.deluge.sensor import get_count, get_state
+from homeassistant.components.deluge.sensor import get_state
 
-from . import GET_TORRENT_STATES_RESPONSE, GET_TORRENT_STATUS_RESPONSE
-
-
-def test_get_count() -> None:
-    """Tests get_count() with different keys."""
-
-    downloading_count = get_count(
-        GET_TORRENT_STATES_RESPONSE, DelugeSensorType.DOWNLOADING_COUNT_SENSOR
-    )
-    assert downloading_count == 1
-
-    seeding_count = get_count(
-        GET_TORRENT_STATES_RESPONSE, DelugeSensorType.SEEDING_COUNT_SENSOR
-    )
-    assert seeding_count == 2
+from . import GET_TORRENT_STATUS_RESPONSE
 
 
 def test_get_state() -> None:

--- a/tests/components/deluge/test_sensor.py
+++ b/tests/components/deluge/test_sensor.py
@@ -1,9 +1,23 @@
 """Test Deluge sensor.py methods."""
 
 from homeassistant.components.deluge.const import DelugeSensorType
-from homeassistant.components.deluge.sensor import get_state
+from homeassistant.components.deluge.sensor import get_count, get_state
 
-from . import GET_TORRENT_STATUS_RESPONSE
+from . import GET_TORRENT_STATES_RESPONSE, GET_TORRENT_STATUS_RESPONSE
+
+
+def test_get_count() -> None:
+    """Tests get_count() with different keys."""
+
+    downloading_count = get_count(
+        GET_TORRENT_STATES_RESPONSE, DelugeSensorType.DOWNLOADING_COUNT_SENSOR
+    )
+    assert downloading_count == 1
+
+    seeding_count = get_count(
+        GET_TORRENT_STATES_RESPONSE, DelugeSensorType.SEEDING_COUNT_SENSOR
+    )
+    assert seeding_count == 2
 
 
 def test_get_state() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add sensors to the Deluge integration to show the current downloading and seeding counts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
