### PR TITLE
Allow modern and trigger template entities to have a config_entry

### DIFF
--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -157,9 +157,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        ALARM_CONTROL_PANEL_DOMAIN,
         config_entry,
         async_add_entities,
         StateAlarmControlPanelEntity,
+        TriggerAlarmControlPanelEntity,
         ALARM_CONTROL_PANEL_CONFIG_ENTRY_SCHEMA,
         True,
     )
@@ -177,7 +179,6 @@ async def async_setup_platform(
         ALARM_CONTROL_PANEL_DOMAIN,
         config,
         StateAlarmControlPanelEntity,
-        TriggerAlarmControlPanelEntity,
         async_add_entities,
         discovery_info,
         LEGACY_FIELDS,

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -133,7 +133,6 @@ async def async_setup_platform(
         BINARY_SENSOR_DOMAIN,
         config,
         StateBinarySensorEntity,
-        TriggerBinarySensorEntity,
         async_add_entities,
         discovery_info,
         LEGACY_FIELDS,
@@ -149,9 +148,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        BINARY_SENSOR_DOMAIN,
         config_entry,
         async_add_entities,
         StateBinarySensorEntity,
+        TriggerBinarySensorEntity,
         BINARY_SENSOR_CONFIG_ENTRY_SCHEMA,
     )
 

--- a/homeassistant/components/template/button.py
+++ b/homeassistant/components/template/button.py
@@ -17,14 +17,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_CLASS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity_platform import (
-    AddConfigEntryEntitiesCallback,
-    AddEntitiesCallback,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import CONF_PRESS, DOMAIN
-from .helpers import async_setup_template_entry, async_setup_template_platform
+from .helpers import async_setup_template_entry
 from .template_entity import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TemplateEntity,
@@ -51,24 +47,6 @@ BUTTON_CONFIG_ENTRY_SCHEMA = vol.Schema(
 ).extend(TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA.schema)
 
 
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the template button."""
-    await async_setup_template_platform(
-        hass,
-        BUTTON_DOMAIN,
-        config,
-        StateButtonEntity,
-        None,
-        async_add_entities,
-        discovery_info,
-    )
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -77,9 +55,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        BUTTON_DOMAIN,
         config_entry,
         async_add_entities,
         StateButtonEntity,
+        None,
         BUTTON_CONFIG_ENTRY_SCHEMA,
     )
 

--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -235,7 +235,7 @@ async def async_validate_config(hass: HomeAssistant, config: ConfigType) -> Conf
     if DOMAIN not in config:
         return config
 
-    config_sections = []
+    config_sections: list[TemplateConfig] = []
 
     for cfg in cv.ensure_list(config[DOMAIN]):
         try:

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_DEVICE_ID,
@@ -357,7 +358,7 @@ config_schema = partial(generate_schema, flow_type="config")
 
 async def choose_options_step(options: dict[str, Any]) -> str:
     """Return next step_id for options flow according to template_type."""
-    return cast(str, options["template_type"])
+    return cast(str, options.get("template_type", "import"))
 
 
 def _validate_unit(options: dict[str, Any]) -> None:
@@ -522,6 +523,7 @@ CONFIG_FLOW = {
 
 
 OPTIONS_FLOW = {
+    "import": SchemaFlowFormStep(schema=None),
     "init": SchemaFlowFormStep(next_step=choose_options_step),
     Platform.ALARM_CONTROL_PANEL: SchemaFlowFormStep(
         options_schema(Platform.ALARM_CONTROL_PANEL),
@@ -622,6 +624,10 @@ class TemplateConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     async def async_setup_preview(hass: HomeAssistant) -> None:
         """Set up preview WS API."""
         websocket_api.async_register_command(hass, ws_start_preview)
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Handle import from configuration.yaml."""
+        return self.async_create_entry(data={CONF_NAME: "configuration.yaml"})
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -1,10 +1,14 @@
 """Constants for the Template Platform Components."""
 
+from dataclasses import dataclass
+
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ICON, CONF_NAME, CONF_UNIQUE_ID, Platform
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.hass_dict import HassKey
 
 CONF_ADVANCED_OPTIONS = "advanced_options"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
@@ -19,6 +23,9 @@ CONF_PRESS = "press"
 CONF_STEP = "step"
 CONF_TURN_OFF = "turn_off"
 CONF_TURN_ON = "turn_on"
+
+DATA_HASS_COORDINATORS = "template_coordinators"
+DATA_PLATFORMS: HassKey[dict[str, list[ConfigType]]] = HassKey("template_platforms")
 
 TEMPLATE_ENTITY_BASE_SCHEMA = vol.Schema(
     {
@@ -56,3 +63,11 @@ class TemplateConfig(dict):
 
     raw_config: ConfigType | None = None
     raw_blueprint_inputs: ConfigType | None = None
+
+
+@dataclass
+class TemplateModule:
+    """List of template platforms."""
+
+    platforms: tuple[str, ...]
+    entry: ConfigEntry

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -14,14 +14,14 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.core import Context, CoreState, Event, HomeAssistant, callback
-from homeassistant.helpers import condition, discovery, trigger as trigger_helper
+from homeassistant.helpers import condition, trigger as trigger_helper
 from homeassistant.helpers.script import Script
 from homeassistant.helpers.script_variables import ScriptVariables
 from homeassistant.helpers.trace import trace_get
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, PLATFORMS
+from .const import DOMAIN, TemplateConfig
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
 
     REMOVE_TRIGGER = object()
 
-    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+    def __init__(self, hass: HomeAssistant, config: TemplateConfig) -> None:
         """Instantiate trigger data."""
         super().__init__(
             hass, _LOGGER, config_entry=None, name="Trigger Update Coordinator"
@@ -75,19 +75,6 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
             self._unsub_start = self.hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_START, self._attach_triggers
             )
-
-        for platform_domain in PLATFORMS:
-            if platform_domain in self.config:
-                self.hass.async_create_task(
-                    discovery.async_load_platform(
-                        self.hass,
-                        platform_domain,
-                        DOMAIN,
-                        {"coordinator": self, "entities": self.config[platform_domain]},
-                        hass_config,
-                    ),
-                    eager_start=True,
-                )
 
     async def _attach_triggers(self, start_event: Event | None = None) -> None:
         """Attach the triggers."""

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -172,7 +172,6 @@ async def async_setup_platform(
         COVER_DOMAIN,
         config,
         StateCoverEntity,
-        TriggerCoverEntity,
         async_add_entities,
         discovery_info,
         LEGACY_FIELDS,
@@ -188,9 +187,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        COVER_DOMAIN,
         config_entry,
         async_add_entities,
         StateCoverEntity,
+        TriggerCoverEntity,
         COVER_CONFIG_ENTRY_SCHEMA,
         True,
     )

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -158,7 +158,6 @@ async def async_setup_platform(
         FAN_DOMAIN,
         config,
         StateFanEntity,
-        TriggerFanEntity,
         async_add_entities,
         discovery_info,
         LEGACY_FIELDS,
@@ -174,9 +173,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        FAN_DOMAIN,
         config_entry,
         async_add_entities,
         StateFanEntity,
+        TriggerFanEntity,
         FAN_CONFIG_ENTRY_SCHEMA,
     )
 

--- a/homeassistant/components/template/image.py
+++ b/homeassistant/components/template/image.py
@@ -17,16 +17,12 @@ from homeassistant.const import CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity_platform import (
-    AddConfigEntryEntitiesCallback,
-    AddEntitiesCallback,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
 from . import TriggerUpdateCoordinator
 from .const import CONF_PICTURE
-from .helpers import async_setup_template_entry, async_setup_template_platform
+from .helpers import async_setup_template_entry
 from .template_entity import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TemplateEntity,
@@ -56,24 +52,6 @@ IMAGE_CONFIG_ENTRY_SCHEMA = vol.Schema(
 ).extend(TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA.schema)
 
 
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the template image."""
-    await async_setup_template_platform(
-        hass,
-        IMAGE_DOMAIN,
-        config,
-        StateImageEntity,
-        TriggerImageEntity,
-        async_add_entities,
-        discovery_info,
-    )
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -82,9 +60,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        IMAGE_DOMAIN,
         config_entry,
         async_add_entities,
         StateImageEntity,
+        TriggerImageEntity,
         IMAGE_CONFIG_ENTRY_SCHEMA,
     )
 

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -223,7 +223,6 @@ async def async_setup_platform(
         LIGHT_DOMAIN,
         config,
         StateLightEntity,
-        TriggerLightEntity,
         async_add_entities,
         discovery_info,
         LEGACY_FIELDS,
@@ -239,9 +238,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        LIGHT_DOMAIN,
         config_entry,
         async_add_entities,
         StateLightEntity,
+        TriggerLightEntity,
         LIGHT_CONFIG_ENTRY_SCHEMA,
         True,
     )

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -108,7 +108,6 @@ async def async_setup_platform(
         LOCK_DOMAIN,
         config,
         StateLockEntity,
-        TriggerLockEntity,
         async_add_entities,
         discovery_info,
         LEGACY_FIELDS,
@@ -123,9 +122,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        LOCK_DOMAIN,
         config_entry,
         async_add_entities,
         StateLockEntity,
+        TriggerLockEntity,
         LOCK_CONFIG_ENTRY_SCHEMA,
     )
 

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -20,20 +20,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_STATE, CONF_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, template
-from homeassistant.helpers.entity_platform import (
-    AddConfigEntryEntitiesCallback,
-    AddEntitiesCallback,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import ConfigType
 
 from . import TriggerUpdateCoordinator
 from .const import CONF_MAX, CONF_MIN, CONF_STEP, DOMAIN
 from .entity import AbstractTemplateEntity
-from .helpers import (
-    async_setup_template_entry,
-    async_setup_template_platform,
-    async_setup_template_preview,
-)
+from .helpers import async_setup_template_entry, async_setup_template_preview
 from .template_entity import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
@@ -69,24 +62,6 @@ NUMBER_CONFIG_ENTRY_SCHEMA = NUMBER_COMMON_SCHEMA.extend(
 )
 
 
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the template number."""
-    await async_setup_template_platform(
-        hass,
-        NUMBER_DOMAIN,
-        config,
-        StateNumberEntity,
-        TriggerNumberEntity,
-        async_add_entities,
-        discovery_info,
-    )
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -95,9 +70,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        NUMBER_DOMAIN,
         config_entry,
         async_add_entities,
         StateNumberEntity,
+        TriggerNumberEntity,
         NUMBER_CONFIG_ENTRY_SCHEMA,
     )
 

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -18,20 +18,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_STATE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity_platform import (
-    AddConfigEntryEntitiesCallback,
-    AddEntitiesCallback,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import TriggerUpdateCoordinator
 from .const import DOMAIN
 from .entity import AbstractTemplateEntity
-from .helpers import (
-    async_setup_template_entry,
-    async_setup_template_platform,
-    async_setup_template_preview,
-)
+from .helpers import async_setup_template_entry, async_setup_template_preview
 from .template_entity import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
@@ -64,24 +56,6 @@ SELECT_CONFIG_ENTRY_SCHEMA = SELECT_COMMON_SCHEMA.extend(
 )
 
 
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the template select."""
-    await async_setup_template_platform(
-        hass,
-        SELECT_DOMAIN,
-        config,
-        TemplateSelect,
-        TriggerSelectEntity,
-        async_add_entities,
-        discovery_info,
-    )
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -90,9 +64,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        SELECT_DOMAIN,
         config_entry,
         async_add_entities,
         TemplateSelect,
+        TriggerSelectEntity,
         SELECT_CONFIG_ENTRY_SCHEMA,
     )
 

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -173,7 +173,6 @@ async def async_setup_platform(
         SENSOR_DOMAIN,
         config,
         StateSensorEntity,
-        TriggerSensorEntity,
         async_add_entities,
         discovery_info,
         LEGACY_FIELDS,
@@ -189,9 +188,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        SENSOR_DOMAIN,
         config_entry,
         async_add_entities,
         StateSensorEntity,
+        TriggerSensorEntity,
         SENSOR_CONFIG_ENTRY_SCHEMA,
     )
 

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -108,7 +108,6 @@ async def async_setup_platform(
         SWITCH_DOMAIN,
         config,
         StateSwitchEntity,
-        TriggerSwitchEntity,
         async_add_entities,
         discovery_info,
         LEGACY_FIELDS,
@@ -124,9 +123,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        SWITCH_DOMAIN,
         config_entry,
         async_add_entities,
         StateSwitchEntity,
+        TriggerSwitchEntity,
         SWITCH_CONFIG_ENTRY_SCHEMA,
         True,
     )

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -156,7 +156,6 @@ async def async_setup_platform(
         VACUUM_DOMAIN,
         config,
         TemplateStateVacuumEntity,
-        TriggerVacuumEntity,
         async_add_entities,
         discovery_info,
         LEGACY_FIELDS,
@@ -172,9 +171,11 @@ async def async_setup_entry(
     """Initialize config entry."""
     await async_setup_template_entry(
         hass,
+        VACUUM_DOMAIN,
         config_entry,
         async_add_entities,
         TemplateStateVacuumEntity,
+        TriggerVacuumEntity,
         VACUUM_CONFIG_ENTRY_SCHEMA,
     )
 

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -31,6 +31,7 @@ from homeassistant.components.weather import (
     WeatherEntity,
     WeatherEntityFeature,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_NAME,
     CONF_TEMPERATURE_UNIT,
@@ -41,7 +42,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv, template
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    AddEntitiesCallback,
+)
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util.unit_conversion import (
@@ -52,7 +56,7 @@ from homeassistant.util.unit_conversion import (
 )
 
 from .coordinator import TriggerUpdateCoordinator
-from .helpers import async_setup_template_platform
+from .helpers import async_setup_template_entry, async_setup_template_platform
 from .template_entity import TemplateEntity, make_template_entity_common_modern_schema
 from .trigger_entity import TriggerEntity
 
@@ -175,10 +179,26 @@ async def async_setup_platform(
         WEATHER_DOMAIN,
         config,
         StateWeatherEntity,
-        TriggerWeatherEntity,
         async_add_entities,
         discovery_info,
         {},
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Initialize config entry."""
+    await async_setup_template_entry(
+        hass,
+        WEATHER_DOMAIN,
+        config_entry,
+        async_add_entities,
+        StateWeatherEntity,
+        TriggerWeatherEntity,
+        vol.Schema({}),
     )
 
 

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -306,7 +306,7 @@ async def test_config_flow(
         **extra_options,
         **availability,
     }
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 2
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert config_entry.data == {}
@@ -492,7 +492,7 @@ async def test_config_flow_device(
         **state_template,
         **extra_options,
     }
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 2
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert config_entry.data == {}

--- a/tests/components/template/test_helpers.py
+++ b/tests/components/template/test_helpers.py
@@ -8,11 +8,9 @@ from homeassistant.components.template.alarm_control_panel import (
 from homeassistant.components.template.binary_sensor import (
     LEGACY_FIELDS as BINARY_SENSOR_LEGACY_FIELDS,
 )
-from homeassistant.components.template.button import StateButtonEntity
 from homeassistant.components.template.cover import LEGACY_FIELDS as COVER_LEGACY_FIELDS
 from homeassistant.components.template.fan import LEGACY_FIELDS as FAN_LEGACY_FIELDS
 from homeassistant.components.template.helpers import (
-    async_setup_template_platform,
     rewrite_legacy_to_modern_config,
     rewrite_legacy_to_modern_configs,
 )
@@ -28,7 +26,6 @@ from homeassistant.components.template.vacuum import (
     LEGACY_FIELDS as VACUUM_LEGACY_FIELDS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.template import Template
 
 
@@ -326,19 +323,3 @@ async def test_friendly_name_template_legacy_to_modern_configs(
             "name": Template("{{ 'foo bar' }}", hass),
         }
     ] == altered_configs
-
-
-async def test_platform_not_ready(
-    hass: HomeAssistant,
-) -> None:
-    """Test async_setup_template_platform raises PlatformNotReady when trigger object is None."""
-    with pytest.raises(PlatformNotReady):
-        await async_setup_template_platform(
-            hass,
-            "button",
-            {},
-            StateButtonEntity,
-            None,
-            None,
-            {"coordinator": None, "entities": []},
-        )

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -191,7 +191,13 @@ async def test_reloadable_handles_partial_valid_config(hass: HomeAssistant) -> N
                         "value_template": "{{ states.sensor.test_sensor.state }}"
                     },
                 },
-            }
+            },
+            "template": {
+                "sensor": {
+                    "name": "my template",
+                    "state": "{{ states.sensor.test_sensor.state }}",
+                },
+            },
         },
     ],
 )
@@ -215,8 +221,9 @@ async def test_reloadable_multiple_platforms(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     assert hass.states.get("sensor.state").state == "mytest"
+    assert hass.states.get("sensor.my_template").state == "mytest"
     assert hass.states.get("binary_sensor.state").state == "off"
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 4
 
     await async_yaml_patch_helper(hass, "sensor_configuration.yaml")
     assert len(hass.states.async_all()) == 4

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -612,7 +612,7 @@ async def test_no_template_match_all(
     assert hass.states.get("sensor.invalid_attribute").state == "hello"
 
 
-@pytest.mark.parametrize(("count", "domain"), [(1, "template")])
+@pytest.mark.parametrize(("count", "domain"), [(1, "sensor")])
 @pytest.mark.parametrize(
     "config",
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is the groundwork for bringing the following functionality to the template integration:

1. Notify platform 
1. Template blueprints in the UI.
1. Template trigger entities through blueprints (in the UI)
1. Device assignment in yaml configuration.
2. Device creation in yaml configuration.
3. Multiple template entities per blueprint (currently restricted to 1 entity per blueprint)
4. Devices created from template blueprints (Yaml or UI) with multiple template entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
