### PR TITLE
Bump ZHA to 0.0.70

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.69"],
+  "requirements": ["zha==0.0.70"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -654,6 +654,9 @@
       },
       "reset_alarm": {
         "name": "Reset alarm"
+      },
+      "calibrate_valve": {
+        "name": "Calibrate valve"
       }
     },
     "climate": {
@@ -1185,6 +1188,33 @@
       },
       "tilt_position_percentage_after_move_to_level": {
         "name": "Tilt position percentage after move to level"
+      },
+      "display_on_time": {
+        "name": "Display on-time"
+      },
+      "closing_duration": {
+        "name": "Closing duration"
+      },
+      "opening_duration": {
+        "name": "Opening duration"
+      },
+      "long_press_duration": {
+        "name": "Long press duration"
+      },
+      "motor_start_delay": {
+        "name": "Motor start delay"
+      },
+      "max_brightness": {
+        "name": "Maximum brightness"
+      },
+      "min_brightness": {
+        "name": "Minimum brightness"
+      },
+      "reporting_interval": {
+        "name": "Reporting interval"
+      },
+      "sensitivity": {
+        "name": "Sensitivity"
       }
     },
     "select": {
@@ -1424,6 +1454,21 @@
       },
       "switch_actions": {
         "name": "Switch actions"
+      },
+      "ctrl_sequence_of_oper": {
+        "name": "Control sequence"
+      },
+      "displayed_temperature": {
+        "name": "Displayed temperature"
+      },
+      "calibration_mode": {
+        "name": "Calibration mode"
+      },
+      "mode_switch": {
+        "name": "Mode switch"
+      },
+      "phase": {
+        "name": "Phase"
       }
     },
     "sensor": {
@@ -1806,6 +1851,15 @@
       },
       "opening": {
         "name": "Opening"
+      },
+      "operating_mode": {
+        "name": "Operating mode"
+      },
+      "valve_adapt_status": {
+        "name": "Valve adaptation status"
+      },
+      "motor_state": {
+        "name": "Motor state"
       }
     },
     "switch": {
@@ -2036,6 +2090,21 @@
       },
       "frient_com_2": {
         "name": "COM 2"
+      },
+      "window_open": {
+        "name": "Window open"
+      },
+      "turn_on_led_when_off": {
+        "name": "Turn on LED when off"
+      },
+      "turn_on_led_when_on": {
+        "name": "Turn on LED when on"
+      },
+      "dimmer_mode": {
+        "name": "Dimmer mode"
+      },
+      "flip_indicator_light": {
+        "name": "Flip indicator light"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3198,7 +3198,7 @@ zeroconf==0.147.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.69
+zha==0.0.70
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2642,7 +2642,7 @@ zeroconf==0.147.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.69
+zha==0.0.70
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.67.1


### PR DESCRIPTION
## Proposed change
This bumps ZHA to [0.0.70](https://github.com/zigpy/zha/releases/tag/0.0.70) (full diff: https://github.com/zigpy/zha/compare/0.0.69...0.0.70).
These dependency upgrades are bundled with it: 

- `zha-quirks` [0.0.145](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.145)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.144...0.0.145

This zha-quirks release also adds a few entities via the quirks v2 API. The entity names are added to `strings.json`.

### ZHA release text

This ZHA release is mostly about zha-quirks adding new device support. To highlight a few of the bigger changes:
- Support for the Bosch Radiator/Room Thermostat 2 (RBSH-TRV0-ZB-EU and RBSH-RTH0-ZB-EU) was also finally added. The Bosch light/shutter control unit 2 (RBSH-MMS-ZB-EU) is also supported.
- The dimming functionality for the Aqara Dimmer Switch H2 EU now also works properly. Configuration entities are also added for that device.
- Frient/Develco devices now expose a "tamper" binary sensor.
- Legrand switches and dimmers also got some new configuration entities. More Legrand remotes now provide device automation triggers.
- And as always, new Tuya device variants are added. Some more IKEA, Philips Hue, and Nimly variants were also added.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
