### PR TITLE
Do not start modbus update process until connection+delay.

### DIFF
--- a/homeassistant/components/modbus/entity.py
+++ b/homeassistant/components/modbus/entity.py
@@ -92,7 +92,7 @@ class BasePlatform(Entity):
         self._scan_interval = int(entry[CONF_SCAN_INTERVAL])
         self._cancel_timer: Callable[[], None] | None = None
         self._cancel_call: Callable[[], None] | None = None
-
+        self._cancel_delay: Callable[[], None] | None = None
         self._attr_unique_id = entry.get(CONF_UNIQUE_ID)
         self._attr_name = entry[CONF_NAME]
         self._attr_device_class = entry.get(CONF_DEVICE_CLASS)
@@ -184,7 +184,7 @@ class BasePlatform(Entity):
 
     async def async_base_added_to_hass(self) -> None:
         """Handle entity which will be added."""
-        async_call_later(
+        self._cancel_delay = async_call_later(
             self.hass,
             self._hub.config_delay + 0.1,
             self.async_await_connection,

--- a/homeassistant/components/modbus/entity.py
+++ b/homeassistant/components/modbus/entity.py
@@ -177,9 +177,18 @@ class BasePlatform(Entity):
         self._attr_available = False
         self.async_write_ha_state()
 
+    async def async_await_connection(self, _now: Any) -> None:
+        """Wait for first connect."""
+        await self._hub.event_connected.wait()
+        self.async_run()
+
     async def async_base_added_to_hass(self) -> None:
         """Handle entity which will be added."""
-        self.async_run()
+        async_call_later(
+            self.hass,
+            self._hub.config_delay + 0.1,
+            self.async_await_connection,
+        )
         self.async_on_remove(
             async_dispatcher_connect(self.hass, SIGNAL_STOP_ENTITY, self.async_hold)
         )

--- a/homeassistant/components/modbus/entity.py
+++ b/homeassistant/components/modbus/entity.py
@@ -168,6 +168,9 @@ class BasePlatform(Entity):
         if self._cancel_timer:
             self._cancel_timer()
             self._cancel_timer = None
+        if self._cancel_delay:
+            self._cancel_delay()
+            self._cancel_delay = None
 
     @callback
     def async_hold(self) -> None:

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
+from homeassistant.util.hass_dict import HassKey
 
 from tests.common import async_fire_time_changed, mock_restore_cache
 
@@ -121,6 +122,7 @@ def mock_pymodbus_fixture(do_exception, register_words):
 async def mock_modbus_fixture(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
     check_config_loaded,
     config_addon,
     do_config,
@@ -157,6 +159,15 @@ async def mock_modbus_fixture(
     ):
         result = await async_setup_component(hass, DOMAIN, config)
         assert result or not check_config_loaded
+    await hass.async_block_till_done()
+    key = HassKey(DOMAIN)
+    if key not in hass.data:
+        return None
+    hub = hass.data[HassKey(DOMAIN)][TEST_MODBUS_NAME]
+    await hub.event_connected.wait()
+    assert hub.event_connected.is_set()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     return mock_pymodbus
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The documentation states that "delay=" starts after the connect, not when the integration is loaded !! Please remember the idea is that some device need time after being to connected before receiving the first request.

The current solution is likely to produce "unavailable" if the connect process is a bit slow, which is seen as spikes in statistics.

This PR helps avoid some spikes, however there are still update problems with the entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
