### PR TITLE
Pin gql to 3.5.3

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -222,4 +222,4 @@ num2words==0.5.14
 pymodbus==3.11.1
 
 # Some packages don't support gql 4.0.0 yet
-gql==3.5.3
+gql<4.0.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -220,3 +220,6 @@ num2words==0.5.14
 # downgraded or upgraded by custom components
 # This ensures all use the same version
 pymodbus==3.11.1
+
+# Some packages don't support gql 4.0.0 yet
+gql==3.5.3

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -246,6 +246,9 @@ num2words==0.5.14
 # downgraded or upgraded by custom components
 # This ensures all use the same version
 pymodbus==3.11.1
+
+# Some packages don't support gql 4.0.0 yet
+gql==3.5.3
 """
 
 GENERATED_MESSAGE = (

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -248,7 +248,7 @@ num2words==0.5.14
 pymodbus==3.11.1
 
 # Some packages don't support gql 4.0.0 yet
-gql==3.5.3
+gql<4.0.0
 """
 
 GENERATED_MESSAGE = (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`gql` [4.0.0](https://github.com/graphql-python/gql/releases/tag/v4.0.0) just came out and it has some breaking changes. Apparently `pyTibber` isn't able to work with the new version. I am not sure if there are ways to find out if it works with the other libraries that depend on `gql`. Anway, let's pin it for now so we unblock the CI.
```py
gql==3.5.0
├── monarchmoney==0.1.15 [requires: gql>=3.4]
│   └── typedmonarchmoney==0.4.4 [requires: monarchmoney>=0.1.13,<0.2.0]
├── pydrawise==2025.7.0 [requires: gql]
├── pyTibber==0.31.6 [requires: gql>=3.0.0]
└── aioaseko==1.0.0 [requires: gql]
```

```
___________________ ERROR collecting tests/components/tibber ___________________
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
venv/lib/python3.13/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
    exec(co, module.__dict__)
tests/components/tibber/conftest.py:9: in <module>
    from homeassistant.components.tibber.const import DOMAIN
homeassistant/components/tibber/__init__.py:6: in <module>
    import tibber
venv/lib/python3.13/site-packages/tibber/__init__.py:20: in <module>
    from .realtime import TibberRT
venv/lib/python3.13/site-packages/tibber/realtime.py:11: in <module>
    from gql.transport.websockets import log as websockets_logger
E   ImportError: cannot import name 'log' from 'gql.transport.websockets' (/home/runner/work/core/core/venv/lib/python3.13/site-packages/gql/transport/websockets.py)
=========================== short test summary info ============================
ERROR tests/components/tibber - ImportError: cannot import name 'log' from 'gql.transport.websockets' (/home/runner/work/core/core/venv/lib/python3.13/site-packages/gql/transport/websockets.py)
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
