### PR TITLE
KNX: Support external scene activation recording

### DIFF
--- a/homeassistant/components/knx/scene.py
+++ b/homeassistant/components/knx/scene.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from xknx.devices import Scene as XknxScene
+from xknx.devices import Device as XknxDevice, Scene as XknxScene
 
 from homeassistant import config_entries
-from homeassistant.components.scene import Scene
+from homeassistant.components.scene import BaseScene
 from homeassistant.const import CONF_ENTITY_CATEGORY, CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities(KNXScene(knx_module, entity_config) for entity_config in config)
 
 
-class KNXScene(KnxYamlEntity, Scene):
+class KNXScene(KnxYamlEntity, BaseScene):
     """Representation of a KNX scene."""
 
     _device: XknxScene
@@ -52,6 +52,11 @@ class KNXScene(KnxYamlEntity, Scene):
             f"{self._device.scene_value.group_address}_{self._device.scene_number}"
         )
 
-    async def async_activate(self, **kwargs: Any) -> None:
+    async def _async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
         await self._device.run()
+
+    def after_update_callback(self, device: XknxDevice) -> None:
+        """Call after device was updated."""
+        self._async_record_activation()
+        super().after_update_callback(device)

--- a/tests/components/knx/test_scene.py
+++ b/tests/components/knx/test_scene.py
@@ -8,6 +8,8 @@ from homeassistant.helpers import entity_registry as er
 
 from .conftest import KNXTestKit
 
+from tests.common import async_capture_events
+
 
 async def test_activate_knx_scene(
     hass: HomeAssistant, knx: KNXTestKit, entity_registry: er.EntityRegistry
@@ -30,9 +32,27 @@ async def test_activate_knx_scene(
     assert entity.entity_category is EntityCategory.DIAGNOSTIC
     assert entity.unique_id == "1/1/1_24"
 
+    events = async_capture_events(hass, "state_changed")
+
+    # activate scene from HA
     await hass.services.async_call(
         "scene", "turn_on", {"entity_id": "scene.test"}, blocking=True
     )
-
-    # assert scene was called on bus
     await knx.assert_write("1/1/1", (0x17,))
+    assert len(events) == 1
+    # consecutive call from HA
+    await hass.services.async_call(
+        "scene", "turn_on", {"entity_id": "scene.test"}, blocking=True
+    )
+    await knx.assert_write("1/1/1", (0x17,))
+    assert len(events) == 2
+
+    # scene activation from bus
+    await knx.receive_write("1/1/1", (0x17,))
+    assert len(events) == 3
+    # same scene number consecutive call
+    await knx.receive_write("1/1/1", (0x17,))
+    assert len(events) == 4
+    # different scene number - should not be recorded
+    await knx.receive_write("1/1/1", (0x00,))
+    assert len(events) == 4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
KNX scene entities now also change their state when a scene was activated externally (from bus). Previously they only updated when activated from within Home Assistant.
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #146884
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40624
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
