### PR TITLE
Update voluptuous-serialize to 2.7.0

### DIFF
--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -199,25 +199,21 @@ class AuthProvidersView(HomeAssistantView):
         )
 
 
-def _prepare_result_json(
-    result: AuthFlowResult,
-) -> AuthFlowResult:
-    """Convert result to JSON."""
+def _prepare_result_json(result: AuthFlowResult) -> dict[str, Any]:
+    """Convert result to JSON serializable dict."""
     if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
-        data = result.copy()
-        data.pop("result")
-        data.pop("data")
+        return {
+            key: val for key, val in result.items() if key not in ("result", "data")
+        }
+
+    data = dict(result)
+    if result["type"] != data_entry_flow.FlowResultType.FORM:
         return data
 
-    if result["type"] != data_entry_flow.FlowResultType.FORM:
-        return result
-
-    data = result.copy()
-
-    if (schema := data["data_schema"]) is None:
-        data["data_schema"] = []  # type: ignore[typeddict-item]  # json result type
+    if (schema := result["data_schema"]) is None:
+        data["data_schema"] = []
     else:
-        data["data_schema"] = voluptuous_serialize.convert(schema)  # type: ignore[typeddict-item]  # json result type
+        data["data_schema"] = voluptuous_serialize.convert(schema)
 
     return data
 

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -206,10 +206,10 @@ def _prepare_result_json(result: AuthFlowResult) -> dict[str, Any]:
             key: val for key, val in result.items() if key not in ("result", "data")
         }
 
-    data = dict(result)
     if result["type"] != data_entry_flow.FlowResultType.FORM:
-        return data
+        return result  # type: ignore[return-value]
 
+    data = dict(result)
     if (schema := result["data_schema"]) is None:
         data["data_schema"] = []
     else:

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -217,7 +217,7 @@ def _prepare_result_json(
     if (schema := data["data_schema"]) is None:
         data["data_schema"] = []  # type: ignore[typeddict-item]  # json result type
     else:
-        data["data_schema"] = voluptuous_serialize.convert(schema)
+        data["data_schema"] = voluptuous_serialize.convert(schema)  # type: ignore[typeddict-item]  # json result type
 
     return data
 

--- a/homeassistant/components/auth/mfa_setup_flow.py
+++ b/homeassistant/components/auth/mfa_setup_flow.py
@@ -151,11 +151,12 @@ def websocket_depose_mfa(
 
 def _prepare_result_json(result: data_entry_flow.FlowResult) -> dict[str, Any]:
     """Convert result to JSON serializable dict."""
-    data = dict(result)
-
+    if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
+        return dict(result)
     if result["type"] != data_entry_flow.FlowResultType.FORM:
-        return data
+        return result  # type: ignore[return-value]
 
+    data = dict(result)
     if (schema := result["data_schema"]) is None:
         data["data_schema"] = []
     else:

--- a/homeassistant/components/auth/mfa_setup_flow.py
+++ b/homeassistant/components/auth/mfa_setup_flow.py
@@ -164,6 +164,6 @@ def _prepare_result_json(
     if (schema := data["data_schema"]) is None:
         data["data_schema"] = []  # type: ignore[typeddict-item]  # json result type
     else:
-        data["data_schema"] = voluptuous_serialize.convert(schema)
+        data["data_schema"] = voluptuous_serialize.convert(schema)  # type: ignore[typeddict-item]  # json result type
 
     return data

--- a/homeassistant/components/auth/mfa_setup_flow.py
+++ b/homeassistant/components/auth/mfa_setup_flow.py
@@ -149,21 +149,16 @@ def websocket_depose_mfa(
     hass.async_create_task(async_depose(msg))
 
 
-def _prepare_result_json(
-    result: data_entry_flow.FlowResult,
-) -> data_entry_flow.FlowResult:
-    """Convert result to JSON."""
-    if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
-        return result.copy()
+def _prepare_result_json(result: data_entry_flow.FlowResult) -> dict[str, Any]:
+    """Convert result to JSON serializable dict."""
+    data = dict(result)
 
     if result["type"] != data_entry_flow.FlowResultType.FORM:
-        return result
+        return data
 
-    data = result.copy()
-
-    if (schema := data["data_schema"]) is None:
-        data["data_schema"] = []  # type: ignore[typeddict-item]  # json result type
+    if (schema := result["data_schema"]) is None:
+        data["data_schema"] = []
     else:
-        data["data_schema"] = voluptuous_serialize.convert(schema)  # type: ignore[typeddict-item]  # json result type
+        data["data_schema"] = voluptuous_serialize.convert(schema)
 
     return data

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -137,20 +137,16 @@ class ConfigManagerEntryResourceReloadView(HomeAssistantView):
 
 def _prepare_config_flow_result_json(
     result: data_entry_flow.FlowResult,
-    prepare_result_json: Callable[
-        [data_entry_flow.FlowResult], data_entry_flow.FlowResult
-    ],
-) -> data_entry_flow.FlowResult:
+    prepare_result_json: Callable[[data_entry_flow.FlowResult], dict[str, Any]],
+) -> dict[str, Any]:
     """Convert result to JSON."""
     if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
         return prepare_result_json(result)
 
-    data = result.copy()
-    entry: config_entries.ConfigEntry = data["result"]  # type: ignore[typeddict-item]
+    data = {key: val for key, val in result.items() if key not in ("data", "context")}
+    entry: config_entries.ConfigEntry = result["result"]  # type: ignore[typeddict-item]
     # We overwrite the ConfigEntry object with its json representation.
-    data["result"] = entry.as_json_fragment  # type: ignore[typeddict-unknown-key]
-    data.pop("data")
-    data.pop("context")
+    data["result"] = entry.as_json_fragment
     return data
 
 
@@ -204,8 +200,8 @@ class ConfigManagerFlowIndexView(
 
     def _prepare_result_json(
         self, result: data_entry_flow.FlowResult
-    ) -> data_entry_flow.FlowResult:
-        """Convert result to JSON."""
+    ) -> dict[str, Any]:
+        """Convert result to JSON serializable dict."""
         return _prepare_config_flow_result_json(result, super()._prepare_result_json)
 
 
@@ -229,8 +225,8 @@ class ConfigManagerFlowResourceView(
 
     def _prepare_result_json(
         self, result: data_entry_flow.FlowResult
-    ) -> data_entry_flow.FlowResult:
-        """Convert result to JSON."""
+    ) -> dict[str, Any]:
+        """Convert result to JSON serializable dict."""
         return _prepare_config_flow_result_json(result, super()._prepare_result_json)
 
 

--- a/homeassistant/components/repairs/websocket_api.py
+++ b/homeassistant/components/repairs/websocket_api.py
@@ -137,9 +137,9 @@ class RepairsFlowIndexView(FlowManagerIndexView):
                 "Handler does not support user", HTTPStatus.BAD_REQUEST
             )
 
-        result = self._prepare_result_json(result)
-
-        return self.json(result)
+        return self.json(
+            self._prepare_result_json(result),
+        )
 
 
 class RepairsFlowResourceView(FlowManagerResourceView):

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -48,7 +48,7 @@ class _BaseFlowManagerView(HomeAssistantView, Generic[_FlowManagerT]):
         if (schema := data["data_schema"]) is None:
             data["data_schema"] = []  # type: ignore[typeddict-item]  # json result type
         else:
-            data["data_schema"] = voluptuous_serialize.convert(
+            data["data_schema"] = voluptuous_serialize.convert(  # type: ignore[typeddict-item]  # json result type
                 schema, custom_serializer=cv.custom_serializer
             )
 

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -31,27 +31,27 @@ class _BaseFlowManagerView(HomeAssistantView, Generic[_FlowManagerT]):
 
     def _prepare_result_json(
         self, result: data_entry_flow.FlowResult
-    ) -> data_entry_flow.FlowResult:
-        """Convert result to JSON."""
+    ) -> dict[str, Any]:
+        """Convert result to JSON serializable dict."""
         if result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY:
-            data = result.copy()
             assert "result" not in result
-            data.pop("data")
-            data.pop("context")
-            return data
+            return {
+                key: val
+                for key, val in result.items()
+                if key not in ("data", "context")
+            }
+
+        data = dict(result)
 
         if "data_schema" not in result:
-            return result
+            return data
 
-        data = result.copy()
-
-        if (schema := data["data_schema"]) is None:
-            data["data_schema"] = []  # type: ignore[typeddict-item]  # json result type
+        if (schema := result["data_schema"]) is None:
+            data["data_schema"] = []
         else:
-            data["data_schema"] = voluptuous_serialize.convert(  # type: ignore[typeddict-item]  # json result type
+            data["data_schema"] = voluptuous_serialize.convert(
                 schema, custom_serializer=cv.custom_serializer
             )
-
         return data
 
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -70,7 +70,7 @@ ulid-transform==1.4.0
 urllib3>=2.0
 uv==0.8.9
 voluptuous-openapi==0.1.0
-voluptuous-serialize==2.6.0
+voluptuous-serialize==2.7.0
 voluptuous==0.15.2
 webrtc-models==0.3.0
 yarl==1.20.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
   "urllib3>=2.0",
   "uv==0.8.9",
   "voluptuous==0.15.2",
-  "voluptuous-serialize==2.6.0",
+  "voluptuous-serialize==2.7.0",
   "voluptuous-openapi==0.1.0",
   "yarl==1.20.1",
   "webrtc-models==0.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ ulid-transform==1.4.0
 urllib3>=2.0
 uv==0.8.9
 voluptuous==0.15.2
-voluptuous-serialize==2.6.0
+voluptuous-serialize==2.7.0
 voluptuous-openapi==0.1.0
 yarl==1.20.1
 webrtc-models==0.3.0

--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -245,7 +245,9 @@ async def test_get_action_capabilities(
         "arm_night": {"extra_fields": []},
         "arm_vacation": {"extra_fields": []},
         "disarm": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "trigger": {"extra_fields": []},
     }
@@ -293,7 +295,7 @@ async def test_get_action_capabilities_legacy(
         "arm_night": {"extra_fields": []},
         "arm_vacation": {"extra_fields": []},
         "disarm": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [{"name": "code", "required": False, "type": "string"}]
         },
         "trigger": {"extra_fields": []},
     }
@@ -338,19 +340,29 @@ async def test_get_action_capabilities_arm_code(
 
     expected_capabilities = {
         "arm_away": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "arm_home": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "arm_night": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "arm_vacation": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "disarm": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "trigger": {"extra_fields": []},
     }
@@ -394,19 +406,29 @@ async def test_get_action_capabilities_arm_code_legacy(
 
     expected_capabilities = {
         "arm_away": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "arm_home": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "arm_night": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "arm_vacation": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "disarm": {
-            "extra_fields": [{"name": "code", "optional": True, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "trigger": {"extra_fields": []},
     }

--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -295,7 +295,9 @@ async def test_get_action_capabilities_legacy(
         "arm_night": {"extra_fields": []},
         "arm_vacation": {"extra_fields": []},
         "disarm": {
-            "extra_fields": [{"name": "code", "required": False, "type": "string"}]
+            "extra_fields": [
+                {"name": "code", "optional": True, "required": False, "type": "string"}
+            ]
         },
         "trigger": {"extra_fields": []},
     }

--- a/tests/components/alarm_control_panel/test_device_trigger.py
+++ b/tests/components/alarm_control_panel/test_device_trigger.py
@@ -191,7 +191,12 @@ async def test_get_trigger_capabilities(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 
@@ -226,7 +231,12 @@ async def test_get_trigger_capabilities_legacy(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -182,7 +182,12 @@ async def test_get_condition_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     conditions = await async_get_device_automations(
@@ -212,7 +217,12 @@ async def test_get_condition_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     conditions = await async_get_device_automations(

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -185,7 +185,12 @@ async def test_get_trigger_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(
@@ -215,7 +220,12 @@ async def test_get_trigger_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(

--- a/tests/components/climate/test_device_trigger.py
+++ b/tests/components/climate/test_device_trigger.py
@@ -354,7 +354,12 @@ async def test_get_trigger_capabilities_hvac_mode(hass: HomeAssistant) -> None:
             "required": True,
             "type": "select",
         },
-        {"name": "for", "optional": True, "type": "positive_time_period_dict"},
+        {
+            "name": "for",
+            "optional": True,
+            "required": False,
+            "type": "positive_time_period_dict",
+        },
     ]
 
 
@@ -389,13 +394,20 @@ async def test_get_trigger_capabilities_temp_humid(
             "description": {"suffix": suffix},
             "name": "above",
             "optional": True,
+            "required": False,
             "type": "float",
         },
         {
             "description": {"suffix": suffix},
             "name": "below",
             "optional": True,
+            "required": False,
             "type": "float",
         },
-        {"name": "for", "optional": True, "type": "positive_time_period_dict"},
+        {
+            "name": "for",
+            "optional": True,
+            "required": False,
+            "type": "positive_time_period_dict",
+        },
     ]

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -625,7 +625,9 @@ async def test_two_step_flow(hass: HomeAssistant, client: TestClient) -> None:
             "type": "form",
             "handler": "test",
             "step_id": "account",
-            "data_schema": [{"name": "user_title", "type": "string"}],
+            "data_schema": [
+                {"name": "user_title", "required": False, "type": "string"}
+            ],
             "description_placeholders": None,
             "errors": None,
             "last_step": None,
@@ -712,7 +714,9 @@ async def test_continue_flow_unauth(
             "type": "form",
             "handler": "test",
             "step_id": "account",
-            "data_schema": [{"name": "user_title", "type": "string"}],
+            "data_schema": [
+                {"name": "user_title", "required": False, "type": "string"}
+            ],
             "description_placeholders": None,
             "errors": None,
             "last_step": None,
@@ -1272,7 +1276,7 @@ async def test_two_step_options_flow(hass: HomeAssistant, client: TestClient) ->
             "type": "form",
             "handler": "test1",
             "step_id": "finish",
-            "data_schema": [{"name": "enabled", "type": "boolean"}],
+            "data_schema": [{"name": "enabled", "required": False, "type": "boolean"}],
             "description_placeholders": None,
             "errors": None,
             "last_step": None,
@@ -1581,7 +1585,7 @@ async def test_subentry_flow_abort_duplicate(hass: HomeAssistant, client) -> Non
         "type": "form",
         "handler": ["test1", "test"],
         "step_id": "finish",
-        "data_schema": [{"name": "enabled", "type": "boolean"}],
+        "data_schema": [{"name": "enabled", "required": False, "type": "boolean"}],
         "description_placeholders": None,
         "errors": None,
         "last_step": None,
@@ -1749,7 +1753,7 @@ async def test_two_step_subentry_flow(hass: HomeAssistant, client) -> None:
         data = await resp.json()
         flow_id = data["flow_id"]
         expected_data = {
-            "data_schema": [{"name": "enabled", "type": "boolean"}],
+            "data_schema": [{"name": "enabled", "required": False, "type": "boolean"}],
             "description_placeholders": None,
             "errors": None,
             "flow_id": flow_id,

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -260,6 +260,7 @@ async def test_get_action_capabilities_set_pos(
             {
                 "name": "position",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 0,
                 "valueMax": 100,
@@ -310,6 +311,7 @@ async def test_get_action_capabilities_set_tilt_pos(
             {
                 "name": "position",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 0,
                 "valueMax": 100,

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -254,6 +254,7 @@ async def test_get_condition_capabilities_set_pos(
             {
                 "name": "above",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 0,
                 "valueMax": 100,
@@ -262,6 +263,7 @@ async def test_get_condition_capabilities_set_pos(
             {
                 "name": "below",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 100,
                 "valueMax": 100,
@@ -311,6 +313,7 @@ async def test_get_condition_capabilities_set_tilt_pos(
             {
                 "name": "above",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 0,
                 "valueMax": 100,
@@ -319,6 +322,7 @@ async def test_get_condition_capabilities_set_tilt_pos(
             {
                 "name": "below",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 100,
                 "valueMax": 100,

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -192,7 +192,12 @@ async def test_get_trigger_capabilities(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 
@@ -230,7 +235,12 @@ async def test_get_trigger_capabilities_legacy(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 
@@ -262,6 +272,7 @@ async def test_get_trigger_capabilities_set_pos(
             {
                 "name": "above",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 0,
                 "valueMax": 100,
@@ -270,6 +281,7 @@ async def test_get_trigger_capabilities_set_pos(
             {
                 "name": "below",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 100,
                 "valueMax": 100,
@@ -293,6 +305,7 @@ async def test_get_trigger_capabilities_set_pos(
                     {
                         "name": "for",
                         "optional": True,
+                        "required": False,
                         "type": "positive_time_period_dict",
                     }
                 ]
@@ -326,6 +339,7 @@ async def test_get_trigger_capabilities_set_tilt_pos(
             {
                 "name": "above",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 0,
                 "valueMax": 100,
@@ -334,6 +348,7 @@ async def test_get_trigger_capabilities_set_tilt_pos(
             {
                 "name": "below",
                 "optional": True,
+                "required": False,
                 "type": "integer",
                 "default": 100,
                 "valueMax": 100,
@@ -357,6 +372,7 @@ async def test_get_trigger_capabilities_set_tilt_pos(
                     {
                         "name": "for",
                         "optional": True,
+                        "required": False,
                         "type": "positive_time_period_dict",
                     }
                 ]

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -293,7 +293,9 @@ async def test_websocket_get_action_capabilities(
     )
     expected_capabilities = {
         "turn_on": {
-            "extra_fields": [{"type": "string", "name": "code", "optional": True}]
+            "extra_fields": [
+                {"type": "string", "name": "code", "optional": True, "required": False}
+            ]
         },
         "turn_off": {"extra_fields": []},
         "toggle": {"extra_fields": []},

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -452,7 +452,12 @@ async def test_websocket_get_condition_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
 
@@ -745,7 +750,12 @@ async def test_websocket_get_trigger_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
 

--- a/tests/components/fan/test_device_trigger.py
+++ b/tests/components/fan/test_device_trigger.py
@@ -125,7 +125,12 @@ async def test_get_trigger_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(
@@ -155,7 +160,12 @@ async def test_get_trigger_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(

--- a/tests/components/hassio/test_repairs.py
+++ b/tests/components/hassio/test_repairs.py
@@ -180,6 +180,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions(
                     ["system_execute_reboot", "system_execute_reboot"],
                     ["system_test_type", "system_test_type"],
                 ],
+                "required": False,
                 "name": "next_step_id",
             }
         ],
@@ -275,6 +276,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions_and_confir
                     ["system_execute_reboot", "system_execute_reboot"],
                     ["system_test_type", "system_test_type"],
                 ],
+                "required": False,
                 "name": "next_step_id",
             }
         ],
@@ -545,6 +547,7 @@ async def test_mount_failed_repair_flow(
                     ["mount_execute_reload", "mount_execute_reload"],
                     ["mount_execute_remove", "mount_execute_remove"],
                 ],
+                "required": False,
                 "name": "next_step_id",
             }
         ],
@@ -756,6 +759,7 @@ async def test_supervisor_issue_repair_flow_multiple_data_disks(
                     ["system_rename_data_disk", "system_rename_data_disk"],
                     ["system_adopt_data_disk", "system_adopt_data_disk"],
                 ],
+                "required": False,
                 "name": "next_step_id",
             }
         ],
@@ -960,6 +964,7 @@ async def test_supervisor_issue_addon_boot_fail(
                     ["addon_execute_start", "addon_execute_start"],
                     ["addon_disable_boot", "addon_disable_boot"],
                 ],
+                "required": False,
                 "name": "next_step_id",
             }
         ],

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -363,6 +363,7 @@ async def test_if_state_legacy(
                 {
                     "name": "for",
                     "optional": True,
+                    "required": False,
                     "type": "positive_time_period_dict",
                 }
             ],
@@ -376,6 +377,7 @@ async def test_if_state_legacy(
                 {
                     "name": "for",
                     "optional": True,
+                    "required": False,
                     "type": "positive_time_period_dict",
                 }
             ],
@@ -417,6 +419,7 @@ async def test_if_state_legacy(
                 {
                     "name": "for",
                     "optional": True,
+                    "required": False,
                     "type": "positive_time_period_dict",
                 }
             ],
@@ -430,6 +433,7 @@ async def test_if_state_legacy(
                 {
                     "name": "for",
                     "optional": True,
+                    "required": False,
                     "type": "positive_time_period_dict",
                 }
             ],
@@ -533,6 +537,7 @@ async def test_capabilities(
                 {
                     "name": "for",
                     "optional": True,
+                    "required": False,
                     "type": "positive_time_period_dict",
                 }
             ],
@@ -546,6 +551,7 @@ async def test_capabilities(
                 {
                     "name": "for",
                     "optional": True,
+                    "required": False,
                     "type": "positive_time_period_dict",
                 }
             ],
@@ -587,6 +593,7 @@ async def test_capabilities(
                 {
                     "name": "for",
                     "optional": True,
+                    "required": False,
                     "type": "positive_time_period_dict",
                 }
             ],
@@ -600,6 +607,7 @@ async def test_capabilities(
                 {
                     "name": "for",
                     "optional": True,
+                    "required": False,
                     "type": "positive_time_period_dict",
                 }
             ],

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -543,7 +543,14 @@ async def test_get_trigger_capabilities_on(hass: HomeAssistant) -> None:
 
     assert voluptuous_serialize.convert(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
-    ) == [{"name": "for", "optional": True, "type": "positive_time_period_dict"}]
+    ) == [
+        {
+            "name": "for",
+            "optional": True,
+            "required": False,
+            "type": "positive_time_period_dict",
+        }
+    ]
 
 
 async def test_get_trigger_capabilities_off(hass: HomeAssistant) -> None:
@@ -563,7 +570,14 @@ async def test_get_trigger_capabilities_off(hass: HomeAssistant) -> None:
 
     assert voluptuous_serialize.convert(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
-    ) == [{"name": "for", "optional": True, "type": "positive_time_period_dict"}]
+    ) == [
+        {
+            "name": "for",
+            "optional": True,
+            "required": False,
+            "type": "positive_time_period_dict",
+        }
+    ]
 
 
 async def test_get_trigger_capabilities_humidity(hass: HomeAssistant) -> None:
@@ -588,13 +602,20 @@ async def test_get_trigger_capabilities_humidity(hass: HomeAssistant) -> None:
             "description": {"suffix": "%"},
             "name": "above",
             "optional": True,
+            "required": False,
             "type": "integer",
         },
         {
             "description": {"suffix": "%"},
             "name": "below",
             "optional": True,
+            "required": False,
             "type": "integer",
         },
-        {"name": "for", "optional": True, "type": "positive_time_period_dict"},
+        {
+            "name": "for",
+            "optional": True,
+            "required": False,
+            "type": "positive_time_period_dict",
+        },
     ]

--- a/tests/components/knx/test_device_trigger.py
+++ b/tests/components/knx/test_device_trigger.py
@@ -301,6 +301,7 @@ async def test_get_trigger_capabilities(
         {
             "name": "destination",
             "optional": True,
+            "required": False,
             "selector": {
                 "select": {
                     "custom_value": True,
@@ -314,6 +315,7 @@ async def test_get_trigger_capabilities(
         {
             "name": "group_value_write",
             "optional": True,
+            "required": False,
             "default": True,
             "selector": {
                 "boolean": {},
@@ -322,6 +324,7 @@ async def test_get_trigger_capabilities(
         {
             "name": "group_value_response",
             "optional": True,
+            "required": False,
             "default": True,
             "selector": {
                 "boolean": {},
@@ -330,6 +333,7 @@ async def test_get_trigger_capabilities(
         {
             "name": "group_value_read",
             "optional": True,
+            "required": False,
             "default": True,
             "selector": {
                 "boolean": {},
@@ -338,6 +342,7 @@ async def test_get_trigger_capabilities(
         {
             "name": "incoming",
             "optional": True,
+            "required": False,
             "default": True,
             "selector": {
                 "boolean": {},
@@ -346,6 +351,7 @@ async def test_get_trigger_capabilities(
         {
             "name": "outgoing",
             "optional": True,
+            "required": False,
             "default": True,
             "selector": {
                 "boolean": {},

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -349,7 +349,15 @@ async def test_get_transponder_trigger_capabilities(
 
     assert voluptuous_serialize.convert(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
-    ) == [{"name": "code", "optional": True, "type": "string", "lower": True}]
+    ) == [
+        {
+            "name": "code",
+            "optional": True,
+            "required": False,
+            "type": "string",
+            "lower": True,
+        }
+    ]
 
 
 async def test_get_fingerprint_trigger_capabilities(
@@ -373,7 +381,15 @@ async def test_get_fingerprint_trigger_capabilities(
 
     assert voluptuous_serialize.convert(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
-    ) == [{"name": "code", "optional": True, "type": "string", "lower": True}]
+    ) == [
+        {
+            "name": "code",
+            "optional": True,
+            "required": False,
+            "type": "string",
+            "lower": True,
+        }
+    ]
 
 
 async def test_get_transmitter_trigger_capabilities(
@@ -398,13 +414,32 @@ async def test_get_transmitter_trigger_capabilities(
     assert voluptuous_serialize.convert(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
     ) == [
-        {"name": "code", "type": "string", "optional": True, "lower": True},
-        {"name": "level", "type": "integer", "optional": True, "valueMin": 0},
-        {"name": "key", "type": "integer", "optional": True, "valueMin": 0},
+        {
+            "name": "code",
+            "type": "string",
+            "optional": True,
+            "required": False,
+            "lower": True,
+        },
+        {
+            "name": "level",
+            "type": "integer",
+            "optional": True,
+            "required": False,
+            "valueMin": 0,
+        },
+        {
+            "name": "key",
+            "type": "integer",
+            "optional": True,
+            "required": False,
+            "valueMin": 0,
+        },
         {
             "name": "action",
             "type": "select",
             "optional": True,
+            "required": False,
             "options": [("hit", "hit"), ("make", "make"), ("break", "break")],
         },
     ]

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -471,6 +471,7 @@ async def test_get_send_keys_trigger_capabilities(
             "name": "key",
             "type": "select",
             "optional": True,
+            "required": False,
             "options": [(send_key.lower(), send_key.lower()) for send_key in SENDKEYS],
         },
         {
@@ -480,6 +481,7 @@ async def test_get_send_keys_trigger_capabilities(
                 (key_action.lower(), key_action.lower()) for key_action in KEY_ACTIONS
             ],
             "optional": True,
+            "required": False,
         },
     ]
 

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -194,6 +194,7 @@ async def test_get_action_capabilities(
                     {
                         "name": "brightness_pct",
                         "optional": True,
+                        "required": False,
                         "type": "float",
                         "valueMax": 100,
                         "valueMin": 0,
@@ -219,6 +220,7 @@ async def test_get_action_capabilities(
                     {
                         "name": "brightness_pct",
                         "optional": True,
+                        "required": False,
                         "type": "float",
                         "valueMax": 100,
                         "valueMin": 0,
@@ -238,6 +240,7 @@ async def test_get_action_capabilities(
                     {
                         "name": "flash",
                         "optional": True,
+                        "required": False,
                         "type": "select",
                         "options": [("short", "short"), ("long", "long")],
                     }
@@ -256,6 +259,7 @@ async def test_get_action_capabilities(
                     {
                         "name": "flash",
                         "optional": True,
+                        "required": False,
                         "type": "select",
                         "options": [("short", "short"), ("long", "long")],
                     }
@@ -341,6 +345,7 @@ async def test_get_action_capabilities_features(
                     {
                         "name": "brightness_pct",
                         "optional": True,
+                        "required": False,
                         "type": "float",
                         "valueMax": 100,
                         "valueMin": 0,
@@ -366,6 +371,7 @@ async def test_get_action_capabilities_features(
                     {
                         "name": "brightness_pct",
                         "optional": True,
+                        "required": False,
                         "type": "float",
                         "valueMax": 100,
                         "valueMin": 0,
@@ -385,6 +391,7 @@ async def test_get_action_capabilities_features(
                     {
                         "name": "flash",
                         "optional": True,
+                        "required": False,
                         "type": "select",
                         "options": [("short", "short"), ("long", "long")],
                     }
@@ -403,6 +410,7 @@ async def test_get_action_capabilities_features(
                     {
                         "name": "flash",
                         "optional": True,
+                        "required": False,
                         "type": "select",
                         "options": [("short", "short"), ("long", "long")],
                     }

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -128,7 +128,12 @@ async def test_get_condition_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     conditions = await async_get_device_automations(
@@ -158,7 +163,12 @@ async def test_get_condition_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     conditions = await async_get_device_automations(

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -133,7 +133,12 @@ async def test_get_trigger_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(
@@ -163,7 +168,12 @@ async def test_get_trigger_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -155,7 +155,12 @@ async def test_get_trigger_capabilities(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 
@@ -187,7 +192,12 @@ async def test_get_trigger_capabilities_legacy(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -161,7 +161,12 @@ async def test_get_trigger_capabilities(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 
@@ -193,7 +198,12 @@ async def test_get_trigger_capabilities_legacy(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -125,7 +125,12 @@ async def test_get_condition_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     conditions = await async_get_device_automations(
@@ -155,7 +160,12 @@ async def test_get_condition_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     conditions = await async_get_device_automations(

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -125,7 +125,12 @@ async def test_get_trigger_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(
@@ -155,7 +160,12 @@ async def test_get_trigger_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(

--- a/tests/components/select/test_device_action.py
+++ b/tests/components/select/test_device_action.py
@@ -376,6 +376,7 @@ async def test_get_action_capabilities(
         {
             "name": "cycle",
             "optional": True,
+            "required": False,
             "type": "boolean",
             "default": True,
         },
@@ -391,6 +392,7 @@ async def test_get_action_capabilities(
         {
             "name": "cycle",
             "optional": True,
+            "required": False,
             "type": "boolean",
             "default": True,
         },
@@ -476,6 +478,7 @@ async def test_get_action_capabilities_legacy(
         {
             "name": "cycle",
             "optional": True,
+            "required": False,
             "type": "boolean",
             "default": True,
         },
@@ -491,6 +494,7 @@ async def test_get_action_capabilities_legacy(
         {
             "name": "cycle",
             "optional": True,
+            "required": False,
             "type": "boolean",
             "default": True,
         },

--- a/tests/components/select/test_device_condition.py
+++ b/tests/components/select/test_device_condition.py
@@ -276,6 +276,7 @@ async def test_get_condition_capabilities(
         {
             "name": "for",
             "optional": True,
+            "required": False,
             "type": "positive_time_period_dict",
         },
     ]
@@ -301,6 +302,7 @@ async def test_get_condition_capabilities(
         {
             "name": "for",
             "optional": True,
+            "required": False,
             "type": "positive_time_period_dict",
         },
     ]
@@ -336,6 +338,7 @@ async def test_get_condition_capabilities_legacy(
         {
             "name": "for",
             "optional": True,
+            "required": False,
             "type": "positive_time_period_dict",
         },
     ]
@@ -361,6 +364,7 @@ async def test_get_condition_capabilities_legacy(
         {
             "name": "for",
             "optional": True,
+            "required": False,
             "type": "positive_time_period_dict",
         },
     ]

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -310,18 +310,21 @@ async def test_get_trigger_capabilities(
         {
             "name": "from",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [],
         },
         {
             "name": "to",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [],
         },
         {
             "name": "for",
             "optional": True,
+            "required": False,
             "type": "positive_time_period_dict",
         },
     ]
@@ -341,18 +344,21 @@ async def test_get_trigger_capabilities(
         {
             "name": "from",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [("option1", "option1"), ("option2", "option2")],
         },
         {
             "name": "to",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [("option1", "option1"), ("option2", "option2")],
         },
         {
             "name": "for",
             "optional": True,
+            "required": False,
             "type": "positive_time_period_dict",
         },
     ]
@@ -380,18 +386,21 @@ async def test_get_trigger_capabilities_unknown(
         {
             "name": "from",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [],
         },
         {
             "name": "to",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [],
         },
         {
             "name": "for",
             "optional": True,
+            "required": False,
             "type": "positive_time_period_dict",
         },
     ]
@@ -421,18 +430,21 @@ async def test_get_trigger_capabilities_legacy(
         {
             "name": "from",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [],
         },
         {
             "name": "to",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [],
         },
         {
             "name": "for",
             "optional": True,
+            "required": False,
             "type": "positive_time_period_dict",
         },
     ]
@@ -452,18 +464,21 @@ async def test_get_trigger_capabilities_legacy(
         {
             "name": "from",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [("option1", "option1"), ("option2", "option2")],
         },
         {
             "name": "to",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [("option1", "option1"), ("option2", "option2")],
         },
         {
             "name": "for",
             "optional": True,
+            "required": False,
             "type": "positive_time_period_dict",
         },
     ]

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -329,12 +329,14 @@ async def test_get_condition_capabilities(
                 "description": {"suffix": PERCENTAGE},
                 "name": "above",
                 "optional": True,
+                "required": False,
                 "type": "float",
             },
             {
                 "description": {"suffix": PERCENTAGE},
                 "name": "below",
                 "optional": True,
+                "required": False,
                 "type": "float",
             },
         ]
@@ -398,12 +400,14 @@ async def test_get_condition_capabilities_legacy(
                 "description": {"suffix": PERCENTAGE},
                 "name": "above",
                 "optional": True,
+                "required": False,
                 "type": "float",
             },
             {
                 "description": {"suffix": PERCENTAGE},
                 "name": "below",
                 "optional": True,
+                "required": False,
                 "type": "float",
             },
         ]

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -277,15 +277,22 @@ async def test_get_trigger_capabilities(
                 "description": {"suffix": PERCENTAGE},
                 "name": "above",
                 "optional": True,
+                "required": False,
                 "type": "float",
             },
             {
                 "description": {"suffix": PERCENTAGE},
                 "name": "below",
                 "optional": True,
+                "required": False,
                 "type": "float",
             },
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"},
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            },
         ]
     }
     triggers = await async_get_device_automations(
@@ -347,15 +354,22 @@ async def test_get_trigger_capabilities_legacy(
                 "description": {"suffix": PERCENTAGE},
                 "name": "above",
                 "optional": True,
+                "required": False,
                 "type": "float",
             },
             {
                 "description": {"suffix": PERCENTAGE},
                 "name": "below",
                 "optional": True,
+                "required": False,
                 "type": "float",
             },
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"},
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            },
         ]
     }
     triggers = await async_get_device_automations(

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -125,7 +125,12 @@ async def test_get_condition_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     conditions = await async_get_device_automations(
@@ -155,7 +160,12 @@ async def test_get_condition_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     conditions = await async_get_device_automations(

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -125,7 +125,12 @@ async def test_get_trigger_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(
@@ -155,7 +160,12 @@ async def test_get_trigger_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(

--- a/tests/components/update/test_device_trigger.py
+++ b/tests/components/update/test_device_trigger.py
@@ -127,7 +127,12 @@ async def test_get_trigger_capabilities(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(
@@ -157,7 +162,12 @@ async def test_get_trigger_capabilities_legacy(
     )
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {
+                "name": "for",
+                "optional": True,
+                "required": False,
+                "type": "positive_time_period_dict",
+            }
         ]
     }
     triggers = await async_get_device_automations(

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -134,7 +134,12 @@ async def test_get_trigger_capabilities(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 
@@ -166,7 +171,12 @@ async def test_get_trigger_capabilities_legacy(
         )
         assert capabilities == {
             "extra_fields": [
-                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+                {
+                    "name": "for",
+                    "optional": True,
+                    "required": False,
+                    "type": "positive_time_period_dict",
+                }
             ]
         }
 

--- a/tests/components/zha/data.py
+++ b/tests/components/zha/data.py
@@ -9,6 +9,7 @@ BASE_CUSTOM_CONFIGURATION = {
                 "valueMax": 6553.6,
                 "name": "default_light_transition",
                 "optional": True,
+                "required": False,
                 "default": 0,
             },
             {
@@ -40,6 +41,7 @@ BASE_CUSTOM_CONFIGURATION = {
                 "valueMin": 0,
                 "name": "consider_unavailable_mains",
                 "optional": True,
+                "required": False,
                 "default": 7200,
             },
             {
@@ -47,6 +49,7 @@ BASE_CUSTOM_CONFIGURATION = {
                 "valueMin": 0,
                 "name": "consider_unavailable_battery",
                 "optional": True,
+                "required": False,
                 "default": 21600,
             },
             {
@@ -80,6 +83,7 @@ CONFIG_WITH_ALARM_OPTIONS = {
                 "valueMax": 6553.6,
                 "name": "default_light_transition",
                 "optional": True,
+                "required": False,
                 "default": 0,
             },
             {
@@ -111,6 +115,7 @@ CONFIG_WITH_ALARM_OPTIONS = {
                 "valueMin": 0,
                 "name": "consider_unavailable_mains",
                 "optional": True,
+                "required": False,
                 "default": 7200,
             },
             {
@@ -118,6 +123,7 @@ CONFIG_WITH_ALARM_OPTIONS = {
                 "valueMin": 0,
                 "name": "consider_unavailable_battery",
                 "optional": True,
+                "required": False,
                 "default": 21600,
             },
             {

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -71,12 +71,14 @@ async def test_zcl_schema_conversions(hass: HomeAssistant) -> None:
             "options": ["Execute if off present"],
             "name": "options_mask",
             "optional": True,
+            "required": False,
         },
         {
             "type": "multi_select",
             "options": ["Execute if off"],
             "name": "options_override",
             "optional": True,
+            "required": False,
         },
     ]
     vol_schema = voluptuous_serialize.convert(

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -549,7 +549,14 @@ async def test_get_action_capabilities(
 
     assert voluptuous_serialize.convert(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
-    ) == [{"type": "boolean", "name": "refresh_all_values", "optional": True}]
+    ) == [
+        {
+            "type": "boolean",
+            "name": "refresh_all_values",
+            "optional": True,
+            "required": False,
+        }
+    ]
 
     # Test ping
     capabilities = await device_action.async_get_action_capabilities(
@@ -611,7 +618,12 @@ async def test_get_action_capabilities(
         {"name": "property_key", "optional": True, "required": False, "type": "string"},
         {"name": "endpoint", "optional": True, "required": False, "type": "string"},
         {"name": "value", "required": True, "type": "string"},
-        {"type": "boolean", "name": "wait_for_result", "optional": True},
+        {
+            "type": "boolean",
+            "name": "wait_for_result",
+            "optional": True,
+            "required": False,
+        },
     ]
 
     # Test enumerated type param
@@ -771,7 +783,7 @@ async def test_get_action_capabilities_meter_triggers(
 
     assert voluptuous_serialize.convert(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
-    ) == [{"type": "string", "name": "value", "optional": True}]
+    ) == [{"type": "string", "name": "value", "optional": True, "required": False}]
 
 
 async def test_failure_scenarios(

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -608,8 +608,8 @@ async def test_get_action_capabilities(
             "type": "select",
         },
         {"name": "property", "required": True, "type": "string"},
-        {"name": "property_key", "optional": True, "type": "string"},
-        {"name": "endpoint", "optional": True, "type": "string"},
+        {"name": "property_key", "optional": True, "required": False, "type": "string"},
+        {"name": "endpoint", "optional": True, "required": False, "type": "string"},
         {"name": "value", "required": True, "type": "string"},
         {"type": "boolean", "name": "wait_for_result", "optional": True},
     ]

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -511,8 +511,8 @@ async def test_get_condition_capabilities_value(
             "type": "select",
         },
         {"name": "property", "required": True, "type": "string"},
-        {"name": "property_key", "optional": True, "type": "string"},
-        {"name": "endpoint", "optional": True, "type": "string"},
+        {"name": "property_key", "optional": True, "required": False, "type": "string"},
+        {"name": "endpoint", "optional": True, "required": False, "type": "string"},
         {"name": "value", "required": True, "type": "string"},
     ]
 

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -201,7 +201,7 @@ async def test_get_trigger_capabilities_notification_notification(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
     ) == unordered(
         [
-            {"name": "type.", "required": False, "type": "string"},
+            {"name": "type.", "optional": True, "required": False, "type": "string"},
             {"name": "label", "optional": True, "required": False, "type": "string"},
             {"name": "event", "optional": True, "required": False, "type": "string"},
             {

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -201,10 +201,15 @@ async def test_get_trigger_capabilities_notification_notification(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
     ) == unordered(
         [
-            {"name": "type.", "optional": True, "type": "string"},
-            {"name": "label", "optional": True, "type": "string"},
-            {"name": "event", "optional": True, "type": "string"},
-            {"name": "event_label", "optional": True, "type": "string"},
+            {"name": "type.", "required": False, "type": "string"},
+            {"name": "label", "optional": True, "required": False, "type": "string"},
+            {"name": "event", "optional": True, "required": False, "type": "string"},
+            {
+                "name": "event_label",
+                "optional": True,
+                "required": False,
+                "type": "string",
+            },
         ]
     )
 
@@ -336,8 +341,18 @@ async def test_get_trigger_capabilities_entry_control_notification(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
     ) == unordered(
         [
-            {"name": "event_type", "optional": True, "type": "string"},
-            {"name": "data_type", "optional": True, "type": "string"},
+            {
+                "name": "event_type",
+                "optional": True,
+                "required": False,
+                "type": "string",
+            },
+            {
+                "name": "data_type",
+                "optional": True,
+                "required": False,
+                "type": "string",
+            },
         ]
     )
 
@@ -580,6 +595,7 @@ async def test_get_trigger_capabilities_node_status(
         {
             "name": "from",
             "optional": True,
+            "required": False,
             "options": [
                 ("asleep", "asleep"),
                 ("awake", "awake"),
@@ -591,6 +607,7 @@ async def test_get_trigger_capabilities_node_status(
         {
             "name": "to",
             "optional": True,
+            "required": False,
             "options": [
                 ("asleep", "asleep"),
                 ("awake", "awake"),
@@ -599,7 +616,12 @@ async def test_get_trigger_capabilities_node_status(
             ],
             "type": "select",
         },
-        {"name": "for", "optional": True, "type": "positive_time_period_dict"},
+        {
+            "name": "for",
+            "optional": True,
+            "required": False,
+            "type": "positive_time_period_dict",
+        },
     ]
 
 
@@ -781,6 +803,7 @@ async def test_get_trigger_capabilities_basic_value_notification(
         {
             "name": "value",
             "optional": True,
+            "required": False,
             "type": "integer",
             "valueMin": 0,
             "valueMax": 255,
@@ -972,6 +995,7 @@ async def test_get_trigger_capabilities_central_scene_value_notification(
         {
             "name": "value",
             "optional": True,
+            "required": False,
             "type": "select",
             "options": [(0, "KeyPressed"), (1, "KeyReleased"), (2, "KeyHeldDown")],
         },
@@ -1156,6 +1180,7 @@ async def test_get_trigger_capabilities_scene_activation_value_notification(
         {
             "name": "value",
             "optional": True,
+            "required": False,
             "type": "integer",
             "valueMin": 1,
             "valueMax": 255,
@@ -1406,10 +1431,10 @@ async def test_get_trigger_capabilities_value_updated_value(
             ],
         },
         {"name": "property", "required": True, "type": "string"},
-        {"name": "property_key", "optional": True, "type": "string"},
-        {"name": "endpoint", "optional": True, "type": "string"},
-        {"name": "from", "optional": True, "type": "string"},
-        {"name": "to", "optional": True, "type": "string"},
+        {"name": "property_key", "optional": True, "required": False, "type": "string"},
+        {"name": "endpoint", "optional": True, "required": False, "type": "string"},
+        {"name": "from", "optional": True, "required": False, "type": "string"},
+        {"name": "to", "optional": True, "required": False, "type": "string"},
     ]
 
 
@@ -1552,6 +1577,7 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_range(
         {
             "name": "from",
             "optional": True,
+            "required": False,
             "valueMin": 0,
             "valueMax": 255,
             "type": "integer",
@@ -1559,6 +1585,7 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_range(
         {
             "name": "to",
             "optional": True,
+            "required": False,
             "valueMin": 0,
             "valueMax": 255,
             "type": "integer",
@@ -1600,12 +1627,14 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_enumerate
         {
             "name": "from",
             "optional": True,
+            "required": False,
             "options": [(0, "Disable Beeper"), (255, "Enable Beeper")],
             "type": "select",
         },
         {
             "name": "to",
             "optional": True,
+            "required": False,
             "options": [(0, "Disable Beeper"), (255, "Enable Beeper")],
             "type": "select",
         },

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -1229,7 +1229,13 @@ def test_section_in_serializer() -> None:
     ) == {
         "expanded": True,
         "schema": [
-            {"default": False, "name": "option_1", "optional": True, "type": "boolean"},
+            {
+                "default": False,
+                "name": "option_1",
+                "optional": True,
+                "required": False,
+                "type": "boolean",
+            },
             {"name": "option_2", "required": True, "type": "integer"},
         ],
         "type": "expandable",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant-libs/voluptuous-serialize/releases/tag/2.7.0

Serialized schemas now have a `"required": False` field additionally to the (to be deprecated) `"optional": True` field.
Please make sure to use "required" in favour of "optional" in frontend code where this is used directly (which, to my knowledge, is already the case in all non-custom frontend code).

There are also type annotations for the convert function now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
