### PR TITLE
Bump airOS to 0.3.0

### DIFF
--- a/homeassistant/components/airos/manifest.json
+++ b/homeassistant/components/airos/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airos",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["airos==0.2.11"]
+  "requirements": ["airos==0.3.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -453,7 +453,7 @@ airgradient==0.9.2
 airly==1.1.0
 
 # homeassistant.components.airos
-airos==0.2.11
+airos==0.3.0
 
 # homeassistant.components.airthings_ble
 airthings-ble==0.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -435,7 +435,7 @@ airgradient==0.9.2
 airly==1.1.0
 
 # homeassistant.components.airos
-airos==0.2.11
+airos==0.3.0
 
 # homeassistant.components.airthings_ble
 airthings-ble==0.9.2

--- a/tests/components/airos/fixtures/airos_loco5ac_ap-ptp.json
+++ b/tests/components/airos/fixtures/airos_loco5ac_ap-ptp.json
@@ -13,8 +13,10 @@
     "access_point": true,
     "mac": "01:23:45:67:89:AB",
     "mac_interface": "br0",
+    "mode": "point_to_point",
     "ptmp": false,
     "ptp": true,
+    "role": "access_point",
     "station": false
   },
   "firewall": {
@@ -25,9 +27,14 @@
   },
   "genuine": "/images/genuine.png",
   "gps": {
+    "alt": null,
+    "dim": null,
+    "dop": null,
     "fix": 0,
     "lat": 52.379894,
-    "lon": 4.901608
+    "lon": 4.901608,
+    "sats": null,
+    "time_synced": null
   },
   "host": {
     "cpuload": 10.10101,

--- a/tests/components/airos/snapshots/test_diagnostics.ambr
+++ b/tests/components/airos/snapshots/test_diagnostics.ambr
@@ -16,8 +16,10 @@
         'access_point': True,
         'mac': '**REDACTED**',
         'mac_interface': 'br0',
+        'mode': 'point_to_point',
         'ptmp': False,
         'ptp': True,
+        'role': 'access_point',
         'station': False,
       }),
       'firewall': dict({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Not intended as a bug fix for patches (i.e. 0.2.11 is still valid for current release)

Update dependency to enable [FR sensors](https://github.com/orgs/home-assistant/discussions/624) requested
 - From the original `sensor` PR; rework of 'Station or Accesspoint' (as enum) and mode (PTP/PTMP) (as enum) (fixture diff has both these and earlier added (but not HA used) GPS data)
 - Addition of `warnings` and (non-forced) `update` check for basic FR on available

https://github.com/CoMPaTech/python-airos/compare/v0.2.11...v0.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
