### PR TITLE
Update togrill to 0.8.0

### DIFF
--- a/homeassistant/components/togrill/event.py
+++ b/homeassistant/components/togrill/event.py
@@ -60,4 +60,4 @@ class ToGrillEventEntity(ToGrillEntity, EventEntity):
         if packet.probe != self._probe_number:
             return
 
-        self._trigger_event(slugify(message.name))
+        self._trigger_event(message.name.lower())

--- a/homeassistant/components/togrill/manifest.json
+++ b/homeassistant/components/togrill/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "loggers": ["togrill_bluetooth"],
   "quality_scale": "bronze",
-  "requirements": ["togrill-bluetooth==0.7.0"]
+  "requirements": ["togrill-bluetooth==0.8.0"]
 }

--- a/homeassistant/components/togrill/strings.json
+++ b/homeassistant/components/togrill/strings.json
@@ -55,7 +55,16 @@
             "state": {
               "probe_acknowledge": "Alarm acknowledged",
               "probe_alarm": "Alarm triggered",
-              "probe_disconnected": "Probe disconnected"
+              "probe_disconnected": "Probe disconnected",
+              "device_low_power": "Device has low battery",
+              "device_high_temp": "Device has too high temperature",
+              "probe_below_minimum": "Temperature too low",
+              "probe_above_maximum": "Temperature too high",
+              "ignition_failure": "Ignition failure",
+              "ambient_low_temp": "Ambient temperature too low",
+              "ambient_over_heat": "Ambient temperature too high",
+              "ambient_cool_down": "Ambient temperature cooldown",
+              "probe_timer_alarm": "Timer alarm"
             }
           }
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2951,7 +2951,7 @@ tmb==0.0.4
 todoist-api-python==2.1.7
 
 # homeassistant.components.togrill
-togrill-bluetooth==0.7.0
+togrill-bluetooth==0.8.0
 
 # homeassistant.components.tolo
 tololib==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2428,7 +2428,7 @@ tilt-pi==0.2.1
 todoist-api-python==2.1.7
 
 # homeassistant.components.togrill
-togrill-bluetooth==0.7.0
+togrill-bluetooth==0.8.0
 
 # homeassistant.components.tolo
 tololib==1.2.2

--- a/tests/components/togrill/snapshots/test_event.ambr
+++ b/tests/components/togrill/snapshots/test_event.ambr
@@ -1,364 +1,4 @@
 # serializer version: 1
-# name: test_events[0][event.pro_05_probe_1-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.pro_05_probe_1',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Probe 1',
-    'platform': 'togrill',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'event',
-    'unique_id': '00000000-0000-0000-0000-000000000001_1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[0][event.pro_05_probe_1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'event_type': 'probe_acknowledge',
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-      'friendly_name': 'Pro-05 Probe 1',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.pro_05_probe_1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2023-10-21T00:00:00.000+00:00',
-  })
-# ---
-# name: test_events[0][event.pro_05_probe_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.pro_05_probe_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Probe 2',
-    'platform': 'togrill',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'event',
-    'unique_id': '00000000-0000-0000-0000-000000000001_2',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[0][event.pro_05_probe_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-      'friendly_name': 'Pro-05 Probe 2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.pro_05_probe_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_events[5][event.pro_05_probe_1-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.pro_05_probe_1',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Probe 1',
-    'platform': 'togrill',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'event',
-    'unique_id': '00000000-0000-0000-0000-000000000001_1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[5][event.pro_05_probe_1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'event_type': 'probe_alarm',
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-      'friendly_name': 'Pro-05 Probe 1',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.pro_05_probe_1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2023-10-21T00:00:00.000+00:00',
-  })
-# ---
-# name: test_events[5][event.pro_05_probe_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.pro_05_probe_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Probe 2',
-    'platform': 'togrill',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'event',
-    'unique_id': '00000000-0000-0000-0000-000000000001_2',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[5][event.pro_05_probe_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-      'friendly_name': 'Pro-05 Probe 2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.pro_05_probe_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_events[6][event.pro_05_probe_1-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.pro_05_probe_1',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Probe 1',
-    'platform': 'togrill',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'event',
-    'unique_id': '00000000-0000-0000-0000-000000000001_1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[6][event.pro_05_probe_1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'event_type': 'probe_disconnected',
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-      'friendly_name': 'Pro-05 Probe 1',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.pro_05_probe_1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2023-10-21T00:00:00.000+00:00',
-  })
-# ---
-# name: test_events[6][event.pro_05_probe_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.pro_05_probe_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Probe 2',
-    'platform': 'togrill',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'event',
-    'unique_id': '00000000-0000-0000-0000-000000000001_2',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[6][event.pro_05_probe_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
-        'probe_acknowledge',
-        'probe_alarm',
-        'probe_disconnected',
-      ]),
-      'friendly_name': 'Pro-05 Probe 2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.pro_05_probe_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_setup[no_data][event.pro_05_probe_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -367,8 +7,17 @@
     'capabilities': dict({
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -406,8 +55,17 @@
       'event_type': None,
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
       'friendly_name': 'Pro-05 Probe 1',
     }),
@@ -427,8 +85,17 @@
     'capabilities': dict({
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -466,8 +133,17 @@
       'event_type': None,
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
       'friendly_name': 'Pro-05 Probe 2',
     }),
@@ -487,8 +163,17 @@
     'capabilities': dict({
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -526,8 +211,17 @@
       'event_type': None,
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
       'friendly_name': 'Pro-05 Probe 1',
     }),
@@ -547,8 +241,17 @@
     'capabilities': dict({
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -586,8 +289,17 @@
       'event_type': None,
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
       'friendly_name': 'Pro-05 Probe 2',
     }),
@@ -607,8 +319,17 @@
     'capabilities': dict({
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -646,8 +367,17 @@
       'event_type': None,
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
       'friendly_name': 'Pro-05 Probe 1',
     }),
@@ -667,8 +397,17 @@
     'capabilities': dict({
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -706,8 +445,17 @@
       'event_type': None,
       'event_types': list([
         'probe_acknowledge',
+        'device_low_power',
+        'device_high_temp',
+        'probe_below_minimum',
+        'probe_above_maximum',
         'probe_alarm',
         'probe_disconnected',
+        'ignition_failure',
+        'ambient_low_temp',
+        'ambient_over_heat',
+        'ambient_cool_down',
+        'probe_timer_alarm',
       ]),
       'friendly_name': 'Pro-05 Probe 2',
     }),

--- a/tests/components/togrill/test_event.py
+++ b/tests/components/togrill/test_event.py
@@ -6,9 +6,11 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from togrill_bluetooth.packets import PacketA1Notify, PacketA5Notify
 
-from homeassistant.const import Platform
+from homeassistant.components.event import ATTR_EVENT_TYPE
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
 
 from . import TOGRILL_SERVICE_INFO, setup_entry
 
@@ -48,7 +50,7 @@ async def test_setup(
 @pytest.mark.freeze_time("2023-10-21")
 @pytest.mark.parametrize(
     "message",
-    list(PacketA5Notify.Message),
+    [pytest.param(message, id=message.name) for message in PacketA5Notify.Message],
 )
 async def test_events(
     hass: HomeAssistant,
@@ -56,7 +58,7 @@ async def test_events(
     snapshot: SnapshotAssertion,
     mock_entry: MockConfigEntry,
     mock_client: Mock,
-    message,
+    message: PacketA5Notify.Message,
 ) -> None:
     """Test all possible events."""
 
@@ -66,4 +68,11 @@ async def test_events(
 
     mock_client.mocked_notify(PacketA5Notify(probe=1, message=message))
 
-    await snapshot_platform(hass, entity_registry, snapshot, mock_entry.entry_id)
+    state = hass.states.get("event.pro_05_probe_2")
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    state = hass.states.get("event.pro_05_probe_1")
+    assert state
+    assert state.state == "2023-10-21T00:00:00.000+00:00"
+    assert state.attributes.get(ATTR_EVENT_TYPE) == slugify(message.name)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update togrill library to 0.8.0 to support new events and prepare for more data.

Release: https://github.com/elupus/togrill-bluetooth/releases/tag/0.8.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40525
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
