### PR TITLE
Raise error for entity services without a correct schema

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import dataclasses
-import inspect
-import logging
 from collections.abc import Callable, Coroutine, Iterable
+import dataclasses
 from enum import Enum
 from functools import cache, partial
+import inspect
+import logging
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, TypedDict, cast, override
 
@@ -53,16 +53,12 @@ from homeassistant.util.yaml.loader import JSON_TYPE
 
 from . import (
     config_validation as cv,
-)
-from . import (
     device_registry,
     entity_registry,
     selector,
+    target as target_helpers,
     template,
     translation,
-)
-from . import (
-    target as target_helpers,
 )
 from .deprecation import deprecated_class, deprecated_function
 from .selector import TargetSelector

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1118,13 +1118,15 @@ class ReloadServiceHelper[_T]:
 
 
 def _validate_entity_service_schema(
-    schema: VolDictType | VolSchemaType | None,
+    schema: VolDictType | VolSchemaType | None, service: str
 ) -> VolSchemaType:
     """Validate that a schema is an entity service schema."""
     if schema is None or isinstance(schema, dict):
         return cv.make_entity_service_schema(schema)
     if not cv.is_entity_service_schema(schema):
-        raise HomeAssistantError("The schema is not an entity service schema")
+        raise HomeAssistantError(
+            f"The {service} service registers an entity service with a non entity service schema"
+        )
     return schema
 
 
@@ -1147,7 +1149,7 @@ def async_register_entity_service(
     EntityPlatform.async_register_entity_service and should not be called
     directly by integrations.
     """
-    schema = _validate_entity_service_schema(schema)
+    schema = _validate_entity_service_schema(schema, f"{domain}.{name}")
 
     service_func: str | HassJob[..., Any]
     service_func = func if isinstance(func, str) else HassJob(func)
@@ -1183,7 +1185,7 @@ def async_register_platform_entity_service(
     """Help registering a platform entity service."""
     from .entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES  # noqa: PLC0415
 
-    schema = _validate_entity_service_schema(schema)
+    schema = _validate_entity_service_schema(schema, f"{service_domain}.{service_name}")
 
     service_func: str | HassJob[..., Any]
     service_func = func if isinstance(func, str) else HassJob(func)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Coroutine, Iterable
 import dataclasses
-from enum import Enum
-from functools import cache, partial
 import inspect
 import logging
+from collections.abc import Callable, Coroutine, Iterable
+from enum import Enum
+from functools import cache, partial
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, TypedDict, cast, override
 
@@ -53,12 +53,16 @@ from homeassistant.util.yaml.loader import JSON_TYPE
 
 from . import (
     config_validation as cv,
+)
+from . import (
     device_registry,
     entity_registry,
     selector,
-    target as target_helpers,
     template,
     translation,
+)
+from . import (
+    target as target_helpers,
 )
 from .deprecation import deprecated_class, deprecated_function
 from .selector import TargetSelector
@@ -1124,13 +1128,7 @@ def _validate_entity_service_schema(
     if schema is None or isinstance(schema, dict):
         return cv.make_entity_service_schema(schema)
     if not cv.is_entity_service_schema(schema):
-        from .frame import ReportBehavior, report_usage  # noqa: PLC0415
-
-        report_usage(
-            "registers an entity service with a non entity service schema",
-            core_behavior=ReportBehavior.LOG,
-            breaks_in_ha_version="2025.9",
-        )
+        raise HomeAssistantError("The schema is not an entity service schema")
     return schema
 
 

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -564,7 +564,6 @@ async def test_register_entity_service_non_entity_service_schema(
 ) -> None:
     """Test attempting to register a service with a non entity service schema."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
-    expected_message = "The schema is not an entity service schema"
 
     for idx, schema in enumerate(
         (
@@ -573,6 +572,7 @@ async def test_register_entity_service_non_entity_service_schema(
             vol.Any(vol.Schema({"some": str})),
         )
     ):
+        expected_message = f"The test_domain.hello_{idx} service registers an entity service with a non entity service schema"
         with pytest.raises(HomeAssistantError, match=expected_message):
             component.async_register_entity_service(f"hello_{idx}", schema, Mock())
 
@@ -583,6 +583,7 @@ async def test_register_entity_service_non_entity_service_schema(
             vol.All(cv.make_entity_service_schema({"some": str})),
         )
     ):
+        expected_message = f"The test_domain.hello_{idx} service registers an entity service with a non entity service schema"
         component.async_register_entity_service(f"test_service_{idx}", schema, Mock())
 
 

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -560,11 +560,11 @@ async def test_register_entity_service(
 
 
 async def test_register_entity_service_non_entity_service_schema(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
 ) -> None:
     """Test attempting to register a service with a non entity service schema."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
-    expected_message = "registers an entity service with a non entity service schema"
+    expected_message = "The schema is not an entity service schema"
 
     for idx, schema in enumerate(
         (
@@ -573,9 +573,8 @@ async def test_register_entity_service_non_entity_service_schema(
             vol.Any(vol.Schema({"some": str})),
         )
     ):
-        component.async_register_entity_service(f"hello_{idx}", schema, Mock())
-        assert expected_message in caplog.text
-        caplog.clear()
+        with pytest.raises(HomeAssistantError, match=expected_message):
+            component.async_register_entity_service(f"hello_{idx}", schema, Mock())
 
     for idx, schema in enumerate(
         (
@@ -585,7 +584,6 @@ async def test_register_entity_service_non_entity_service_schema(
         )
     ):
         component.async_register_entity_service(f"test_service_{idx}", schema, Mock())
-        assert expected_message not in caplog.text
 
 
 async def test_register_entity_service_response_data(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -583,7 +583,6 @@ async def test_register_entity_service_non_entity_service_schema(
             vol.All(cv.make_entity_service_schema({"some": str})),
         )
     ):
-        expected_message = f"The test_domain.hello_{idx} service registers an entity service with a non entity service schema"
         component.async_register_entity_service(f"test_service_{idx}", schema, Mock())
 
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1878,13 +1878,13 @@ async def test_register_entity_service_none_schema(
 
 
 async def test_register_entity_service_non_entity_service_schema(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
 ) -> None:
     """Test attempting to register a service with a non entity service schema."""
     entity_platform = MockEntityPlatform(
         hass, domain="mock_integration", platform_name="mock_platform", platform=None
     )
-    expected_message = "registers an entity service with a non entity service schema"
+    expected_message = "The schema is not an entity service schema"
 
     for idx, schema in enumerate(
         (
@@ -1893,9 +1893,10 @@ async def test_register_entity_service_non_entity_service_schema(
             vol.Any(vol.Schema({"some": str})),
         )
     ):
-        entity_platform.async_register_entity_service(f"hello_{idx}", schema, Mock())
-        assert expected_message in caplog.text
-        caplog.clear()
+        with pytest.raises(HomeAssistantError, match=expected_message):
+            entity_platform.async_register_entity_service(
+                f"hello_{idx}", schema, Mock()
+            )
 
     for idx, schema in enumerate(
         (
@@ -1907,7 +1908,6 @@ async def test_register_entity_service_non_entity_service_schema(
         entity_platform.async_register_entity_service(
             f"test_service_{idx}", schema, Mock()
         )
-        assert expected_message not in caplog.text
 
 
 @pytest.mark.parametrize("update_before_add", [True, False])

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1905,7 +1905,6 @@ async def test_register_entity_service_non_entity_service_schema(
             vol.All(cv.make_entity_service_schema({"some": str})),
         )
     ):
-        expected_message = f"The mock_platform.hello_{idx} service registers an entity service with a non entity service schema"
         entity_platform.async_register_entity_service(
             f"test_service_{idx}", schema, Mock()
         )

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1884,7 +1884,6 @@ async def test_register_entity_service_non_entity_service_schema(
     entity_platform = MockEntityPlatform(
         hass, domain="mock_integration", platform_name="mock_platform", platform=None
     )
-    expected_message = "The schema is not an entity service schema"
 
     for idx, schema in enumerate(
         (
@@ -1893,6 +1892,7 @@ async def test_register_entity_service_non_entity_service_schema(
             vol.Any(vol.Schema({"some": str})),
         )
     ):
+        expected_message = f"The mock_platform.hello_{idx} service registers an entity service with a non entity service schema"
         with pytest.raises(HomeAssistantError, match=expected_message):
             entity_platform.async_register_entity_service(
                 f"hello_{idx}", schema, Mock()
@@ -1905,6 +1905,7 @@ async def test_register_entity_service_non_entity_service_schema(
             vol.All(cv.make_entity_service_schema({"some": str})),
         )
     ):
+        expected_message = f"The mock_platform.hello_{idx} service registers an entity service with a non entity service schema"
         entity_platform.async_register_entity_service(
             f"test_service_{idx}", schema, Mock()
         )


### PR DESCRIPTION
## Breaking change
Incorrect schemas in entity services now fails, has been deprecated in #125057 (12M)

## Proposed change


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 