### PR TITLE
Fix HomeKit Controller entity state restore issues for IP/COAP devices

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -294,7 +294,6 @@ class HKDevice:
             await self.pairing.async_populate_accessories_state(
                 force_update=True, attempts=attempts
             )
-            self._async_start_polling()
 
         entry.async_on_unload(pairing.dispatcher_connect(self.process_new_events))
         entry.async_on_unload(
@@ -306,6 +305,12 @@ class HKDevice:
         entry.async_on_unload(self._async_cancel_subscription_timer)
 
         await self.async_process_entity_map()
+
+        if transport != Transport.BLE:
+            # Do a single poll to make sure the chars are
+            # up to date so we don't restore old data.
+            await self.async_update()
+            self._async_start_polling()
 
         # If everything is up to date, we can create the entities
         # since we know the data is not stale.

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -49,6 +49,10 @@ class EntityMapStorage:
 
         self.storage_data = raw_storage.get("pairings", {})
 
+    async def async_save(self) -> None:
+        """Save the pairing cache data."""
+        await self.store.async_save(self._data_to_save())
+
     def get_map(self, homekit_id: str) -> Pairing | None:
         """Get a pairing cache item."""
         return self.storage_data.get(homekit_id)

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -49,10 +49,6 @@ class EntityMapStorage:
 
         self.storage_data = raw_storage.get("pairings", {})
 
-    async def async_save(self) -> None:
-        """Save the pairing cache data."""
-        await self.store.async_save(self._data_to_save())
-
     def get_map(self, homekit_id: str) -> Pairing | None:
         """Get a pairing cache item."""
         return self.storage_data.get(homekit_id)

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -900,7 +900,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery-20',
             'original_name': 'eufyCam2-0000 Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -1156,7 +1156,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery-40',
             'original_name': 'eufyCam2-000A Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -1412,7 +1412,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery-alert',
             'original_name': 'eufyCam2-000A Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -1848,7 +1848,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Contact Sensor Battery Sensor',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -2270,7 +2270,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Programmable Switch Battery Sensor',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -2601,7 +2601,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery-80',
             'original_name': 'ArloBabyA0 Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -4473,7 +4473,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Basement Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -4780,7 +4780,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Basement Window 1 Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -5037,7 +5037,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Deck Door Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -5294,7 +5294,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Front Door Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -5551,7 +5551,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Garage Door Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -5765,7 +5765,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Living Room Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -6072,7 +6072,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Living Room Window 1 Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -6329,7 +6329,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Loft window Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -6543,7 +6543,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Master BR Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -6850,7 +6850,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Master BR Window Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -7462,7 +7462,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Upstairs BR Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -7769,7 +7769,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Upstairs BR Window Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -10111,7 +10111,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery-60',
             'original_name': 'Eve Degree AA11 Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -11099,7 +11099,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Family Room North Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -11351,7 +11351,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Kitchen Window Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -12392,7 +12392,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Laundry Smoke ED78 Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -12568,7 +12568,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Family Room North Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -12820,7 +12820,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Kitchen Window Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -14645,7 +14645,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Laundry Smoke ED78 Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -16083,7 +16083,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Hue dimmer switch battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -20820,7 +20820,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'Master Bath South RYSE Shade Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -21072,7 +21072,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'RYSE SmartShade RYSE Shade Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -21248,7 +21248,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'BR Left RYSE Shade Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -21420,7 +21420,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery-90',
             'original_name': 'LR Left RYSE Shade Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -21592,7 +21592,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery',
             'original_name': 'LR Right RYSE Shade Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,
@@ -21844,7 +21844,7 @@
             'options': dict({
             }),
             'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
-            'original_icon': 'mdi:battery-unknown',
+            'original_icon': 'mdi:battery-alert',
             'original_name': 'RZSS RYSE Shade Battery',
             'platform': 'homekit_controller',
             'previous_unique_id': None,

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -43,13 +43,13 @@ async def test_storage_is_removed(
     entity_map.async_create_or_update_map(hkid, 1, [])
     assert hkid in entity_map.storage_data
     await flush_store(entity_map.store)
-    assert hkid in hass_storage["homekit_controller-entity-map"]["data"]["pairings"]
+    assert hkid in hass_storage[ENTITY_MAP]["data"]["pairings"]
 
     entity_map.async_delete_map(hkid)
     assert hkid not in hass.data[ENTITY_MAP].storage_data
     await flush_store(entity_map.store)
 
-    assert hass_storage["homekit_controller-entity-map"]["data"]["pairings"] == {}
+    assert hass_storage[ENTITY_MAP]["data"]["pairings"] == {}
 
 
 async def test_storage_is_removed_idempotent(hass: HomeAssistant) -> None:
@@ -87,7 +87,7 @@ async def test_storage_is_updated_on_add(
 
     # Is saved out to store?
     await flush_store(entity_map.store)
-    assert hkid in hass_storage["homekit_controller-entity-map"]["data"]["pairings"]
+    assert hkid in hass_storage[ENTITY_MAP]["data"]["pairings"]
 
 
 async def test_storage_is_saved_on_stop(

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -103,7 +103,7 @@ async def test_storage_is_saved_on_stop(
     assert hkid in entity_map.storage_data
 
     # Clear the storage to verify it gets saved on stop
-    hass_storage.pop(ENTITY_MAP, None)
+    del hass_storage[ENTITY_MAP]
 
     # Make a change to trigger a save
     entity_map.async_create_or_update_map(hkid, 2, [])  # Update config_num

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -98,13 +98,12 @@ async def test_storage_is_saved_on_stop(
 
     entity_map: EntityMapStorage = hass.data[ENTITY_MAP]
     hkid = "00:00:00:00:00:00"
-    storage_key = "homekit_controller-entity-map"
 
     # Verify the device is in memory
     assert hkid in entity_map.storage_data
 
     # Clear the storage to verify it gets saved on stop
-    hass_storage.pop(storage_key, None)
+    hass_storage.pop(ENTITY_MAP, None)
 
     # Make a change to trigger a save
     entity_map.async_create_or_update_map(hkid, 2, [])  # Update config_num
@@ -114,7 +113,7 @@ async def test_storage_is_saved_on_stop(
     await hass.async_block_till_done()
 
     # Verify the storage was saved
-    assert storage_key in hass_storage
-    assert hkid in hass_storage[storage_key]["data"]["pairings"]
+    assert ENTITY_MAP in hass_storage
+    assert hkid in hass_storage[ENTITY_MAP]["data"]["pairings"]
     # Verify the updated data was saved
-    assert hass_storage[storage_key]["data"]["pairings"][hkid]["config_num"] == 2
+    assert hass_storage[ENTITY_MAP]["data"]["pairings"][hkid]["config_num"] == 2


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where HomeKit Controller entities (particularly energy sensors) would restore with stale or unavailable state after Home Assistant restarts, causing incorrect readings like energy consumption spikes or drops.

### Technical Background

HomeKit Controller maintains an internal characteristic and service map that mirrors the device's characteristic and service map. This internal map is kept in sync with the device through polling and push notifications during normal operation. However, when Home Assistant is restarting, this synchronization is lost - the device continues to update its values while Home Assistant is offline, causing the internal map to become stale.

### The Problem

The root cause had two parts:
1. **Stale data on startup**: When Home Assistant restarts, entities were being created and restored using the stale internal map before the integration had a chance to re-sync with the device's current values. This meant entities would briefly show old values from before the restart, then jump to current values once polling occurred.
2. **Unavailable state on shutdown**: During shutdown, entities were being marked as unavailable, which meant they would restore as unavailable on the next startup rather than their last known good state.

This was particularly problematic for cumulative sensors like energy meters where any discontinuity in readings causes issues with statistics and energy tracking - a jump from an old value to the current value would appear as massive energy consumption.

### The Solution

The fix:
1. **Startup - Re-sync before entity creation**: For IP and COAP (Thread) devices, we now poll the device immediately on startup to re-sync our internal characteristic map with the device's current values BEFORE entities are created. This ensures entities are created with fresh, accurate data rather than stale cached values. BLE devices are excluded from this startup polling as they would significantly delay startup due to slow connection times.

2. **Shutdown - Preserve last known state**: Aligns HomeKit Controller with standard Home Assistant patterns by:
   - Skipping the unavailable state change when `hass.is_stopping` is true
   - Not unloading platforms during shutdown (they'll be cleaned up anyway)
   
   Most other integrations don't remove all their platforms and entities at shutdown. This change brings HomeKit Controller in line with that standard approach, ensuring entities preserve their last known state rather than being marked unavailable.
   
This two-pronged approach ensures that:
- The internal map is synchronized with the device's actual state before entities are created
- Entities preserve their last known good state through the restart cycle
- Energy and other cumulative sensors maintain continuity without artificial spikes or drops
- HomeKit Controller follows the same shutdown patterns as other Home Assistant integrations

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #134288
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The issue remained unresolved for 8 months because initial attempts tried to solve this for all transport types including BLE. However, BLE devices cannot be efficiently polled at startup without causing significant delays. This PR implements a pragmatic solution by only polling IP and COAP/Thread devices which can respond quickly.

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr