### PR TITLE
Add total active power sensor to Tesla Wall Connector integration.

### DIFF
--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfFrequency,
+    UnitOfPower,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -163,6 +164,33 @@ WALL_CONNECTOR_SENSORS = [
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    WallConnectorSensorDescription(
+        key="total_power_w",
+        translation_key="total_power_w",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
+        value_fn=lambda data: (
+            round(
+                (
+                    data[WALLCONNECTOR_DATA_VITALS].voltageA_v
+                    * data[WALLCONNECTOR_DATA_VITALS].currentA_a
+                )
+                + (
+                    data[WALLCONNECTOR_DATA_VITALS].voltageB_v
+                    * data[WALLCONNECTOR_DATA_VITALS].currentB_a
+                )
+                + (
+                    data[WALLCONNECTOR_DATA_VITALS].voltageC_v
+                    * data[WALLCONNECTOR_DATA_VITALS].currentC_a
+                ),
+                1,
+            )
+            if data[WALLCONNECTOR_DATA_VITALS]
+            else None
+        ),
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     WallConnectorSensorDescription(
         key="session_energy_wh",

--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -42,7 +42,7 @@ EVSE_STATE = {
 }
 
 
-def _get_total_power(data):
+def _get_total_power(data: dict[str, Any]) -> float | None:
     """Calculate total active power from three phases."""
     vitals = data[WALLCONNECTOR_DATA_VITALS]
     if not vitals:

--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -42,6 +42,20 @@ EVSE_STATE = {
 }
 
 
+def _get_total_power(data):
+    """Calculate total active power from three phases."""
+    vitals = data[WALLCONNECTOR_DATA_VITALS]
+    if not vitals:
+        return None
+
+    return round(
+        (vitals.voltageA_v * vitals.currentA_a)
+        + (vitals.voltageB_v * vitals.currentB_a)
+        + (vitals.voltageC_v * vitals.currentC_a),
+        1,
+    )
+
+
 @dataclass(frozen=True)
 class WallConnectorSensorDescription(
     SensorEntityDescription, WallConnectorLambdaValueGetterMixin
@@ -170,25 +184,7 @@ WALL_CONNECTOR_SENSORS = [
         translation_key="total_power_w",
         native_unit_of_measurement=UnitOfPower.WATT,
         suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
-        value_fn=lambda data: (
-            round(
-                (
-                    data[WALLCONNECTOR_DATA_VITALS].voltageA_v
-                    * data[WALLCONNECTOR_DATA_VITALS].currentA_a
-                )
-                + (
-                    data[WALLCONNECTOR_DATA_VITALS].voltageB_v
-                    * data[WALLCONNECTOR_DATA_VITALS].currentB_a
-                )
-                + (
-                    data[WALLCONNECTOR_DATA_VITALS].voltageC_v
-                    * data[WALLCONNECTOR_DATA_VITALS].currentC_a
-                ),
-                1,
-            )
-            if data[WALLCONNECTOR_DATA_VITALS]
-            else None
-        ),
+        value_fn=_get_total_power,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -42,20 +42,6 @@ EVSE_STATE = {
 }
 
 
-def _get_total_power(data: dict[str, Any]) -> float | None:
-    """Calculate total active power from three phases."""
-    vitals = data[WALLCONNECTOR_DATA_VITALS]
-    if not vitals:
-        return None
-
-    return round(
-        (vitals.voltageA_v * vitals.currentA_a)
-        + (vitals.voltageB_v * vitals.currentB_a)
-        + (vitals.voltageC_v * vitals.currentC_a),
-        1,
-    )
-
-
 @dataclass(frozen=True)
 class WallConnectorSensorDescription(
     SensorEntityDescription, WallConnectorLambdaValueGetterMixin
@@ -184,7 +170,7 @@ WALL_CONNECTOR_SENSORS = [
         translation_key="total_power_w",
         native_unit_of_measurement=UnitOfPower.WATT,
         suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
-        value_fn=_get_total_power,
+        value_fn=lambda data: data[WALLCONNECTOR_DATA_VITALS].total_power_w,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/tesla_wall_connector/strings.json
+++ b/homeassistant/components/tesla_wall_connector/strings.json
@@ -75,6 +75,9 @@
       "status_code": {
         "name": "Status code"
       },
+      "total_power_w": {
+        "name": "Total power"
+      },
       "voltage_a_v": {
         "name": "Phase A voltage"
       },
@@ -83,9 +86,6 @@
       },
       "voltage_c_v": {
         "name": "Phase C voltage"
-      },
-      "total_power_w": {
-        "name": "Total power"
       }
     }
   }

--- a/homeassistant/components/tesla_wall_connector/strings.json
+++ b/homeassistant/components/tesla_wall_connector/strings.json
@@ -83,6 +83,9 @@
       },
       "voltage_c_v": {
         "name": "Phase C voltage"
+      },
+      "total_power_w": {
+        "name": "Total power"
       }
     }
   }

--- a/tests/components/tesla_wall_connector/conftest.py
+++ b/tests/components/tesla_wall_connector/conftest.py
@@ -101,6 +101,7 @@ def get_vitals_mock() -> Vitals:
     mock.currentA_a = 10
     mock.currentB_a = 11.1
     mock.currentC_a = 12
+    mock.total_power_w = 7650.3
     mock.session_energy_wh = 1234.56
     mock.contactor_closed = False
     mock.vehicle_connected = True

--- a/tests/components/tesla_wall_connector/test_sensor.py
+++ b/tests/components/tesla_wall_connector/test_sensor.py
@@ -54,6 +54,9 @@ async def test_sensors(hass: HomeAssistant) -> None:
             "sensor.tesla_wall_connector_phase_c_voltage", "232.1", "230"
         ),
         EntityAndExpectedValues(
+            "sensor.tesla_wall_connector_total_power", "7650.3", "5499.5"
+        ),
+        EntityAndExpectedValues(
             "sensor.tesla_wall_connector_session_energy", "1.23456", "0.1122"
         ),
     ]

--- a/tests/components/tesla_wall_connector/test_sensor.py
+++ b/tests/components/tesla_wall_connector/test_sensor.py
@@ -54,7 +54,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
             "sensor.tesla_wall_connector_phase_c_voltage", "232.1", "230"
         ),
         EntityAndExpectedValues(
-            "sensor.tesla_wall_connector_total_power_w", "7650.3", "5499.5"
+            "sensor.tesla_wall_connector_total_power", "7.6503", "5.4995"
         ),
         EntityAndExpectedValues(
             "sensor.tesla_wall_connector_session_energy", "1.23456", "0.1122"

--- a/tests/components/tesla_wall_connector/test_sensor.py
+++ b/tests/components/tesla_wall_connector/test_sensor.py
@@ -54,7 +54,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
             "sensor.tesla_wall_connector_phase_c_voltage", "232.1", "230"
         ),
         EntityAndExpectedValues(
-            "sensor.tesla_wall_connector_total_power", "7650.3", "5499.5"
+            "sensor.tesla_wall_connector_total_power_w", "7650.3", "5499.5"
         ),
         EntityAndExpectedValues(
             "sensor.tesla_wall_connector_session_energy", "1.23456", "0.1122"
@@ -76,6 +76,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     mock_vitals_second_update.currentA_a = 7
     mock_vitals_second_update.currentB_a = 8
     mock_vitals_second_update.currentC_a = 9
+    mock_vitals_second_update.total_power_w = 5499.5
     mock_vitals_second_update.session_energy_wh = 112.2
 
     lifetime_mock_first_update = get_lifetime_mock()


### PR DESCRIPTION
## Proposed change

This integration currently provides per-phase voltage and current information. I would find it useful if it would also provide total active power, which can be calculated from voltages/currents. I propose to add a calculated sensor for that. 

_This PR was created with the help of the Claude AI. [Tag1 consulting](https://tag1.com) sponsored my time to work in this feature._

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist


- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
