### PR TITLE
Add jiecang curtain device integration support

### DIFF
--- a/homeassistant/components/my_curtain/__init__.py
+++ b/homeassistant/components/my_curtain/__init__.py
@@ -1,0 +1,53 @@
+"""My Curtain curtain integration"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+
+from .api import MyCurtainApiClient
+from .const import CONF_PASSWORD, CONF_USERNAME, DOMAIN, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set configuration items."""
+    # Create API client
+    _LOGGER.info("launch")
+    client = MyCurtainApiClient(
+        username=entry.data[CONF_USERNAME],
+        password=entry.data[CONF_PASSWORD],
+    )
+
+    # Store the client instance
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
+
+    # Set up the platform
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Set update options
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Uninstall configuration items."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Listener for updating configuration items."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/my_curtain/api.py
+++ b/homeassistant/components/my_curtain/api.py
@@ -1,0 +1,209 @@
+"""My Curtain."""
+
+import binascii
+import logging
+import asyncio
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MyCurtainApiClient:
+    """API client."""
+
+    def __init__(
+        self,
+        username: str,
+        password: str,
+    ) -> None:
+        """Initialize the API client."""
+        _LOGGER.info("Initialize the API client" + username + "#" + password)  # noqa: G003
+        self._username = username
+        self._password = password
+        self._devices = []  # 初始化为空列表，将从API获取
+        self._token = None  # 存储获取到的Token
+        self._auth_url = "https://wly87bcr9j.execute-api.cn-north-1.amazonaws.com.cn/prod/assistantLogin"
+        self._device_url = " https://wly87bcr9j.execute-api.cn-north-1.amazonaws.com.cn/prod/findDeviceByAccount"  # 设备列表URL
+        self._command_url = "https://wly87bcr9j.execute-api.cn-north-1.amazonaws.com.cn/prod/assistantSendOrder"  # 命令发送URL
+
+    async def authenticate(self) -> None:
+        """Authenticate the user and obtain a Token through an actual URL request."""
+        # Construct request parameters
+        data = {"account": self._username, "password": self._password}
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(self._auth_url, json=data) as response:
+                    result = await response.json()
+                    # Check the response status code
+                    if result.get("code") != 200:
+                        raise ValueError(
+                            f"Authentication request failed, status code: {result.get('code')}"
+                        )
+                    # Parse the response JSON to obtain the token
+                    result_data = result.get("data")
+                    token = result_data.get("token")
+                    if not token:
+                        raise ValueError(
+                            "The authentication response does not contain a Token."
+                        )
+                    # Store the Token
+                    self._token = token
+        except aiohttp.ClientError as e:
+            raise ValueError(f"Network request error: {str(e)}")
+        await asyncio.sleep(0.5)  # Simulate network delay
+
+    async def get_devices(self) -> list[dict]:
+        """Get the list of devices"""
+        # If there is no token, perform authentication first.
+        if not self._token:
+            await self.authenticate()
+
+        # Construct the request header and add the token
+        headers = {
+            "token": f"{self._token}"  # 假设使用Bearer token，根据实际API调整
+        }
+
+        # Construct the request body and add the account parameter
+        data = {}
+
+        try:
+            async with aiohttp.ClientSession() as session:  # noqa: SIM117
+                # Change to a POST request and pass the account parameter in JSON format.
+                async with session.post(
+                    self._device_url, headers=headers, json=data
+                ) as response:
+                    result = await response.json()
+                    # Check the response status code
+                    if result.get("code") != 200:
+                        raise ValueError(
+                            f"Failed to retrieve the device list, status code: {result.get('code')}"
+                        )
+
+                    # Correctly parse the nested list structure
+                    devices_data = []
+                    data_list = result.get("data", {}).get("list", [])
+
+                    # Check if the list is empty
+                    if data_list and len(data_list) > 0:
+                        # Get the first element in the list
+                        first_item = data_list[0]
+                        # Get the device list from the first element
+                        if isinstance(first_item, dict):
+                            devices_data = first_item.get("list", [])
+
+                    # Convert to internal format
+                    self._devices = self._parse_devices(devices_data)
+        except aiohttp.ClientError as e:
+            raise ValueError(
+                f"Network request error when getting the device list: {str(e)}"
+            )
+        await asyncio.sleep(0.3)  # Simulate delay
+        return self._devices
+
+    def _parse_devices(self, devices_data: list[dict]) -> list[dict]:
+        """Parse the device data returned by the API into an internal format."""
+        parsed_devices = []
+        for device in devices_data:
+            # Adjust the parsing logic according to the actual data structure returned by the API
+            parsed_device = {
+                "id": device.get("deviceId", ""),
+                "name": device.get("deviceName", ""),
+                "subID": device.get("gatewayMac", ""),
+                "type": device.get("deviceType", "curtain"),
+                "state": "idle",  # 假设初始状态为idle
+                "position": device.get("position", 50),
+                "is_open": device.get("position", 50) > 50,
+                "is_closed": device.get("position", 50) == 0,
+                "online_status": device.get("onlineStatus", 0),  # 添加在线状态
+                "battery": device.get("electric", 100),  # 添加电池电量
+                # Keep the original data for debugging purposes
+                # "raw_data": device,
+            }
+            parsed_devices.append(parsed_device)
+        return parsed_devices
+
+    async def set_device_position(self, device_id: str, position: int) -> bool:
+        """Set the device location."""
+        for device in self._devices:
+            if device["id"] == device_id:
+                device["state"] = (
+                    "opening" if position > device["position"] else "closing"
+                )
+                device["position"] = position
+                # Asynchronously execute the device operation completion logic
+                asyncio.create_task(  # noqa: RUF006
+                    self._complete_device_operation(
+                        device_id, position, f"{device['subID']}"
+                    )
+                )
+                return True
+        return False
+
+    async def _complete_device_operation(
+        self, device_id: str, position: int, subID: str
+    ) -> None:
+        """Send a request to modify the device's location."""
+        # If there is no token, perform authentication first.
+        if not self._token:
+            await self.authenticate()
+
+        # Construct request headers and add token
+        headers = {
+            "token": f"{self._token}"  # Assuming Bearer token is used, adjust according to the actual API.
+        }
+
+        # Generate control commands
+        byte_data = device_id.encode("utf-8")  # Convert to bytes
+        hex_str = binascii.hexlify(byte_data).decode(
+            "ascii"
+        )  # Convert to a hexadecimal string
+        # Revise: Convert position to a two-digit hexadecimal string
+        hex_height = f"{position:02X}"
+        # Revise: Construct a complete res string and calculate its length
+        res = f"01 {hex_str} 02 {hex_height}"
+        res_bytes = res.replace(" ", "").encode("ascii")
+        length = len(res_bytes) // 2
+
+        # Revise: Convert the length to a two-digit hexadecimal string
+        hex_length = f"{length:02X}"
+
+        # Construct a complete command
+        order = f"4A640040FF{hex_length}00{res.replace(' ', '')}"
+
+        # Calculate the checksum and append it to the end of the command
+        checksum = self.make_checksum(order)
+        order = order + checksum
+
+        # Construct the request body
+        data = {"deviceId": subID, "order": order}
+
+        try:
+            async with (
+                aiohttp.ClientSession() as session,
+                session.post(
+                    self._command_url, headers=headers, json=data
+                ) as response1,
+            ):
+                result = await response1.json()
+                if result.get("code") != 200:
+                    raise ValueError(  # noqa: TRY301
+                        f"Sending the command failed, status code: {result.get('code')}, Response: {result}"
+                    )
+        except aiohttp.ClientError as e:
+            raise ValueError(
+                f"Network request error when sending device commands: {e!s}"
+            )  # noqa: B904
+        except Exception as e:
+            raise
+
+    @staticmethod
+    def make_checksum(data: str) -> str:
+        if not data:
+            return ""
+        total = 0
+        for i in range(0, len(data), 2):
+            s = data[i : i + 2]
+            total += int(s, 16)
+        mod = total % 256
+        hex_result = hex(mod)[2:].upper().zfill(2)
+        return hex_result

--- a/homeassistant/components/my_curtain/config_flow.py
+++ b/homeassistant/components/my_curtain/config_flow.py
@@ -1,0 +1,101 @@
+"""Configuration process."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+
+from .api import MyCurtainApiClient
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Configuration process."""
+
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Process of acquiring options."""
+        return OptionsFlowHandler(config_entry)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """User steps."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                # Verify username and password
+                client = MyCurtainApiClient(
+                    username=user_input[CONF_USERNAME],
+                    password=user_input[CONF_PASSWORD],
+                )
+                await client.authenticate()
+
+                # Prevent duplicate configurations
+                await self.async_set_unique_id(DOMAIN)
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title="My Curtain",
+                    data=user_input,
+                )
+            except ValueError:
+                errors["base"] = "invalid_auth"
+            except Exception as exception:  # pylint: disable=broad-except
+                _LOGGER.error("Verification failed:", exception)
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Processing of option flow."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialization of option flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USERNAME,
+                        default=self.config_entry.data.get(CONF_USERNAME),
+                    ): str,
+                    vol.Required(
+                        CONF_PASSWORD,
+                        default=self.config_entry.data.get(CONF_PASSWORD),
+                    ): str,
+                }
+            ),
+        )

--- a/homeassistant/components/my_curtain/const.py
+++ b/homeassistant/components/my_curtain/const.py
@@ -1,0 +1,9 @@
+"""Constant definition."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "my_curtain"
+PLATFORMS = [Platform.COVER]
+
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"

--- a/homeassistant/components/my_curtain/cover.py
+++ b/homeassistant/components/my_curtain/cover.py
@@ -1,0 +1,179 @@
+"""Implementation of curtain devices."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+import logging
+import time
+from typing import Any
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .api import MyCurtainApiClient
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set the curtain entity."""
+    client = MyCurtainApiClient(
+        username=entry.data[CONF_USERNAME],
+        password=entry.data[CONF_PASSWORD],
+    )
+
+    async def async_update_data():
+        """Update device data and convert it into a dictionary structure."""
+        devices = await client.get_devices()
+        device_dict = {device["id"]: device for device in devices}
+        _LOGGER.info(f"[Key] The coordinator obtains data.: {device_dict}")
+        return device_dict
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="my_curtain_devices",
+        update_method=async_update_data,
+        update_interval=timedelta(seconds=30),
+    )
+
+    await coordinator.async_config_entry_first_refresh()
+
+    entities = []
+    for device_id in coordinator.data:
+        device_info = coordinator.data[device_id]
+        entities.append(MyCurtainEntity(coordinator, client, device_info))
+
+    async_add_entities(entities)
+
+
+class MyCurtainEntity(CoordinatorEntity, CoverEntity)
+    _attr_device_class = CoverDeviceClass.CURTAIN
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.SET_POSITION
+    )
+
+    def __init__(self, coordinator, client, device) -> None:
+        super().__init__(coordinator)
+        self._client = client
+        self._device_id = device["id"]
+        self._attr_unique_id = f"my_curtain_{device['id']}"
+        self._attr_name = device["name"]
+        self._update_from_device(device)
+
+    def _update_from_device(self, device):
+        """Update the entity status from the device data."""
+        _LOGGER.info("Update the entity status from the device data." + str(device))  # noqa: G003
+        self._attr_current_cover_position = device["position"]
+        self._attr_is_opening = device["state"] == "opening"
+        self._attr_is_closing = device["state"] == "closing"
+        self._attr_is_closed = device["is_closed"]
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": self.name,
+            "manufacturer": "My Curtain",
+            "model": "Smart Curtain",
+        }
+
+    @property
+    def extra_state_attributes(self):
+        device_data = self.coordinator.data.get(self._device_id, {})
+        return {
+            "device_id": self._device_id,
+            "device_state": device_data.get("state", "unknown"),
+        }
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """update the entity status from the device data.（0-100）."""
+        return self.coordinator.data[self._device_id].get("position")
+
+    @property
+    def is_closed(self) -> bool:
+        """Return whether the curtain is closed."""
+        return self.coordinator.data[self._device_id].get("is_closed", False)
+
+    @property
+    def is_opening(self) -> bool:
+        """Return whether the curtain is opening."""
+        return self.coordinator.data[self._device_id].get("state") == "opening"
+
+    @property
+    def is_closing(self) -> bool:
+        """Return whether the curtain is closing."""
+        return self.coordinator.data[self._device_id].get("state") == "closing"
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the curtain."""
+        _LOGGER.info("Open the curtain." + str(self))  # noqa: G003
+        await self._client.set_device_position(self._device_id, 100)
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the curtain."""
+        # _LOGGER.info("Close the curtain." + str(self))  # noqa: G003
+        await self._client.set_device_position(self._device_id, 0)
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+        await asyncio.sleep(5)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Set the curtain position."""
+        position = kwargs.get(ATTR_POSITION)
+        if position is not None:
+            await self._client.set_device_position(self._device_id, position)
+            await asyncio.sleep(5)
+            await self.coordinator.async_request_refresh()
+            await asyncio.sleep(5)
+            await self.coordinator.async_request_refresh()
+            await asyncio.sleep(5)
+            await self.coordinator.async_request_refresh()
+            await asyncio.sleep(5)
+            await self.coordinator.async_request_refresh()
+            await asyncio.sleep(5)
+            await self.coordinator.async_request_refresh()
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self.async_write_ha_state)
+        )
+        await self.async_update()

--- a/homeassistant/components/my_curtain/manifest.json
+++ b/homeassistant/components/my_curtain/manifest.json
@@ -1,0 +1,22 @@
+{
+  "domain": "my_curtain",
+  "name": "JLM Smart Blind",
+  "version": "0.0.1",
+  "documentation": "https://example.com/my_curtain",
+  "issue_tracker": "https://example.com/my_curtain/issues",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": ["jiecang"],
+  "homeassistant": "2025.8.15",
+  "iot_class": "local_polling",
+  "loggers": ["custom_components.my_curtain"],
+  "config_flow": true,
+  "integration_type": "device",
+  "is_built_in": false,
+  "release_notes": "Initial release of My Curtain integration",
+  "title": "My Curtain",
+  "description": "Control your My Curtain smart curtains",
+  "homekit": {
+    "models": ["my_curtain"]
+  }
+}

--- a/homeassistant/components/my_curtain/quality_scale.yaml
+++ b/homeassistant/components/my_curtain/quality_scale.yaml
@@ -1,0 +1,74 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: no actions
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: no actions
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: entities do not explicitly subscribe to events
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info:
+    status: exempt
+    comment: Network information not relevant
+  discovery:
+    status: exempt
+    comment: There are a ton of mac address ranges in use, but also by kindles which are not supported by this integration
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices: todo
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: no known use cases for repair issues or flows, yet
+  stale-devices:
+    status: todo
+    comment: automate the cleanup process
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/tests/components/my_curtain/__init__.py
+++ b/tests/components/my_curtain/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the my_curtain integration."""

--- a/tests/components/my_curtain/test_cover.py
+++ b/tests/components/my_curtain/test_cover.py
@@ -1,0 +1,166 @@
+                                                                                                                                                                                                                                                """Test Alexa cover capabilities."""
+
+import pytest
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_POSITION,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+)
+from homeassistant.core import HomeAssistant
+
+from .test_common import (
+    assert_request_calls_service,
+    assert_request_fails,
+    get_default_config,
+    get_new_request,
+    reported_properties,
+)
+
+
+async def test_discovery_cover(hass: HomeAssistant) -> None:
+    """Test discovery for a cover entity."""
+    request = get_new_request("Alexa.Discovery", "Discover")
+    #  setup test cover device
+    hass.states.async_set(
+        "cover.test",
+        STATE_OPEN,
+        {
+            "friendly_name": "Test Curtain",
+            ATTR_CURRENT_POSITION: 80,
+            "supported_features": 15,  # 支持打开、关闭、停止、设置位置
+        },
+    )
+    msg = await smart_home.async_handle_message(hass, get_default_config(hass), request)
+    assert "event" in msg
+    msg = msg["event"]
+    assert len(msg["payload"]["endpoints"]) == 1
+    endpoint = msg["payload"]["endpoints"][0]
+    assert endpoint["endpointId"] == "cover#test"
+    interfaces = {capability["interface"] for capability in endpoint["capabilities"]}
+    assert "Alexa.PowerController" in interfaces
+    assert "Alexa.RangeController" in interfaces
+
+
+async def test_api_open_cover(hass: HomeAssistant) -> None:
+    """Test opening a cover."""
+    call, _ = await assert_request_calls_service(
+        "Alexa.PowerController",
+        "TurnOn",
+        "cover#test",
+        "cover.open_cover",
+        hass,
+    )
+    assert call.data["entity_id"] == "cover.test"
+
+
+async def test_api_close_cover(hass: HomeAssistant) -> None:
+    """Test closing a cover."""
+    call, _ = await assert_request_calls_service(
+        "Alexa.PowerController",
+        "TurnOff",
+        "cover#test",
+        "cover.close_cover",
+        hass,
+    )
+    assert call.data["entity_id"] == "cover.test"
+
+
+async def test_api_stop_cover(hass: HomeAssistant) -> None:
+    """Test stopping a cover."""
+    call, _ = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "AdjustRangeValue",
+        "cover#test",
+        "cover.stop_cover",
+        hass,
+        payload={"rangeValueDelta": 0, "unit": "percentage"},
+        instance="Cover.Position",
+    )
+    assert call.data["entity_id"] == "cover.test"
+
+
+@pytest.mark.parametrize("position", [0, 50, 100])
+async def test_api_set_cover_position(hass: HomeAssistant, position: int) -> None:
+    """Test setting cover position."""
+    call, _ = await assert_request_calls_service(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "cover#test",
+        "cover.set_cover_position",
+        hass,
+        payload={"rangeValue": position, "unit": "percentage"},
+        instance="Cover.Position",
+    )
+    assert call.data["entity_id"] == "cover.test"
+    assert call.data[ATTR_POSITION] == position
+
+
+async def test_api_set_invalid_position(hass: HomeAssistant) -> None:
+    """Test setting invalid cover position (out of 0-100 range)."""
+    await assert_request_fails(
+        "Alexa.RangeController",
+        "SetRangeValue",
+        "cover#test",
+        "cover.set_cover_position",
+        hass,
+        payload={"rangeValue": 150, "unit": "percentage"},
+        instance="Cover.Position",
+    )
+
+
+async def test_reported_properties(hass: HomeAssistant) -> None:
+    """Test reported properties for cover."""
+    hass.states.async_set(
+        "cover.test",
+        STATE_OPEN,
+        {
+            ATTR_CURRENT_POSITION: 30,
+            "friendly_name": "Test Curtain",
+        },
+    )
+    props = await reported_properties(hass, "cover#test")
+    props.assert_equal("Alexa.RangeController", "rangeValue", 30)
+    props.assert_equal("Alexa.PowerController", "powerState", "ON")
+
+    hass.states.async_set(
+        "cover.test",
+        STATE_CLOSED,
+        {
+            ATTR_CURRENT_POSITION: 0,
+            "friendly_name": "Test Curtain",
+        },
+    )
+    props = await reported_properties(hass, "cover#test")
+    props.assert_equal("Alexa.RangeController", "rangeValue", 0)
+    props.assert_equal("Alexa.PowerController", "powerState", "OFF")
+
+
+async def test_cover_in_transition(hass: HomeAssistant) -> None:
+    """Test cover in opening/closing state reports correct properties."""
+    hass.states.async_set(
+        "cover.test",
+        STATE_OPENING,
+        {
+            ATTR_CURRENT_POSITION: 50,
+            "friendly_name": "Test Curtain",
+        },
+    )
+    props = await reported_properties(hass, "cover#test")
+    props.assert_equal("Alexa.RangeController", "rangeValue", 50)
+    props.assert_equal("Alexa.PowerController", "powerState", "ON")
+
+    hass.states.async_set(
+        "cover.test",
+        STATE_CLOSING,
+        {
+            ATTR_CURRENT_POSITION: 50,
+            "friendly_name": "Test Curtain",
+        },
+    )
+    props = await reported_properties(hass, "cover#test")
+    props.assert_equal("Alexa.RangeController", "rangeValue", 50)
+    props.assert_equal("Alexa.PowerController", "powerState", "ON")

--- a/tests/components/my_curtain/test_init.py
+++ b/tests/components/my_curtain/test_init.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import patch
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.components.my_curtain import (
+    async_setup_entry,
+    async_unload_entry,
+    update_listener,
+    DOMAIN,
+    PLATFORMS,
+)
+from homeassistant.components.my_curtain.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.components.my_curtain.api import MyCurtainApiClient
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry(hass: HomeAssistant):
+    entry = ConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "test_user", CONF_PASSWORD: "test_password"},
+        entry_id="test_entry_id",
+    )
+    with (
+        patch.object(MyCurtainApiClient, "__init__", return_value=None),
+        patch.object(hass.config_entries, "async_forward_entry_setups"),
+        patch.object(entry, "add_update_listener"),
+    ):
+        result = await async_setup_entry(hass, entry)
+        assert result is True
+        assert entry.entry_id in hass.data[DOMAIN]
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry(hass: HomeAssistant):
+    entry = ConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "test_user", CONF_PASSWORD: "test_password"},
+        entry_id="test_entry_id",
+    )
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = "test_client"
+    with patch.object(hass.config_entries, "async_unload_platforms", return_value=True):
+        result = await async_unload_entry(hass, entry)
+        assert result is True
+        assert entry.entry_id not in hass.data[DOMAIN]
+
+
+@pytest.mark.asyncio
+async def test_update_listener(hass: HomeAssistant):
+    entry = ConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "test_user", CONF_PASSWORD: "test_password"},
+        entry_id="test_entry_id",
+    )
+    with patch.object(hass.config_entries, "async_reload") as mock_reload:
+        await update_listener(hass, entry)
+        mock_reload.assert_called_once_with(entry.entry_id)


### PR DESCRIPTION
## Proposed change
Add integration support for JieCang curtain devices that work with the Blindzoom App. This integration enables users to connect and control JieCang curtain devices through Home Assistant, supporting core functionalities including:
- Opening and closing curtains
- Stopping curtain movement
- Setting precise curtain positions (0-100%)
- Real-time status synchronization (current position, operating state)
- Compatibility with Blindzoom App communication protocols

This allows users to seamlessly integrate their existing JieCang curtain devices (configured via Blindzoom App) into Home Assistant automations and dashboards.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR adds support for JieCang curtain devices that use the Blindzoom App for control
- Link to documentation pull request: [Will be submitted separately to home-assistant.io]
- Link to developer documentation pull request: [Pending]

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr