### PR TITLE
Fix broken translation key for "update_percentage" in `template`

### DIFF
--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -439,7 +439,7 @@
           "title": "[%key:component::update::entity_component::_::state_attributes::title::name%]",
           "backup": "Backup",
           "specific_version": "Specific version",
-          "update_percent": "Update percentage"
+          "update_percentage": "Update percentage"
         },
         "data_description": {
           "device_id": "[%key:component::template::common::device_id_description%]",
@@ -452,7 +452,7 @@
           "title": "Defines a template to get the update title.",
           "backup": "Enable or disable the `automatic backup before update` option in the update repair. When disabled, the `backup` variable will always provide `False` during the `install` action and it will not accept the `backup` option.",
           "specific_version": "Enable or disable using the `version` variable with the `install` action. When disabled, the `specific_version` variable will always provide `None` in the `install` actions",
-          "update_percent": "Defines a template to get the update completion percentage."
+          "update_percentage": "Defines a template to get the update completion percentage."
         },
         "sections": {
           "advanced_options": {

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -910,7 +910,7 @@
           "title": "[%key:component::update::entity_component::_::state_attributes::title::name%]",
           "backup": "[%key:component::template::config::step::update::data::backup%]",
           "specific_version": "[%key:component::template::config::step::update::data::specific_version%]",
-          "update_percent": "[%key:component::template::config::step::update::data::update_percent%]"
+          "update_percent": "[%key:component::template::config::step::update::data::update_percentage%]"
         },
         "data_description": {
           "device_id": "[%key:component::template::common::device_id_description%]",
@@ -923,7 +923,7 @@
           "title": "[%key:component::template::config::step::update::data_description::title%]",
           "backup": "[%key:component::template::config::step::update::data_description::backup%]",
           "specific_version": "[%key:component::template::config::step::update::data_description::specific_version%]",
-          "update_percent": "[%key:component::template::config::step::update::data_description::update_percent%]"
+          "update_percent": "[%key:component::template::config::step::update::data_description::update_percentage%]"
         },
         "sections": {
           "advanced_options": {

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -910,7 +910,7 @@
           "title": "[%key:component::update::entity_component::_::state_attributes::title::name%]",
           "backup": "[%key:component::template::config::step::update::data::backup%]",
           "specific_version": "[%key:component::template::config::step::update::data::specific_version%]",
-          "update_percent": "[%key:component::template::config::step::update::data::update_percentage%]"
+          "update_percentage": "[%key:component::template::config::step::update::data::update_percentage%]"
         },
         "data_description": {
           "device_id": "[%key:component::template::common::device_id_description%]",
@@ -923,7 +923,7 @@
           "title": "[%key:component::template::config::step::update::data_description::title%]",
           "backup": "[%key:component::template::config::step::update::data_description::backup%]",
           "specific_version": "[%key:component::template::config::step::update::data_description::specific_version%]",
-          "update_percent": "[%key:component::template::config::step::update::data_description::update_percentage%]"
+          "update_percentage": "[%key:component::template::config::step::update::data_description::update_percentage%]"
         },
         "sections": {
           "advanced_options": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make the string match the translation key to fix the missing text in the UI:

<img width="925" height="527" alt="image" src="https://github.com/user-attachments/assets/57763c73-9a33-44de-ae4a-3fbca4b852eb" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
