### PR TITLE
Make sensor startup code more dry in System monitor

### DIFF
--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -54,6 +54,13 @@ SENSOR_TYPE_MANDATORY_ARG = 4
 
 SIGNAL_SYSTEMMONITOR_UPDATE = "systemmonitor_update"
 
+SENSORS_NO_ARG = ("load_", "memory_", "processor_use", "swap_", "last_boot")
+SENSORS_WITH_ARG = {
+    "disk_": "disk_arguments",
+    "ipv": "network_arguments",
+    **dict.fromkeys(NET_IO_TYPES, "network_arguments"),
+}
+
 
 @lru_cache
 def get_cpu_icon() -> Literal["mdi:cpu-64-bit", "mdi:cpu-32-bit"]:
@@ -422,105 +429,27 @@ async def async_setup_entry(
     startup_arguments["cpu_temperature"] = cpu_temperature
 
     _LOGGER.debug("Setup from options %s", entry.options)
-
     for _type, sensor_description in SENSOR_TYPES.items():
-        if _type.startswith("disk_"):
-            for argument in startup_arguments["disk_arguments"]:
-                is_enabled = check_legacy_resource(
-                    f"{_type}_{argument}", legacy_resources
-                )
-                if (_add := slugify(f"{_type}_{argument}")) not in loaded_resources:
-                    loaded_resources.add(_add)
-                    entities.append(
-                        SystemMonitorSensor(
-                            coordinator,
-                            sensor_description,
-                            entry.entry_id,
-                            argument,
-                            is_enabled,
+        for sensor_type, sensor_argument in SENSORS_WITH_ARG.items():
+            if _type.startswith(sensor_type):
+                for argument in startup_arguments[sensor_argument]:
+                    is_enabled = check_legacy_resource(
+                        f"{_type}_{argument}", legacy_resources
+                    )
+                    if (_add := slugify(f"{_type}_{argument}")) not in loaded_resources:
+                        loaded_resources.add(_add)
+                        entities.append(
+                            SystemMonitorSensor(
+                                coordinator,
+                                sensor_description,
+                                entry.entry_id,
+                                argument,
+                                is_enabled,
+                            )
                         )
-                    )
-            continue
+                continue
 
-        if _type.startswith("ipv"):
-            for argument in startup_arguments["network_arguments"]:
-                is_enabled = check_legacy_resource(
-                    f"{_type}_{argument}", legacy_resources
-                )
-                loaded_resources.add(slugify(f"{_type}_{argument}"))
-                entities.append(
-                    SystemMonitorSensor(
-                        coordinator,
-                        sensor_description,
-                        entry.entry_id,
-                        argument,
-                        is_enabled,
-                    )
-                )
-            continue
-
-        if _type == "last_boot":
-            argument = ""
-            is_enabled = check_legacy_resource(f"{_type}_{argument}", legacy_resources)
-            loaded_resources.add(slugify(f"{_type}_{argument}"))
-            entities.append(
-                SystemMonitorSensor(
-                    coordinator,
-                    sensor_description,
-                    entry.entry_id,
-                    argument,
-                    is_enabled,
-                )
-            )
-            continue
-
-        if _type.startswith("load_"):
-            argument = ""
-            is_enabled = check_legacy_resource(f"{_type}_{argument}", legacy_resources)
-            loaded_resources.add(slugify(f"{_type}_{argument}"))
-            entities.append(
-                SystemMonitorSensor(
-                    coordinator,
-                    sensor_description,
-                    entry.entry_id,
-                    argument,
-                    is_enabled,
-                )
-            )
-            continue
-
-        if _type.startswith("memory_"):
-            argument = ""
-            is_enabled = check_legacy_resource(f"{_type}_{argument}", legacy_resources)
-            loaded_resources.add(slugify(f"{_type}_{argument}"))
-            entities.append(
-                SystemMonitorSensor(
-                    coordinator,
-                    sensor_description,
-                    entry.entry_id,
-                    argument,
-                    is_enabled,
-                )
-            )
-
-        if _type in NET_IO_TYPES:
-            for argument in startup_arguments["network_arguments"]:
-                is_enabled = check_legacy_resource(
-                    f"{_type}_{argument}", legacy_resources
-                )
-                loaded_resources.add(slugify(f"{_type}_{argument}"))
-                entities.append(
-                    SystemMonitorSensor(
-                        coordinator,
-                        sensor_description,
-                        entry.entry_id,
-                        argument,
-                        is_enabled,
-                    )
-                )
-            continue
-
-        if _type == "processor_use":
+        if _type.startswith(SENSORS_NO_ARG):
             argument = ""
             is_enabled = check_legacy_resource(f"{_type}_{argument}", legacy_resources)
             loaded_resources.add(slugify(f"{_type}_{argument}"))
@@ -552,20 +481,6 @@ async def async_setup_entry(
                 )
             )
             continue
-
-        if _type.startswith("swap_"):
-            argument = ""
-            is_enabled = check_legacy_resource(f"{_type}_{argument}", legacy_resources)
-            loaded_resources.add(slugify(f"{_type}_{argument}"))
-            entities.append(
-                SystemMonitorSensor(
-                    coordinator,
-                    sensor_description,
-                    entry.entry_id,
-                    argument,
-                    is_enabled,
-                )
-            )
 
     # Ensure legacy imported disk_* resources are loaded if they are not part
     # of mount points automatically discovered


### PR DESCRIPTION
## Breaking change


## Proposed change
Make code more dry in setup for `sensor` platform.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 