### PR TITLE
Make event entity dependend on websocket in Husqvarna Automower

### DIFF
--- a/homeassistant/components/husqvarna_automower/event.py
+++ b/homeassistant/components/husqvarna_automower/event.py
@@ -122,4 +122,5 @@ class AutomowerMessageEventEntity(AutomowerBaseEntity, EventEntity):
         if self.websocket_alive == is_alive:
             return
         self.websocket_alive = is_alive
+        _LOGGER.debug("WebSocket status changed to %s, updating entity state", is_alive)
         self.async_write_ha_state()

--- a/homeassistant/components/husqvarna_automower/event.py
+++ b/homeassistant/components/husqvarna_automower/event.py
@@ -87,7 +87,7 @@ class AutomowerMessageEventEntity(AutomowerBaseEntity, EventEntity):
     @property
     def available(self) -> bool:
         """Return True if the entity is available."""
-        return self.websocket_alive
+        return self.websocket_alive and self.mower_id in self.coordinator.data
 
     @callback
     def _handle(self, msg: SingleMessageData) -> None:

--- a/homeassistant/components/husqvarna_automower/event.py
+++ b/homeassistant/components/husqvarna_automower/event.py
@@ -1,6 +1,7 @@
 """Creates the event entities for supported mowers."""
 
 from collections.abc import Callable
+import logging
 
 from aioautomower.model import SingleMessageData
 
@@ -18,6 +19,7 @@ from .const import ERROR_KEYS
 from .coordinator import AutomowerDataUpdateCoordinator
 from .entity import AutomowerBaseEntity
 
+_LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
 ATTR_SEVERITY = "severity"
@@ -80,6 +82,12 @@ class AutomowerMessageEventEntity(AutomowerBaseEntity, EventEntity):
         """Initialize Automower message event entity."""
         super().__init__(mower_id, coordinator)
         self._attr_unique_id = f"{mower_id}_message"
+        self.websocket_alive: bool = coordinator.websocket_alive
+
+    @property
+    def available(self) -> bool:
+        """Return True if the entity is available."""
+        return self.websocket_alive
 
     @callback
     def _handle(self, msg: SingleMessageData) -> None:
@@ -102,7 +110,16 @@ class AutomowerMessageEventEntity(AutomowerBaseEntity, EventEntity):
         """Register callback when entity is added to hass."""
         await super().async_added_to_hass()
         self.coordinator.api.register_single_message_callback(self._handle)
+        self.coordinator.websocket_callbacks.append(self._handle_websocket_update)
 
     async def async_will_remove_from_hass(self) -> None:
         """Unregister WebSocket callback when entity is removed."""
         self.coordinator.api.unregister_single_message_callback(self._handle)
+        self.coordinator.websocket_callbacks.remove(self._handle_websocket_update)
+
+    def _handle_websocket_update(self, is_alive: bool) -> None:
+        """Handle websocket status changes."""
+        if self.websocket_alive == is_alive:
+            return
+        self.websocket_alive = is_alive
+        self.async_write_ha_state()

--- a/tests/components/husqvarna_automower/snapshots/test_event.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_event.ambr
@@ -298,6 +298,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2023-06-05T12:00:00.000+00:00',
+    'state': '2023-06-05T12:00:01.000+00:00',
   })
 # ---

--- a/tests/components/husqvarna_automower/snapshots/test_event.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_event.ambr
@@ -298,6 +298,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2023-06-05T12:00:01.000+00:00',
+    'state': '2023-06-05T12:00:00.000+00:00',
   })
 # ---

--- a/tests/components/husqvarna_automower/test_event.py
+++ b/tests/components/husqvarna_automower/test_event.py
@@ -183,7 +183,6 @@ async def test_event_snapshot(
     hass: HomeAssistant,
     mock_automower_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -220,9 +219,6 @@ async def test_event_snapshot(
         # Start the watchdog and let it run once
         for cb in ws_ready_callbacks:
             cb()
-        await hass.async_block_till_done()
-        freezer.tick(1)
-        async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
         # Ensure callback was registered for the test mower

--- a/tests/components/husqvarna_automower/test_event.py
+++ b/tests/components/husqvarna_automower/test_event.py
@@ -33,7 +33,7 @@ async def test_event(
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
     values: dict[str, MowerAttributes],
-    automower_ws_ready,
+    automower_ws_ready: list[Callable[[], None]],
 ) -> None:
     """Test that a new message arriving over the websocket creates and updates the sensor."""
     callbacks: list[Callable[[SingleMessageData], None]] = []
@@ -171,7 +171,7 @@ async def test_event_snapshot(
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
-    automower_ws_ready,
+    automower_ws_ready: list[Callable[[], None]],
 ) -> None:
     """Test that a new message arriving over the websocket updates the sensor."""
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The event entity can only work if there is a websocket connection. But currently the availability depends on the success of the last coordinator update. Which is not correct. So this gets fixed, by depending on the function of the websocket connection.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
