### PR TITLE
SharkIQ new/updated authorization method.

### DIFF
--- a/homeassistant/components/sharkiq/__init__.py
+++ b/homeassistant/components/sharkiq/__init__.py
@@ -15,7 +15,7 @@ from homeassistant import exceptions
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
     API_TIMEOUT,
@@ -37,6 +37,7 @@ async def async_connect_or_timeout(ayla_api: AylaApi) -> bool:
     try:
         async with asyncio.timeout(API_TIMEOUT):
             LOGGER.debug("Initialize connection to Ayla networks API")
+            await ayla_api.async_set_cookie()
             await ayla_api.async_sign_in()
     except SharkIqAuthError:
         LOGGER.error("Authentication error connecting to Shark IQ api")
@@ -59,7 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     ayla_api = get_ayla_api(
         username=config_entry.data[CONF_USERNAME],
         password=config_entry.data[CONF_PASSWORD],
-        websession=async_get_clientsession(hass),
+        websession=async_create_clientsession(hass),
         europe=(config_entry.data[CONF_REGION] == SHARKIQ_REGION_EUROPE),
     )
 
@@ -94,7 +95,7 @@ async def async_disconnect_or_timeout(coordinator: SharkIqUpdateCoordinator):
             await coordinator.ayla_api.async_sign_out()
 
 
-async def async_update_options(hass, config_entry):
+async def async_update_options(hass: HomeAssistant, config_entry):
     """Update options."""
     await hass.config_entries.async_reload(config_entry.entry_id)
 

--- a/homeassistant/components/sharkiq/config_flow.py
+++ b/homeassistant/components/sharkiq/config_flow.py
@@ -1,158 +1,69 @@
-"""Config flow for Shark IQ integration."""
+import urllib.parse
 
-from __future__ import annotations
+async def do_auth0_login(session, username, password):
+    AUTH_DOMAIN = "https://login.sharkninja.com"
+    CLIENT_ID = "wsguxrqm77mq4LtrTrwg8ZJUxmSrexGi"
+    REDIRECT_URI = "com.sharkninja.shark://login.sharkninja.com/ios/com.sharkninja.shark/callback"
+    SCOPE = "openid profile email offline_access"
 
-import asyncio
-from collections.abc import Mapping
-from typing import Any
-
-import aiohttp
-from sharkiq import SharkIqAuthError, get_ayla_api
-import voluptuous as vol
-
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import selector
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-
-from .const import (
-    DOMAIN,
-    LOGGER,
-    SHARKIQ_REGION_DEFAULT,
-    SHARKIQ_REGION_EUROPE,
-    SHARKIQ_REGION_OPTIONS,
-)
-
-SHARKIQ_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
-        vol.Required(
-            CONF_REGION, default=SHARKIQ_REGION_DEFAULT
-        ): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=SHARKIQ_REGION_OPTIONS, translation_key="region"
-            ),
-        ),
+    HEADERS = {
+        "User-Agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Mobile Safari/537.36",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Origin": AUTH_DOMAIN,
+        "Referer": AUTH_DOMAIN + "/",
     }
-)
 
-
-async def _validate_input(
-    hass: HomeAssistant, data: Mapping[str, Any]
-) -> dict[str, str]:
-    """Validate the user input allows us to connect."""
-    ayla_api = get_ayla_api(
-        username=data[CONF_USERNAME],
-        password=data[CONF_PASSWORD],
-        websession=async_get_clientsession(hass),
-        europe=(data[CONF_REGION] == SHARKIQ_REGION_EUROPE),
+    # 1. GET /authorize
+    authorize_url = (
+        f"{AUTH_DOMAIN}/authorize?"
+        + urllib.parse.urlencode(
+            {
+                "os": "android",
+                "response_type": "code",
+                "client_id": CLIENT_ID,
+                "redirect_uri": REDIRECT_URI,
+                "scope": SCOPE,
+            }
+        )
     )
+    async with session.get(authorize_url, headers=HEADERS, allow_redirects=True) as resp:
+        parsed = urllib.parse.urlparse(str(resp.url))
+        state = urllib.parse.parse_qs(parsed.query).get("state", [None])[0]
+    if not state:
+        raise CannotConnect("No state returned from authorize")
 
-    try:
-        async with asyncio.timeout(10):
-            LOGGER.debug("Initialize connection to Ayla networks API")
-            await ayla_api.async_sign_in()
-    except (TimeoutError, aiohttp.ClientError, TypeError) as error:
-        LOGGER.error(error)
-        raise CannotConnect(
-            "Unable to connect to SharkIQ services.  Check your region settings."
-        ) from error
-    except SharkIqAuthError as error:
-        LOGGER.error(error)
-        raise InvalidAuth(
-            "Username or password incorrect.  Please check your credentials."
-        ) from error
-    except Exception as error:
-        LOGGER.exception("Unexpected exception")
-        LOGGER.error(error)
-        raise UnknownAuth(
-            "An unknown error occurred. Check your region settings and open an issue on Github if the issue persists."
-        ) from error
+    # 2. POST /u/login
+    login_url = f"{AUTH_DOMAIN}/u/login?state={state}"
+    form_data = {"state": state, "username": username, "password": password, "action": "default"}
+    async with session.post(login_url, headers=HEADERS, data=form_data, allow_redirects=False) as resp:
+        redirect_url = resp.headers.get("Location")
 
-    # Return info that you want to store in the config entry.
-    return {"title": data[CONF_USERNAME]}
+    code = None
+    if redirect_url and redirect_url.startswith("/authorize/resume"):
+        resume_url = AUTH_DOMAIN + redirect_url
+        async with session.get(resume_url, headers=HEADERS, allow_redirects=False) as resp:
+            final_url = resp.headers.get("Location")
+            if final_url:
+                parsed = urllib.parse.urlparse(final_url)
+                code = urllib.parse.parse_qs(parsed.query).get("code", [None])[0]
+    else:
+        parsed = urllib.parse.urlparse(redirect_url or "")
+        code = urllib.parse.parse_qs(parsed.query).get("code", [None])[0]
 
+    if not code:
+        raise CannotConnect("No authorization code received")
 
-class SharkIqConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Shark IQ."""
+    # 3. Exchange code for tokens
+    token_url = f"{AUTH_DOMAIN}/oauth/token"
+    payload = {
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+    }
+    async with session.post(token_url, headers={"Content-Type": "application/json"}, json=payload) as resp:
+        token_data = await resp.json()
+    if "access_token" not in token_data:
+        raise InvalidAuth("Auth0 did not return an access token")
 
-    VERSION = 1
-
-    async def _async_validate_input(
-        self, user_input: Mapping[str, Any]
-    ) -> tuple[dict[str, str] | None, dict[str, str]]:
-        """Validate form input."""
-        errors = {}
-        info = None
-
-        # noinspection PyBroadException
-        try:
-            info = await _validate_input(self.hass, user_input)
-        except CannotConnect:
-            errors["base"] = "cannot_connect"
-        except InvalidAuth:
-            errors["base"] = "invalid_auth"
-        except UnknownAuth:
-            errors["base"] = "unknown"
-        return info, errors
-
-    async def async_step_user(
-        self, user_input: dict[str, str] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the initial step."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            info, errors = await self._async_validate_input(user_input)
-            if info:
-                await self.async_set_unique_id(user_input[CONF_USERNAME])
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=info["title"], data=user_input)
-
-        return self.async_show_form(
-            step_id="user", data_schema=SHARKIQ_SCHEMA, errors=errors
-        )
-
-    async def async_step_reauth(
-        self, entry_data: Mapping[str, Any]
-    ) -> ConfigFlowResult:
-        """Handle re-auth if login is invalid."""
-        return await self.async_step_reauth_confirm()
-
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a flow initiated by reauthentication."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            _, errors = await self._async_validate_input(user_input)
-
-            if not errors:
-                errors = {"base": "unknown"}
-                if entry := await self.async_set_unique_id(self.unique_id):
-                    self.hass.config_entries.async_update_entry(entry, data=user_input)
-                    return self.async_abort(reason="reauth_successful")
-
-            if errors["base"] != "invalid_auth":
-                return self.async_abort(reason=errors["base"])
-
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            data_schema=SHARKIQ_SCHEMA,
-            errors=errors,
-        )
-
-
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""
-
-
-class UnknownAuth(HomeAssistantError):
-    """Error to indicate there is an uncaught auth error."""
+    return token_data

--- a/homeassistant/components/sharkiq/manifest.json
+++ b/homeassistant/components/sharkiq/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/sharkiq",
   "iot_class": "cloud_polling",
   "loggers": ["sharkiq"],
-  "requirements": ["sharkiq==1.1.1"]
+  "requirements": ["sharkiq==1.3.4", "auth0-python"]
 }


### PR DESCRIPTION


Breaking change

N/A – This does not introduce a breaking change. Existing users who were previously unable to log in can now authenticate again without changing their configuration.

Proposed change

The SharkIQ integration was broken due to changes in Auth0. The previous login logic used a direct Resource Owner Password flow, which now results in a 401: Suspicious request requires verification.

This PR updates the login flow to follow the same sequence used by the official SharkClean mobile app:

GET /authorize to obtain state and session cookies

POST /u/login with username and password

Follow /authorize/resume when present

Exchange the returned authorization code at /oauth/token for access and refresh tokens

With this change, authentication works again and users can connect their Shark IQ devices as expected.
