### PR TITLE
Add support for load switches to WMS WebControl pro

### DIFF
--- a/homeassistant/components/wmspro/__init__.py
+++ b/homeassistant/components/wmspro/__init__.py
@@ -20,6 +20,7 @@ PLATFORMS: list[Platform] = [
     Platform.COVER,
     Platform.LIGHT,
     Platform.SCENE,
+    Platform.SWITCH,
 ]
 
 type WebControlProConfigEntry = ConfigEntry[WebControlPro]

--- a/homeassistant/components/wmspro/switch.py
+++ b/homeassistant/components/wmspro/switch.py
@@ -1,0 +1,64 @@
+"""Support for loads connected with WMS WebControl pro."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from wmspro.const import (
+    WMS_WebControl_pro_API_actionDescription,
+    WMS_WebControl_pro_API_responseType,
+)
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import WebControlProConfigEntry
+from .entity import WebControlProGenericEntity
+
+SCAN_INTERVAL = timedelta(seconds=15)
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: WebControlProConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the WMS based switches from a config entry."""
+    hub = config_entry.runtime_data
+
+    entities: list[WebControlProGenericEntity] = [
+        WebControlProSwitch(config_entry.entry_id, dest)
+        for dest in hub.dests.values()
+        if dest.hasAction(WMS_WebControl_pro_API_actionDescription.LoadSwitch)
+    ]
+
+    async_add_entities(entities)
+
+
+class WebControlProSwitch(WebControlProGenericEntity, SwitchEntity):
+    """Representation of a WMS based switch."""
+
+    _attr_name = None
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if switch is on."""
+        action = self._dest.action(WMS_WebControl_pro_API_actionDescription.LoadSwitch)
+        return action["onOffState"]
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        action = self._dest.action(WMS_WebControl_pro_API_actionDescription.LoadSwitch)
+        await action(
+            onOffState=True, responseType=WMS_WebControl_pro_API_responseType.Detailed
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        action = self._dest.action(WMS_WebControl_pro_API_actionDescription.LoadSwitch)
+        await action(
+            onOffState=False, responseType=WMS_WebControl_pro_API_responseType.Detailed
+        )

--- a/homeassistant/components/wmspro/switch.py
+++ b/homeassistant/components/wmspro/switch.py
@@ -29,13 +29,11 @@ async def async_setup_entry(
     """Set up the WMS based switches from a config entry."""
     hub = config_entry.runtime_data
 
-    entities: list[WebControlProGenericEntity] = [
+    async_add_entities(
         WebControlProSwitch(config_entry.entry_id, dest)
         for dest in hub.dests.values()
         if dest.hasAction(WMS_WebControl_pro_API_actionDescription.LoadSwitch)
-    ]
-
-    async_add_entities(entities)
+    )
 
 
 class WebControlProSwitch(WebControlProGenericEntity, SwitchEntity):

--- a/tests/components/wmspro/conftest.py
+++ b/tests/components/wmspro/conftest.py
@@ -83,6 +83,16 @@ def mock_hub_configuration_prod_awning_valance() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
+def mock_hub_configuration_prod_load_switch() -> Generator[AsyncMock]:
+    """Override WebControlPro._getConfiguration."""
+    with patch(
+        "wmspro.webcontrol.WebControlPro._getConfiguration",
+        return_value=load_json_object_fixture("config_prod_load_switch.json", DOMAIN),
+    ) as mock_hub_configuration:
+        yield mock_hub_configuration
+
+
+@pytest.fixture
 def mock_hub_configuration_prod_roller_shutter() -> Generator[AsyncMock]:
     """Override WebControlPro._getConfiguration."""
     with patch(
@@ -110,6 +120,16 @@ def mock_hub_status_prod_dimmer() -> Generator[AsyncMock]:
     with patch(
         "wmspro.webcontrol.WebControlPro._getStatus",
         return_value=load_json_object_fixture("status_prod_dimmer.json", DOMAIN),
+    ) as mock_hub_status:
+        yield mock_hub_status
+
+
+@pytest.fixture
+def mock_hub_status_prod_load_switch() -> Generator[AsyncMock]:
+    """Override WebControlPro._getStatus."""
+    with patch(
+        "wmspro.webcontrol.WebControlPro._getStatus",
+        return_value=load_json_object_fixture("status_prod_load_switch.json", DOMAIN),
     ) as mock_hub_status:
         yield mock_hub_status
 

--- a/tests/components/wmspro/fixtures/config_prod_load_switch.json
+++ b/tests/components/wmspro/fixtures/config_prod_load_switch.json
@@ -1,0 +1,249 @@
+{
+  "command": "getConfiguration",
+  "protocolVersion": "1.0.0",
+  "destinations": [
+    {
+      "id": 65355,
+      "animationType": 3,
+      "names": ["DACH", "", "", ""],
+      "actions": [
+        {
+          "id": 6,
+          "actionType": 2,
+          "actionDescription": 3,
+          "minValue": -127,
+          "maxValue": 127
+        },
+        {
+          "id": 16,
+          "actionType": 6,
+          "actionDescription": 12
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        },
+        {
+          "id": 23,
+          "actionType": 7,
+          "actionDescription": 12
+        }
+      ]
+    },
+    {
+      "id": 90732,
+      "animationType": 1,
+      "names": ["MARKISE LINKS", "", "", ""],
+      "actions": [
+        {
+          "id": 0,
+          "actionType": 0,
+          "actionDescription": 0,
+          "minValue": 0,
+          "maxValue": 100
+        },
+        {
+          "id": 16,
+          "actionType": 6,
+          "actionDescription": 12
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        }
+      ]
+    },
+    {
+      "id": 159890,
+      "animationType": 1,
+      "names": ["MARKISE VORNE", "", "", ""],
+      "actions": [
+        {
+          "id": 0,
+          "actionType": 0,
+          "actionDescription": 0,
+          "minValue": 0,
+          "maxValue": 100
+        },
+        {
+          "id": 16,
+          "actionType": 6,
+          "actionDescription": 12
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        }
+      ]
+    },
+    {
+      "id": 201106,
+      "animationType": 1,
+      "names": ["MARKISE RECHTS", "", "", ""],
+      "actions": [
+        {
+          "id": 0,
+          "actionType": 0,
+          "actionDescription": 0,
+          "minValue": 0,
+          "maxValue": 100
+        },
+        {
+          "id": 16,
+          "actionType": 6,
+          "actionDescription": 12
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        }
+      ]
+    },
+    {
+      "id": 317448,
+      "animationType": 6,
+      "names": ["LICHT SENKRECHT", "", "", ""],
+      "actions": [
+        {
+          "id": 0,
+          "actionType": 0,
+          "actionDescription": 8,
+          "minValue": 0,
+          "maxValue": 100
+        },
+        {
+          "id": 17,
+          "actionType": 6,
+          "actionDescription": 12
+        },
+        {
+          "id": 20,
+          "actionType": 4,
+          "actionDescription": 6
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        }
+      ]
+    },
+    {
+      "id": 382168,
+      "animationType": 6,
+      "names": ["LICHT OBEN", "", "", ""],
+      "actions": [
+        {
+          "id": 0,
+          "actionType": 0,
+          "actionDescription": 8,
+          "minValue": 0,
+          "maxValue": 100
+        },
+        {
+          "id": 17,
+          "actionType": 6,
+          "actionDescription": 12
+        },
+        {
+          "id": 20,
+          "actionType": 4,
+          "actionDescription": 6
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        }
+      ]
+    },
+    {
+      "id": 414040,
+      "animationType": 6,
+      "names": ["LICHT UNTEN", "", "", ""],
+      "actions": [
+        {
+          "id": 0,
+          "actionType": 0,
+          "actionDescription": 8,
+          "minValue": 0,
+          "maxValue": 100
+        },
+        {
+          "id": 17,
+          "actionType": 6,
+          "actionDescription": 12
+        },
+        {
+          "id": 20,
+          "actionType": 4,
+          "actionDescription": 6
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        }
+      ]
+    },
+    {
+      "id": 499120,
+      "animationType": 5,
+      "names": ["HEIZUNG LINKS", "", "", ""],
+      "actions": [
+        {
+          "id": 20,
+          "actionType": 4,
+          "actionDescription": 7
+        },
+        {
+          "id": 21,
+          "actionType": 5,
+          "actionDescription": 10
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        }
+      ]
+    },
+    {
+      "id": 533844,
+      "animationType": 5,
+      "names": ["HEIZUNG RECHTS", "", "", ""],
+      "actions": [
+        {
+          "id": 20,
+          "actionType": 4,
+          "actionDescription": 7
+        },
+        {
+          "id": 21,
+          "actionType": 5,
+          "actionDescription": 10
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        }
+      ]
+    }
+  ],
+  "rooms": [
+    {
+      "id": 39443,
+      "name": "Terasse",
+      "destinations": [
+        65355, 90732, 159890, 201106, 317448, 382168, 414040, 499120, 533844
+      ],
+      "scenes": []
+    }
+  ],
+  "scenes": []
+}

--- a/tests/components/wmspro/fixtures/status_prod_load_switch.json
+++ b/tests/components/wmspro/fixtures/status_prod_load_switch.json
@@ -1,0 +1,28 @@
+{
+  "command": "getStatus",
+  "protocolVersion": "1.0.0",
+  "details": [
+    {
+      "destinationId": 499120,
+      "data": {
+        "drivingCause": 0,
+        "heartbeatError": false,
+        "blocking": false,
+        "productData": [
+          {
+            "actionId": 20,
+            "value": {
+              "onOffState": false
+            }
+          },
+          {
+            "actionId": 21,
+            "value": {
+              "onOffState": false
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/components/wmspro/snapshots/test_switch.ambr
+++ b/tests/components/wmspro/snapshots/test_switch.ambr
@@ -1,0 +1,46 @@
+# serializer version: 1
+# name: test_switch_device
+  DeviceRegistryEntrySnapshot({
+    'area_id': 'terasse',
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': 'http://webcontrol/control',
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'wmspro',
+        '499120',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'WAREMA Renkhoff SE',
+    'model': 'Switch',
+    'model_id': None,
+    'name': 'HEIZUNG LINKS',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': '499120',
+    'sw_version': None,
+    'via_device_id': <ANY>,
+  })
+# ---
+# name: test_switch_update
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by WMS WebControl pro API',
+      'friendly_name': 'HEIZUNG LINKS',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.heizung_links',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/wmspro/test_switch.py
+++ b/tests/components/wmspro/test_switch.py
@@ -1,0 +1,127 @@
+"""Test the wmspro switch support."""
+
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.wmspro.const import DOMAIN
+from homeassistant.components.wmspro.switch import SCAN_INTERVAL
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import setup_config_entry
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_switch_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hub_ping: AsyncMock,
+    mock_hub_configuration_prod_load_switch: AsyncMock,
+    mock_hub_status_prod_load_switch: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that a switch device is created correctly."""
+    assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_configuration_prod_load_switch.mock_calls) == 1
+    assert len(mock_hub_status_prod_load_switch.mock_calls) >= 2
+
+    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "499120")})
+    assert device_entry is not None
+    assert device_entry == snapshot
+
+
+async def test_switch_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hub_ping: AsyncMock,
+    mock_hub_configuration_prod_load_switch: AsyncMock,
+    mock_hub_status_prod_load_switch: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that a switch entity is created and updated correctly."""
+    assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_configuration_prod_load_switch.mock_calls) == 1
+    assert len(mock_hub_status_prod_load_switch.mock_calls) >= 2
+
+    entity = hass.states.get("switch.heizung_links")
+    assert entity is not None
+    assert entity == snapshot
+
+    before = len(mock_hub_status_prod_load_switch.mock_calls)
+
+    # Move time to next update
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert len(mock_hub_status_prod_load_switch.mock_calls) > before
+
+
+async def test_switch_turn_on_and_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hub_ping: AsyncMock,
+    mock_hub_configuration_prod_load_switch: AsyncMock,
+    mock_hub_status_prod_load_switch: AsyncMock,
+    mock_action_call: AsyncMock,
+) -> None:
+    """Test that a switch entity is turned on and off correctly."""
+    assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_configuration_prod_load_switch.mock_calls) == 1
+    assert len(mock_hub_status_prod_load_switch.mock_calls) >= 1
+
+    entity = hass.states.get("switch.heizung_links")
+    assert entity is not None
+    assert entity.state == STATE_OFF
+
+    with patch(
+        "wmspro.destination.Destination.refresh",
+        return_value=True,
+    ):
+        before = len(mock_hub_status_prod_load_switch.mock_calls)
+
+        await hass.services.async_call(
+            Platform.SWITCH,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity.entity_id},
+            blocking=True,
+        )
+
+        entity = hass.states.get("switch.heizung_links")
+        assert entity is not None
+        assert entity.state == STATE_ON
+        assert len(mock_hub_status_prod_load_switch.mock_calls) == before
+
+    with patch(
+        "wmspro.destination.Destination.refresh",
+        return_value=True,
+    ):
+        before = len(mock_hub_status_prod_load_switch.mock_calls)
+
+        await hass.services.async_call(
+            Platform.SWITCH,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity.entity_id},
+            blocking=True,
+        )
+
+        entity = hass.states.get("switch.heizung_links")
+        assert entity is not None
+        assert entity.state == STATE_OFF
+        assert len(mock_hub_status_prod_load_switch.mock_calls) == before


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for load switches (e.g. controlling heaters) to WMS WebControl pro, see:
https://github.com/mback2k/pywmspro/issues/1#issuecomment-2564749169

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/mback2k/pywmspro/issues/1#issuecomment-2564749169
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42466
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
