### PR TITLE
Use constants in Tuya tests

### DIFF
--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -9,13 +9,16 @@ from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
 from homeassistant.components.climate import (
+    ATTR_FAN_MODE,
+    ATTR_HUMIDITY,
+    ATTR_TEMPERATURE,
     DOMAIN as CLIMATE_DOMAIN,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_TEMPERATURE,
 )
 from homeassistant.components.tuya import ManagerCompat
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotSupported
 from homeassistant.helpers import entity_registry as er
@@ -60,11 +63,11 @@ async def test_set_temperature(
         CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {
-            "entity_id": entity_id,
-            "temperature": 22.7,
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_TEMPERATURE: 22.7,
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id, [{"code": "temp_set", "value": 22}]
     )
@@ -86,16 +89,16 @@ async def test_fan_mode_windspeed(
 
     state = hass.states.get(entity_id)
     assert state is not None, f"{entity_id} does not exist"
-    assert state.attributes["fan_mode"] == 1
+    assert state.attributes[ATTR_FAN_MODE] == 1
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_FAN_MODE,
         {
-            "entity_id": entity_id,
-            "fan_mode": 2,
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_FAN_MODE: 2,
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id, [{"code": "windspeed", "value": "2"}]
     )
@@ -122,14 +125,14 @@ async def test_fan_mode_no_valid_code(
 
     state = hass.states.get(entity_id)
     assert state is not None, f"{entity_id} does not exist"
-    assert state.attributes.get("fan_mode") is None
+    assert state.attributes.get(ATTR_FAN_MODE) is None
     with pytest.raises(ServiceNotSupported):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_FAN_MODE,
             {
-                "entity_id": entity_id,
-                "fan_mode": 2,
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_FAN_MODE: 2,
             },
             blocking=True,
         )
@@ -156,8 +159,8 @@ async def test_set_humidity_not_supported(
             CLIMATE_DOMAIN,
             SERVICE_SET_HUMIDITY,
             {
-                "entity_id": entity_id,
-                "humidity": 50,
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_HUMIDITY: 50,
             },
             blocking=True,
         )

--- a/tests/components/tuya/test_cover.py
+++ b/tests/components/tuya/test_cover.py
@@ -9,6 +9,9 @@ from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
 from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
@@ -16,7 +19,7 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_TILT_POSITION,
 )
 from homeassistant.components.tuya import ManagerCompat
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotSupported
 from homeassistant.helpers import entity_registry as er
@@ -62,10 +65,10 @@ async def test_open_service(
         COVER_DOMAIN,
         SERVICE_OPEN_COVER,
         {
-            "entity_id": entity_id,
+            ATTR_ENTITY_ID: entity_id,
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id,
         [
@@ -96,10 +99,10 @@ async def test_close_service(
         COVER_DOMAIN,
         SERVICE_CLOSE_COVER,
         {
-            "entity_id": entity_id,
+            ATTR_ENTITY_ID: entity_id,
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id,
         [
@@ -129,11 +132,11 @@ async def test_set_position(
         COVER_DOMAIN,
         SERVICE_SET_COVER_POSITION,
         {
-            "entity_id": entity_id,
-            "position": 25,
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_POSITION: 25,
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id,
         [
@@ -173,7 +176,7 @@ async def test_percent_state_on_cover(
 
     state = hass.states.get(entity_id)
     assert state is not None, f"{entity_id} does not exist"
-    assert state.attributes["current_position"] == percent_state
+    assert state.attributes[ATTR_CURRENT_POSITION] == percent_state
 
 
 @pytest.mark.parametrize(
@@ -197,8 +200,8 @@ async def test_set_tilt_position_not_supported(
             COVER_DOMAIN,
             SERVICE_SET_COVER_TILT_POSITION,
             {
-                "entity_id": entity_id,
-                "tilt_position": 50,
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_TILT_POSITION: 50,
             },
             blocking=True,
         )

--- a/tests/components/tuya/test_humidifier.py
+++ b/tests/components/tuya/test_humidifier.py
@@ -9,13 +9,14 @@ from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
 from homeassistant.components.humidifier import (
+    ATTR_HUMIDITY,
     DOMAIN as HUMIDIFIER_DOMAIN,
     SERVICE_SET_HUMIDITY,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
 from homeassistant.components.tuya import ManagerCompat
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
@@ -59,9 +60,9 @@ async def test_turn_on(
     await hass.services.async_call(
         HUMIDIFIER_DOMAIN,
         SERVICE_TURN_ON,
-        {"entity_id": entity_id},
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id, [{"code": "switch", "value": True}]
     )
@@ -86,9 +87,9 @@ async def test_turn_off(
     await hass.services.async_call(
         HUMIDIFIER_DOMAIN,
         SERVICE_TURN_OFF,
-        {"entity_id": entity_id},
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id, [{"code": "switch", "value": False}]
     )
@@ -114,11 +115,11 @@ async def test_set_humidity(
         HUMIDIFIER_DOMAIN,
         SERVICE_SET_HUMIDITY,
         {
-            "entity_id": entity_id,
-            "humidity": 50,
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_HUMIDITY: 50,
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id, [{"code": "dehumidify_set_value", "value": 50}]
     )
@@ -149,7 +150,7 @@ async def test_turn_on_unsupported(
         await hass.services.async_call(
             HUMIDIFIER_DOMAIN,
             SERVICE_TURN_ON,
-            {"entity_id": entity_id},
+            {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
     assert err.value.translation_key == "action_dpcode_not_found"
@@ -184,7 +185,7 @@ async def test_turn_off_unsupported(
         await hass.services.async_call(
             HUMIDIFIER_DOMAIN,
             SERVICE_TURN_OFF,
-            {"entity_id": entity_id},
+            {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
     assert err.value.translation_key == "action_dpcode_not_found"
@@ -220,8 +221,8 @@ async def test_set_humidity_unsupported(
             HUMIDIFIER_DOMAIN,
             SERVICE_SET_HUMIDITY,
             {
-                "entity_id": entity_id,
-                "humidity": 50,
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_HUMIDITY: 50,
             },
             blocking=True,
         )

--- a/tests/components/tuya/test_light.py
+++ b/tests/components/tuya/test_light.py
@@ -10,12 +10,14 @@ from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
 from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_WHITE,
     DOMAIN as LIGHT_DOMAIN,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
 from homeassistant.components.tuya import ManagerCompat
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -48,7 +50,7 @@ async def test_platform_setup_and_discovery(
     [
         (
             {
-                "white": True,
+                ATTR_WHITE: True,
             },
             [
                 {"code": "switch_led", "value": True},
@@ -58,7 +60,7 @@ async def test_platform_setup_and_discovery(
         ),
         (
             {
-                "brightness": 150,
+                ATTR_BRIGHTNESS: 150,
             },
             [
                 {"code": "switch_led", "value": True},
@@ -67,8 +69,8 @@ async def test_platform_setup_and_discovery(
         ),
         (
             {
-                "white": True,
-                "brightness": 150,
+                ATTR_WHITE: True,
+                ATTR_BRIGHTNESS: 150,
             },
             [
                 {"code": "switch_led", "value": True},
@@ -78,7 +80,7 @@ async def test_platform_setup_and_discovery(
         ),
         (
             {
-                "white": 150,
+                ATTR_WHITE: 150,
             },
             [
                 {"code": "switch_led", "value": True},
@@ -106,11 +108,11 @@ async def test_turn_on_white(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            "entity_id": entity_id,
+            ATTR_ENTITY_ID: entity_id,
             **turn_on_input,
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id,
         expected_commands,
@@ -137,10 +139,10 @@ async def test_turn_off(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
         {
-            "entity_id": entity_id,
+            ATTR_ENTITY_ID: entity_id,
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id, [{"code": "switch_led", "value": False}]
     )

--- a/tests/components/tuya/test_number.py
+++ b/tests/components/tuya/test_number.py
@@ -8,9 +8,13 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
-from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, SERVICE_SET_VALUE
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
 from homeassistant.components.tuya import ManagerCompat
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
@@ -55,11 +59,11 @@ async def test_set_value(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
         {
-            "entity_id": entity_id,
-            "value": 18,
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_VALUE: 18,
         },
+        blocking=True,
     )
-    await hass.async_block_till_done()
     mock_manager.send_commands.assert_called_once_with(
         mock_device.id, [{"code": "delay_set", "value": 18}]
     )
@@ -91,8 +95,8 @@ async def test_set_value_no_function(
             NUMBER_DOMAIN,
             SERVICE_SET_VALUE,
             {
-                "entity_id": entity_id,
-                "value": 18,
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_VALUE: 18,
             },
             blocking=True,
         )

--- a/tests/components/tuya/test_select.py
+++ b/tests/components/tuya/test_select.py
@@ -9,11 +9,12 @@ from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
 from homeassistant.components.select import (
+    ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.components.tuya import ManagerCompat
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
@@ -58,8 +59,8 @@ async def test_select_option(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {
-            "entity_id": entity_id,
-            "option": "forward",
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_OPTION: "forward",
         },
         blocking=True,
     )
@@ -89,8 +90,8 @@ async def test_select_invalid_option(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
-                "entity_id": entity_id,
-                "option": "hello",
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_OPTION: "hello",
             },
             blocking=True,
         )

--- a/tests/components/tuya/test_vacuum.py
+++ b/tests/components/tuya/test_vacuum.py
@@ -13,7 +13,7 @@ from homeassistant.components.vacuum import (
     DOMAIN as VACUUM_DOMAIN,
     SERVICE_RETURN_TO_BASE,
 )
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -58,7 +58,7 @@ async def test_return_home(
         VACUUM_DOMAIN,
         SERVICE_RETURN_TO_BASE,
         {
-            "entity_id": entity_id,
+            ATTR_ENTITY_ID: entity_id,
         },
         blocking=True,
     )

--- a/tests/components/tuya/test_valve.py
+++ b/tests/components/tuya/test_valve.py
@@ -14,7 +14,7 @@ from homeassistant.components.valve import (
     SERVICE_CLOSE_VALVE,
     SERVICE_OPEN_VALVE,
 )
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -58,7 +58,7 @@ async def test_open_valve(
         VALVE_DOMAIN,
         SERVICE_OPEN_VALVE,
         {
-            "entity_id": entity_id,
+            ATTR_ENTITY_ID: entity_id,
         },
         blocking=True,
     )
@@ -87,7 +87,7 @@ async def test_close_valve(
         VALVE_DOMAIN,
         SERVICE_CLOSE_VALVE,
         {
-            "entity_id": entity_id,
+            ATTR_ENTITY_ID: entity_id,
         },
         blocking=True,
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, and make service calls blocking to drop `async_block_till_done`

As spotted/requested by @joostlek 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
