### PR TITLE
Bump ESPHome minimum stable BLE version to 2025.8.0

### DIFF
--- a/homeassistant/components/esphome/const.py
+++ b/homeassistant/components/esphome/const.py
@@ -17,7 +17,7 @@ DEFAULT_NEW_CONFIG_ALLOW_ALLOW_SERVICE_CALLS = False
 
 DEFAULT_PORT: Final = 6053
 
-STABLE_BLE_VERSION_STR = "2025.5.0"
+STABLE_BLE_VERSION_STR = "2025.8.0"
 STABLE_BLE_VERSION = AwesomeVersion(STABLE_BLE_VERSION_STR)
 PROJECT_URLS = {
     "esphome.bluetooth-proxy": "https://esphome.github.io/bluetooth-proxies/",


### PR DESCRIPTION
needs https://github.com/esphome/esphome/pull/10309

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump ESPHome minimum stable BLE version to 2025.8.0 to inform users when their BLE proxy devices need updating for optimal performance.

This change updates the version check that determines whether Home Assistant should notify users to update their ESPHome BLE proxy devices. ESPHome 2025.8.0 contains significant Bluetooth enhancements that improve BLE proxy reliability:

### Critical Bug Fixes
- **Connection stability**: Fixes race conditions preventing BLE connection slot corruption and "Connection Rejected Due to Limited Resources" errors
- **Service discovery reliability**: Prevents cache pollution and ensures complete GATT service data transmission
- **False reboot prevention**: Fixes race condition causing unnecessary device reboots when event loops are temporarily blocked
- **Connection parameter handling**: Sets fast parameters to complete service discovery within 10s timeout, then restores to efficient settings for ongoing connection. This makes the WiFi based ESP32S3 proxies usable.

### Major Performance Improvements  
- **67-75% reduction in service discovery API messages** during critical first connection phase through batched discovery and native UUID formats
- **~145ms faster BLE connections** by eliminating unnecessary wait states and optimizing connection flow
- **2x faster service discovery** with optimized connection parameters for ESP32 variants
- **Zero heap allocations** for 95%+ of BLE events through inline storage optimization

### Memory & Resource Optimization
- **6KB+ memory savings** by removing redundant ring buffers
- **50%-100% reduction in heap allocations** per BLE event
- **117x performance improvement** in connection state reporting
- **Configurable notification limits** supporting more simultaneous BLE devices (increased default from 9 to 12)

These improvements collectively make BLE proxies more stable, responsive, and capable of handling more devices simultaneously.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

### Sample of more relevant ESPHome PRs included in 2025.8.0:
- https://github.com/esphome/esphome/pull/10303 - Fix Bluetooth proxy race condition on connection slots
- https://github.com/esphome/esphome/pull/10001 - Dynamic batching for GATT service discovery
- https://github.com/esphome/esphome/pull/9992 - Batch BLE service discovery messages
- https://github.com/esphome/esphome/pull/9902 - Fix cache pollution and descriptor count bugs
- https://github.com/esphome/esphome/pull/9995 - Optimize UUID transmission with native formats
- https://github.com/esphome/esphome/pull/9993 - Improve connection stability with medium parameters
- https://github.com/esphome/esphome/pull/9971 - Fix ESP32 variant connection issues
- https://github.com/esphome/esphome/pull/9761 - Zero-copy protobuf encoding
- https://github.com/esphome/esphome/pull/9765 - Memory optimization in service discovery
- https://github.com/esphome/esphome/pull/9697 - Fix service discovery on disconnected connections
- https://github.com/esphome/esphome/pull/10144 - Fix BLE tracker false reboots
- https://github.com/esphome/esphome/pull/10098 - Configurable BLE notification limits
- https://github.com/esphome/esphome/pull/10057 - Remove redundant ring buffer
- https://github.com/esphome/esphome/pull/10061 - Optimize connection latency
- https://github.com/esphome/esphome/pull/10055 - Simplify scanner state machine
- https://github.com/esphome/esphome/pull/10052 - Optimize connection parameters
- https://github.com/esphome/esphome/pull/10051 - Reduce connection latency
- https://github.com/esphome/esphome/pull/10062 - Early MTU negotiation
- https://github.com/esphome/esphome/pull/10059 - Fix connection parameter handling
- https://github.com/esphome/esphome/pull/10015 - Memory optimization with fixed arrays
- https://github.com/esphome/esphome/pull/10010 - Eliminate heap allocations in connection reporting
- https://github.com/esphome/esphome/pull/10247 - Optimize BLE event memory usage
- https://github.com/esphome/esphome/pull/10249 - Inline storage for BLE events

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr