### PR TITLE
Allow specifying a custom system prompt in AI Task actions

### DIFF
--- a/homeassistant/components/ai_task/__init__.py
+++ b/homeassistant/components/ai_task/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     ATTR_INSTRUCTIONS,
     ATTR_REQUIRED,
     ATTR_STRUCTURE,
+    ATTR_SYSTEM_PROMPT,
     ATTR_TASK_NAME,
     DATA_COMPONENT,
     DATA_IMAGES,
@@ -106,6 +107,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             {
                 vol.Required(ATTR_TASK_NAME): cv.string,
                 vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
+                vol.Optional(ATTR_SYSTEM_PROMPT): cv.string,
                 vol.Required(ATTR_INSTRUCTIONS): cv.string,
                 vol.Optional(ATTR_STRUCTURE): vol.All(
                     vol.Schema({str: STRUCTURE_FIELD_SCHEMA}),

--- a/homeassistant/components/ai_task/const.py
+++ b/homeassistant/components/ai_task/const.py
@@ -25,6 +25,7 @@ MAX_IMAGES = 20
 SERVICE_GENERATE_DATA = "generate_data"
 SERVICE_GENERATE_IMAGE = "generate_image"
 
+ATTR_SYSTEM_PROMPT: Final = "system_prompt"
 ATTR_INSTRUCTIONS: Final = "instructions"
 ATTR_TASK_NAME: Final = "task_name"
 ATTR_STRUCTURE: Final = "structure"

--- a/homeassistant/components/ai_task/entity.py
+++ b/homeassistant/components/ai_task/entity.py
@@ -76,7 +76,7 @@ class AITaskEntity(RestoreEntity):
                     assistant=DOMAIN,
                     device_id=None,
                 ),
-                user_llm_prompt=DEFAULT_SYSTEM_PROMPT,
+                user_llm_prompt=task.system_prompt or DEFAULT_SYSTEM_PROMPT,
             )
 
             chat_log.async_add_user_content(

--- a/homeassistant/components/ai_task/services.yaml
+++ b/homeassistant/components/ai_task/services.yaml
@@ -5,6 +5,12 @@ generate_data:
       required: true
       selector:
         text:
+    system_prompt:
+      example: "You are a Home Assistant expert"
+      required: false
+      selector:
+        text:
+          multiline: true
     instructions:
       example: "Generate a funny notification that the garage door was left open"
       required: true

--- a/homeassistant/components/ai_task/strings.json
+++ b/homeassistant/components/ai_task/strings.json
@@ -8,6 +8,10 @@
           "name": "Task name",
           "description": "Name of the task."
         },
+        "system_prompt": {
+          "name": "System prompt",
+          "description": "Custom system prompt."
+        },
         "instructions": {
           "name": "Instructions",
           "description": "Instructions on what needs to be done."

--- a/homeassistant/components/ai_task/task.py
+++ b/homeassistant/components/ai_task/task.py
@@ -112,6 +112,7 @@ async def async_generate_data(
     *,
     task_name: str,
     entity_id: str | None = None,
+    system_prompt: str | None = None,
     instructions: str,
     structure: vol.Schema | None = None,
     attachments: list[dict] | None = None,
@@ -148,6 +149,7 @@ async def async_generate_data(
             GenDataTask(
                 name=task_name,
                 instructions=instructions,
+                system_prompt=system_prompt,
                 structure=structure,
                 attachments=resolved_attachments or None,
             ),
@@ -254,6 +256,9 @@ class GenDataTask:
 
     instructions: str
     """Instructions on what needs to be done."""
+
+    system_prompt: str | None = None
+    """Custom system prompt."""
 
     structure: vol.Schema | None = None
     """Optional structure for the data to be generated."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability to specify a custom system prompt in AI Task `generate_data` actions.

I would like to use AI Task `generate_data` with Ollama to generate fun and unpredictable notification messages and reports using the same system prompt (character) as my voice assistant.

All `generate_data` prompts are currently hard-coded to use a generic `"You are a Home Assistant expert..."` system prompt. This heavily influences `generate_data` into mostly outputting documentation-style text as if I'm asking for help with HA.

Additionally, because the AI Task system prompt is hard-coded and appears at the very beginning of the prompt, the upstream LLM cache will always be reset between voice assistant and `generate_data` invocations. This increases generation/response time, energy consumption, and API usage costs for users.
(My LLM character prompt is over a thousand tokens and takes over two minutes to evaluate on local CPU, so careful consideration of prompt layout to preserve as much of the LLM cache as possible between interactions is very important for me.)

Perhaps instead of extending the `generate_data` action, it might be better to put the system prompt in the AI Task entity similar to LLM conversation agents. The system prompt option seems to have been omitted from the AI task entity configuration vs the conversation agent config, (at least for Ollama) so I went this route instead.

Using AI Task to generate my automatic notifications and reports with the variety and summarizing ability of the LLM voice assistant is quite exciting! My existing large randomizing template-based notifications and reports have been getting quite stale.

Let me know if there is interest in this and I'll get the documentation PR going.
Thanks! :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr