### PR TITLE
Fix entities/devices stuck in disabled state after config entry re-add

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1460,12 +1460,18 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             if config_entry_id not in config_entries:
                 continue
             if config_entries == {config_entry_id}:
+                # Clear disabled_by if it was disabled by the config entry
+                if deleted_device.disabled_by is DeviceEntryDisabler.CONFIG_ENTRY:
+                    disabled_by = None
+                else:
+                    disabled_by = deleted_device.disabled_by
                 # Add a time stamp when the deleted device became orphaned
                 self.deleted_devices[deleted_device.id] = attr.evolve(
                     deleted_device,
                     orphaned_timestamp=now_time,
                     config_entries=set(),
                     config_entries_subentries={},
+                    disabled_by=disabled_by,
                 )
             else:
                 config_entries = config_entries - {config_entry_id}

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1613,9 +1613,17 @@ class EntityRegistry(BaseRegistry):
         for key, deleted_entity in list(self.deleted_entities.items()):
             if config_entry_id != deleted_entity.config_entry_id:
                 continue
+            # Clear disabled_by if it was disabled by the config entry
+            if deleted_entity.disabled_by is RegistryEntryDisabler.CONFIG_ENTRY:
+                disabled_by = None
+            else:
+                disabled_by = deleted_entity.disabled_by
             # Add a time stamp when the deleted entity became orphaned
             self.deleted_entities[key] = attr.evolve(
-                deleted_entity, orphaned_timestamp=now_time, config_entry_id=None
+                deleted_entity,
+                orphaned_timestamp=now_time,
+                config_entry_id=None,
+                disabled_by=disabled_by,
             )
             self.async_schedule_save()
 

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -3368,6 +3368,98 @@ async def test_cleanup_startup(hass: HomeAssistant) -> None:
     assert len(mock_call.mock_calls) == 1
 
 
+async def test_deleted_device_clears_disabled_by_on_config_entry_removal(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that disabled_by is cleared when config entry is removed."""
+    config_entry = MockConfigEntry(domain="test", entry_id="mock-id-1")
+    config_entry.add_to_hass(hass)
+
+    # Create a device disabled by the config entry
+    device = device_registry.async_get_or_create(
+        config_entry_id="mock-id-1",
+        identifiers={("test", "device_1")},
+        name="Test Device",
+        disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
+    )
+    assert device.config_entries == {"mock-id-1"}
+    assert device.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+
+    # Remove the device (it moves to deleted_devices)
+    device_registry.async_remove_device(device.id)
+
+    assert len(device_registry.devices) == 0
+    assert len(device_registry.deleted_devices) == 1
+    deleted_device = device_registry.deleted_devices[device.id]
+    assert deleted_device.config_entries == {"mock-id-1"}
+    assert deleted_device.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+    assert deleted_device.orphaned_timestamp is None
+
+    # Clear the config entry
+    device_registry.async_clear_config_entry("mock-id-1")
+
+    # Verify disabled_by is cleared
+    deleted_device = device_registry.deleted_devices[device.id]
+    assert deleted_device.config_entries == set()
+    assert deleted_device.disabled_by is None  # Should be cleared
+    assert deleted_device.orphaned_timestamp is not None
+
+    # Now re-add the config entry and device to verify it can be enabled
+    config_entry2 = MockConfigEntry(domain="test", entry_id="mock-id-2")
+    config_entry2.add_to_hass(hass)
+
+    # Re-create the device with same identifiers
+    device2 = device_registry.async_get_or_create(
+        config_entry_id="mock-id-2",
+        identifiers={("test", "device_1")},
+        name="Test Device",
+    )
+    assert device2.config_entries == {"mock-id-2"}
+    assert device2.disabled_by is None  # Should not be disabled anymore
+    assert device2.id == device.id  # Should keep the same device id
+
+
+async def test_deleted_device_disabled_by_user_not_cleared(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that disabled_by=USER is not cleared when config entry is removed."""
+    config_entry = MockConfigEntry(domain="test", entry_id="mock-id-1")
+    config_entry.add_to_hass(hass)
+
+    # Create a device disabled by the user
+    device = device_registry.async_get_or_create(
+        config_entry_id="mock-id-1",
+        identifiers={("test", "device_1")},
+        name="Test Device",
+        disabled_by=dr.DeviceEntryDisabler.USER,
+    )
+    assert device.config_entries == {"mock-id-1"}
+    assert device.disabled_by is dr.DeviceEntryDisabler.USER
+
+    # Remove the device (it moves to deleted_devices)
+    device_registry.async_remove_device(device.id)
+
+    assert len(device_registry.devices) == 0
+    assert len(device_registry.deleted_devices) == 1
+    deleted_device = device_registry.deleted_devices[device.id]
+    assert deleted_device.config_entries == {"mock-id-1"}
+    assert deleted_device.disabled_by is dr.DeviceEntryDisabler.USER
+    assert deleted_device.orphaned_timestamp is None
+
+    # Clear the config entry
+    device_registry.async_clear_config_entry("mock-id-1")
+
+    # Verify disabled_by is NOT cleared for USER disabled devices
+    deleted_device = device_registry.deleted_devices[device.id]
+    assert deleted_device.config_entries == set()
+    assert (
+        deleted_device.disabled_by is dr.DeviceEntryDisabler.USER
+    )  # Should remain USER
+    assert deleted_device.orphaned_timestamp is not None
+
+
 @pytest.mark.parametrize("load_registries", [False])
 async def test_cleanup_entity_registry_change(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -782,6 +782,97 @@ async def test_deleted_entity_removing_config_entry_id(
     assert entity_registry.deleted_entities[("light", "hue", "1234")] == deleted_entry2
 
 
+async def test_deleted_entity_clears_disabled_by_on_config_entry_removal(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that disabled_by is cleared when config entry is removed."""
+    mock_config = MockConfigEntry(domain="light", entry_id="mock-id-1")
+    mock_config.add_to_hass(hass)
+
+    # Create an entity disabled by the config entry
+    entry = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "5678",
+        config_entry=mock_config,
+        disabled_by=er.RegistryEntryDisabler.CONFIG_ENTRY,
+    )
+    assert entry.config_entry_id == "mock-id-1"
+    assert entry.disabled_by is er.RegistryEntryDisabler.CONFIG_ENTRY
+
+    # Remove the entity (it moves to deleted_entities)
+    entity_registry.async_remove(entry.entity_id)
+
+    assert len(entity_registry.entities) == 0
+    assert len(entity_registry.deleted_entities) == 1
+    deleted_entry = entity_registry.deleted_entities[("light", "hue", "5678")]
+    assert deleted_entry.config_entry_id == "mock-id-1"
+    assert deleted_entry.disabled_by is er.RegistryEntryDisabler.CONFIG_ENTRY
+    assert deleted_entry.orphaned_timestamp is None
+
+    # Clear the config entry
+    entity_registry.async_clear_config_entry("mock-id-1")
+
+    # Verify disabled_by is cleared
+    deleted_entry = entity_registry.deleted_entities[("light", "hue", "5678")]
+    assert deleted_entry.config_entry_id is None
+    assert deleted_entry.disabled_by is None  # Should be cleared
+    assert deleted_entry.orphaned_timestamp is not None
+
+    # Now re-add the config entry and entity to verify it can be enabled
+    mock_config2 = MockConfigEntry(domain="light", entry_id="mock-id-2")
+    mock_config2.add_to_hass(hass)
+
+    # Re-create the entity with same unique ID
+    entry2 = entity_registry.async_get_or_create(
+        "light", "hue", "5678", config_entry=mock_config2
+    )
+    assert entry2.config_entry_id == "mock-id-2"
+    assert entry2.disabled_by is None  # Should not be disabled anymore
+
+
+async def test_deleted_entity_disabled_by_user_not_cleared(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that disabled_by=USER is not cleared when config entry is removed."""
+    mock_config = MockConfigEntry(domain="light", entry_id="mock-id-1")
+    mock_config.add_to_hass(hass)
+
+    # Create an entity disabled by the user
+    entry = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "5678",
+        config_entry=mock_config,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+    assert entry.config_entry_id == "mock-id-1"
+    assert entry.disabled_by is er.RegistryEntryDisabler.USER
+
+    # Remove the entity (it moves to deleted_entities)
+    entity_registry.async_remove(entry.entity_id)
+
+    assert len(entity_registry.entities) == 0
+    assert len(entity_registry.deleted_entities) == 1
+    deleted_entry = entity_registry.deleted_entities[("light", "hue", "5678")]
+    assert deleted_entry.config_entry_id == "mock-id-1"
+    assert deleted_entry.disabled_by is er.RegistryEntryDisabler.USER
+    assert deleted_entry.orphaned_timestamp is None
+
+    # Clear the config entry
+    entity_registry.async_clear_config_entry("mock-id-1")
+
+    # Verify disabled_by is NOT cleared for USER disabled entities
+    deleted_entry = entity_registry.deleted_entities[("light", "hue", "5678")]
+    assert deleted_entry.config_entry_id is None
+    assert (
+        deleted_entry.disabled_by is er.RegistryEntryDisabler.USER
+    )  # Should remain USER
+    assert deleted_entry.orphaned_timestamp is not None
+
+
 async def test_removing_config_subentry_id(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes an issue where entities and devices that were disabled by a config entry (`disabled_by: CONFIG_ENTRY`) would remain permanently disabled even after the config entry was deleted and re-added. This prevented users from being able to re-enable these entities/devices through the UI.

The root cause was that when a config entry was removed, the `disabled_by` field was not cleared for deleted entities/devices in the registry. When the same config entry was re-added (common during troubleshooting), the entities/devices would be restored from the deleted registry with `disabled_by: CONFIG_ENTRY` still set, making them appear disabled with no way to enable them.

The fix clears the `disabled_by` field when a config entry is removed, but only if it was set to `CONFIG_ENTRY`. This makes logical sense because:
1. An entity/device cannot be disabled by a config entry that no longer exists
2. When the config entry is gone, the reason for the automatic disabling is no longer valid
3. User-disabled entities/devices (`disabled_by: USER`) are intentionally preserved to respect user preferences

This approach ensures that:
- Users can successfully delete and re-add config entries as a troubleshooting step
- Entities/devices that were automatically disabled can be re-enabled after re-adding
- User preferences for manually disabled items are preserved across delete/re-add cycles

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148529
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
