### PR TITLE
Improve handling decode errors in rest

### DIFF
--- a/homeassistant/components/rest/data.py
+++ b/homeassistant/components/rest/data.py
@@ -45,6 +45,7 @@ class RestData:
         self._method = method
         self._resource = resource
         self._encoding = encoding
+        self._force_use_set_encoding = False
 
         # Convert auth tuple to aiohttp.BasicAuth if needed
         if isinstance(auth, tuple) and len(auth) == 2:
@@ -152,10 +153,19 @@ class RestData:
                 # Read the response
                 # Only use configured encoding if no charset in Content-Type header
                 # If charset is present in Content-Type, let aiohttp use it
-                if response.charset:
+                if self._force_use_set_encoding is False and response.charset:
                     # Let aiohttp use the charset from Content-Type header
-                    self.data = await response.text()
-                else:
+                    try:
+                        self.data = await response.text()
+                    except UnicodeDecodeError as ex:
+                        self._force_use_set_encoding = True
+                        _LOGGER.debug(
+                            "Response charset came back as %s but could not be decoded, continue with configured encoding %s. %s",
+                            response.charset,
+                            self._encoding,
+                            ex,
+                        )
+                if self._force_use_set_encoding or not response.charset:
                     # Use configured encoding as fallback
                     self.data = await response.text(encoding=self._encoding)
                 self.headers = response.headers

--- a/tests/components/rest/test_data.py
+++ b/tests/components/rest/test_data.py
@@ -1,13 +1,17 @@
 """Test REST data module logging improvements."""
 
+from datetime import timedelta
 import logging
+from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.rest import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.common import async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -87,6 +91,59 @@ async def test_rest_data_no_warning_on_200_with_wrong_content_type(
     assert (
         "REST request to http://example.com/api returned status 200" not in caplog.text
     )
+
+
+async def test_rest_data_with_incorrect_charset_in_header(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that no warning is logged for 200 status with wrong content."""
+    aioclient_mock.get(
+        "http://example.com/api",
+        status=200,
+        text="<p>Some html</p>",
+        headers={"Content-Type": "text/html; charset=utf-8"},
+    )
+
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "resource": "http://example.com/api",
+                "method": "GET",
+                "encoding": "windows-1250",
+                "sensor": [
+                    {
+                        "name": "test_sensor",
+                        "value_template": "{{ value }}",
+                    }
+                ],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    with patch(
+        "tests.test_util.aiohttp.AiohttpClientMockResponse.text",
+        side_effect=UnicodeDecodeError("utf-8", b"", 1, 0, ""),
+    ):
+        freezer.tick(timedelta(minutes=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    log_text = "Response charset came back as utf-8 but could not be decoded, continue with configured encoding windows-1250."
+    assert log_text in caplog.text
+
+    caplog.clear()
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Only log once as we only try once with automatic decoding
+    assert log_text not in caplog.text
 
 
 async def test_rest_data_no_warning_on_success_json(

--- a/tests/components/rest/test_data.py
+++ b/tests/components/rest/test_data.py
@@ -99,7 +99,7 @@ async def test_rest_data_with_incorrect_charset_in_header(
     caplog: pytest.LogCaptureFixture,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that no warning is logged for 200 status with wrong content."""
+    """Test that we can handle sites which provides an incorrect charset."""
     aioclient_mock.get(
         "http://example.com/api",
         status=200,


### PR DESCRIPTION
## Breaking change


## Proposed change
Improves the handling of decode errors in rest when websites provide a charset which does not match the real encoding of the provided text.
See example in linked issue.

Only try once to use automatic encoding, fallback to provided encoding (which also defaults to `utf-8`

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #148712
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 