### PR TITLE
Add the `dial` action to the  FRITZ!Box Tools integration

### DIFF
--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -16,6 +16,7 @@ from fritzconnection.core.exceptions import (
     FritzConnectionException,
     FritzSecurityError,
 )
+from fritzconnection.lib.fritzcall import FritzCall
 from fritzconnection.lib.fritzhosts import FritzHosts
 from fritzconnection.lib.fritzstatus import FritzStatus
 from fritzconnection.lib.fritzwlan import FritzGuestWLAN
@@ -120,6 +121,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         self.fritz_guest_wifi: FritzGuestWLAN = None
         self.fritz_hosts: FritzHosts = None
         self.fritz_status: FritzStatus = None
+        self.fritz_call: FritzCall = None
         self.host = host
         self.mesh_role = MeshRoles.NONE
         self.mesh_wifi_uplink = False
@@ -183,6 +185,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         self.fritz_hosts = FritzHosts(fc=self.connection)
         self.fritz_guest_wifi = FritzGuestWLAN(fc=self.connection)
         self.fritz_status = FritzStatus(fc=self.connection)
+        self.fritz_call = FritzCall(fc=self.connection)
         info = self.fritz_status.get_device_info()
 
         _LOGGER.debug(
@@ -616,6 +619,10 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         await self.hass.async_add_executor_job(
             self.fritz_guest_wifi.set_password, password, length
         )
+
+    async def async_trigger_dial(self, number: str) -> None:
+        """Trigger service to dial a number."""
+        await self.hass.async_add_executor_job(self.fritz_call.dial, number)
 
     async def async_trigger_cleanup(self) -> None:
         """Trigger device trackers cleanup."""

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -620,9 +621,14 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
             self.fritz_guest_wifi.set_password, password, length
         )
 
-    async def async_trigger_dial(self, number: str) -> None:
+    async def async_trigger_dial(
+        self, number: str, max_ring_seconds: float | None = None
+    ) -> None:
         """Trigger service to dial a number."""
         await self.hass.async_add_executor_job(self.fritz_call.dial, number)
+        if max_ring_seconds is not None:
+            await asyncio.sleep(max_ring_seconds)
+            await self.hass.async_add_executor_job(self.fritz_call.hangup)
 
     async def async_trigger_cleanup(self) -> None:
         """Trigger device trackers cleanup."""

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -622,7 +622,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         )
 
     async def async_trigger_dial(
-        self, number: str, max_ring_seconds: float
+        self, number: str, max_ring_seconds: int
     ) -> None:
         """Trigger service to dial a number."""
         try:

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -621,9 +621,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
             self.fritz_guest_wifi.set_password, password, length
         )
 
-    async def async_trigger_dial(
-        self, number: str, max_ring_seconds: int
-    ) -> None:
+    async def async_trigger_dial(self, number: str, max_ring_seconds: int) -> None:
         """Trigger service to dial a number."""
         try:
             await self.hass.async_add_executor_job(self.fritz_call.dial, number)

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -622,12 +622,13 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         )
 
     async def async_trigger_dial(
-        self, number: str, max_ring_seconds: float | None = None
+        self, number: str, max_ring_seconds: float
     ) -> None:
         """Trigger service to dial a number."""
-        await self.hass.async_add_executor_job(self.fritz_call.dial, number)
-        if max_ring_seconds is not None:
+        try:
+            await self.hass.async_add_executor_job(self.fritz_call.dial, number)
             await asyncio.sleep(max_ring_seconds)
+        finally:
             await self.hass.async_add_executor_job(self.fritz_call.hangup)
 
     async def async_trigger_cleanup(self) -> None:

--- a/homeassistant/components/fritz/icons.json
+++ b/homeassistant/components/fritz/icons.json
@@ -62,6 +62,9 @@
     },
     "set_guest_wifi_password": {
       "service": "mdi:form-textbox-password"
+    },
+    "dial": {
+      "service": "mdi:phone-dial"
     }
   }
 }

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -33,6 +33,9 @@ SERVICE_SCHEMA_DIAL = vol.Schema(
     {
         vol.Required("device_id"): str,
         vol.Required("number"): str,
+        vol.Optional("max_ring_seconds"): vol.All(
+            vol.Coerce(float), vol.Range(min=0.1, max=360.0)
+        ),
     }
 )
 
@@ -94,7 +97,10 @@ async def _async_dial(service_call: ServiceCall) -> None:
         _LOGGER.debug("Executing service %s", service_call.service)
         avm_wrapper = target_entry.runtime_data
         try:
-            await avm_wrapper.async_trigger_dial(service_call.data.get("number"))
+            await avm_wrapper.async_trigger_dial(
+                service_call.data.get("number"),
+                max_ring_seconds=service_call.data.get("max_ring_seconds"),
+            )
         except (FritzServiceError, FritzActionError) as ex:
             raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="service_parameter_unknown"

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -27,6 +27,13 @@ SERVICE_SCHEMA_SET_GUEST_WIFI_PW = vol.Schema(
         vol.Optional("length"): vol.Range(min=8, max=63),
     }
 )
+SERVICE_DIAL = "dial"
+SERVICE_SCHEMA_DIAL = vol.Schema(
+    {
+        vol.Required("device_id"): str,
+        vol.Required("number"): str,
+    }
+)
 
 
 async def _async_set_guest_wifi_password(service_call: ServiceCall) -> None:
@@ -65,6 +72,38 @@ async def _async_set_guest_wifi_password(service_call: ServiceCall) -> None:
             ) from ex
 
 
+async def _async_dial(service_call: ServiceCall) -> None:
+    """Call Fritz dial service."""
+    hass = service_call.hass
+    target_entry_ids = await async_extract_config_entry_ids(hass, service_call)
+    target_entries: list[FritzConfigEntry] = [
+        loaded_entry
+        for loaded_entry in hass.config_entries.async_loaded_entries(DOMAIN)
+        if loaded_entry.entry_id in target_entry_ids
+    ]
+
+    if not target_entries:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="config_entry_not_found",
+            translation_placeholders={"service": service_call.service},
+        )
+
+    for target_entry in target_entries:
+        _LOGGER.debug("Executing service %s", service_call.service)
+        avm_wrapper = target_entry.runtime_data
+        try:
+            await avm_wrapper.async_trigger_dial(service_call.data.get("number"))
+        except (FritzServiceError, FritzActionError) as ex:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="service_parameter_unknown"
+            ) from ex
+        except FritzConnectionException as ex:
+            raise HomeAssistantError(  # Check if dial-help of the Fritz!Box is activated
+                translation_domain=DOMAIN, translation_key="service_not_supported"
+            ) from ex
+
+
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up services for Fritz integration."""
@@ -75,3 +114,4 @@ def async_setup_services(hass: HomeAssistant) -> None:
         _async_set_guest_wifi_password,
         SERVICE_SCHEMA_SET_GUEST_WIFI_PW,
     )
+    hass.services.async_register(DOMAIN, SERVICE_DIAL, _async_dial, SERVICE_SCHEMA_DIAL)

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -34,7 +34,7 @@ SERVICE_SCHEMA_DIAL = vol.Schema(
         vol.Required("device_id"): str,
         vol.Required("number"): str,
         vol.Optional("max_ring_seconds"): vol.All(
-            vol.Coerce(float), vol.Range(min=0.1, max=360.0)
+            vol.Coerce(int), vol.Range(min=1, max=300)
         ),
     }
 )

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -4,9 +4,9 @@ import logging
 
 from fritzconnection.core.exceptions import (
     FritzActionError,
+    FritzActionFailedError,
     FritzConnectionException,
     FritzServiceError,
-    FritzActionFailedError,
 )
 from fritzconnection.lib.fritzwlan import DEFAULT_PASSWORD_LENGTH
 import voluptuous as vol

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -33,9 +33,7 @@ SERVICE_SCHEMA_DIAL = vol.Schema(
     {
         vol.Required("device_id"): str,
         vol.Required("number"): str,
-        vol.Optional("max_ring_seconds"): vol.All(
-            vol.Coerce(int), vol.Range(min=1, max=300)
-        ),
+        vol.Required("max_ring_seconds"): vol.Range(min=1, max=300),
     }
 )
 

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -6,6 +6,7 @@ from fritzconnection.core.exceptions import (
     FritzActionError,
     FritzConnectionException,
     FritzServiceError,
+    FritzActionFailedError,
 )
 from fritzconnection.lib.fritzwlan import DEFAULT_PASSWORD_LENGTH
 import voluptuous as vol
@@ -98,8 +99,12 @@ async def _async_dial(service_call: ServiceCall) -> None:
             raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="service_parameter_unknown"
             ) from ex
+        except FritzActionFailedError as ex:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="service_dial_failed"
+            ) from ex
         except FritzConnectionException as ex:
-            raise HomeAssistantError(  # Check if dial-help of the Fritz!Box is activated
+            raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="service_not_supported"
             ) from ex
 

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -95,8 +95,8 @@ async def _async_dial(service_call: ServiceCall) -> None:
         avm_wrapper = target_entry.runtime_data
         try:
             await avm_wrapper.async_trigger_dial(
-                service_call.data.get("number"),
-                max_ring_seconds=service_call.data.get("max_ring_seconds"),
+                service_call.data["number"],
+                max_ring_seconds=service_call.data["max_ring_seconds"],
             )
         except (FritzServiceError, FritzActionError) as ex:
             raise HomeAssistantError(

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -76,11 +76,10 @@ async def _async_set_guest_wifi_password(service_call: ServiceCall) -> None:
 
 async def _async_dial(service_call: ServiceCall) -> None:
     """Call Fritz dial service."""
-    hass = service_call.hass
-    target_entry_ids = await async_extract_config_entry_ids(hass, service_call)
+    target_entry_ids = await async_extract_config_entry_ids(service_call)
     target_entries: list[FritzConfigEntry] = [
         loaded_entry
-        for loaded_entry in hass.config_entries.async_loaded_entries(DOMAIN)
+        for loaded_entry in service_call.hass.config_entries.async_loaded_entries(DOMAIN)
         if loaded_entry.entry_id in target_entry_ids
     ]
 

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -79,7 +79,9 @@ async def _async_dial(service_call: ServiceCall) -> None:
     target_entry_ids = await async_extract_config_entry_ids(service_call)
     target_entries: list[FritzConfigEntry] = [
         loaded_entry
-        for loaded_entry in service_call.hass.config_entries.async_loaded_entries(DOMAIN)
+        for loaded_entry in service_call.hass.config_entries.async_loaded_entries(
+            DOMAIN
+        )
         if loaded_entry.entry_id in target_entry_ids
     ]
 

--- a/homeassistant/components/fritz/services.yaml
+++ b/homeassistant/components/fritz/services.yaml
@@ -17,3 +17,16 @@ set_guest_wifi_password:
         number:
           min: 8
           max: 63
+dial:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: fritz
+          entity:
+            device_class: connectivity
+    number:
+      required: true
+      selector:
+        text:

--- a/homeassistant/components/fritz/services.yaml
+++ b/homeassistant/components/fritz/services.yaml
@@ -30,3 +30,12 @@ dial:
       required: true
       selector:
         text:
+    max_ring_seconds:
+      default: 15
+      required: false
+      selector:
+        number:
+          min: 0.1
+          max: 360
+          step: 0.1
+          unit_of_measurement: seconds

--- a/homeassistant/components/fritz/services.yaml
+++ b/homeassistant/components/fritz/services.yaml
@@ -37,5 +37,4 @@ dial:
         number:
           min: 1
           max: 300
-          step: 1
           unit_of_measurement: seconds

--- a/homeassistant/components/fritz/services.yaml
+++ b/homeassistant/components/fritz/services.yaml
@@ -32,10 +32,10 @@ dial:
         text:
     max_ring_seconds:
       default: 15
-      required: false
+      required: true
       selector:
         number:
-          min: 0.1
-          max: 360
-          step: 0.1
+          min: 1
+          max: 300
+          step: 1
           unit_of_measurement: seconds

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -223,7 +223,7 @@
       "message": "Failed to perform action \"{service}\". Config entry for target not found"
     },
     "service_dial_failed": {
-      "message": "Failed to dial, check if the dial-help service of the FRITZ!Box is activated"
+      "message": "Failed to dial, check if the click to dial service of the FRITZ!Box is activated"
     },
     "service_parameter_unknown": {
       "message": "Action or parameter unknown"

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -198,6 +198,20 @@
           "description": "Length of the new password. It will be auto-generated if no password is set."
         }
       }
+    },
+    "dial": {
+      "name": "Dial a phone number",
+      "description": "Let the Fritz!Box dial a phone number. The dial-help of the Fritz!Box must be activated to make this work.",
+      "fields": {
+        "device_id": {
+          "name": "Fritz!Box Device",
+          "description": "Select the Fritz!Box to dial from."
+        },
+        "number": {
+          "name": "Phone number",
+          "description": "Phone number to dial."
+        }
+      }
     }
   },
   "exceptions": {

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -213,7 +213,7 @@
         },
         "max_ring_seconds": {
           "name": "Maximum ring duration",
-          "description": "The maximum number of seconds to ring after dialing. Note that the actual ring duration might be shorter depending on the receivers phone settings."
+          "description": "The maximum number of seconds to ring after dialing. Note that the actual ring duration might be shorter depending on the receiver's phone settings."
         }
       }
     }

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -201,15 +201,15 @@
     },
     "dial": {
       "name": "Dial a phone number",
-      "description": "Let the Fritz!Box dial a phone number. The dial-help of the Fritz!Box must be activated to make this work.",
+      "description": "Makes the Fritz!Box dial a phone number. The dial-help service of the Fritz!Box must be activated to make this work.",
       "fields": {
         "device_id": {
-          "name": "Fritz!Box Device",
+          "name": "Fritz!Box device",
           "description": "Select the Fritz!Box to dial from."
         },
         "number": {
           "name": "Phone number",
-          "description": "Phone number to dial."
+          "description": "The phone number to dial."
         }
       }
     }
@@ -219,7 +219,7 @@
       "message": "Failed to perform action \"{service}\". Config entry for target not found"
     },
     "service_dial_failed": {
-      "message": "Failed to dial, check if the dial-help of the Fritz!Box is activated"
+      "message": "Failed to dial, check if the dial-help service of the Fritz!Box is activated"
     },
     "service_parameter_unknown": {
       "message": "Action or parameter unknown"

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -218,6 +218,9 @@
     "config_entry_not_found": {
       "message": "Failed to perform action \"{service}\". Config entry for target not found"
     },
+    "service_dial_failed": {
+      "message": "Failed to dial, check if the dial-help of the Fritz!Box is activated"
+    },
     "service_parameter_unknown": {
       "message": "Action or parameter unknown"
     },

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -201,11 +201,11 @@
     },
     "dial": {
       "name": "Dial a phone number",
-      "description": "Makes the Fritz!Box dial a phone number. The dial-help service of the Fritz!Box must be activated to make this work.",
+      "description": "Makes the FRITZ!Box dial a phone number.",
       "fields": {
         "device_id": {
-          "name": "Fritz!Box device",
-          "description": "Select the Fritz!Box to dial from."
+          "name": "FRITZ!Box device",
+          "description": "Select the FRITZ!Box to dial from."
         },
         "number": {
           "name": "Phone number",
@@ -213,7 +213,7 @@
         },
         "max_ring_seconds": {
           "name": "Maximum ring duration",
-          "description": "The maximum number of seconds to ring after dialing. Note that the actual ring duration might be shorter depending on the receiver's phone settings."
+          "description": "The maximum number of seconds to ring after dialing."
         }
       }
     }
@@ -223,7 +223,7 @@
       "message": "Failed to perform action \"{service}\". Config entry for target not found"
     },
     "service_dial_failed": {
-      "message": "Failed to dial, check if the dial-help service of the Fritz!Box is activated"
+      "message": "Failed to dial, check if the dial-help service of the FRITZ!Box is activated"
     },
     "service_parameter_unknown": {
       "message": "Action or parameter unknown"

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -210,6 +210,10 @@
         "number": {
           "name": "Phone number",
           "description": "The phone number to dial."
+        },
+        "max_ring_seconds": {
+          "name": "Maximum ring duration",
+          "description": "The maximum number of seconds to ring after dialing. Note that the actual ring duration might be shorter depending on the receivers phone settings."
         }
       }
     }

--- a/tests/components/fritz/test_services.py
+++ b/tests/components/fritz/test_services.py
@@ -3,17 +3,17 @@
 from unittest.mock import patch
 
 from fritzconnection.core.exceptions import (
+    FritzActionFailedError,
     FritzConnectionException,
     FritzServiceError,
-    FritzActionFailedError,
 )
 import pytest
 from voluptuous import MultipleInvalid
 
 from homeassistant.components.fritz.const import DOMAIN
 from homeassistant.components.fritz.services import (
-    SERVICE_SET_GUEST_WIFI_PW,
     SERVICE_DIAL,
+    SERVICE_SET_GUEST_WIFI_PW,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr

--- a/tests/components/fritz/test_services.py
+++ b/tests/components/fritz/test_services.py
@@ -317,7 +317,7 @@ async def test_service_dial_failed(
         )
         assert mock_async_trigger_dial.called
         assert (
-            "HomeAssistantError: Failed to dial, check if the dial-help service of the FRITZ!Box is activated"
+            "HomeAssistantError: Failed to dial, check if the click to dial service of the FRITZ!Box is activated"
             in caplog.text
         )
 

--- a/tests/components/fritz/test_services.py
+++ b/tests/components/fritz/test_services.py
@@ -6,7 +6,10 @@ from fritzconnection.core.exceptions import FritzConnectionException, FritzServi
 import pytest
 
 from homeassistant.components.fritz.const import DOMAIN
-from homeassistant.components.fritz.services import SERVICE_SET_GUEST_WIFI_PW
+from homeassistant.components.fritz.services import (
+    SERVICE_SET_GUEST_WIFI_PW,
+    SERVICE_DIAL,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
@@ -24,6 +27,7 @@ async def test_setup_services(hass: HomeAssistant) -> None:
     services = hass.services.async_services_for_domain(DOMAIN)
     assert services
     assert SERVICE_SET_GUEST_WIFI_PW in services
+    assert SERVICE_DIAL in services
 
 
 async def test_service_set_guest_wifi_password(
@@ -130,5 +134,112 @@ async def test_service_set_guest_wifi_password_unloaded(
         assert not mock_async_trigger_set_guest_password.called
         assert (
             'ServiceValidationError: Failed to perform action "set_guest_wifi_password". Config entry for target not found'
+            in caplog.text
+        )
+
+async def test_service_dial(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    fc_class_mock,
+    fh_class_mock,
+) -> None:
+    """Test service dial."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "1C:ED:6F:12:34:11")}
+    )
+    assert device
+    with patch(
+        "homeassistant.components.fritz.coordinator.AvmWrapper.async_trigger_dial"
+    ) as mock_async_trigger_dial:
+        await hass.services.async_call(
+            DOMAIN, SERVICE_DIAL, {"device_id": device.id, "number": "1234567890"}
+        )
+        assert mock_async_trigger_dial.called
+
+
+async def test_service_dial_unknown_parameter(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    fc_class_mock,
+    fh_class_mock,
+) -> None:
+    """Test service dial with unknown parameters."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "1C:ED:6F:12:34:11")}
+    )
+    assert device
+
+    with patch(
+        "homeassistant.components.fritz.coordinator.AvmWrapper.async_trigger_dial",
+        side_effect=FritzServiceError("boom"),
+    ) as mock_async_trigger_dial:
+        await hass.services.async_call(
+            DOMAIN, SERVICE_DIAL, {"device_id": device.id, "number": "1234567890"}
+        )
+        assert mock_async_trigger_dial.called
+        assert "HomeAssistantError: Action or parameter unknown" in caplog.text
+
+
+async def test_service_dial_service_not_supported(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    fc_class_mock,
+    fh_class_mock,
+) -> None:
+    """Test service dial with connection error."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "1C:ED:6F:12:34:11")}
+    )
+    assert device
+
+    with patch(
+        "homeassistant.components.fritz.coordinator.AvmWrapper.async_trigger_dial",
+        side_effect=FritzConnectionException("boom"),
+    ) as mock_async_trigger_dial:
+        await hass.services.async_call(
+            DOMAIN, SERVICE_DIAL, {"device_id": device.id, "number": "1234567890"}
+        )
+        assert mock_async_trigger_dial.called
+        assert "HomeAssistantError: Action not supported" in caplog.text
+
+
+async def test_service_dial_unloaded(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test service dial."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.fritz.coordinator.AvmWrapper.async_trigger_dial"
+    ) as mock_async_trigger_dial:
+        await hass.services.async_call(
+            DOMAIN, SERVICE_DIAL, {"device_id": "12345678", "number": "1234567890"}
+        )
+        assert not mock_async_trigger_dial.called
+        assert (
+            f'ServiceValidationError: Failed to perform action "{SERVICE_DIAL}". Config entry for target not found'
             in caplog.text
         )

--- a/tests/components/fritz/test_services.py
+++ b/tests/components/fritz/test_services.py
@@ -176,10 +176,10 @@ async def test_service_dial(
         await hass.services.async_call(
             DOMAIN,
             SERVICE_DIAL,
-            {"device_id": device.id, "number": "1234567890", "max_ring_seconds": 10.0},
+            {"device_id": device.id, "number": "1234567890", "max_ring_seconds": 10},
         )
         assert mock_async_trigger_dial.called
-        assert mock_async_trigger_dial.call_args.kwargs == {"max_ring_seconds": 10.0}
+        assert mock_async_trigger_dial.call_args.kwargs == {"max_ring_seconds": 10}
         assert mock_async_trigger_dial.call_args.args == ("1234567890",)
 
 
@@ -256,7 +256,7 @@ async def test_service_dial_wrong_parameter(
                 {
                     "device_id": device.id,
                     "number": "1234567890",
-                    "max_ring_seconds": 0.0,
+                    "max_ring_seconds": 0,
                 },
             )
         assert not mock_async_trigger_dial.called

--- a/tests/components/fritz/test_services.py
+++ b/tests/components/fritz/test_services.py
@@ -317,7 +317,7 @@ async def test_service_dial_failed(
         )
         assert mock_async_trigger_dial.called
         assert (
-            "HomeAssistantError: Failed to dial, check if the dial-help service of the Fritz!Box is activated"
+            "HomeAssistantError: Failed to dial, check if the dial-help service of the FRITZ!Box is activated"
             in caplog.text
         )
 

--- a/tests/components/fritz/test_services.py
+++ b/tests/components/fritz/test_services.py
@@ -165,15 +165,6 @@ async def test_service_dial(
         "homeassistant.components.fritz.coordinator.AvmWrapper.async_trigger_dial"
     ) as mock_async_trigger_dial:
         await hass.services.async_call(
-            DOMAIN, SERVICE_DIAL, {"device_id": device.id, "number": "1234567890"}
-        )
-        assert mock_async_trigger_dial.called
-        assert mock_async_trigger_dial.call_args.kwargs == {"max_ring_seconds": None}
-        assert mock_async_trigger_dial.call_args.args == ("1234567890",)
-    with patch(
-        "homeassistant.components.fritz.coordinator.AvmWrapper.async_trigger_dial"
-    ) as mock_async_trigger_dial:
-        await hass.services.async_call(
             DOMAIN,
             SERVICE_DIAL,
             {"device_id": device.id, "number": "1234567890", "max_ring_seconds": 10},
@@ -207,7 +198,9 @@ async def test_service_dial_unknown_parameter(
         side_effect=FritzServiceError("boom"),
     ) as mock_async_trigger_dial:
         await hass.services.async_call(
-            DOMAIN, SERVICE_DIAL, {"device_id": device.id, "number": "1234567890"}
+            DOMAIN,
+            SERVICE_DIAL,
+            {"device_id": device.id, "number": "1234567890", "max_ring_seconds": 10},
         )
         assert mock_async_trigger_dial.called
         assert "HomeAssistantError: Action or parameter unknown" in caplog.text
@@ -286,7 +279,9 @@ async def test_service_dial_service_not_supported(
         side_effect=FritzConnectionException("boom"),
     ) as mock_async_trigger_dial:
         await hass.services.async_call(
-            DOMAIN, SERVICE_DIAL, {"device_id": device.id, "number": "1234567890"}
+            DOMAIN,
+            SERVICE_DIAL,
+            {"device_id": device.id, "number": "1234567890", "max_ring_seconds": 10},
         )
         assert mock_async_trigger_dial.called
         assert "HomeAssistantError: Action not supported" in caplog.text
@@ -316,7 +311,9 @@ async def test_service_dial_failed(
         side_effect=FritzActionFailedError("boom"),
     ) as mock_async_trigger_dial:
         await hass.services.async_call(
-            DOMAIN, SERVICE_DIAL, {"device_id": device.id, "number": "1234567890"}
+            DOMAIN,
+            SERVICE_DIAL,
+            {"device_id": device.id, "number": "1234567890", "max_ring_seconds": 10},
         )
         assert mock_async_trigger_dial.called
         assert (
@@ -337,7 +334,9 @@ async def test_service_dial_unloaded(
         "homeassistant.components.fritz.coordinator.AvmWrapper.async_trigger_dial"
     ) as mock_async_trigger_dial:
         await hass.services.async_call(
-            DOMAIN, SERVICE_DIAL, {"device_id": "12345678", "number": "1234567890"}
+            DOMAIN,
+            SERVICE_DIAL,
+            {"device_id": "12345678", "number": "1234567890", "max_ring_seconds": 10},
         )
         assert not mock_async_trigger_dial.called
         assert (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a new action to the existing AVM FRITZ!Box Tools integration, that allows to dial a number via the Fritzbox. It will ring the number for a couple of seconds and then stop.

I use this with an internal number as a doorbell, but it could be used for all sorts of alerts.

<details><summary>Configuration interface for new action</summary>
<p>

<img width="1273" height="516" alt="New action configuration initerface" src="https://github.com/user-attachments/assets/3aa9588b-7dfa-4ac3-b800-36299860dd84" />
</p>
</details> 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40590
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] ~The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.~
- [x] ~New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.~
- [x] ~For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.~

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
