### PR TITLE
Update husqvarna_automower_ble bluetooth discovery checks

### DIFF
--- a/homeassistant/components/husqvarna_automower_ble/config_flow.py
+++ b/homeassistant/components/husqvarna_automower_ble/config_flow.py
@@ -34,12 +34,8 @@ def _is_supported(discovery_info: BluetoothServiceInfo):
         service == "98bd0001-0b0e-421a-84e5-ddbf75dc6de4"
         for service in discovery_info.service_uuids
     )
-    service_generic = any(
-        service == "00001800-0000-1000-8000-00805f9b34fb"
-        for service in discovery_info.service_uuids
-    )
 
-    return manufacturer and service_husqvarna and service_generic
+    return manufacturer and service_husqvarna
 
 
 def _pin_valid(pin: str) -> bool:

--- a/tests/components/husqvarna_automower_ble/__init__.py
+++ b/tests/components/husqvarna_automower_ble/__init__.py
@@ -17,7 +17,6 @@ AUTOMOWER_SERVICE_INFO = BluetoothServiceInfo(
     manufacturer_data={1062: b"\x05\x04\xbf\xcf\xbb\r"},
     service_uuids=[
         "98bd0001-0b0e-421a-84e5-ddbf75dc6de4",
-        "00001800-0000-1000-8000-00805f9b34fb",
     ],
     source="local",
 )
@@ -30,7 +29,6 @@ AUTOMOWER_UNNAMED_SERVICE_INFO = BluetoothServiceInfo(
     manufacturer_data={1062: b"\x05\x04\xbf\xcf\xbb\r"},
     service_uuids=[
         "98bd0001-0b0e-421a-84e5-ddbf75dc6de4",
-        "00001800-0000-1000-8000-00805f9b34fb",
     ],
     source="local",
 )
@@ -43,7 +41,6 @@ AUTOMOWER_MISSING_MANUFACTURER_DATA_SERVICE_INFO = BluetoothServiceInfo(
     manufacturer_data={},
     service_uuids=[
         "98bd0001-0b0e-421a-84e5-ddbf75dc6de4",
-        "00001800-0000-1000-8000-00805f9b34fb",
     ],
     source="local",
 )

--- a/tests/components/husqvarna_automower_ble/test_config_flow.py
+++ b/tests/components/husqvarna_automower_ble/test_config_flow.py
@@ -13,9 +13,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
+    AUTOMOWER_MISSING_MANUFACTURER_DATA_SERVICE_INFO,
     AUTOMOWER_SERVICE_INFO,
     AUTOMOWER_UNNAMED_SERVICE_INFO,
-    AUTOMOWER_UNSUPPORTED_GROUP_SERVICE_INFO,
 )
 
 from tests.common import MockConfigEntry
@@ -277,13 +277,15 @@ async def test_bluetooth_not_paired(
 async def test_bluetooth_invalid(hass: HomeAssistant) -> None:
     """Test bluetooth device discovery with invalid data."""
 
-    inject_bluetooth_service_info(hass, AUTOMOWER_UNSUPPORTED_GROUP_SERVICE_INFO)
+    inject_bluetooth_service_info(
+        hass, AUTOMOWER_MISSING_MANUFACTURER_DATA_SERVICE_INFO
+    )
     await hass.async_block_till_done(wait_background_tasks=True)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_BLUETOOTH},
-        data=AUTOMOWER_UNSUPPORTED_GROUP_SERVICE_INFO,
+        data=AUTOMOWER_MISSING_MANUFACTURER_DATA_SERVICE_INFO,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update `husqvarna_automower_ble` bluetooth discovery checks

Rationale: Not all mowers have the generic service `00001800-0000-1000-8000-00805f9b34fb`, so we should not require it

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
