### PR TITLE
Enable country site autodetection in Alexa Devices

### DIFF
--- a/homeassistant/components/alexa_devices/__init__.py
+++ b/homeassistant/components/alexa_devices/__init__.py
@@ -42,9 +42,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> bo
 
 async def async_migrate_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> bool:
     """Migrate old entry."""
-    _LOGGER.debug("Migrating from version %s", entry.version)
+    if entry.version == 1 and entry.minor_version == 0:
+        _LOGGER.debug(
+            "Migrating from version %s.%s", entry.version, entry.minor_version
+        )
 
-    if entry.version == 1:
         # Convert country in domain
         country = entry.data[CONF_COUNTRY]
         domain = COUNTRY_DOMAINS.get(country, country)
@@ -52,11 +54,14 @@ async def async_migrate_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> 
         # Save domain and remove country
         new_data = entry.data.copy()
         new_data.update({"site": f"https://www.amazon.{domain}"})
-        new_data.pop(CONF_COUNTRY)
 
-        hass.config_entries.async_update_entry(entry, data=new_data, version=2)
+        hass.config_entries.async_update_entry(
+            entry, data=new_data, version=1, minor_version=1
+        )
 
-    _LOGGER.info("Migration to version %s successful", entry.version)
+    _LOGGER.info(
+        "Migration to version %s.%s successful", entry.version, entry.minor_version
+    )
 
     return True
 

--- a/homeassistant/components/alexa_devices/config_flow.py
+++ b/homeassistant/components/alexa_devices/config_flow.py
@@ -45,7 +45,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 class AmazonDevicesConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Alexa Devices."""
 
-    VERSION = 2
+    VERSION = 1
+    MINOR_VERSION = 1
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/alexa_devices/config_flow.py
+++ b/homeassistant/components/alexa_devices/config_flow.py
@@ -10,16 +10,14 @@ from aioamazondevices.exceptions import (
     CannotAuthenticate,
     CannotConnect,
     CannotRetrieveData,
-    WrongCountry,
 )
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_CODE, CONF_COUNTRY, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.selector import CountrySelector
 
 from .const import CONF_LOGIN_DATA, DOMAIN
 
@@ -37,7 +35,6 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     session = aiohttp_client.async_create_clientsession(hass)
     api = AmazonEchoApi(
         session,
-        data[CONF_COUNTRY],
         data[CONF_USERNAME],
         data[CONF_PASSWORD],
     )
@@ -47,6 +44,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
 class AmazonDevicesConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Alexa Devices."""
+
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -62,8 +61,6 @@ class AmazonDevicesConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_auth"
             except CannotRetrieveData:
                 errors["base"] = "cannot_retrieve_data"
-            except WrongCountry:
-                errors["base"] = "wrong_country"
             else:
                 await self.async_set_unique_id(data["customer_info"]["user_id"])
                 self._abort_if_unique_id_configured()
@@ -78,9 +75,6 @@ class AmazonDevicesConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_COUNTRY, default=self.hass.config.country
-                    ): CountrySelector(),
                     vol.Required(CONF_USERNAME): cv.string,
                     vol.Required(CONF_PASSWORD): cv.string,
                     vol.Required(CONF_CODE): cv.string,

--- a/homeassistant/components/alexa_devices/const.py
+++ b/homeassistant/components/alexa_devices/const.py
@@ -6,3 +6,22 @@ _LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "alexa_devices"
 CONF_LOGIN_DATA = "login_data"
+
+DEFAULT_DOMAIN = {"domain": "com"}
+COUNTRY_DOMAINS = {
+    "ar": DEFAULT_DOMAIN,
+    "at": DEFAULT_DOMAIN,
+    "au": {"domain": "com.au"},
+    "be": {"domain": "com.be"},
+    "br": DEFAULT_DOMAIN,
+    "gb": {"domain": "co.uk"},
+    "il": DEFAULT_DOMAIN,
+    "jp": {"domain": "co.jp"},
+    "mx": {"domain": "com.mx"},
+    "no": DEFAULT_DOMAIN,
+    "nz": {"domain": "com.au"},
+    "pl": DEFAULT_DOMAIN,
+    "tr": {"domain": "com.tr"},
+    "us": DEFAULT_DOMAIN,
+    "za": {"domain": "co.za"},
+}

--- a/homeassistant/components/alexa_devices/coordinator.py
+++ b/homeassistant/components/alexa_devices/coordinator.py
@@ -11,7 +11,7 @@ from aioamazondevices.exceptions import (
 from aiohttp import ClientSession
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_COUNTRY, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -44,7 +44,6 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
         )
         self.api = AmazonEchoApi(
             session,
-            entry.data[CONF_COUNTRY],
             entry.data[CONF_USERNAME],
             entry.data[CONF_PASSWORD],
             entry.data[CONF_LOGIN_DATA],

--- a/homeassistant/components/alexa_devices/manifest.json
+++ b/homeassistant/components/alexa_devices/manifest.json
@@ -8,7 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aioamazondevices"],
   "quality_scale": "silver",
-  "requirements": [
-    "git+https://github.com/chemelli74/aioamazondevices.git@refs/pull/449/head#aioamazondevices==4.1.0-beta.1"
-  ]
+  "requirements": ["aioamazondevices==5.0.0"]
 }

--- a/homeassistant/components/alexa_devices/manifest.json
+++ b/homeassistant/components/alexa_devices/manifest.json
@@ -8,5 +8,7 @@
   "iot_class": "cloud_polling",
   "loggers": ["aioamazondevices"],
   "quality_scale": "silver",
-  "requirements": ["aioamazondevices==4.0.0"]
+  "requirements": [
+    "git+https://github.com/chemelli74/aioamazondevices.git@refs/pull/449/head#aioamazondevices==4.1.0-beta.1"
+  ]
 }

--- a/homeassistant/components/alexa_devices/strings.json
+++ b/homeassistant/components/alexa_devices/strings.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "data_code": "One-time password (OTP code)",
-    "data_description_country": "The country where your Amazon account is registered.",
     "data_description_username": "The email address of your Amazon account.",
     "data_description_password": "The password of your Amazon account.",
     "data_description_code": "The one-time password to log in to your account. Currently, only tokens from OTP applications are supported.",
@@ -12,13 +11,11 @@
     "step": {
       "user": {
         "data": {
-          "country": "[%key:common::config_flow::data::country%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "code": "[%key:component::alexa_devices::common::data_code%]"
         },
         "data_description": {
-          "country": "[%key:component::alexa_devices::common::data_description_country%]",
           "username": "[%key:component::alexa_devices::common::data_description_username%]",
           "password": "[%key:component::alexa_devices::common::data_description_password%]",
           "code": "[%key:component::alexa_devices::common::data_description_code%]"
@@ -46,7 +43,6 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "cannot_retrieve_data": "Unable to retrieve data from Amazon. Please try again later.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "wrong_country": "Wrong country selected. Please select the country where your Amazon account is registered.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ aioairzone-cloud==0.7.1
 aioairzone==1.0.0
 
 # homeassistant.components.alexa_devices
-aioamazondevices==4.0.0
+aioamazondevices==5.0.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,7 +173,7 @@ aioairzone-cloud==0.7.1
 aioairzone==1.0.0
 
 # homeassistant.components.alexa_devices
-aioamazondevices==4.0.0
+aioamazondevices==5.0.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/tests/components/alexa_devices/conftest.py
+++ b/tests/components/alexa_devices/conftest.py
@@ -8,9 +8,9 @@ from aioamazondevices.const import DEVICE_TYPE_TO_MODEL
 import pytest
 
 from homeassistant.components.alexa_devices.const import CONF_LOGIN_DATA, DOMAIN
-from homeassistant.const import CONF_COUNTRY, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import TEST_COUNTRY, TEST_PASSWORD, TEST_SERIAL_NUMBER, TEST_USERNAME
+from .const import TEST_PASSWORD, TEST_SERIAL_NUMBER, TEST_USERNAME
 
 from tests.common import MockConfigEntry
 
@@ -80,7 +80,6 @@ def mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         title="Amazon Test Account",
         data={
-            CONF_COUNTRY: TEST_COUNTRY,
             CONF_USERNAME: TEST_USERNAME,
             CONF_PASSWORD: TEST_PASSWORD,
             CONF_LOGIN_DATA: {"session": "test-session"},

--- a/tests/components/alexa_devices/snapshots/test_diagnostics.ambr
+++ b/tests/components/alexa_devices/snapshots/test_diagnostics.ambr
@@ -47,7 +47,6 @@
     }),
     'entry': dict({
       'data': dict({
-        'country': 'IT',
         'login_data': dict({
           'session': 'test-session',
         }),

--- a/tests/components/alexa_devices/test_config_flow.py
+++ b/tests/components/alexa_devices/test_config_flow.py
@@ -6,17 +6,16 @@ from aioamazondevices.exceptions import (
     CannotAuthenticate,
     CannotConnect,
     CannotRetrieveData,
-    WrongCountry,
 )
 import pytest
 
 from homeassistant.components.alexa_devices.const import CONF_LOGIN_DATA, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_CODE, CONF_COUNTRY, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .const import TEST_CODE, TEST_COUNTRY, TEST_PASSWORD, TEST_USERNAME
+from .const import TEST_CODE, TEST_PASSWORD, TEST_USERNAME
 
 from tests.common import MockConfigEntry
 
@@ -37,7 +36,6 @@ async def test_full_flow(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_COUNTRY: TEST_COUNTRY,
             CONF_USERNAME: TEST_USERNAME,
             CONF_PASSWORD: TEST_PASSWORD,
             CONF_CODE: TEST_CODE,
@@ -46,7 +44,6 @@ async def test_full_flow(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == TEST_USERNAME
     assert result["data"] == {
-        CONF_COUNTRY: TEST_COUNTRY,
         CONF_USERNAME: TEST_USERNAME,
         CONF_PASSWORD: TEST_PASSWORD,
         CONF_LOGIN_DATA: {
@@ -63,7 +60,6 @@ async def test_full_flow(
         (CannotConnect, "cannot_connect"),
         (CannotAuthenticate, "invalid_auth"),
         (CannotRetrieveData, "cannot_retrieve_data"),
-        (WrongCountry, "wrong_country"),
     ],
 )
 async def test_flow_errors(
@@ -87,7 +83,6 @@ async def test_flow_errors(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_COUNTRY: TEST_COUNTRY,
             CONF_USERNAME: TEST_USERNAME,
             CONF_PASSWORD: TEST_PASSWORD,
             CONF_CODE: TEST_CODE,
@@ -102,7 +97,6 @@ async def test_flow_errors(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_COUNTRY: TEST_COUNTRY,
             CONF_USERNAME: TEST_USERNAME,
             CONF_PASSWORD: TEST_PASSWORD,
             CONF_CODE: TEST_CODE,
@@ -131,7 +125,6 @@ async def test_already_configured(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_COUNTRY: TEST_COUNTRY,
             CONF_USERNAME: TEST_USERNAME,
             CONF_PASSWORD: TEST_PASSWORD,
             CONF_CODE: TEST_CODE,

--- a/tests/components/alexa_devices/test_init.py
+++ b/tests/components/alexa_devices/test_init.py
@@ -4,12 +4,14 @@ from unittest.mock import AsyncMock
 
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.alexa_devices.const import DOMAIN
+from homeassistant.components.alexa_devices.const import CONF_LOGIN_DATA, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_COUNTRY, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
-from .const import TEST_SERIAL_NUMBER
+from .const import TEST_COUNTRY, TEST_PASSWORD, TEST_SERIAL_NUMBER, TEST_USERNAME
 
 from tests.common import MockConfigEntry
 
@@ -28,3 +30,32 @@ async def test_device_info(
     )
     assert device_entry is not None
     assert device_entry == snapshot
+
+
+async def test_migrate_entry(
+    hass: HomeAssistant,
+    mock_amazon_devices_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test successful migration of entry data."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Amazon Test Account",
+        data={
+            CONF_COUNTRY: TEST_COUNTRY,
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_LOGIN_DATA: {"session": "test-session"},
+        },
+        unique_id=TEST_USERNAME,
+        version=1,
+        minor_version=0,
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.minor_version == 1
+    assert config_entry.data["site"] == f"https://www.amazon.{TEST_COUNTRY}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Global Access allows all users to log in via [www.amazon.com](http://www.amazon.com/) and automatically detect the correct country API site, eliminating the need for country settings.

It should address even the most complex scenarios with users from one country but digital content and addresses from different countries.
We expect this PR to resolve 99% of the remaining access issues.

Side note: I left in place old CONF_COUNTRY parameter to allow easy rollback.

Bump aioamazondevices to 5.0.0

changelog: https://github.com/chemelli74/aioamazondevices/releases/tag/v5.0.0
diff: https://github.com/chemelli74/aioamazondevices/compare/v4.0.0...v5.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #150723, fixes #150717, fixes #150527, fixes #150521, fixes #150373, fixes #150336, fixes #150282, fixes #150189, fixes #149776, fixes #149752, fixes #149615, fixes #149549, fixes #149467, fixes #149235, fixes #148979 , fixes #148777, fixes #148747
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
