### PR TITLE
Add ability to use dict reference in translations

### DIFF
--- a/homeassistant/components/sql/strings.json
+++ b/homeassistant/components/sql/strings.json
@@ -38,35 +38,11 @@
   "options": {
     "step": {
       "init": {
-        "data": {
-          "db_url": "[%key:component::sql::config::step::user::data::db_url%]",
-          "name": "[%key:common::config_flow::data::name%]",
-          "query": "[%key:component::sql::config::step::user::data::query%]",
-          "column": "[%key:component::sql::config::step::user::data::column%]",
-          "unit_of_measurement": "[%key:component::sql::config::step::user::data::unit_of_measurement%]",
-          "value_template": "[%key:component::sql::config::step::user::data::value_template%]",
-          "device_class": "[%key:component::sql::config::step::user::data::device_class%]",
-          "state_class": "[%key:component::sql::config::step::user::data::state_class%]"
-        },
-        "data_description": {
-          "db_url": "[%key:component::sql::config::step::user::data_description::db_url%]",
-          "name": "[%key:component::sql::config::step::user::data_description::name%]",
-          "query": "[%key:component::sql::config::step::user::data_description::query%]",
-          "column": "[%key:component::sql::config::step::user::data_description::column%]",
-          "unit_of_measurement": "[%key:component::sql::config::step::user::data_description::unit_of_measurement%]",
-          "value_template": "[%key:component::sql::config::step::user::data_description::value_template%]",
-          "device_class": "[%key:component::sql::config::step::user::data_description::device_class%]",
-          "state_class": "[%key:component::sql::config::step::user::data_description::state_class%]"
-        }
+        "data": "[%dict:component::sql::config::step::user::data%]",
+        "data_description": "[%dict:component::sql::config::step::user::data_description%]"
       }
     },
-    "error": {
-      "db_url_invalid": "[%key:component::sql::config::error::db_url_invalid%]",
-      "query_invalid": "[%key:component::sql::config::error::query_invalid%]",
-      "query_no_read_only": "[%key:component::sql::config::error::query_no_read_only%]",
-      "multiple_queries": "[%key:component::sql::config::error::multiple_queries%]",
-      "column_invalid": "[%key:component::sql::config::error::column_invalid%]"
-    }
+    "error": "[%dict:component::sql::config::error%]"
   },
   "selector": {
     "device_class": {
@@ -130,14 +106,7 @@
         "wind_speed": "[%key:component::sensor::entity_component::wind_speed::name%]"
       }
     },
-    "state_class": {
-      "options": {
-        "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
-        "measurement_angle": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement_angle%]",
-        "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
-        "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"
-      }
-    }
+    "state_class": "[%dict:component::sensor::entity_component::_::state_attributes::state_class%]"
   },
   "issues": {
     "entity_id_query_does_full_table_scan": {

--- a/script/translations/download.py
+++ b/script/translations/download.py
@@ -151,7 +151,16 @@ def pick_keys(component: str, translations: dict[str, Any]) -> dict[str, Any]:
     flat_translations = flatten_translations(translations)
     flat_current_keys = flatten_translations(get_current_keys(component))
     flatten_result = {}
-    for key in flat_current_keys:
+    for key, value in flat_current_keys.items():
+        if value.startswith(r"[%dict"):
+            flatten_result.update(
+                {
+                    translated_key: translated_value
+                    for translated_key, translated_value in flat_translations.items()
+                    if translated_key.startswith(key)
+                }
+            )
+
         if key in flat_translations:
             flatten_result[key] = flat_translations[key]
     result = {}

--- a/script/translations/util.py
+++ b/script/translations/util.py
@@ -68,7 +68,7 @@ def load_json_from_path(path: pathlib.Path) -> Any:
         raise JSONDecodeErrorWithPath(err.msg, err.doc, err.pos, path) from err
 
 
-def flatten_translations(translations):
+def flatten_translations(translations: dict[str, Any]) -> dict[str, Any]:
     """Flatten all translations."""
     stack = [iter(translations.items())]
     key_stack = []


### PR DESCRIPTION
## Breaking change


## Proposed change
Adds the ability to reference a dict (not only a key) for translations.

Examples illustrated in the modification of `strings.json` for the `sql` integration.

hassfest also needs to be updated to handle this, but I would like to see if there's a chance of acceptance before proceeding with those mods.

Given that we don't have specific key references, of course something could be removed in the referenced dict which removes translation. But as we normally only allow references inside the same integration or to entity components, I see that risk as pretty much non-existing.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 