### PR TITLE
Russound RNET Zone Mediaplayer Entities provide DeviceInfo

### DIFF
--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -81,7 +81,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.SELECT_SOURCE
     )
 
-    def __init__(self , _, russ, sources, zone_id, extra) -> None:
+    def __init__(self, _, russ, sources, zone_id, extra) -> None:
         """Initialise the Russound RNET device."""
         self._attr_name = extra["name"]
         self._russ = russ

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -64,7 +64,7 @@ def setup_platform(
     if russ.is_connected():
         for zone_id, extra in config[CONF_ZONES].items():
             add_entities(
-                [RussoundRNETDevice(hass, russ, sources, zone_id, extra)], True
+                [RussoundRNETDevice(russ, sources, zone_id, extra)], True
             )
     else:
         _LOGGER.error("Not connected to %s:%s", host, port)
@@ -81,7 +81,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.SELECT_SOURCE
     )
 
-    def __init__(self, _, russ, sources, zone_id, extra) -> None:
+    def __init__(self, russ, sources, zone_id, extra) -> None:
         """Initialise the Russound RNET device."""
         self._attr_name = extra["name"]
         self._russ = russ

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity import DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,6 +91,20 @@ class RussoundRNETDevice(MediaPlayerEntity):
         self._controller_id = str(math.ceil(zone_id / 6))
         # Each zone resets to 1-6 per controller
         self._zone_id = (zone_id - 1) % 6 + 1
+
+        # Stable unique_id so entity/device get registered once
+        self._attr_unique_id = f"rnet_{self._controller_id}_zone_{self._zone_id}"  # <-- NEW
+
+    # Expose a per-zone device
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for this Russound zone."""
+        return DeviceInfo(
+            identifiers={("russound_rnet", f"{self._controller_id}-{self._zone_id}")},
+            name=self._attr_name,
+            manufacturer="Russound",
+            model="RNET",
+        )
 
     def update(self) -> None:
         """Retrieve latest state."""

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -21,7 +21,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ZONES = "zones"

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -25,6 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_ZONES = "zones"
 CONF_SOURCES = "sources"
+DOMAIN = "russound_rnet"
 
 
 ZONE_SCHEMA = vol.Schema({vol.Required(CONF_NAME): cv.string})
@@ -78,10 +79,11 @@ class RussoundRNETDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.SELECT_SOURCE
     )
+    _attr_has_entity_name = True
+    _attr_name = None
 
     def __init__(self, russ, sources, zone_id, extra) -> None:
         """Initialise the Russound RNET device."""
-        self._attr_name = extra["name"]
         self._russ = russ
         self._attr_source_list = sources
         # Each controller has a maximum of 6 zones, every increment of 6 zones
@@ -95,8 +97,8 @@ class RussoundRNETDevice(MediaPlayerEntity):
 
         # Expose a per-zone device
         self._attr_device_info = DeviceInfo(
-            identifiers={("russound_rnet", f"{self._controller_id}-{self._zone_id}")},
-            name=self._attr_name,
+            identifiers={(DOMAIN, f"{self._controller_id}-{self._zone_id}")},
+            name=extra["name"],
             manufacturer="Russound",
             model="RNET",
         )

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.SELECT_SOURCE
     )
 
-    def __init__(self, hass, russ, sources, zone_id, extra):
+    def __init__(self , _, russ, sources, zone_id, extra) -> None:
         """Initialise the Russound RNET device."""
         self._attr_name = extra["name"]
         self._russ = russ
@@ -93,7 +93,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
         self._zone_id = (zone_id - 1) % 6 + 1
 
         # Stable unique_id so entity/device get registered once
-        self._attr_unique_id = f"rnet_{self._controller_id}_zone_{self._zone_id}"  # <-- NEW
+        self._attr_unique_id = f"rnet_{self._controller_id}_zone_{self._zone_id}"
 
     # Expose a per-zone device
     @property

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -63,9 +63,7 @@ def setup_platform(
 
     if russ.is_connected():
         for zone_id, extra in config[CONF_ZONES].items():
-            add_entities(
-                [RussoundRNETDevice(russ, sources, zone_id, extra)], True
-            )
+            add_entities([RussoundRNETDevice(russ, sources, zone_id, extra)], True)
     else:
         _LOGGER.error("Not connected to %s:%s", host, port)
 

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -17,9 +17,10 @@ from homeassistant.components.media_player import (
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.helpers.device_registry import DeviceInfo
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -95,11 +95,8 @@ class RussoundRNETDevice(MediaPlayerEntity):
         # Stable unique_id so entity/device get registered once
         self._attr_unique_id = f"rnet_{self._controller_id}_zone_{self._zone_id}"
 
-    # Expose a per-zone device
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for this Russound zone."""
-        return DeviceInfo(
+        # Expose a per-zone device
+        self._attr_device_info = DeviceInfo(
             identifiers={("russound_rnet", f"{self._controller_id}-{self._zone_id}")},
             name=self._attr_name,
             manufacturer="Russound",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The existing Russound RNET component does not allow the individual zones (which are exposed as media players) to be assigned to areas. Which is very annoying, since the purpose of a multi-room sound system is to provide sound to multiple rooms. 
With this proposed change, each zone aka media player can be assigned to an area from within the HASS UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
