### PR TITLE
Use unhealthy/unsupported reason enums from aiohasupervisor

### DIFF
--- a/homeassistant/components/hassio/issues.py
+++ b/homeassistant/components/hassio/issues.py
@@ -10,7 +10,12 @@ from typing import Any, NotRequired, TypedDict
 from uuid import UUID
 
 from aiohasupervisor import SupervisorError
-from aiohasupervisor.models import ContextType, Issue as SupervisorIssue
+from aiohasupervisor.models import (
+    ContextType,
+    Issue as SupervisorIssue,
+    UnhealthyReason,
+    UnsupportedReason,
+)
 
 from homeassistant.core import HassJob, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -59,42 +64,9 @@ INFO_URL_UNSUPPORTED = "https://www.home-assistant.io/more-info/unsupported"
 
 PLACEHOLDER_KEY_REASON = "reason"
 
-UNSUPPORTED_REASONS = {
-    "apparmor",
-    "cgroup_version",
-    "connectivity_check",
-    "content_trust",
-    "dbus",
-    "dns_server",
-    "docker_configuration",
-    "docker_version",
-    "job_conditions",
-    "lxc",
-    "network_manager",
-    "os",
-    "os_agent",
-    "os_version",
-    "restart_policy",
-    "software",
-    "source_mods",
-    "supervisor_version",
-    "systemd",
-    "systemd_journal",
-    "systemd_resolved",
-    "virtualization_image",
-}
 # Some unsupported reasons also mark the system as unhealthy. If the unsupported reason
 # provides no additional information beyond the unhealthy one then skip that repair.
 UNSUPPORTED_SKIP_REPAIR = {"privileged"}
-UNHEALTHY_REASONS = {
-    "docker",
-    "duplicate_os_installation",
-    "oserror_bad_message",
-    "privileged",
-    "setup",
-    "supervisor",
-    "untrusted",
-}
 
 # Keys (type + context) of issues that when found should be made into a repair
 ISSUE_KEYS_FOR_REPAIRS = {
@@ -206,7 +178,7 @@ class SupervisorIssues:
     def unhealthy_reasons(self, reasons: set[str]) -> None:
         """Set unhealthy reasons. Create or delete repairs as necessary."""
         for unhealthy in reasons - self.unhealthy_reasons:
-            if unhealthy in UNHEALTHY_REASONS:
+            if unhealthy in UnhealthyReason:
                 translation_key = f"{ISSUE_KEY_UNHEALTHY}_{unhealthy}"
                 translation_placeholders = None
             else:
@@ -238,7 +210,7 @@ class SupervisorIssues:
     def unsupported_reasons(self, reasons: set[str]) -> None:
         """Set unsupported reasons. Create or delete repairs as necessary."""
         for unsupported in reasons - UNSUPPORTED_SKIP_REPAIR - self.unsupported_reasons:
-            if unsupported in UNSUPPORTED_REASONS:
+            if unsupported in UnsupportedReason:
                 translation_key = f"{ISSUE_KEY_UNSUPPORTED}_{unsupported}"
                 translation_placeholders = None
             else:


### PR DESCRIPTION
## Proposed change

Today core maintains a list of known unsupported and unhealthy reasons in Supervisor. This way if a new one is added that isn't known to core yet the repair fails back to a generic translation that is functional but non-specific rather then failing or skipping it entirely.

There's no reason to maintain this list in core anymore, the client library has this list. This PR replaces these lists with those enums. It also adds tests that require every unhealthy and unsupported reason in the client library has its own non-generic translation. This will require translations for any new unhealthy/unsupported reasons to be added to the hassio integration in order to bump the client library if the new version adds any.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
