### PR TITLE
Use OptionsFlowWithReload in pvpc_hourly_pricing

### DIFF
--- a/homeassistant/components/pvpc_hourly_pricing/__init__.py
+++ b/homeassistant/components/pvpc_hourly_pricing/__init__.py
@@ -4,7 +4,6 @@ from homeassistant.const import CONF_API_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .const import ATTR_POWER, ATTR_POWER_P3
 from .coordinator import ElecPricesDataUpdateCoordinator, PVPCConfigEntry
 from .helpers import get_enabled_sensor_keys
 
@@ -23,21 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PVPCConfigEntry) -> bool
 
     entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(async_update_options))
     return True
-
-
-async def async_update_options(hass: HomeAssistant, entry: PVPCConfigEntry) -> None:
-    """Handle options update."""
-    if any(
-        entry.data.get(attrib) != entry.options.get(attrib)
-        for attrib in (ATTR_POWER, ATTR_POWER_P3, CONF_API_TOKEN)
-    ):
-        # update entry replacing data with new options
-        hass.config_entries.async_update_entry(
-            entry, data={**entry.data, **entry.options}
-        )
-        await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: PVPCConfigEntry) -> bool:

--- a/homeassistant/components/pvpc_hourly_pricing/config_flow.py
+++ b/homeassistant/components/pvpc_hourly_pricing/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
-    OptionsFlow,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import CONF_API_TOKEN, CONF_NAME
 from homeassistant.core import callback
@@ -178,7 +178,7 @@ class TariffSelectorConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(step_id="reauth_confirm", data_schema=data_schema)
 
 
-class PVPCOptionsFlowHandler(OptionsFlow):
+class PVPCOptionsFlowHandler(OptionsFlowWithReload):
     """Handle PVPC options."""
 
     _power: float | None = None

--- a/homeassistant/components/pvpc_hourly_pricing/coordinator.py
+++ b/homeassistant/components/pvpc_hourly_pricing/coordinator.py
@@ -29,13 +29,16 @@ class ElecPricesDataUpdateCoordinator(DataUpdateCoordinator[EsiosApiData]):
         self, hass: HomeAssistant, entry: PVPCConfigEntry, sensor_keys: set[str]
     ) -> None:
         """Initialize."""
+        config = entry.data.copy()
+        config.update({attr: value for attr, value in entry.options.items() if value})
+
         self.api = PVPCData(
             session=async_get_clientsession(hass),
-            tariff=entry.data[ATTR_TARIFF],
+            tariff=config[ATTR_TARIFF],
             local_timezone=hass.config.time_zone,
-            power=entry.data[ATTR_POWER],
-            power_valley=entry.data[ATTR_POWER_P3],
-            api_token=entry.data.get(CONF_API_TOKEN),
+            power=config[ATTR_POWER],
+            power_valley=config[ATTR_POWER_P3],
+            api_token=config.get(CONF_API_TOKEN),
             sensor_keys=tuple(sensor_keys),
         )
         super().__init__(

--- a/tests/components/pvpc_hourly_pricing/test_config_flow.py
+++ b/tests/components/pvpc_hourly_pricing/test_config_flow.py
@@ -125,11 +125,10 @@ async def test_config_flow(
         result["flow_id"], user_input={CONF_API_TOKEN: "test-token"}
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert pvpc_aioclient_mock.call_count == 2
     await hass.async_block_till_done()
     state = hass.states.get("sensor.esios_pvpc")
     check_valid_state(state, tariff=TARIFFS[1])
-    assert pvpc_aioclient_mock.call_count == 4
+    assert pvpc_aioclient_mock.call_count == 3
     assert state.attributes["period"] == "P3"
     assert state.attributes["next_period"] == "P2"
     assert state.attributes["available_power"] == 4600
@@ -150,7 +149,7 @@ async def test_config_flow(
     state = hass.states.get("sensor.esios_pvpc")
     check_valid_state(state, tariff=TARIFFS[0], value="unavailable")
     assert "period" not in state.attributes
-    assert pvpc_aioclient_mock.call_count == 6
+    assert pvpc_aioclient_mock.call_count == 5
 
     # disable api token in options
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
@@ -162,9 +161,8 @@ async def test_config_flow(
         user_input={ATTR_POWER: 3.0, ATTR_POWER_P3: 4.6, CONF_USE_API_TOKEN: False},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert pvpc_aioclient_mock.call_count == 6
     await hass.async_block_till_done()
-    assert pvpc_aioclient_mock.call_count == 7
+    assert pvpc_aioclient_mock.call_count == 6
 
     state = hass.states.get("sensor.esios_pvpc")
     state_inyection = hass.states.get("sensor.esios_injection_price")

--- a/tests/components/pvpc_hourly_pricing/test_config_flow.py
+++ b/tests/components/pvpc_hourly_pricing/test_config_flow.py
@@ -121,7 +121,6 @@ async def test_config_flow(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "api_token"
     assert pvpc_aioclient_mock.call_count == 2
-
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={CONF_API_TOKEN: "test-token"}
     )


### PR DESCRIPTION
## Breaking change


## Proposed change
SSIA

Ref: https://github.com/home-assistant/core/pull/146910

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 