### PR TITLE
Add python3 open file descriptor sensor to Systemmonitor

### DIFF
--- a/homeassistant/components/systemmonitor/strings.json
+++ b/homeassistant/components/systemmonitor/strings.json
@@ -100,6 +100,9 @@
       },
       "swap_use_percent": {
         "name": "Swap usage"
+      },
+      "python3_num_fds": {
+        "name": "Python3 open file descriptors"
       }
     }
   }

--- a/tests/components/systemmonitor/conftest.py
+++ b/tests/components/systemmonitor/conftest.py
@@ -27,18 +27,23 @@ def mock_sys_platform() -> Generator[None]:
 class MockProcess(Process):
     """Mock a Process class."""
 
-    def __init__(self, name: str, ex: bool = False) -> None:
+    def __init__(self, name: str, ex: bool = False, num_fds: int = 3) -> None:
         """Initialize the process."""
         super().__init__(1)
         self._name = name
         self._ex = ex
         self._create_time = 1708700400
+        self._num_fds = num_fds
 
     def name(self):
         """Return a name."""
         if self._ex:
             raise NoSuchProcess(1, self._name)
         return self._name
+
+    def num_fds(self):
+        """Return open file descriptors."""
+        return self._num_fds
 
 
 @pytest.fixture

--- a/tests/components/systemmonitor/snapshots/test_sensor.ambr
+++ b/tests/components/systemmonitor/snapshots/test_sensor.ambr
@@ -114,16 +114,6 @@
 # name: test_sensor[System Monitor Last boot - state]
   '2024-02-24T15:00:00+00:00'
 # ---
-# name: test_sensor[System Monitor Load (15 min) - attributes]
-  ReadOnlyDict({
-    'friendly_name': 'System Monitor Load (15 min)',
-    'icon': 'mdi:cpu-64-bit',
-    'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-  })
-# ---
-# name: test_sensor[System Monitor Load (15 min) - state]
-  '3'
-# ---
 # name: test_sensor[System Monitor Load (1 min) - attributes]
   ReadOnlyDict({
     'friendly_name': 'System Monitor Load (1 min)',
@@ -133,6 +123,16 @@
 # ---
 # name: test_sensor[System Monitor Load (1 min) - state]
   '1'
+# ---
+# name: test_sensor[System Monitor Load (15 min) - attributes]
+  ReadOnlyDict({
+    'friendly_name': 'System Monitor Load (15 min)',
+    'icon': 'mdi:cpu-64-bit',
+    'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+  })
+# ---
+# name: test_sensor[System Monitor Load (15 min) - state]
+  '3'
 # ---
 # name: test_sensor[System Monitor Load (5 min) - attributes]
   ReadOnlyDict({
@@ -321,6 +321,15 @@
 # ---
 # name: test_sensor[System Monitor Processor use - state]
   '10'
+# ---
+# name: test_sensor[System Monitor Python3 open file descriptors - attributes]
+  ReadOnlyDict({
+    'friendly_name': 'System Monitor Python3 open file descriptors',
+    'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+  })
+# ---
+# name: test_sensor[System Monitor Python3 open file descriptors - state]
+  '3'
 # ---
 # name: test_sensor[System Monitor Swap free - attributes]
   ReadOnlyDict({

--- a/tests/components/systemmonitor/test_sensor.py
+++ b/tests/components/systemmonitor/test_sensor.py
@@ -18,6 +18,8 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from .conftest import MockProcess
+
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
@@ -453,7 +455,7 @@ async def test_remove_obsolete_entities(
                 mock_added_config_entry.entry_id
             )
         )
-        == 37
+        == 38
     )
 
     entity_registry.async_update_entity(
@@ -494,7 +496,7 @@ async def test_remove_obsolete_entities(
                 mock_added_config_entry.entry_id
             )
         )
-        == 38
+        == 39
     )
 
     assert (
@@ -544,3 +546,56 @@ async def test_no_duplicate_disk_entities(
     assert disk_sensor.state == "60.0"
 
     assert "Platform systemmonitor does not generate unique IDs." not in caplog.text
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_python3_num_fds(
+    hass: HomeAssistant,
+    mock_psutil: Mock,
+    mock_os: Mock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test python3 open file descriptors sensor."""
+    mock_config_entry = MockConfigEntry(
+        title="System Monitor",
+        domain=DOMAIN,
+        data={},
+        options={
+            "resources": [
+                "disk_use_percent_/",
+                "disk_use_percent_/home/notexist/",
+                "memory_free_",
+                "network_out_eth0",
+                "process_python3",
+            ],
+        },
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    num_fds_sensor = hass.states.get(
+        "sensor.system_monitor_python3_open_file_descriptors"
+    )
+    assert num_fds_sensor is not None
+    assert num_fds_sensor.state == "3"
+    assert num_fds_sensor.attributes == {
+        "state_class": "measurement",
+        "friendly_name": "System Monitor Python3 open file descriptors",
+    }
+
+    _process = MockProcess("python3", num_fds=5)
+    assert _process.num_fds() == 5
+    mock_psutil.process_iter.return_value = [_process]
+
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    num_fds_sensor = hass.states.get(
+        "sensor.system_monitor_python3_open_file_descriptors"
+    )
+    assert num_fds_sensor is not None
+    assert num_fds_sensor.state == "5"


### PR DESCRIPTION
## Breaking change


## Proposed change
As subject, always adds a sensor to display the open file descriptors for the `python3` process.

Closes task: https://github.com/home-assistant/core/issues/148807

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #148807
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 