### PR TITLE
Use media_selector for media_player.play_media

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -161,6 +161,8 @@ CACHE_LOCK: Final = "lock"
 CACHE_URL: Final = "url"
 CACHE_CONTENT: Final = "content"
 
+ATTR_MEDIA = "media"
+
 
 class MediaPlayerEnqueue(StrEnum):
     """Enqueue types for playing media."""
@@ -198,6 +200,23 @@ _DEPRECATED_DEVICE_CLASS_RECEIVER = DeprecatedConstantEnum(
     MediaPlayerDeviceClass.RECEIVER, "2025.10"
 )
 DEVICE_CLASSES = [cls.value for cls in MediaPlayerDeviceClass]
+
+
+def _promote_media_fields(data: dict[str, Any]) -> dict[str, Any]:
+    """If 'media' key exists, promote its fields to the top level."""
+    if ATTR_MEDIA in data and isinstance(data[ATTR_MEDIA], dict):
+        media_data = data[ATTR_MEDIA]
+        # Only overwrite if not already present
+        if (
+            ATTR_MEDIA_CONTENT_TYPE not in data
+            and ATTR_MEDIA_CONTENT_TYPE in media_data
+        ):
+            data[ATTR_MEDIA_CONTENT_TYPE] = media_data[ATTR_MEDIA_CONTENT_TYPE]
+        if ATTR_MEDIA_CONTENT_ID not in data and ATTR_MEDIA_CONTENT_ID in media_data:
+            data[ATTR_MEDIA_CONTENT_ID] = media_data[ATTR_MEDIA_CONTENT_ID]
+
+        del data[ATTR_MEDIA]
+    return data
 
 
 MEDIA_PLAYER_PLAY_MEDIA_SCHEMA = {
@@ -436,6 +455,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     component.async_register_entity_service(
         SERVICE_PLAY_MEDIA,
         vol.All(
+            _promote_media_fields,
             cv.make_entity_service_schema(MEDIA_PLAYER_PLAY_MEDIA_SCHEMA),
             _rewrite_enqueue,
             _rename_keys(

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -205,14 +205,15 @@ DEVICE_CLASSES = [cls.value for cls in MediaPlayerDeviceClass]
 def _promote_media_fields(data: dict[str, Any]) -> dict[str, Any]:
     """If 'media' key exists, promote its fields to the top level."""
     if ATTR_MEDIA in data and isinstance(data[ATTR_MEDIA], dict):
+        if ATTR_MEDIA_CONTENT_TYPE in data or ATTR_MEDIA_CONTENT_ID in data:
+            raise vol.Invalid(
+                f"Play media cannot contain '{ATTR_MEDIA}' and '{ATTR_MEDIA_CONTENT_ID}' or '{ATTR_MEDIA_CONTENT_TYPE}'"
+            )
         media_data = data[ATTR_MEDIA]
-        # Only overwrite if not already present
-        if (
-            ATTR_MEDIA_CONTENT_TYPE not in data
-            and ATTR_MEDIA_CONTENT_TYPE in media_data
-        ):
+
+        if ATTR_MEDIA_CONTENT_TYPE in media_data:
             data[ATTR_MEDIA_CONTENT_TYPE] = media_data[ATTR_MEDIA_CONTENT_TYPE]
-        if ATTR_MEDIA_CONTENT_ID not in data and ATTR_MEDIA_CONTENT_ID in media_data:
+        if ATTR_MEDIA_CONTENT_ID in media_data:
             data[ATTR_MEDIA_CONTENT_ID] = media_data[ATTR_MEDIA_CONTENT_ID]
 
         del data[ATTR_MEDIA]

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -131,17 +131,13 @@ play_media:
       supported_features:
         - media_player.MediaPlayerEntityFeature.PLAY_MEDIA
   fields:
-    media_content_id:
+    media:
       required: true
-      example: "https://home-assistant.io/images/cast/splash.png"
       selector:
-        text:
-
-    media_content_type:
-      required: true
-      example: "music"
-      selector:
-        text:
+        media:
+      example:
+        media_content_id: "https://home-assistant.io/images/cast/splash.png"
+        media_content_type: "music"
 
     enqueue:
       filter:

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -242,13 +242,9 @@
       "name": "Play media",
       "description": "Starts playing specified media.",
       "fields": {
-        "media_content_id": {
-          "name": "Content ID",
-          "description": "The ID of the content to play. Platform dependent."
-        },
-        "media_content_type": {
-          "name": "Content type",
-          "description": "The type of the content to play, such as image, music, tv show, video, episode, channel, or playlist."
+        "media": {
+          "name": "Media",
+          "description": "The media selected to play."
         },
         "enqueue": {
           "name": "Enqueue",

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -654,3 +654,41 @@ async def test_get_async_get_browse_image_quoting(
         url = player.get_browse_image_url("album", media_content_id)
         await client.get(url)
         mock_browse_image.assert_called_with("album", media_content_id, None)
+
+
+async def test_play_media_via_selector(hass: HomeAssistant) -> None:
+    """Test that play_media data under 'media' is remapped to top level keys for backward compatibility."""
+    await async_setup_component(
+        hass, "media_player", {"media_player": {"platform": "demo"}}
+    )
+    await hass.async_block_till_done()
+
+    # Fake group support for DemoYoutubePlayer
+    with patch(
+        "homeassistant.components.demo.media_player.DemoYoutubePlayer.play_media",
+    ) as mock_play_media:
+        await hass.services.async_call(
+            "media_player",
+            "play_media",
+            {
+                "entity_id": "media_player.bedroom",
+                "media": {
+                    "media_content_type": "music",
+                    "media_content_id": "1234",
+                },
+            },
+            blocking=True,
+        )
+        await hass.services.async_call(
+            "media_player",
+            "play_media",
+            {
+                "entity_id": "media_player.bedroom",
+                "media_content_type": "music",
+                "media_content_id": "1234",
+            },
+            blocking=True,
+        )
+
+    assert len(mock_play_media.mock_calls) == 2
+    assert mock_play_media.mock_calls[0].args == mock_play_media.mock_calls[1].args

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -692,3 +692,18 @@ async def test_play_media_via_selector(hass: HomeAssistant) -> None:
 
     assert len(mock_play_media.mock_calls) == 2
     assert mock_play_media.mock_calls[0].args == mock_play_media.mock_calls[1].args
+
+    with pytest.raises(vol.Invalid, match="Play media cannot contain 'media'"):
+        await hass.services.async_call(
+            "media_player",
+            "play_media",
+            {
+                "media_content_id": "1234",
+                "entity_id": "media_player.bedroom",
+                "media": {
+                    "media_content_type": "music",
+                    "media_content_id": "1234",
+                },
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Attempt to fix media_player.play_media to use the media selector. This requires some migration in both frontend and backend. 

Currently, media_player.play_media just provides two text inputs for ID and type, which is nearly impossible to use as an end user, as we make it extremely difficult to extract the actual ID for a media anywhere, it seems not intended to be user visible. 

Frontend does attempt to provide a hacky custom frontend to this service, but it doesn't really work, and ends up creating two duplicate entries for play_media, and also it can't be used in developer-tools/action, or in a frontend card action.

To clean this up, I will attempt the following, in both core and frontend:

- Change the service to remove those two fields, and replace it with a single `media` field, which will consume the single object output from the media selector. 
- Change the media selector to optionally take it's entity_id as a context from the service target. 
- To avoid a breaking change, we will still support service calls with `media_content_id` as a top level data item, we will just use a preprocessor in the service to convert both methods to the same format. 
- To avoid breaking the automation editor, if we have existing actions using `media_content_id` as a top level data item, migrate this to use the new `media` format, which will allow using the media browser in legacy scripts. 
- Remove the customized frontend element for the play_media action.

New UI (button launches the media browser):

<img width="818" height="434" alt="image" src="https://github.com/user-attachments/assets/adbe585b-6a95-4dd0-9305-03e028737d31" />

Selected element:
<img width="825" height="437" alt="image" src="https://github.com/user-attachments/assets/cc076e3e-7e5c-45db-9cb0-940658094804" />

Non browsable media player will still have fields:
<img width="823" height="620" alt="image" src="https://github.com/user-attachments/assets/c0f9f71a-59f2-47b3-8437-4007e27a8c5c" />


I can work on writing more tests but would like some initial feedback to bless this approach. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/20817

- This PR is related to issue: 
https://community.home-assistant.io/t/wth-why-is-putting-media-playback-on-a-dashboard-so-difficult/809565
https://community.home-assistant.io/t/wth-is-it-so-difficult-to-find-the-media-content-id-in-the-media-browser/804365
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/26559

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
