### PR TITLE
Fix schedule entity can't delete icon

### DIFF
--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -242,7 +242,7 @@ class ScheduleStorageCollection(DictStorageCollection):
     async def _update_data(self, item: dict, update_data: dict) -> dict:
         """Return a new updated data object."""
         self.SCHEMA(update_data)
-        return item | update_data
+        return {CONF_ID: item[CONF_ID]} | update_data
 
     async def _async_load_data(self) -> SerializedStorageCollection | None:
         """Load the data."""

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -617,11 +617,26 @@ async def test_ws_delete(
 
 @pytest.mark.freeze_time("2022-08-10 20:10:00-07:00")
 @pytest.mark.parametrize(
-    ("to", "next_event", "saved_to"),
+    ("to", "next_event", "saved_to", "icon_dict"),
     [
-        ("23:59:59", "2022-08-10T23:59:59-07:00", "23:59:59"),
-        ("24:00", "2022-08-11T00:00:00-07:00", "24:00:00"),
-        ("24:00:00", "2022-08-11T00:00:00-07:00", "24:00:00"),
+        (
+            "23:59:59",
+            "2022-08-10T23:59:59-07:00",
+            "23:59:59",
+            {CONF_ICON: "mdi:party-popper"},
+        ),
+        (
+            "24:00",
+            "2022-08-11T00:00:00-07:00",
+            "24:00:00",
+            {CONF_ICON: "mdi:calendar"},
+        ),
+        (
+            "24:00:00",
+            "2022-08-11T00:00:00-07:00",
+            "24:00:00",
+            {},
+        ),
     ],
 )
 async def test_update(
@@ -632,6 +647,7 @@ async def test_update(
     to: str,
     next_event: str,
     saved_to: str,
+    icon_dict: dict,
 ) -> None:
     """Test updating the schedule."""
     assert await schedule_setup()
@@ -654,7 +670,7 @@ async def test_update(
             "type": f"{DOMAIN}/update",
             f"{DOMAIN}_id": "from_storage",
             CONF_NAME: "Party pooper",
-            CONF_ICON: "mdi:party-pooper",
+            **icon_dict,
             CONF_MONDAY: [],
             CONF_TUESDAY: [],
             CONF_WEDNESDAY: [{CONF_FROM: "17:00:00", CONF_TO: to}],
@@ -671,7 +687,7 @@ async def test_update(
     assert state
     assert state.state == STATE_ON
     assert state.attributes[ATTR_FRIENDLY_NAME] == "Party pooper"
-    assert state.attributes[ATTR_ICON] == "mdi:party-pooper"
+    assert state.attributes.get(ATTR_ICON) == icon_dict.get(CONF_ICON)
     assert state.attributes[ATTR_NEXT_EVENT].isoformat() == next_event
 
     await client.send_json({"id": 2, "type": f"{DOMAIN}/list"})

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -623,13 +623,13 @@ async def test_ws_delete(
             "23:59:59",
             "2022-08-10T23:59:59-07:00",
             "23:59:59",
-            {CONF_ICON: "mdi:party-popper"},
+            {CONF_ICON: "mdi:party-pooper"},
         ),
         (
             "24:00",
             "2022-08-11T00:00:00-07:00",
             "24:00:00",
-            {CONF_ICON: "mdi:calendar"},
+            {CONF_ICON: "mdi:party-popper"},
         ),
         (
             "24:00:00",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Fix schedule entity can't unset an icon once it has been set.

This was fixed for all other collection helpers a few years ago, but a similar patch was never made for schedule.

E.g.: 
 - https://github.com/home-assistant/core/pull/78371 
 - https://github.com/home-assistant/core/pull/78374

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #150971 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
