### PR TITLE
Add websocket command to rename config subentry

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -62,6 +62,7 @@ def async_setup(hass: HomeAssistant) -> bool:
     websocket_api.async_register_command(hass, config_entries_flow_subscribe)
     websocket_api.async_register_command(hass, ignore_config_flow)
 
+    websocket_api.async_register_command(hass, config_subentry_rename)
     websocket_api.async_register_command(hass, config_subentry_delete)
     websocket_api.async_register_command(hass, config_subentry_list)
 
@@ -733,6 +734,41 @@ async def config_subentry_list(
         for subentry in entry.subentries.values()
     ]
     connection.send_result(msg["id"], result)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        "type": "config_entries/subentries/rename",
+        "entry_id": str,
+        "subentry_id": str,
+        "new_title": str,
+    }
+)
+@websocket_api.async_response
+async def config_subentry_rename(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Rename a subentry of a config entry."""
+    entry = get_entry(hass, connection, msg["entry_id"], msg["id"])
+    if entry is None:
+        connection.send_error(
+            msg["entry_id"], websocket_api.const.ERR_NOT_FOUND, "Config entry not found"
+        )
+        return
+
+    subentry = entry.subentries.get(msg["subentry_id"])
+    if subentry is None:
+        connection.send_error(
+            msg["id"], websocket_api.const.ERR_NOT_FOUND, "Config subentry not found"
+        )
+        return
+
+    hass.config_entries.async_update_subentry(entry, subentry, title=msg["new_title"])
+
+    connection.send_result(msg["id"])
 
 
 @websocket_api.require_admin

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from http import HTTPStatus
 from typing import Any, NoReturn
 
@@ -742,9 +742,7 @@ async def config_subentry_list(
         "type": "config_entries/subentries/update",
         "entry_id": str,
         "subentry_id": str,
-        vol.Optional("data"): Mapping,
         vol.Optional("title"): str,
-        vol.Optional("unique_id"): str,
     }
 )
 @websocket_api.async_response
@@ -753,7 +751,7 @@ async def config_subentry_update(
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Rename a subentry of a config entry."""
+    """Update a subentry of a config entry."""
     entry = get_entry(hass, connection, msg["entry_id"], msg["id"])
     if entry is None:
         connection.send_error(

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -767,9 +767,9 @@ async def config_subentry_update(
         return
 
     changes = dict(msg)
+    changes.pop("id")
     changes.pop("type")
     changes.pop("entry_id")
-    changes.pop("id")
     changes.pop("subentry_id")
 
     hass.config_entries.async_update_subentry(entry, subentry, **changes)

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -3347,10 +3347,10 @@ async def test_list_subentries(
     }
 
 
-async def test_rename_subentry(
+async def test_update_subentry(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
-    """Test that we can rename a subentry."""
+    """Test that we can update a subentry."""
     assert await async_setup_component(hass, "config", {})
     ws_client = await hass_ws_client(hass)
 
@@ -3363,6 +3363,7 @@ async def test_rename_subentry(
                 subentry_id="mock_id",
                 subentry_type="test",
                 title="Mock title",
+                unique_id="mock_unique_id",
             )
         ],
     )
@@ -3373,10 +3374,12 @@ async def test_rename_subentry(
 
     await ws_client.send_json_auto_id(
         {
-            "type": "config_entries/subentries/rename",
+            "type": "config_entries/subentries/update",
             "entry_id": entry.entry_id,
             "subentry_id": "mock_id",
-            "new_title": "Updated Title",
+            "title": "Updated Title",
+            "data": {"test": "updated test"},
+            "unique_id": "updated_unique_id",
         }
     )
     response = await ws_client.receive_json()
@@ -3385,15 +3388,17 @@ async def test_rename_subentry(
     assert response["result"] is None
 
     assert list(entry.subentries.values())[0].title == "Updated Title"
+    assert list(entry.subentries.values())[0].unique_id == "updated_unique_id"
+    assert list(entry.subentries.values())[0].data["test"] == "updated test"
 
     # Try renaming subentry from an unknown entry
     ws_client = await hass_ws_client(hass)
     await ws_client.send_json_auto_id(
         {
-            "type": "config_entries/subentries/rename",
+            "type": "config_entries/subentries/update",
             "entry_id": "no_such_entry",
             "subentry_id": "mock_id",
-            "new_title": "Updated Title",
+            "title": "Updated Title",
         }
     )
     response = await ws_client.receive_json()
@@ -3408,10 +3413,10 @@ async def test_rename_subentry(
     ws_client = await hass_ws_client(hass)
     await ws_client.send_json_auto_id(
         {
-            "type": "config_entries/subentries/rename",
+            "type": "config_entries/subentries/update",
             "entry_id": entry.entry_id,
             "subentry_id": "no_such_entry2",
-            "new_title": "Updated Title2",
+            "title": "Updated Title2",
         }
     )
     response = await ws_client.receive_json()

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -3369,17 +3369,12 @@ async def test_update_subentry(
     )
     entry.add_to_hass(hass)
 
-    assert entry.pref_disable_new_entities is False
-    assert entry.pref_disable_polling is False
-
     await ws_client.send_json_auto_id(
         {
             "type": "config_entries/subentries/update",
             "entry_id": entry.entry_id,
             "subentry_id": "mock_id",
             "title": "Updated Title",
-            "data": {"test": "updated test"},
-            "unique_id": "updated_unique_id",
         }
     )
     response = await ws_client.receive_json()
@@ -3388,8 +3383,8 @@ async def test_update_subentry(
     assert response["result"] is None
 
     assert list(entry.subentries.values())[0].title == "Updated Title"
-    assert list(entry.subentries.values())[0].unique_id == "updated_unique_id"
-    assert list(entry.subentries.values())[0].data["test"] == "updated test"
+    assert list(entry.subentries.values())[0].unique_id == "mock_unique_id"
+    assert list(entry.subentries.values())[0].data["test"] == "test"
 
     # Try renaming subentry from an unknown entry
     ws_client = await hass_ws_client(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new functionality to rename config subentry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/26574

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
