### PR TITLE
Matter `SensitivityLevel` for Aqara Door and Window Sensor P2

### DIFF
--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -524,5 +524,6 @@ DISCOVERY_SCHEMAS = [
         required_attributes=(
             clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,
         ),
+        featuremap_contains=clusters.BooleanStateConfiguration.Bitmaps.Feature.kSensitivityLevel,
     ),
 ]

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -508,21 +508,21 @@ DISCOVERY_SCHEMAS = [
             key="BooleanStateConfigurationCurrentSensitivityLevel",
             entity_category=EntityCategory.CONFIG,
             translation_key="sensitivity_level",
-            options=["low", "standard", "high"],
+            options=["10 mm", "20 mm", "30 mm"],
             device_to_ha={
-                0: "low",
-                1: "standard",
-                2: "high",
+                0:  "10 mm",  # 10 mm => CurrentSensitivityLevel=0 / highest sensitivity level
+                1:  "20 mm",  # 20 mm => CurrentSensitivityLevel=1 / medium sensitivity level
+                2:  "30 mm",  # 30 mm => CurrentSensitivityLevel=2 / lowest sensitivity level
             }.get,
             ha_to_device={
-                "low": 0,
-                "standard": 1,
-                "high": 2,
+                "10 mm": 0,
+                "20 mm": 1,
+                "30 mm": 2,
             }.get,
         ),
         entity_class=MatterAttributeSelectEntity,
-        required_attributes=(
-            clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,
-        ),
+        required_attributes=(clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,),
+        vendor_id=(4447,),
+        product_id=(8194,),
     ),
 ]

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -521,6 +521,8 @@ DISCOVERY_SCHEMAS = [
             }.get,
         ),
         entity_class=MatterAttributeSelectEntity,
-        required_attributes=(clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,),
+        required_attributes=(
+            clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,
+        ),
     ),
 ]

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -505,7 +505,7 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.SELECT,
         entity_description=MatterSelectEntityDescription(
-            key="BooleanStateConfigurationCurrentSensitivityLevel",
+            key="AqaraBooleanStateConfigurationCurrentSensitivityLevel",
             entity_category=EntityCategory.CONFIG,
             translation_key="sensitivity_level",
             options=["10 mm", "20 mm", "30 mm"],
@@ -523,6 +523,6 @@ DISCOVERY_SCHEMAS = [
         entity_class=MatterAttributeSelectEntity,
         required_attributes=(clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,),
         vendor_id=(4447,),
-        product_id=(8194,),
+        product_name=("Aqara Door and Window Sensor P2",),
     ),
 ]

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -510,9 +510,9 @@ DISCOVERY_SCHEMAS = [
             translation_key="sensitivity_level",
             options=["10 mm", "20 mm", "30 mm"],
             device_to_ha={
-                0:  "10 mm",  # 10 mm => CurrentSensitivityLevel=0 / highest sensitivity level
-                1:  "20 mm",  # 20 mm => CurrentSensitivityLevel=1 / medium sensitivity level
-                2:  "30 mm",  # 30 mm => CurrentSensitivityLevel=2 / lowest sensitivity level
+                0: "10 mm",  # 10 mm => CurrentSensitivityLevel=0 / highest sensitivity level
+                1: "20 mm",  # 20 mm => CurrentSensitivityLevel=1 / medium sensitivity level
+                2: "30 mm",  # 30 mm => CurrentSensitivityLevel=2 / lowest sensitivity level
             }.get,
             ha_to_device={
                 "10 mm": 0,
@@ -521,7 +521,9 @@ DISCOVERY_SCHEMAS = [
             }.get,
         ),
         entity_class=MatterAttributeSelectEntity,
-        required_attributes=(clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,),
+        required_attributes=(
+            clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,
+        ),
         vendor_id=(4447,),
         product_name=("Aqara Door and Window Sensor P2",),
     ),

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -502,4 +502,25 @@ DISCOVERY_SCHEMAS = [
             clusters.PumpConfigurationAndControl.Attributes.OperationMode,
         ),
     ),
+    MatterDiscoverySchema(
+        platform=Platform.SELECT,
+        entity_description=MatterSelectEntityDescription(
+            key="BooleanStateConfigurationCurrentSensitivityLevel",
+            entity_category=EntityCategory.CONFIG,
+            translation_key="sensitivity_level",
+            options=["high", "standard", "low"],
+            device_to_ha={
+                0: "high",
+                1: "standard",
+                2: "low",
+            }.get,
+            ha_to_device={
+                "high": 0,
+                "standard": 1,
+                "low": 2,
+            }.get,
+        ),
+        entity_class=MatterAttributeSelectEntity,
+        required_attributes=(clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,),
+    ),
 ]

--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -508,22 +508,21 @@ DISCOVERY_SCHEMAS = [
             key="BooleanStateConfigurationCurrentSensitivityLevel",
             entity_category=EntityCategory.CONFIG,
             translation_key="sensitivity_level",
-            options=["high", "standard", "low"],
+            options=["low", "standard", "high"],
             device_to_ha={
-                0: "high",
+                0: "low",
                 1: "standard",
-                2: "low",
+                2: "high",
             }.get,
             ha_to_device={
-                "high": 0,
+                "low": 0,
                 "standard": 1,
-                "low": 2,
+                "high": 2,
             }.get,
         ),
         entity_class=MatterAttributeSelectEntity,
         required_attributes=(
             clusters.BooleanStateConfiguration.Attributes.CurrentSensitivityLevel,
         ),
-        featuremap_contains=clusters.BooleanStateConfiguration.Bitmaps.Feature.kSensitivityLevel,
     ),
 ]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support for Matter `SensitivityLevel` for Aqara Door and Window Sensor P2 as select entity:
- CurrentSensitivityLevelattribute

About Supported Sensitivity Levels:
> 1.8.6.2. SupportedSensitivityLevels Attribute
> This attribute SHALL indicate the number of supported sensitivity levels by the device.
> These supported sensitivity levels SHALL be ordered by sensitivity, where a value of 0 SHALL be
> considered the lowest sensitivity level (least sensitive) and the highest supported value SHALL be
> considered the highest sensitivity level.
> The number of supported sensitivity levels SHOULD represent unique sensitivity levels supported
> by the device.

![image](https://github.com/user-attachments/assets/8be24462-ac8b-4f28-9c46-5b4eaa5d35cb)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
