### PR TITLE
Bump reolink-aio to 0.14.7

### DIFF
--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -253,6 +253,7 @@ class ReolinkChimeCoordinatorEntity(ReolinkChannelCoordinatorEntity):
         coordinator: DataUpdateCoordinator[None] | None = None,
     ) -> None:
         """Initialize ReolinkChimeCoordinatorEntity for a chime."""
+        assert chime.channel is not None
         super().__init__(reolink_data, chime.channel, coordinator)
 
         self._chime = chime

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.14.6"]
+  "requirements": ["reolink-aio==0.14.7"]
 }

--- a/homeassistant/components/reolink/number.py
+++ b/homeassistant/components/reolink/number.py
@@ -816,7 +816,8 @@ async def async_setup_entry(
         ReolinkChimeNumberEntity(reolink_data, chime, entity_description)
         for entity_description in CHIME_NUMBER_ENTITIES
         for chime in api.chime_list
-        for chime in api.chime_list if chime.channel is not None
+        for chime in api.chime_list
+        if chime.channel is not None
     )
     async_add_entities(entities)
 

--- a/homeassistant/components/reolink/number.py
+++ b/homeassistant/components/reolink/number.py
@@ -816,7 +816,7 @@ async def async_setup_entry(
         ReolinkChimeNumberEntity(reolink_data, chime, entity_description)
         for entity_description in CHIME_NUMBER_ENTITIES
         for chime in api.chime_list
-        if chime.channel is not None
+        for chime in api.chime_list if chime.channel is not None
     )
     async_add_entities(entities)
 

--- a/homeassistant/components/reolink/number.py
+++ b/homeassistant/components/reolink/number.py
@@ -816,6 +816,7 @@ async def async_setup_entry(
         ReolinkChimeNumberEntity(reolink_data, chime, entity_description)
         for entity_description in CHIME_NUMBER_ENTITIES
         for chime in api.chime_list
+        if chime.channel is not None
     )
     async_add_entities(entities)
 

--- a/homeassistant/components/reolink/select.py
+++ b/homeassistant/components/reolink/select.py
@@ -381,7 +381,7 @@ async def async_setup_entry(
         for entity_description in CHIME_SELECT_ENTITIES
         for chime in reolink_data.host.api.chime_list
         if entity_description.supported(chime)
-        if chime.channel is not None
+        if entity_description.supported(chime) and chime.channel is not None
     )
     async_add_entities(entities)
 

--- a/homeassistant/components/reolink/select.py
+++ b/homeassistant/components/reolink/select.py
@@ -381,6 +381,7 @@ async def async_setup_entry(
         for entity_description in CHIME_SELECT_ENTITIES
         for chime in reolink_data.host.api.chime_list
         if entity_description.supported(chime)
+        if chime.channel is not None
     )
     async_add_entities(entities)
 

--- a/homeassistant/components/reolink/switch.py
+++ b/homeassistant/components/reolink/switch.py
@@ -381,6 +381,7 @@ async def async_setup_entry(
         ReolinkChimeSwitchEntity(reolink_data, chime, entity_description)
         for entity_description in CHIME_SWITCH_ENTITIES
         for chime in reolink_data.host.api.chime_list
+        if chime.channel is not None
     )
 
     # Can be removed in HA 2025.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2661,7 +2661,7 @@ renault-api==0.4.0
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.14.6
+reolink-aio==0.14.7
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2207,7 +2207,7 @@ renault-api==0.4.0
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.14.6
+reolink-aio==0.14.7
 
 # homeassistant.components.rflink
 rflink==0.0.67


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.14.7:
**Additions:**
- [Add Hub siren play](https://github.com/starkillerOG/reolink_aio/commit/d4b04bbb7b0ca06edd4fdc15941fd82bc437bb6b)
- [Add GetNetPort and SetNetPort Baichuan fallback](https://github.com/starkillerOG/reolink_aio/commit/4c01eae484ca2e37b125de87412afc2b91e1f7f9)
- [Support chime connected to Home Hub](https://github.com/starkillerOG/reolink_aio/commit/097bd6c184cfb08ae58a8102fd3a154318a8cc6e)
- [Add Chime silent time](https://github.com/starkillerOG/reolink_aio/commit/1855fc3a63bca4b5ce919ab3deb0a518bed1acde)
- [Switch to using Baichuan for volume and add Speek and Doorbell volume](https://github.com/starkillerOG/reolink_aio/commit/8a2bd464cf5812807c96a5360ea69a0147214f78)
- [Add set_encoding support](https://github.com/starkillerOG/reolink_aio/commit/e0be43e001ff9624cd3c4f0e2d9ce33c8ae47d53)

**Bug fixes:**
- [Fix KeyError for Manual record settings](https://github.com/starkillerOG/reolink_aio/commit/70edf1aa4da19bd2652794cd97f966fd86624083)
- [Fix parsing of firmware version with 9 chars date](https://github.com/starkillerOG/reolink_aio/commit/67dac8a525e94a57f2da7cd0d2f2216c48cfe910)
- [Fix software version parsing when last digits are >60](https://github.com/starkillerOG/reolink_aio/commit/324603b748dbf05d5b90a490e144e80e33ddc528)
- [Always use baichuan GetDingDongCfg to circumvent bugs](https://github.com/starkillerOG/reolink_aio/commit/228eec70984979ccf54e84541712b3d46c5d01aa)
- [Always use baichuan SetDingDongCfg to circumvent bugs](https://github.com/starkillerOG/reolink_aio/commit/a435b9026fd438681a3dd44dbbc04e76495db10d)
- [Use Baichuan to set encoding](https://github.com/starkillerOG/reolink_aio/commit/7118abcf6b1adba0b8078d693a36198549cf3b2f)

**Optimizations:**
- [Enable isort formatting](https://github.com/starkillerOG/reolink_aio/commit/8e31ece31d910c841a97cfa64ca184aa0903c9ec)
- [Use binary flags for smart AI detection capabilities](https://github.com/starkillerOG/reolink_aio/commit/46ee721117c23295dfdb1c68da764f4409564a35)
- [Use Baichuan motion/AI detect flags](https://github.com/starkillerOG/reolink_aio/commit/f631e7869b53310e251318b91fa3b726525fc6b6)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.14.6...0.14.7

The `if chime.channel is not None` is to prevent the setup of Chimes connected to the Home Hub. These chimes were not supported before this library bump. They will be supported, but they need a follow up PR to change some more code on the HomeAssistant side.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/150591 https://github.com/home-assistant/core/issues/150590 https://github.com/home-assistant/core/issues/150974
- This PR is related to issue: https://github.com/starkillerOG/reolink_aio/issues/123 https://github.com/home-assistant/core/issues/150174 https://github.com/home-assistant/core/issues/139794 https://github.com/home-assistant/core/issues/144949
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
