### PR TITLE
snoo: add button entity for calling start_snoo

### DIFF
--- a/homeassistant/components/snoo/__init__.py
+++ b/homeassistant/components/snoo/__init__.py
@@ -19,6 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.EVENT,
     Platform.SELECT,
     Platform.SENSOR,

--- a/homeassistant/components/snoo/button.py
+++ b/homeassistant/components/snoo/button.py
@@ -1,0 +1,69 @@
+"""Support for Snoo Buttons."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from python_snoo.containers import SnooDevice
+from python_snoo.exceptions import SnooCommandException
+from python_snoo.snoo import Snoo
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SnooConfigEntry
+from .entity import SnooDescriptionEntity
+
+
+@dataclass(kw_only=True, frozen=True)
+class SnooButtonEntityDescription(ButtonEntityDescription):
+    """Description for Snoo button entities."""
+
+    press_fn: Callable[[Snoo, SnooDevice], Awaitable[None]]
+
+
+BUTTON_DESCRIPTIONS: list[SnooButtonEntityDescription] = [
+    SnooButtonEntityDescription(
+        key="start_snoo",
+        translation_key="start_snoo",
+        press_fn=lambda snoo, device: snoo.start_snoo(
+            device,
+        ),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SnooConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up buttons for Snoo device."""
+    coordinators = entry.runtime_data
+    async_add_entities(
+        SnooButton(coordinator, description)
+        for coordinator in coordinators.values()
+        for description in BUTTON_DESCRIPTIONS
+    )
+
+
+class SnooButton(SnooDescriptionEntity, ButtonEntity):
+    """Representation of a Snoo button."""
+
+    entity_description: SnooButtonEntityDescription
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        try:
+            await self.entity_description.press_fn(
+                self.coordinator.snoo,
+                self.coordinator.device,
+            )
+        except SnooCommandException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key=f"{self.entity_description.key}_failed",
+                translation_placeholders={"name": str(self.name)},
+            ) from err

--- a/homeassistant/components/snoo/icons.json
+++ b/homeassistant/components/snoo/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "button": {
+      "start_snoo": {
+        "default": "mdi:play"
+      }
+    }
+  }
+}

--- a/homeassistant/components/snoo/strings.json
+++ b/homeassistant/components/snoo/strings.json
@@ -25,6 +25,9 @@
     "select_failed": {
       "message": "Error while updating {name} to {option}"
     },
+    "start_snoo_failed": {
+      "message": "Starting {name} failed"
+    },
     "switch_on_failed": {
       "message": "Turning {name} on failed"
     },
@@ -39,6 +42,11 @@
       },
       "right_clip": {
         "name": "Right safety clip"
+      }
+    },
+    "button": {
+      "start_snoo": {
+        "name": "Start"
       }
     },
     "event": {

--- a/tests/components/snoo/snapshots/test_button.ambr
+++ b/tests/components/snoo/snapshots/test_button.ambr
@@ -1,0 +1,49 @@
+# serializer version: 1
+# name: test_entities[button.test_snoo_start-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_snoo_start',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Start',
+    'platform': 'snoo',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'start_snoo',
+    'unique_id': 'random_num_start_snoo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[button.test_snoo_start-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Snoo Start',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_snoo_start',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---

--- a/tests/components/snoo/test_button.py
+++ b/tests/components/snoo/test_button.py
@@ -1,12 +1,30 @@
 """Test Snoo Buttons."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
+
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from . import async_init_integration
+
+from tests.common import snapshot_platform
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    bypass_api: AsyncMock,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test buttons."""
+    with patch("homeassistant.components.snoo.PLATFORMS", [Platform.BUTTON]):
+        entry = await async_init_integration(hass)
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 
 async def test_button_starts_snoo(hass: HomeAssistant, bypass_api: AsyncMock) -> None:

--- a/tests/components/snoo/test_button.py
+++ b/tests/components/snoo/test_button.py
@@ -1,0 +1,23 @@
+"""Test Snoo Buttons."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from . import async_init_integration
+
+
+async def test_button_starts_snoo(hass: HomeAssistant, bypass_api: AsyncMock) -> None:
+    """Test start_snoo button works correctly."""
+    await async_init_integration(hass)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_snoo_start"},
+        blocking=True,
+    )
+
+    assert bypass_api.start_snoo.assert_called_once


### PR DESCRIPTION
This considers settings from the app such as weaning mode, car ride mode and the starting intensity.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new button entity to the Snoo integration which mimics the play button in the official Snoo app. This is different from directly setting the intensity level because it considers app-side settings such as car ride mode, weaning mode, and the starting intensity. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/40591
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
