### PR TITLE
Bump python-mystrom to 2.5.0

### DIFF
--- a/homeassistant/components/mystrom/manifest.json
+++ b/homeassistant/components/mystrom/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/mystrom",
   "iot_class": "local_polling",
   "loggers": ["pymystrom"],
-  "requirements": ["python-mystrom==2.4.0"]
+  "requirements": ["python-mystrom==2.5.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2473,7 +2473,7 @@ python-miio==0.5.12
 python-mpd2==3.1.1
 
 # homeassistant.components.mystrom
-python-mystrom==2.4.0
+python-mystrom==2.5.0
 
 # homeassistant.components.open_router
 python-open-router==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2046,7 +2046,7 @@ python-miio==0.5.12
 python-mpd2==3.1.1
 
 # homeassistant.components.mystrom
-python-mystrom==2.4.0
+python-mystrom==2.5.0
 
 # homeassistant.components.open_router
 python-open-router==0.3.1


### PR DESCRIPTION
## Proposed change
Update the myStrom dependency to `python-mystrom==2.5.0`. This release includes a fix to handle legacy v1 switches that omit the `type` key in their info response.

## Type of change
- [x] Dependency
- [x] Bugfix (non-breaking change that fixes an issue)

## Additional information
- This PR fixes or closes issue: home-assistant/core#150264
- Link to release notes: https://github.com/home-assistant-ecosystem/python-mystrom/releases/tag/2.5.0
- Link to the change log/diff: https://github.com/home-assistant-ecosystem/python-mystrom/compare/2.4.0...2.5.0

## Checklist for dependency bumps
- [x] For the updated dependency, a link to the changelog or a diff between versions is added above.
- [x] New or updated dependencies have been added to `requirements_all.txt` (and related generated files if applicable).
- [x] Updated by running: `python3 -m script.gen_requirements_all`

## Testing instructions
- myStrom v1 switch (legacy firmware): verify the entity sets up successfully, can be toggled, and reports power/consumption.
- myStrom v2+ switch: verify there are no regressions in setup and state updates.

## Documentation
- No documentation changes required.

## Breaking change
- None.