### PR TITLE
Fix sort order in media browser  for music assistant integration

### DIFF
--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -70,7 +70,7 @@ LIBRARY_MEDIA_CLASS_MAP = {
 
 MEDIA_CONTENT_TYPE_FLAC = "audio/flac"
 THUMB_SIZE = 200
-SORT_NAME_ASC = "sort_name_asc"
+SORT_NAME = "sort_name"
 LOGGER = logging.getLogger(__name__)
 
 
@@ -173,7 +173,7 @@ async def build_playlists_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for item in await mass.music.get_library_playlists(
-                limit=500, order_by=SORT_NAME_ASC
+                limit=500, order_by=SORT_NAME
             )
             if item.available
         ],
@@ -225,7 +225,7 @@ async def build_artists_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for artist in await mass.music.get_library_artists(
-                limit=500, order_by=SORT_NAME_ASC
+                limit=500, order_by=SORT_NAME
             )
             if artist.available
         ],
@@ -275,7 +275,7 @@ async def build_albums_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for album in await mass.music.get_library_albums(
-                limit=500, order_by=SORT_NAME_ASC
+                limit=500, order_by=SORT_NAME
             )
             if album.available
         ],
@@ -323,7 +323,7 @@ async def build_tracks_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for track in await mass.music.get_library_tracks(
-                limit=500, order_by=SORT_NAME_ASC
+                limit=500, order_by=SORT_NAME
             )
             if track.available
         ],
@@ -346,7 +346,7 @@ async def build_podcasts_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for podcast in await mass.music.get_library_podcasts(
-                limit=500, order_by=SORT_NAME_ASC
+                limit=500, order_by=SORT_NAME
             )
             if podcast.available
         ],
@@ -369,7 +369,7 @@ async def build_audiobooks_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for audiobook in await mass.music.get_library_audiobooks(
-                limit=500, order_by=SORT_NAME_ASC
+                limit=500, order_by=SORT_NAME
             )
             if audiobook.available
         ],
@@ -392,7 +392,7 @@ async def build_radio_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for track in await mass.music.get_library_radios(
-                limit=500, order_by=SORT_NAME_ASC
+                limit=500, order_by=SORT_NAME
             )
             if track.available
         ],

--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -70,7 +70,7 @@ LIBRARY_MEDIA_CLASS_MAP = {
 
 MEDIA_CONTENT_TYPE_FLAC = "audio/flac"
 THUMB_SIZE = 200
-SORT_NAME_DESC = "sort_name_desc"
+SORT_NAME_ASC = "sort_name_asc"
 LOGGER = logging.getLogger(__name__)
 
 
@@ -173,7 +173,7 @@ async def build_playlists_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for item in await mass.music.get_library_playlists(
-                limit=500, order_by=SORT_NAME_DESC
+                limit=500, order_by=SORT_NAME_ASC
             )
             if item.available
         ],
@@ -225,7 +225,7 @@ async def build_artists_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for artist in await mass.music.get_library_artists(
-                limit=500, order_by=SORT_NAME_DESC
+                limit=500, order_by=SORT_NAME_ASC
             )
             if artist.available
         ],
@@ -275,7 +275,7 @@ async def build_albums_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for album in await mass.music.get_library_albums(
-                limit=500, order_by=SORT_NAME_DESC
+                limit=500, order_by=SORT_NAME_ASC
             )
             if album.available
         ],
@@ -323,7 +323,7 @@ async def build_tracks_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for track in await mass.music.get_library_tracks(
-                limit=500, order_by=SORT_NAME_DESC
+                limit=500, order_by=SORT_NAME_ASC
             )
             if track.available
         ],
@@ -346,7 +346,7 @@ async def build_podcasts_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for podcast in await mass.music.get_library_podcasts(
-                limit=500, order_by=SORT_NAME_DESC
+                limit=500, order_by=SORT_NAME_ASC
             )
             if podcast.available
         ],
@@ -369,7 +369,7 @@ async def build_audiobooks_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for audiobook in await mass.music.get_library_audiobooks(
-                limit=500, order_by=SORT_NAME_DESC
+                limit=500, order_by=SORT_NAME_ASC
             )
             if audiobook.available
         ],
@@ -392,7 +392,7 @@ async def build_radio_listing(mass: MusicAssistantClient) -> BrowseMedia:
             # we only grab the first page here because the
             # HA media browser does not support paging
             for track in await mass.music.get_library_radios(
-                limit=500, order_by=SORT_NAME_DESC
+                limit=500, order_by=SORT_NAME_ASC
             )
             if track.available
         ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes a long standing issue of reverse sort order in music assistant media browser

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
