### PR TITLE
Remove filters from device analytics payload

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -390,7 +390,6 @@ def _domains_from_yaml_config(yaml_configuration: dict[str, Any]) -> set[str]:
 
 async def async_devices_payload(hass: HomeAssistant) -> dict:
     """Return the devices payload."""
-    integrations_without_model_id: set[str] = set()
     devices: list[dict[str, Any]] = []
     dev_reg = dr.async_get(hass)
     # Devices that need via device info set
@@ -400,10 +399,6 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
     seen_integrations = set()
 
     for device in dev_reg.devices.values():
-        # Ignore services
-        if device.entry_type:
-            continue
-
         if not device.primary_config_entry:
             continue
 
@@ -413,13 +408,6 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
             continue
 
         seen_integrations.add(config_entry.domain)
-
-        if not device.model_id:
-            integrations_without_model_id.add(config_entry.domain)
-            continue
-
-        if not device.manufacturer:
-            continue
 
         new_indexes[device.id] = len(devices)
         devices.append(
@@ -432,8 +420,10 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
                 "hw_version": device.hw_version,
                 "has_configuration_url": device.configuration_url is not None,
                 "via_device": None,
+                "entry_type": device.entry_type.value if device.entry_type else None,
             }
         )
+
         if device.via_device_id:
             via_devices[device.id] = device.via_device_id
 
@@ -453,15 +443,11 @@ async def async_devices_payload(hass: HomeAssistant) -> dict:
     for device_info in devices:
         if integration := integrations.get(device_info["integration"]):
             device_info["is_custom_integration"] = not integration.is_built_in
+            # Include version for custom integrations
+            if not integration.is_built_in and integration.version:
+                device_info["custom_integration_version"] = str(integration.version)
 
     return {
         "version": "home-assistant:1",
-        "no_model_id": sorted(
-            [
-                domain
-                for domain in integrations_without_model_id
-                if domain in integrations and integrations[domain].is_built_in
-            ]
-        ),
         "devices": devices,
     }

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -975,6 +975,7 @@ async def test_submitting_legacy_integrations(
     assert snapshot == submitted_data
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_devices_payload(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -984,14 +985,16 @@ async def test_devices_payload(
     assert await async_setup_component(hass, "analytics", {})
     assert await async_devices_payload(hass) == {
         "version": "home-assistant:1",
-        "no_model_id": [],
         "devices": [],
     }
 
     mock_config_entry = MockConfigEntry(domain="hue")
     mock_config_entry.add_to_hass(hass)
 
-    # Normal entry
+    mock_custom_config_entry = MockConfigEntry(domain="test")
+    mock_custom_config_entry.add_to_hass(hass)
+
+    # Normal device with all fields
     device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("device", "1")},
@@ -1005,7 +1008,7 @@ async def test_devices_payload(
         configuration_url="http://example.com/config",
     )
 
-    # Ignored because service type
+    # Service type device
     device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("device", "2")},
@@ -1014,7 +1017,7 @@ async def test_devices_payload(
         entry_type=dr.DeviceEntryType.SERVICE,
     )
 
-    # Ignored because no model id
+    # Device without model_id
     no_model_id_config_entry = MockConfigEntry(domain="no_model_id")
     no_model_id_config_entry.add_to_hass(hass)
     device_registry.async_get_or_create(
@@ -1023,14 +1026,14 @@ async def test_devices_payload(
         manufacturer="test-manufacturer",
     )
 
-    # Ignored because no manufacturer
+    # Device without manufacturer
     device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("device", "5")},
         model_id="test-model-id",
     )
 
-    # Entry with via device
+    # Device with via_device reference
     device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("device", "6")},
@@ -1039,9 +1042,16 @@ async def test_devices_payload(
         via_device=("device", "1"),
     )
 
+    # Device from custom integration
+    device_registry.async_get_or_create(
+        config_entry_id=mock_custom_config_entry.entry_id,
+        identifiers={("device", "7")},
+        manufacturer="test-manufacturer7",
+        model_id="test-model-id7",
+    )
+
     assert await async_devices_payload(hass) == {
         "version": "home-assistant:1",
-        "no_model_id": [],
         "devices": [
             {
                 "manufacturer": "test-manufacturer",
@@ -1053,6 +1063,42 @@ async def test_devices_payload(
                 "is_custom_integration": False,
                 "has_configuration_url": True,
                 "via_device": None,
+                "entry_type": None,
+            },
+            {
+                "manufacturer": "test-manufacturer",
+                "model_id": "test-model-id",
+                "model": None,
+                "sw_version": None,
+                "hw_version": None,
+                "integration": "hue",
+                "is_custom_integration": False,
+                "has_configuration_url": False,
+                "via_device": None,
+                "entry_type": "service",
+            },
+            {
+                "manufacturer": "test-manufacturer",
+                "model_id": None,
+                "model": None,
+                "sw_version": None,
+                "hw_version": None,
+                "integration": "no_model_id",
+                "has_configuration_url": False,
+                "via_device": None,
+                "entry_type": None,
+            },
+            {
+                "manufacturer": None,
+                "model_id": "test-model-id",
+                "model": None,
+                "sw_version": None,
+                "hw_version": None,
+                "integration": "hue",
+                "is_custom_integration": False,
+                "has_configuration_url": False,
+                "via_device": None,
+                "entry_type": None,
             },
             {
                 "manufacturer": "test-manufacturer6",
@@ -1064,6 +1110,20 @@ async def test_devices_payload(
                 "is_custom_integration": False,
                 "has_configuration_url": False,
                 "via_device": 0,
+                "entry_type": None,
+            },
+            {
+                "entry_type": None,
+                "has_configuration_url": False,
+                "hw_version": None,
+                "integration": "test",
+                "manufacturer": "test-manufacturer7",
+                "model": None,
+                "model_id": "test-model-id7",
+                "sw_version": None,
+                "via_device": None,
+                "is_custom_integration": True,
+                "custom_integration_version": "1.2.3",
             },
         ],
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The devices payload was initially tuned for the device DB prototype from last year. Realized that it's better to have data that is being filtered out, so we can work with code owners to see how to get that information.

This PR removes the filters from the initial payload and includes information about devices, even if they cannot be indexed by the original prototype.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
