### PR TITLE
Play url_resolved for radio browser instead of url

### DIFF
--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -66,7 +66,7 @@ class RadioMediaSource(MediaSource):
         # Register "click" with Radio Browser
         await radios.station_click(uuid=station.uuid)
 
-        return PlayMedia(station.url, mime_type)
+        return PlayMedia(station.url_resolved, mime_type)
 
     async def async_browse_media(
         self,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
I had a local radio station (id: `ac721368-0ba0-4b89-b895-010b4dec5720`) that is present in the radio browser, but it would never play in Home Assistant. Every time you select it, I just get a buffering wheel forever. It plays with no problem when playing through [radio-browser.info](https://www.radio-browser.info/history/ac721368-0ba0-4b89-b895-010b4dec5720)

I dug into a bit why, and it seems like the station returned by python-radios is not a playable stream, but just an m3u playlist. 

```
Station(bitrate=0,
        change_uuid='1f788d83-90a5-4564-be64-844722d73be7',
        codec='AAC',
        country_code='US',
        favicon='https://i.iheart.com/v3/re/assets.streams/676311318ba6e31078732028',
        latitude=45.487487855397035,
        longitude=-122.806056981255,
        has_extended_info=False,
        hls=False,
        homepage='https://k103.iheart.com/',
        iso_3166_2='',
        language=['english'],
        language_codes=['en'],
        lastchange_time=datetime.datetime(2025, 8, 9, 7, 4, 11, tzinfo=datetime.timezone.utc),
        lastcheckok=True,
        last_check_ok_time=datetime.datetime(2025, 8, 19, 8, 10, 29, tzinfo=datetime.timezone.utc),
        last_check_time=datetime.datetime(2025, 8, 19, 8, 10, 29, tzinfo=datetime.timezone.utc),
        last_local_check_time=datetime.datetime(2025, 8, 18, 14, 41, 44, tzinfo=datetime.timezone.utc),
        name='K103',
        ssl_error=0,
        state='Oregon',
        uuid='ac721368-0ba0-4b89-b895-010b4dec5720',
        tags=['adult contemporary'],
        url_resolved='https://cloud.revma.ihrhls.com/zc1957?rj-org=n03a-e2&rj-ttl=5&rj-tok=AAABmMFcv1QAIp5gi27cJ92Hnw',
        url='https://stream.revma.ihrhls.com/zc1957.m3u',
        votes=1)
```

The url is not directly playable, but you need to fetch that url, and then the url returned by that fetch is the playable stream.

I see radios returns both a `url` and a `url_resolved`. For many stations these are the same string. For this one it is different, and the resolved url is playable, and the url is not. 

Does it make sense to just use the resolved url here instead of url? Or do you expect the media clients to handle that resolve?

Changing to url_resolved fixes the problem and the station plays correctly after that. I tested many other stations at the top of the popular category in the browser media player, and those all still work too.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
