### PR TITLE
Drop index from motionmount preset name

### DIFF
--- a/homeassistant/components/motionmount/const.py
+++ b/homeassistant/components/motionmount/const.py
@@ -3,4 +3,4 @@
 DOMAIN = "motionmount"
 
 EMPTY_MAC = "00:00:00:00:00:00"
-WALL_PRESET_NAME = "Wall"
+WALL_PRESET_NAME = "0_wall"

--- a/homeassistant/components/motionmount/const.py
+++ b/homeassistant/components/motionmount/const.py
@@ -3,4 +3,4 @@
 DOMAIN = "motionmount"
 
 EMPTY_MAC = "00:00:00:00:00:00"
-WALL_PRESET_NAME = "0_wall"
+WALL_PRESET_NAME = "Wall"

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -50,14 +50,8 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     def _update_options(self, presets: list[motionmount.Preset]) -> None:
         """Convert presets to select options."""
-        # Ordered list of options (wall first, then presets)
-        options = [WALL_PRESET_NAME] + [preset.name for preset in presets]
-
-        # Build mapping name → index (wall = 0)
-        self._attr_name_to_index = {WALL_PRESET_NAME: 0}
-        self._attr_name_to_index.update(
-            {preset.name: preset.index for preset in presets}
-        )
+        options = [f"{preset.index}: {preset.name}" for preset in presets]
+        options.insert(0, WALL_PRESET_NAME)
 
         self._attr_options = options
 
@@ -129,10 +123,7 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Set the new option."""
-        index = self._attr_name_to_index.get(option)
-        if index is None:
-            raise HomeAssistantError(f"Unknown preset selected: {option}")
-
+        index = int(option[:1])
         try:
             await self.mm.go_to_preset(index)
         except (TimeoutError, socket.gaierror) as ex:

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -50,8 +50,14 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     def _update_options(self, presets: list[motionmount.Preset]) -> None:
         """Convert presets to select options."""
-        options = [f"{preset.index}: {preset.name}" for preset in presets]
-        options.insert(0, WALL_PRESET_NAME)
+        # Ordered list of options (wall first, then presets)
+        options = [WALL_PRESET_NAME] + [preset.name for preset in presets]
+
+        # Build mapping name → index (wall = 0)
+        self._attr_name_to_index = {WALL_PRESET_NAME: 0}
+        self._attr_name_to_index.update(
+            {preset.name: preset.index for preset in presets}
+        )
 
         self._attr_options = options
 
@@ -123,7 +129,10 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Set the new option."""
-        index = int(option[:1])
+        index = self._attr_name_to_index.get(option)
+        if index is None:
+            raise HomeAssistantError(f"Unknown preset selected: {option}")
+
         try:
             await self.mm.go_to_preset(index)
         except (TimeoutError, socket.gaierror) as ex:

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -128,7 +128,6 @@ class SelectEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     entity_description: SelectEntityDescription
     _attr_current_option: str | None = None
-    _attr_name_to_index: dict[str, int]
     _attr_options: list[str]
     _attr_state: None = None
 

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -128,6 +128,7 @@ class SelectEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     entity_description: SelectEntityDescription
     _attr_current_option: str | None = None
+    _attr_name_to_index: dict[str, int]
     _attr_options: list[str]
     _attr_state: None = None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes issue https://github.com/home-assistant/core/issues/148681, "MotionMount position naming problem" by excluding the number from the name. Hereafter the name displayed in the select dropdown matches what is provided in the mobile app with which the name was originally provided instead of prepending it with an index. Internally, indexing of presets is not necessarily the same as the order of appearance, which is why the original workaround was used. But now there is a guarantee of name uniqueness, so the new implementation of mapping name to index is cleaner.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148681
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
