### PR TITLE
Update object_id to default_entity_id and consolidate common schemas

### DIFF
--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -47,12 +47,12 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -115,7 +115,11 @@ ALARM_CONTROL_PANEL_COMMON_SCHEMA = vol.Schema(
 
 ALARM_CONTROL_PANEL_YAML_SCHEMA = ALARM_CONTROL_PANEL_COMMON_SCHEMA.extend(
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA
-).extend(make_template_entity_common_modern_schema(DEFAULT_NAME).schema)
+).extend(
+    make_template_entity_common_modern_schema(
+        ALARM_CONTROL_PANEL_DOMAIN, DEFAULT_NAME
+    ).schema
+)
 
 ALARM_CONTROL_PANEL_LEGACY_YAML_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -48,23 +48,25 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
 from . import TriggerUpdateCoordinator
-from .const import CONF_AVAILABILITY_TEMPLATE
 from .helpers import (
     async_setup_template_entry,
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
+    TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA_LEGACY,
+    TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY,
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
-    TEMPLATE_ENTITY_COMMON_SCHEMA,
-    TemplateEntity,
+    make_template_entity_common_modern_attributes_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
+
+DEFAULT_NAME = "Template Binary Sensor"
 
 CONF_DELAY_ON = "delay_on"
 CONF_DELAY_OFF = "delay_off"
 CONF_AUTO_OFF = "auto_off"
-CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 
 LEGACY_FIELDS = {
     CONF_FRIENDLY_NAME_TEMPLATE: CONF_NAME,
@@ -83,7 +85,9 @@ BINARY_SENSOR_COMMON_SCHEMA = vol.Schema(
 )
 
 BINARY_SENSOR_YAML_SCHEMA = BINARY_SENSOR_COMMON_SCHEMA.extend(
-    TEMPLATE_ENTITY_COMMON_SCHEMA.schema
+    make_template_entity_common_modern_attributes_schema(
+        BINARY_SENSOR_DOMAIN, DEFAULT_NAME
+    ).schema
 )
 
 BINARY_SENSOR_CONFIG_ENTRY_SCHEMA = BINARY_SENSOR_COMMON_SCHEMA.extend(
@@ -97,10 +101,6 @@ BINARY_SENSOR_LEGACY_YAML_SCHEMA = vol.All(
             vol.Required(CONF_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_ICON_TEMPLATE): cv.template,
             vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
-            vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
-            vol.Optional(CONF_ATTRIBUTE_TEMPLATES): vol.Schema(
-                {cv.string: cv.template}
-            ),
             vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
             vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
             vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
@@ -108,7 +108,9 @@ BINARY_SENSOR_LEGACY_YAML_SCHEMA = vol.All(
             vol.Optional(CONF_DELAY_OFF): vol.Any(cv.positive_time_period, cv.template),
             vol.Optional(CONF_UNIQUE_ID): cv.string,
         }
-    ),
+    )
+    .extend(TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA_LEGACY.schema)
+    .extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY.schema),
 )
 
 

--- a/homeassistant/components/template/button.py
+++ b/homeassistant/components/template/button.py
@@ -25,11 +25,11 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import CONF_PRESS, DOMAIN
 from .helpers import async_setup_template_entry, async_setup_template_platform
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ BUTTON_YAML_SCHEMA = vol.Schema(
         vol.Required(CONF_PRESS): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
     }
-).extend(make_template_entity_common_modern_schema(DEFAULT_NAME).schema)
+).extend(make_template_entity_common_modern_schema(BUTTON_DOMAIN, DEFAULT_NAME).schema)
 
 BUTTON_CONFIG_ENTRY_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -288,7 +288,7 @@ async def async_validate_config(hass: HomeAssistant, config: ConfigType) -> Conf
             )
             definitions.extend(
                 rewrite_legacy_to_modern_configs(
-                    hass, template_config[old_key], legacy_fields
+                    hass, new_key, template_config[old_key], legacy_fields
                 )
             )
             template_config = TemplateConfig({**template_config, new_key: definitions})

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -1,9 +1,6 @@
 """Constants for the Template Platform Components."""
 
-import voluptuous as vol
-
-from homeassistant.const import CONF_ICON, CONF_NAME, CONF_UNIQUE_ID, Platform
-from homeassistant.helpers import config_validation as cv
+from homeassistant.const import Platform
 from homeassistant.helpers.typing import ConfigType
 
 CONF_ADVANCED_OPTIONS = "advanced_options"
@@ -19,16 +16,6 @@ CONF_PRESS = "press"
 CONF_STEP = "step"
 CONF_TURN_OFF = "turn_off"
 CONF_TURN_ON = "turn_on"
-
-TEMPLATE_ENTITY_BASE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_DEFAULT_ENTITY_ID): cv.entity_id,
-        vol.Optional(CONF_ICON): cv.template,
-        vol.Optional(CONF_NAME): cv.template,
-        vol.Optional(CONF_PICTURE): cv.template,
-        vol.Optional(CONF_UNIQUE_ID): cv.string,
-    }
-)
 
 DOMAIN = "template"
 

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -22,7 +22,7 @@ CONF_TURN_ON = "turn_on"
 
 TEMPLATE_ENTITY_BASE_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_DEFAULT_ENTITY_ID): cv.string,
+        vol.Optional(CONF_DEFAULT_ENTITY_ID): cv.entity_id,
         vol.Optional(CONF_ICON): cv.template,
         vol.Optional(CONF_NAME): cv.template,
         vol.Optional(CONF_PICTURE): cv.template,

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -11,9 +11,9 @@ CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 CONF_ATTRIBUTES = "attributes"
 CONF_AVAILABILITY = "availability"
 CONF_AVAILABILITY_TEMPLATE = "availability_template"
+CONF_DEFAULT_ENTITY_ID = "default_entity_id"
 CONF_MAX = "max"
 CONF_MIN = "min"
-CONF_OBJECT_ID = "object_id"
 CONF_PICTURE = "picture"
 CONF_PRESS = "press"
 CONF_STEP = "step"
@@ -22,11 +22,11 @@ CONF_TURN_ON = "turn_on"
 
 TEMPLATE_ENTITY_BASE_SCHEMA = vol.Schema(
     {
+        vol.Optional(CONF_DEFAULT_ENTITY_ID): cv.string,
         vol.Optional(CONF_ICON): cv.template,
         vol.Optional(CONF_NAME): cv.template,
         vol.Optional(CONF_PICTURE): cv.template,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
-        vol.Optional(CONF_OBJECT_ID): cv.string,
     }
 )
 

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -46,13 +46,13 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_COMMON_SCHEMA_LEGACY,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -122,7 +122,9 @@ COVER_YAML_SCHEMA = vol.All(
     )
     .extend(COVER_COMMON_SCHEMA.schema)
     .extend(TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA)
-    .extend(make_template_entity_common_modern_schema(DEFAULT_NAME).schema),
+    .extend(
+        make_template_entity_common_modern_schema(COVER_DOMAIN, DEFAULT_NAME).schema
+    ),
     cv.has_at_least_one_key(OPEN_ACTION, POSITION_ACTION),
 )
 

--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.script import Script, _VarsType
 from homeassistant.helpers.template import Template, TemplateStateFromEntityId
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_OBJECT_ID
+from .const import CONF_DEFAULT_ENTITY_ID
 
 
 class AbstractTemplateEntity(Entity):
@@ -49,9 +49,9 @@ class AbstractTemplateEntity(Entity):
                 optimistic is None and assumed_optimistic
             )
 
-        if (object_id := config.get(CONF_OBJECT_ID)) is not None:
+        if (default_entity_id := config.get(CONF_DEFAULT_ENTITY_ID)) is not None:
             self.entity_id = async_generate_entity_id(
-                self._entity_id_format, object_id, hass=self.hass
+                self._entity_id_format, default_entity_id, hass=self.hass
             )
 
         device_registry = dr.async_get(hass)

--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -53,7 +53,7 @@ class AbstractTemplateEntity(Entity):
             )
 
         if (default_entity_id := config.get(CONF_DEFAULT_ENTITY_ID)) is not None:
-            _, object_id = default_entity_id.split(".")
+            _, _, object_id = default_entity_id.partition(".")
             self.entity_id = async_generate_entity_id(
                 self._entity_id_format, object_id, hass=self.hass
             )

--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_OPTIMISTIC, CONF_STATE
-from homeassistant.core import Context, HomeAssistant, callback, valid_entity_id
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.script import Script, _VarsType
@@ -53,20 +53,7 @@ class AbstractTemplateEntity(Entity):
             )
 
         if (default_entity_id := config.get(CONF_DEFAULT_ENTITY_ID)) is not None:
-            # Legacy template entities use the slug as the object_id where
-            # modern template entities use a full domain.object_id as the input.
-            if valid_entity_id(default_entity_id):
-                domain, object_id = default_entity_id.split(".")
-                if domain + ".{}" != self._entity_id_format:
-                    _LOGGER.warning(
-                        "Default entity_id: %s does not match the entity domain: %s, update the default_entity_id to: %s",
-                        default_entity_id,
-                        self._entity_id_format.split(".")[0],
-                        self._entity_id_format.format(object_id),
-                    )
-            else:
-                object_id = default_entity_id
-
+            _, object_id = default_entity_id.split(".")
             self.entity_id = async_generate_entity_id(
                 self._entity_id_format, object_id, hass=self.hass
             )

--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -2,10 +2,11 @@
 
 from abc import abstractmethod
 from collections.abc import Sequence
+import logging
 from typing import Any
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_OPTIMISTIC, CONF_STATE
-from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.core import Context, HomeAssistant, callback, valid_entity_id
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.script import Script, _VarsType
@@ -13,6 +14,8 @@ from homeassistant.helpers.template import Template, TemplateStateFromEntityId
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_DEFAULT_ENTITY_ID
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class AbstractTemplateEntity(Entity):
@@ -50,8 +53,22 @@ class AbstractTemplateEntity(Entity):
             )
 
         if (default_entity_id := config.get(CONF_DEFAULT_ENTITY_ID)) is not None:
+            # Legacy template entities use the slug as the object_id where
+            # modern template entities use a full domain.object_id as the input.
+            if valid_entity_id(default_entity_id):
+                domain, object_id = default_entity_id.split(".")
+                if domain + ".{}" != self._entity_id_format:
+                    _LOGGER.warning(
+                        "Default entity_id: %s does not match the entity domain: %s, update the default_entity_id to: %s",
+                        default_entity_id,
+                        self._entity_id_format.split(".")[0],
+                        self._entity_id_format.format(object_id),
+                    )
+            else:
+                object_id = default_entity_id
+
             self.entity_id = async_generate_entity_id(
-                self._entity_id_format, default_entity_id, hass=self.hass
+                self._entity_id_format, object_id, hass=self.hass
             )
 
         device_registry = dr.async_get(hass)

--- a/homeassistant/components/template/event.py
+++ b/homeassistant/components/template/event.py
@@ -31,11 +31,11 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_attributes_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,7 +56,9 @@ EVENT_COMMON_SCHEMA = vol.Schema(
 )
 
 EVENT_YAML_SCHEMA = EVENT_COMMON_SCHEMA.extend(
-    make_template_entity_common_modern_attributes_schema(DEFAULT_NAME).schema
+    make_template_entity_common_modern_attributes_schema(
+        EVENT_DOMAIN, DEFAULT_NAME
+    ).schema
 )
 
 

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -49,13 +49,13 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY,
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ FAN_COMMON_SCHEMA = vol.Schema(
 )
 
 FAN_YAML_SCHEMA = FAN_COMMON_SCHEMA.extend(TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA).extend(
-    make_template_entity_common_modern_schema(DEFAULT_NAME).schema
+    make_template_entity_common_modern_schema(FAN_DOMAIN, DEFAULT_NAME).schema
 )
 
 FAN_LEGACY_YAML_SCHEMA = vol.All(

--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -38,7 +38,7 @@ from .const import (
     CONF_ATTRIBUTES,
     CONF_AVAILABILITY,
     CONF_AVAILABILITY_TEMPLATE,
-    CONF_OBJECT_ID,
+    CONF_DEFAULT_ENTITY_ID,
     CONF_PICTURE,
     DOMAIN,
 )
@@ -147,7 +147,7 @@ def rewrite_legacy_to_modern_configs(
     """Rewrite legacy configuration definitions to modern ones."""
     entities = []
     for object_id, entity_conf in entity_cfg.items():
-        entity_conf = {**entity_conf, CONF_OBJECT_ID: object_id}
+        entity_conf = {**entity_conf, CONF_DEFAULT_ENTITY_ID: object_id}
 
         entity_conf = rewrite_legacy_to_modern_config(
             hass, entity_conf, extra_legacy_fields

--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -141,13 +141,14 @@ def rewrite_legacy_to_modern_config(
 
 def rewrite_legacy_to_modern_configs(
     hass: HomeAssistant,
+    domain: str,
     entity_cfg: dict[str, dict],
     extra_legacy_fields: dict[str, str],
 ) -> list[dict]:
     """Rewrite legacy configuration definitions to modern ones."""
     entities = []
     for object_id, entity_conf in entity_cfg.items():
-        entity_conf = {**entity_conf, CONF_DEFAULT_ENTITY_ID: object_id}
+        entity_conf = {**entity_conf, CONF_DEFAULT_ENTITY_ID: f"{domain}.{object_id}"}
 
         entity_conf = rewrite_legacy_to_modern_config(
             hass, entity_conf, extra_legacy_fields
@@ -196,7 +197,7 @@ async def async_setup_template_platform(
         if legacy_fields is not None:
             if legacy_key:
                 configs = rewrite_legacy_to_modern_configs(
-                    hass, config[legacy_key], legacy_fields
+                    hass, domain, config[legacy_key], legacy_fields
                 )
             else:
                 configs = [rewrite_legacy_to_modern_config(hass, config, legacy_fields)]

--- a/homeassistant/components/template/image.py
+++ b/homeassistant/components/template/image.py
@@ -27,11 +27,11 @@ from homeassistant.util import dt as dt_util
 from . import TriggerUpdateCoordinator
 from .const import CONF_PICTURE
 from .helpers import async_setup_template_entry, async_setup_template_platform
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_attributes_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,7 +45,11 @@ IMAGE_YAML_SCHEMA = vol.Schema(
         vol.Required(CONF_URL): cv.template,
         vol.Optional(CONF_VERIFY_SSL, default=True): bool,
     }
-).extend(make_template_entity_common_modern_attributes_schema(DEFAULT_NAME).schema)
+).extend(
+    make_template_entity_common_modern_attributes_schema(
+        IMAGE_DOMAIN, DEFAULT_NAME
+    ).schema
+)
 
 
 IMAGE_CONFIG_ENTRY_SCHEMA = vol.Schema(

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -59,13 +59,13 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_COMMON_SCHEMA_LEGACY,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -161,7 +161,7 @@ LIGHT_COMMON_SCHEMA = vol.Schema(
 
 LIGHT_YAML_SCHEMA = LIGHT_COMMON_SCHEMA.extend(
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA
-).extend(make_template_entity_common_modern_schema(DEFAULT_NAME).schema)
+).extend(make_template_entity_common_modern_schema(LIGHT_DOMAIN, DEFAULT_NAME).schema)
 
 LIGHT_LEGACY_YAML_SCHEMA = vol.All(
     cv.deprecated(CONF_ENTITY_ID),

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -41,13 +41,13 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY,
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 CONF_CODE_FORMAT_TEMPLATE = "code_format_template"
@@ -75,7 +75,7 @@ LOCK_COMMON_SCHEMA = vol.Schema(
 )
 
 LOCK_YAML_SCHEMA = LOCK_COMMON_SCHEMA.extend(TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA).extend(
-    make_template_entity_common_modern_schema(DEFAULT_NAME).schema
+    make_template_entity_common_modern_schema(LOCK_DOMAIN, DEFAULT_NAME).schema
 )
 
 PLATFORM_SCHEMA = LOCK_PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -34,12 +34,12 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,11 +58,11 @@ NUMBER_COMMON_SCHEMA = vol.Schema(
         vol.Optional(CONF_STEP, default=DEFAULT_STEP): cv.template,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     }
-).extend(make_template_entity_common_modern_schema(DEFAULT_NAME).schema)
+)
 
 NUMBER_YAML_SCHEMA = NUMBER_COMMON_SCHEMA.extend(
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA
-).extend(make_template_entity_common_modern_schema(DEFAULT_NAME).schema)
+).extend(make_template_entity_common_modern_schema(NUMBER_DOMAIN, DEFAULT_NAME).schema)
 
 NUMBER_CONFIG_ENTRY_SCHEMA = NUMBER_COMMON_SCHEMA.extend(
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA.schema

--- a/homeassistant/components/template/schemas.py
+++ b/homeassistant/components/template/schemas.py
@@ -1,0 +1,109 @@
+"""Shared schemas for config entry and YAML config items."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_ENTITY_PICTURE_TEMPLATE,
+    CONF_ICON,
+    CONF_ICON_TEMPLATE,
+    CONF_NAME,
+    CONF_OPTIMISTIC,
+    CONF_UNIQUE_ID,
+    CONF_VARIABLES,
+)
+from homeassistant.helpers import config_validation as cv, selector
+
+from .const import (
+    CONF_ATTRIBUTE_TEMPLATES,
+    CONF_ATTRIBUTES,
+    CONF_AVAILABILITY,
+    CONF_AVAILABILITY_TEMPLATE,
+    CONF_DEFAULT_ENTITY_ID,
+    CONF_PICTURE,
+)
+
+TEMPLATE_ENTITY_AVAILABILITY_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_AVAILABILITY): cv.template,
+    }
+)
+
+TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_ATTRIBUTES): vol.Schema({cv.string: cv.template}),
+    }
+)
+
+TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.template,
+        vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
+    }
+).extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA.schema)
+
+
+TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA = {
+    vol.Optional(CONF_OPTIMISTIC): cv.boolean,
+}
+
+TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA_LEGACY = vol.Schema(
+    {
+        vol.Optional(CONF_ATTRIBUTE_TEMPLATES, default={}): vol.Schema(
+            {cv.string: cv.template}
+        ),
+    }
+)
+
+TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY = vol.Schema(
+    {
+        vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
+    }
+)
+
+TEMPLATE_ENTITY_COMMON_SCHEMA_LEGACY = vol.Schema(
+    {
+        vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
+        vol.Optional(CONF_ICON_TEMPLATE): cv.template,
+    }
+).extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY.schema)
+
+
+def make_template_entity_base_schema(domain: str, default_name: str) -> vol.Schema:
+    """Return a schema with default name."""
+    return vol.Schema(
+        {
+            vol.Optional(CONF_DEFAULT_ENTITY_ID): vol.All(
+                cv.entity_id, cv.entity_domain(domain)
+            ),
+            vol.Optional(CONF_ICON): cv.template,
+            vol.Optional(CONF_NAME, default=default_name): cv.template,
+            vol.Optional(CONF_PICTURE): cv.template,
+            vol.Optional(CONF_UNIQUE_ID): cv.string,
+        }
+    )
+
+
+def make_template_entity_common_modern_schema(
+    domain: str,
+    default_name: str,
+) -> vol.Schema:
+    """Return a schema with default name."""
+    return vol.Schema(
+        {
+            vol.Optional(CONF_AVAILABILITY): cv.template,
+            vol.Optional(CONF_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
+        }
+    ).extend(make_template_entity_base_schema(domain, default_name).schema)
+
+
+def make_template_entity_common_modern_attributes_schema(
+    domain: str,
+    default_name: str,
+) -> vol.Schema:
+    """Return a schema with default name."""
+    return make_template_entity_common_modern_schema(domain, default_name).extend(
+        TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA.schema
+    )

--- a/homeassistant/components/template/schemas.py
+++ b/homeassistant/components/template/schemas.py
@@ -75,9 +75,7 @@ def make_template_entity_base_schema(domain: str, default_name: str) -> vol.Sche
     """Return a schema with default name."""
     return vol.Schema(
         {
-            vol.Optional(CONF_DEFAULT_ENTITY_ID): vol.All(
-                cv.entity_id, cv.entity_domain(domain)
-            ),
+            vol.Optional(CONF_DEFAULT_ENTITY_ID): cv.entity_domain(domain),
             vol.Optional(CONF_ICON): cv.template,
             vol.Optional(CONF_NAME, default=default_name): cv.template,
             vol.Optional(CONF_PICTURE): cv.template,

--- a/homeassistant/components/template/schemas.py
+++ b/homeassistant/components/template/schemas.py
@@ -75,7 +75,9 @@ def make_template_entity_base_schema(domain: str, default_name: str) -> vol.Sche
     """Return a schema with default name."""
     return vol.Schema(
         {
-            vol.Optional(CONF_DEFAULT_ENTITY_ID): cv.entity_domain(domain),
+            vol.Optional(CONF_DEFAULT_ENTITY_ID): vol.All(
+                cv.entity_id, cv.entity_domain(domain)
+            ),
             vol.Optional(CONF_ICON): cv.template,
             vol.Optional(CONF_NAME, default=default_name): cv.template,
             vol.Optional(CONF_PICTURE): cv.template,

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -32,12 +32,12 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ SELECT_COMMON_SCHEMA = vol.Schema(
 
 SELECT_YAML_SCHEMA = SELECT_COMMON_SCHEMA.extend(
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA
-).extend(make_template_entity_common_modern_schema(DEFAULT_NAME).schema)
+).extend(make_template_entity_common_modern_schema(SELECT_DOMAIN, DEFAULT_NAME).schema)
 
 SELECT_CONFIG_ENTRY_SCHEMA = SELECT_COMMON_SCHEMA.extend(
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA.schema

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -52,18 +52,21 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
 from . import TriggerUpdateCoordinator
-from .const import CONF_ATTRIBUTE_TEMPLATES, CONF_AVAILABILITY_TEMPLATE
 from .helpers import (
     async_setup_template_entry,
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
+    TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA_LEGACY,
+    TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY,
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
-    TEMPLATE_ENTITY_COMMON_SCHEMA,
-    TemplateEntity,
+    make_template_entity_common_modern_attributes_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
+
+DEFAULT_NAME = "Template Sensor"
 
 LEGACY_FIELDS = {
     CONF_FRIENDLY_NAME_TEMPLATE: CONF_NAME,
@@ -100,7 +103,11 @@ SENSOR_YAML_SCHEMA = vol.All(
         }
     )
     .extend(SENSOR_COMMON_SCHEMA.schema)
-    .extend(TEMPLATE_ENTITY_COMMON_SCHEMA.schema),
+    .extend(
+        make_template_entity_common_modern_attributes_schema(
+            SENSOR_DOMAIN, DEFAULT_NAME
+        ).schema
+    ),
     validate_last_reset,
 )
 
@@ -116,17 +123,15 @@ SENSOR_LEGACY_YAML_SCHEMA = vol.All(
             vol.Optional(CONF_ICON_TEMPLATE): cv.template,
             vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
             vol.Optional(CONF_FRIENDLY_NAME_TEMPLATE): cv.template,
-            vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
-            vol.Optional(CONF_ATTRIBUTE_TEMPLATES, default={}): vol.Schema(
-                {cv.string: cv.template}
-            ),
             vol.Optional(CONF_FRIENDLY_NAME): cv.string,
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
             vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
             vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
         }
-    ),
+    )
+    .extend(TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA_LEGACY.schema)
+    .extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY.schema),
 )
 
 

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -44,13 +44,13 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_COMMON_SCHEMA_LEGACY,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _VALID_STATES = [STATE_ON, STATE_OFF, "true", "false"]
@@ -71,7 +71,7 @@ SWITCH_COMMON_SCHEMA = vol.Schema(
 
 SWITCH_YAML_SCHEMA = SWITCH_COMMON_SCHEMA.extend(
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA
-).extend(make_template_entity_common_modern_schema(DEFAULT_NAME).schema)
+).extend(make_template_entity_common_modern_schema(SWITCH_DOMAIN, DEFAULT_NAME).schema)
 
 SWITCH_LEGACY_YAML_SCHEMA = vol.All(
     cv.deprecated(ATTR_ENTITY_ID),

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -12,12 +12,8 @@ import voluptuous as vol
 
 from homeassistant.components.blueprint import CONF_USE_BLUEPRINT
 from homeassistant.const import (
-    CONF_DEVICE_ID,
-    CONF_ENTITY_PICTURE_TEMPLATE,
     CONF_ICON,
-    CONF_ICON_TEMPLATE,
     CONF_NAME,
-    CONF_OPTIMISTIC,
     CONF_PATH,
     CONF_VARIABLES,
     STATE_UNKNOWN,
@@ -32,7 +28,7 @@ from homeassistant.core import (
     validate_state,
 )
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import config_validation as cv, selector
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     TrackTemplate,
@@ -47,106 +43,12 @@ from homeassistant.helpers.template import (
     TemplateStateFromEntityId,
     result_as_boolean,
 )
-from homeassistant.helpers.trigger_template_entity import (
-    make_template_entity_base_schema,
-)
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_ATTRIBUTE_TEMPLATES,
-    CONF_ATTRIBUTES,
-    CONF_AVAILABILITY,
-    CONF_AVAILABILITY_TEMPLATE,
-    CONF_PICTURE,
-    TEMPLATE_ENTITY_BASE_SCHEMA,
-)
+from .const import CONF_ATTRIBUTES, CONF_AVAILABILITY, CONF_PICTURE
 from .entity import AbstractTemplateEntity
 
 _LOGGER = logging.getLogger(__name__)
-
-TEMPLATE_ENTITY_AVAILABILITY_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_AVAILABILITY): cv.template,
-    }
-)
-
-TEMPLATE_ENTITY_ICON_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_ICON): cv.template,
-    }
-)
-
-TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_ATTRIBUTES): vol.Schema({cv.string: cv.template}),
-    }
-)
-
-TEMPLATE_ENTITY_COMMON_SCHEMA = (
-    vol.Schema(
-        {
-            vol.Optional(CONF_AVAILABILITY): cv.template,
-            vol.Optional(CONF_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
-        }
-    )
-    .extend(TEMPLATE_ENTITY_BASE_SCHEMA.schema)
-    .extend(TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA.schema)
-)
-
-TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_NAME): cv.template,
-        vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
-    }
-).extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA.schema)
-
-
-TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA = {
-    vol.Optional(CONF_OPTIMISTIC): cv.boolean,
-}
-
-
-def make_template_entity_common_modern_schema(
-    default_name: str,
-) -> vol.Schema:
-    """Return a schema with default name."""
-    return vol.Schema(
-        {
-            vol.Optional(CONF_AVAILABILITY): cv.template,
-            vol.Optional(CONF_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
-        }
-    ).extend(make_template_entity_base_schema(default_name).schema)
-
-
-def make_template_entity_common_modern_attributes_schema(
-    default_name: str,
-) -> vol.Schema:
-    """Return a schema with default name."""
-    return make_template_entity_common_modern_schema(default_name).extend(
-        TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA.schema
-    )
-
-
-TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA_LEGACY = vol.Schema(
-    {
-        vol.Optional(CONF_ATTRIBUTE_TEMPLATES, default={}): vol.Schema(
-            {cv.string: cv.template}
-        ),
-    }
-)
-
-TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY = vol.Schema(
-    {
-        vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
-    }
-)
-
-TEMPLATE_ENTITY_COMMON_SCHEMA_LEGACY = vol.Schema(
-    {
-        vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
-        vol.Optional(CONF_ICON_TEMPLATE): cv.template,
-    }
-).extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY.schema)
 
 
 class _TemplateAttribute:

--- a/homeassistant/components/template/update.py
+++ b/homeassistant/components/template/update.py
@@ -41,11 +41,11 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ UPDATE_COMMON_SCHEMA = vol.Schema(
 )
 
 UPDATE_YAML_SCHEMA = UPDATE_COMMON_SCHEMA.extend(
-    make_template_entity_common_modern_schema(DEFAULT_NAME).schema
+    make_template_entity_common_modern_schema(UPDATE_DOMAIN, DEFAULT_NAME).schema
 )
 
 UPDATE_CONFIG_ENTRY_SCHEMA = UPDATE_COMMON_SCHEMA.extend(

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -54,14 +54,14 @@ from .helpers import (
     async_setup_template_platform,
     async_setup_template_preview,
 )
-from .template_entity import (
+from .schemas import (
     TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA_LEGACY,
     TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY,
     TEMPLATE_ENTITY_COMMON_CONFIG_ENTRY_SCHEMA,
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA,
-    TemplateEntity,
     make_template_entity_common_modern_attributes_schema,
 )
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -109,7 +109,11 @@ VACUUM_COMMON_SCHEMA = vol.Schema(
 
 VACUUM_YAML_SCHEMA = VACUUM_COMMON_SCHEMA.extend(
     TEMPLATE_ENTITY_OPTIMISTIC_SCHEMA
-).extend(make_template_entity_common_modern_attributes_schema(DEFAULT_NAME).schema)
+).extend(
+    make_template_entity_common_modern_attributes_schema(
+        VACUUM_DOMAIN, DEFAULT_NAME
+    ).schema
+)
 
 VACUUM_LEGACY_YAML_SCHEMA = vol.All(
     cv.deprecated(CONF_ENTITY_ID),

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -53,7 +53,8 @@ from homeassistant.util.unit_conversion import (
 
 from .coordinator import TriggerUpdateCoordinator
 from .helpers import async_setup_template_platform
-from .template_entity import TemplateEntity, make_template_entity_common_modern_schema
+from .schemas import make_template_entity_common_modern_schema
+from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
 CHECK_FORECAST_KEYS = (
@@ -132,7 +133,7 @@ WEATHER_YAML_SCHEMA = vol.Schema(
         vol.Optional(CONF_WIND_SPEED_TEMPLATE): cv.template,
         vol.Optional(CONF_WIND_SPEED_UNIT): vol.In(SpeedConverter.VALID_UNITS),
     }
-).extend(make_template_entity_common_modern_schema(DEFAULT_NAME).schema)
+).extend(make_template_entity_common_modern_schema(WEATHER_DOMAIN, DEFAULT_NAME).schema)
 
 PLATFORM_SCHEMA = vol.Schema(
     {

--- a/tests/components/template/test_config.py
+++ b/tests/components/template/test_config.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant.components.template.config import CONFIG_SECTION_SCHEMA
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.template import Template
 
 
 @pytest.mark.parametrize(
@@ -46,5 +47,49 @@ from homeassistant.core import HomeAssistant
 )
 async def test_invalid_schema(hass: HomeAssistant, config: dict) -> None:
     """Test invalid config schemas."""
+    with pytest.raises(vol.Invalid):
+        CONFIG_SECTION_SCHEMA(config)
+
+
+async def test_valid_default_entity_id(hass: HomeAssistant) -> None:
+    """Test valid default_entity_id schemas."""
+    config = {
+        "button": {
+            "press": [],
+            "default_entity_id": "button.test",
+        },
+    }
+    assert CONFIG_SECTION_SCHEMA(config) == {
+        "button": [
+            {
+                "press": [],
+                "name": Template("Template Button", hass),
+                "default_entity_id": "button.test",
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    "default_entity_id",
+    [
+        "foo",
+        "{{ 'my_template' }}",
+        "SJLIVan as dfkaj;heafha faass00",
+        48,
+        None,
+        "bttn.test",
+    ],
+)
+async def test_invalid_default_entity_id(
+    hass: HomeAssistant, default_entity_id: dict
+) -> None:
+    """Test invalid default_entity_id schemas."""
+    config = {
+        "button": {
+            "press": [],
+            "default_entity_id": default_entity_id,
+        },
+    }
     with pytest.raises(vol.Invalid):
         CONFIG_SECTION_SCHEMA(config)

--- a/tests/components/template/test_helpers.py
+++ b/tests/components/template/test_helpers.py
@@ -78,177 +78,206 @@ async def test_legacy_to_modern_config(
 
 
 @pytest.mark.parametrize(
-    ("legacy_fields", "old_attr", "new_attr", "attr_template"),
+    ("domain", "legacy_fields", "old_attr", "new_attr", "attr_template"),
     [
         (
+            "alarm_control_panel",
             ALARM_CONTROL_PANEL_LEGACY_FIELDS,
             "value_template",
             "state",
             "{{ 1 == 1 }}",
         ),
         (
+            "binary_sensor",
             BINARY_SENSOR_LEGACY_FIELDS,
             "value_template",
             "state",
             "{{ 1 == 1 }}",
         ),
         (
+            "cover",
             COVER_LEGACY_FIELDS,
             "value_template",
             "state",
             "{{ 1 == 1 }}",
         ),
         (
+            "cover",
             COVER_LEGACY_FIELDS,
             "position_template",
             "position",
             "{{ 100 }}",
         ),
         (
+            "cover",
             COVER_LEGACY_FIELDS,
             "tilt_template",
             "tilt",
             "{{ 100 }}",
         ),
         (
+            "fan",
             FAN_LEGACY_FIELDS,
             "value_template",
             "state",
             "{{ 1 == 1 }}",
         ),
         (
+            "fan",
             FAN_LEGACY_FIELDS,
             "direction_template",
             "direction",
             "{{ 1 == 1 }}",
         ),
         (
+            "fan",
             FAN_LEGACY_FIELDS,
             "oscillating_template",
             "oscillating",
             "{{ True }}",
         ),
         (
+            "fan",
             FAN_LEGACY_FIELDS,
             "percentage_template",
             "percentage",
             "{{ 100 }}",
         ),
         (
+            "fan",
             FAN_LEGACY_FIELDS,
             "preset_mode_template",
             "preset_mode",
             "{{ 'foo' }}",
         ),
         (
+            "fan",
             LIGHT_LEGACY_FIELDS,
             "value_template",
             "state",
             "{{ 1 == 1 }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "rgb_template",
             "rgb",
             "{{ (255,255,255) }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "rgbw_template",
             "rgbw",
             "{{ (255,255,255,255) }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "rgbww_template",
             "rgbww",
             "{{ (255,255,255,255,255) }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "effect_list_template",
             "effect_list",
             "{{ ['a', 'b'] }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "effect_template",
             "effect",
             "{{ 'a' }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "level_template",
             "level",
             "{{ 255 }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "max_mireds_template",
             "max_mireds",
             "{{ 255 }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "min_mireds_template",
             "min_mireds",
             "{{ 255 }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "supports_transition_template",
             "supports_transition",
             "{{ True }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "temperature_template",
             "temperature",
             "{{ 255 }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "white_value_template",
             "white_value",
             "{{ 255 }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "hs_template",
             "hs",
             "{{ (255, 255) }}",
         ),
         (
+            "light",
             LIGHT_LEGACY_FIELDS,
             "color_template",
             "hs",
             "{{ (255, 255) }}",
         ),
         (
+            "sensor",
             SENSOR_LEGACY_FIELDS,
             "value_template",
             "state",
             "{{ 1 == 1 }}",
         ),
         (
+            "sensor",
             SWITCH_LEGACY_FIELDS,
             "value_template",
             "state",
             "{{ 1 == 1 }}",
         ),
         (
+            "vacuum",
             VACUUM_LEGACY_FIELDS,
             "value_template",
             "state",
             "{{ 1 == 1 }}",
         ),
         (
+            "vacuum",
             VACUUM_LEGACY_FIELDS,
             "battery_level_template",
             "battery_level",
             "{{ 100 }}",
         ),
         (
+            "vacuum",
             VACUUM_LEGACY_FIELDS,
             "fan_speed_template",
             "fan_speed",
@@ -258,6 +287,7 @@ async def test_legacy_to_modern_config(
 )
 async def test_legacy_to_modern_configs(
     hass: HomeAssistant,
+    domain: str,
     legacy_fields,
     old_attr: str,
     new_attr: str,
@@ -274,7 +304,9 @@ async def test_legacy_to_modern_configs(
             old_attr: attr_template,
         }
     }
-    altered_configs = rewrite_legacy_to_modern_configs(hass, config, legacy_fields)
+    altered_configs = rewrite_legacy_to_modern_configs(
+        hass, domain, config, legacy_fields
+    )
 
     assert len(altered_configs) == 1
 
@@ -283,7 +315,7 @@ async def test_legacy_to_modern_configs(
             "availability": Template("{{ 1 == 1 }}", hass),
             "icon": Template("{{ 'mdi.abc' }}", hass),
             "name": Template("foo bar", hass),
-            "default_entity_id": "foo",
+            "default_entity_id": f"{domain}.foo",
             "picture": Template("{{ 'mypicture.jpg' }}", hass),
             "unique_id": "foo-bar-entity",
             new_attr: Template(attr_template, hass),
@@ -292,14 +324,15 @@ async def test_legacy_to_modern_configs(
 
 
 @pytest.mark.parametrize(
-    "legacy_fields",
+    ("domain", "legacy_fields"),
     [
-        BINARY_SENSOR_LEGACY_FIELDS,
-        SENSOR_LEGACY_FIELDS,
+        ("binary_sensor", BINARY_SENSOR_LEGACY_FIELDS),
+        ("sensor", SENSOR_LEGACY_FIELDS),
     ],
 )
 async def test_friendly_name_template_legacy_to_modern_configs(
     hass: HomeAssistant,
+    domain: str,
     legacy_fields,
 ) -> None:
     """Test the conversion of friendly_name_tempalte in legacy template to modern template."""
@@ -312,7 +345,9 @@ async def test_friendly_name_template_legacy_to_modern_configs(
             "friendly_name_template": "{{ 'foo bar' }}",
         }
     }
-    altered_configs = rewrite_legacy_to_modern_configs(hass, config, legacy_fields)
+    altered_configs = rewrite_legacy_to_modern_configs(
+        hass, domain, config, legacy_fields
+    )
 
     assert len(altered_configs) == 1
 
@@ -320,7 +355,7 @@ async def test_friendly_name_template_legacy_to_modern_configs(
         {
             "availability": Template("{{ 1 == 1 }}", hass),
             "icon": Template("{{ 'mdi.abc' }}", hass),
-            "default_entity_id": "foo",
+            "default_entity_id": f"{domain}.foo",
             "picture": Template("{{ 'mypicture.jpg' }}", hass),
             "unique_id": "foo-bar-entity",
             "name": Template("{{ 'foo bar' }}", hass),

--- a/tests/components/template/test_helpers.py
+++ b/tests/components/template/test_helpers.py
@@ -283,7 +283,7 @@ async def test_legacy_to_modern_configs(
             "availability": Template("{{ 1 == 1 }}", hass),
             "icon": Template("{{ 'mdi.abc' }}", hass),
             "name": Template("foo bar", hass),
-            "object_id": "foo",
+            "default_entity_id": "foo",
             "picture": Template("{{ 'mypicture.jpg' }}", hass),
             "unique_id": "foo-bar-entity",
             new_attr: Template(attr_template, hass),
@@ -320,7 +320,7 @@ async def test_friendly_name_template_legacy_to_modern_configs(
         {
             "availability": Template("{{ 1 == 1 }}", hass),
             "icon": Template("{{ 'mdi.abc' }}", hass),
-            "object_id": "foo",
+            "default_entity_id": "foo",
             "picture": Template("{{ 'mypicture.jpg' }}", hass),
             "unique_id": "foo-bar-entity",
             "name": Template("{{ 'foo bar' }}", hass),

--- a/tests/components/template/test_template_entity.py
+++ b/tests/components/template/test_template_entity.py
@@ -20,11 +20,11 @@ async def test_template_entity_requires_hass_set(hass: HomeAssistant) -> None:
     assert len(entity._template_attrs.get(tpl_with_hass, [])) == 1
 
 
-async def test_object_id(hass: HomeAssistant) -> None:
-    """Test template entity creates suggested entity_id from the object_id."""
+async def test_default_entity_id(hass: HomeAssistant) -> None:
+    """Test template entity creates suggested entity_id from the default_entity_id."""
 
     class TemplateTest(template_entity.TemplateEntity):
         _entity_id_format = "test.{}"
 
-    entity = TemplateTest(hass, {"object_id": "test"}, "a")
+    entity = TemplateTest(hass, {"default_entity_id": "test"}, "a")
     assert entity.entity_id == "test.test"

--- a/tests/components/template/test_template_entity.py
+++ b/tests/components/template/test_template_entity.py
@@ -30,9 +30,7 @@ async def test_default_entity_id(hass: HomeAssistant) -> None:
     assert entity.entity_id == "test.test"
 
 
-async def test_bad_default_entity_id(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_bad_default_entity_id(hass: HomeAssistant) -> None:
     """Test template entity creates suggested entity_id from the default_entity_id."""
 
     class TemplateTest(template_entity.TemplateEntity):
@@ -40,8 +38,3 @@ async def test_bad_default_entity_id(
 
     entity = TemplateTest(hass, {"default_entity_id": "bad.test"}, "a")
     assert entity.entity_id == "test.test"
-
-    assert (
-        "Default entity_id: bad.test does not match the entity domain: test, update the default_entity_id to: test.test"
-        in caplog.text
-    )

--- a/tests/components/template/test_template_entity.py
+++ b/tests/components/template/test_template_entity.py
@@ -26,5 +26,22 @@ async def test_default_entity_id(hass: HomeAssistant) -> None:
     class TemplateTest(template_entity.TemplateEntity):
         _entity_id_format = "test.{}"
 
-    entity = TemplateTest(hass, {"default_entity_id": "test"}, "a")
+    entity = TemplateTest(hass, {"default_entity_id": "test.test"}, "a")
     assert entity.entity_id == "test.test"
+
+
+async def test_bad_default_entity_id(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test template entity creates suggested entity_id from the default_entity_id."""
+
+    class TemplateTest(template_entity.TemplateEntity):
+        _entity_id_format = "test.{}"
+
+    entity = TemplateTest(hass, {"default_entity_id": "bad.test"}, "a")
+    assert entity.entity_id == "test.test"
+
+    assert (
+        "Default entity_id: bad.test does not match the entity domain: test, update the default_entity_id to: test.test"
+        in caplog.text
+    )

--- a/tests/components/template/test_trigger_entity.py
+++ b/tests/components/template/test_trigger_entity.py
@@ -144,14 +144,8 @@ async def test_default_entity_id(hass: HomeAssistant) -> None:
     assert entity.entity_id == "test.test"
 
 
-async def test_bad_default_entity_id(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_bad_default_entity_id(hass: HomeAssistant) -> None:
     """Test template entity creates suggested entity_id from the default_entity_id."""
     coordinator = TriggerUpdateCoordinator(hass, {})
     entity = TestEntity(hass, coordinator, {"default_entity_id": "bad.test"})
     assert entity.entity_id == "test.test"
-    assert (
-        "Default entity_id: bad.test does not match the entity domain: test, update the default_entity_id to: test.test"
-        in caplog.text
-    )

--- a/tests/components/template/test_trigger_entity.py
+++ b/tests/components/template/test_trigger_entity.py
@@ -137,8 +137,21 @@ async def test_script_variables_from_coordinator(hass: HomeAssistant) -> None:
     assert entity._render_script_variables() == {"value": STATE_ON}
 
 
-async def test_object_id(hass: HomeAssistant) -> None:
+async def test_default_entity_id(hass: HomeAssistant) -> None:
     """Test template entity creates suggested entity_id from the default_entity_id."""
     coordinator = TriggerUpdateCoordinator(hass, {})
-    entity = TestEntity(hass, coordinator, {"default_entity_id": "test"})
+    entity = TestEntity(hass, coordinator, {"default_entity_id": "test.test"})
     assert entity.entity_id == "test.test"
+
+
+async def test_bad_default_entity_id(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test template entity creates suggested entity_id from the default_entity_id."""
+    coordinator = TriggerUpdateCoordinator(hass, {})
+    entity = TestEntity(hass, coordinator, {"default_entity_id": "bad.test"})
+    assert entity.entity_id == "test.test"
+    assert (
+        "Default entity_id: bad.test does not match the entity domain: test, update the default_entity_id to: test.test"
+        in caplog.text
+    )

--- a/tests/components/template/test_trigger_entity.py
+++ b/tests/components/template/test_trigger_entity.py
@@ -138,7 +138,7 @@ async def test_script_variables_from_coordinator(hass: HomeAssistant) -> None:
 
 
 async def test_object_id(hass: HomeAssistant) -> None:
-    """Test template entity creates suggested entity_id from the object_id."""
+    """Test template entity creates suggested entity_id from the default_entity_id."""
     coordinator = TriggerUpdateCoordinator(hass, {})
-    entity = TestEntity(hass, coordinator, {"object_id": "test"})
+    entity = TestEntity(hass, coordinator, {"default_entity_id": "test"})
     assert entity.entity_id == "test.test"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

After discussion with the core team about https://github.com/home-assistant/core/pull/150489, we decided on using the term `default_entity_id` in favor of `object_id`.  This PR addresses that decision.

As a result of the requested changes, all common schemas were moved into a new `schemas.py` file for all platforms to import.  Sensor and Binary Sensor were also updated to support the common schemas.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/150489
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
