### PR TITLE
Show charging power as 0 when not charging for the Volvo integration

### DIFF
--- a/homeassistant/components/volvo/sensor.py
+++ b/homeassistant/components/volvo/sensor.py
@@ -67,8 +67,8 @@ def _calculate_time_to_service(field: VolvoCarsValue) -> int:
 
 def _charging_power_value(field: VolvoCarsValue) -> int:
     return (
-        int(field.value)
-        if isinstance(field, VolvoCarsValueStatusField) and field.status == "OK"
+        field.value
+        if isinstance(field, VolvoCarsValueStatusField) and isinstance(field.value, int)
         else 0
     )
 

--- a/tests/components/volvo/conftest.py
+++ b/tests/components/volvo/conftest.py
@@ -9,7 +9,7 @@ from volvocarsapi.auth import TOKEN_URL
 from volvocarsapi.models import (
     VolvoCarsAvailableCommand,
     VolvoCarsLocation,
-    VolvoCarsValueField,
+    VolvoCarsValueStatusField,
     VolvoCarsVehicle,
 )
 
@@ -98,7 +98,7 @@ async def mock_api(hass: HomeAssistant, full_model: str) -> AsyncGenerator[Async
             hass, "energy_state", full_model
         )
         energy_state = {
-            key: VolvoCarsValueField.from_dict(value)
+            key: VolvoCarsValueStatusField.from_dict(value)
             for key, value in energy_state_data.items()
         }
         engine_status = await async_load_fixture_as_value_field(

--- a/tests/components/volvo/fixtures/ex30_2024/energy_capabilities.json
+++ b/tests/components/volvo/fixtures/ex30_2024/energy_capabilities.json
@@ -9,7 +9,7 @@
   "chargerConnectionStatus": {
     "isSupported": true
   },
-  "chargingSystemStatus": {
+  "chargingStatus": {
     "isSupported": true
   },
   "chargingType": {
@@ -25,7 +25,7 @@
     "isSupported": true
   },
   "chargingCurrentLimit": {
-    "isSupported": true
+    "isSupported": false
   },
   "chargingPower": {
     "isSupported": true

--- a/tests/components/volvo/fixtures/ex30_2024/energy_state.json
+++ b/tests/components/volvo/fixtures/ex30_2024/energy_state.json
@@ -50,7 +50,7 @@
   },
   "chargingPower": {
     "status": "ERROR",
-    "code": "NOT_SUPPORTED",
-    "message": "Resource is not supported for this vehicle"
+    "code": "PROPERTY_NOT_FOUND",
+    "message": "No valid value could be found for the requested property"
   }
 }

--- a/tests/components/volvo/fixtures/xc40_electric_2024/energy_capabilities.json
+++ b/tests/components/volvo/fixtures/xc40_electric_2024/energy_capabilities.json
@@ -9,7 +9,7 @@
   "chargerConnectionStatus": {
     "isSupported": true
   },
-  "chargingSystemStatus": {
+  "chargingStatus": {
     "isSupported": true
   },
   "chargingType": {

--- a/tests/components/volvo/fixtures/xc60_phev_2020/energy_capabilities.json
+++ b/tests/components/volvo/fixtures/xc60_phev_2020/energy_capabilities.json
@@ -9,7 +9,7 @@
   "chargerConnectionStatus": {
     "isSupported": true
   },
-  "chargingSystemStatus": {
+  "chargingStatus": {
     "isSupported": true
   },
   "chargingType": {

--- a/tests/components/volvo/fixtures/xc60_phev_2020/energy_state.json
+++ b/tests/components/volvo/fixtures/xc60_phev_2020/energy_state.json
@@ -40,9 +40,10 @@
     "message": "Resource is not supported for this vehicle"
   },
   "targetBatteryChargeLevel": {
-    "status": "ERROR",
-    "code": "NOT_SUPPORTED",
-    "message": "Resource is not supported for this vehicle"
+    "status": "OK",
+    "value": 80,
+    "unit": "percentage",
+    "updatedAt": "2024-09-22T09:40:12Z"
   },
   "chargingPower": {
     "status": "ERROR",

--- a/tests/components/volvo/snapshots/test_sensor.ambr
+++ b/tests/components/volvo/snapshots/test_sensor.ambr
@@ -232,6 +232,62 @@
     'state': 'connected',
   })
 # ---
+# name: test_sensor[ex30_2024][sensor.volvo_ex30_charging_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.volvo_ex30_charging_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Charging power',
+    'platform': 'volvo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charging_power',
+    'unique_id': 'yv1abcdefg1234567_charging_power',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[ex30_2024][sensor.volvo_ex30_charging_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Volvo EX30 Charging power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.volvo_ex30_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
 # name: test_sensor[ex30_2024][sensor.volvo_ex30_charging_power_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -2164,7 +2220,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': '1386',
   })
 # ---
 # name: test_sensor[xc40_electric_2024][sensor.volvo_xc40_charging_power_status-entry]
@@ -3599,6 +3655,58 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '30000',
+  })
+# ---
+# name: test_sensor[xc60_phev_2020][sensor.volvo_xc60_target_battery_charge_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.volvo_xc60_target_battery_charge_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Target battery charge level',
+    'platform': 'volvo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'target_battery_charge_level',
+    'unique_id': 'yv1abcdefg1234567_target_battery_charge_level',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[xc60_phev_2020][sensor.volvo_xc60_target_battery_charge_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Volvo XC60 Target battery charge level',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.volvo_xc60_target_battery_charge_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
   })
 # ---
 # name: test_sensor[xc60_phev_2020][sensor.volvo_xc60_time_to_engine_service-entry]

--- a/tests/components/volvo/test_sensor.py
+++ b/tests/components/volvo/test_sensor.py
@@ -68,4 +68,20 @@ async def test_skip_invalid_api_fields(
     with patch("homeassistant.components.volvo.PLATFORMS", [Platform.SENSOR]):
         assert await setup_integration()
 
-    assert not hass.states.get(f"sensor.volvo_{short_model}_charging_power")
+    assert not hass.states.get(f"sensor.volvo_{short_model}_charging_current_limit")
+
+
+@pytest.mark.parametrize(
+    "full_model",
+    ["ex30_2024"],
+)
+async def test_charging_power_value(
+    hass: HomeAssistant,
+    setup_integration: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test if charging_power_value is zero if supported, but not charging."""
+
+    with patch("homeassistant.components.volvo.PLATFORMS", [Platform.SENSOR]):
+        assert await setup_integration()
+
+    assert hass.states.get("sensor.volvo_ex30_charging_power").state == "0"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes an issue where the Volvo API would return `ERROR` instead of `0` for `Charging power` when the car is not charging. This resulted in the entity to become unavailable, or even not created if the integration was being added when the car is not charging.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #150751
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
