### PR TITLE
Fix endpoint deprecation warning in Mastodon

### DIFF
--- a/homeassistant/components/mastodon/__init__.py
+++ b/homeassistant/components/mastodon/__init__.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from mastodon.Mastodon import Account, Instance, InstanceV2, Mastodon, MastodonError
+from mastodon.Mastodon import (
+    Account,
+    Instance,
+    InstanceV2,
+    Mastodon,
+    MastodonError,
+    MastodonNotFoundError,
+)
 
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
@@ -105,10 +112,11 @@ def setup_mastodon(
         entry.data[CONF_ACCESS_TOKEN],
     )
 
-    if client.mastodon_api_version == 1:
-        instance = client.instance_v1()
-    else:
+    try:
         instance = client.instance_v2()
+    except MastodonNotFoundError:
+        instance = client.instance_v1()
+
     account = client.account_verify_credentials()
 
     return client, instance, account

--- a/homeassistant/components/mastodon/__init__.py
+++ b/homeassistant/components/mastodon/__init__.py
@@ -105,7 +105,10 @@ def setup_mastodon(
         entry.data[CONF_ACCESS_TOKEN],
     )
 
-    instance = client.instance()
+    if client.mastodon_api_version == 1:
+        instance = client.instance_v1()
+    else:
+        instance = client.instance_v2()
     account = client.account_verify_credentials()
 
     return client, instance, account

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -7,6 +7,7 @@ from typing import Any
 from mastodon.Mastodon import (
     Account,
     Instance,
+    InstanceV2,
     MastodonNetworkError,
     MastodonUnauthorizedError,
 )
@@ -61,7 +62,7 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
         client_secret: str,
         access_token: str,
     ) -> tuple[
-        Instance | None,
+        InstanceV2 | Instance | None,
         Account | None,
         dict[str, str],
     ]:
@@ -73,7 +74,10 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
                 client_secret,
                 access_token,
             )
-            instance = client.instance()
+            if client.mastodon_api_version == 1:
+                instance = client.instance_v1()
+            else:
+                instance = client.instance_v2()
             account = client.account_verify_credentials()
 
         except MastodonNetworkError:

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -9,6 +9,7 @@ from mastodon.Mastodon import (
     Instance,
     InstanceV2,
     MastodonNetworkError,
+    MastodonNotFoundError,
     MastodonUnauthorizedError,
 )
 import voluptuous as vol
@@ -74,10 +75,10 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
                 client_secret,
                 access_token,
             )
-            if client.mastodon_api_version == 1:
-                instance = client.instance_v1()
-            else:
+            try:
                 instance = client.instance_v2()
+            except MastodonNotFoundError:
+                instance = client.instance_v1()
             account = client.account_verify_credentials()
 
         except MastodonNetworkError:

--- a/homeassistant/components/mastodon/diagnostics.py
+++ b/homeassistant/components/mastodon/diagnostics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mastodon.Mastodon import Account, Instance
+from mastodon.Mastodon import Account, Instance, InstanceV2
 
 from homeassistant.core import HomeAssistant
 
@@ -27,11 +27,16 @@ async def async_get_config_entry_diagnostics(
     }
 
 
-def get_diagnostics(config_entry: MastodonConfigEntry) -> tuple[Instance, Account]:
+def get_diagnostics(
+    config_entry: MastodonConfigEntry,
+) -> tuple[InstanceV2 | Instance, Account]:
     """Get mastodon diagnostics."""
     client = config_entry.runtime_data.client
 
-    instance = client.instance()
+    if client.mastodon_api_version == 1:
+        instance = client.instance_v1()
+    else:
+        instance = client.instance_v2()
     account = client.account_verify_credentials()
 
     return instance, account

--- a/homeassistant/components/mastodon/diagnostics.py
+++ b/homeassistant/components/mastodon/diagnostics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mastodon.Mastodon import Account, Instance, InstanceV2
+from mastodon.Mastodon import Account, Instance, InstanceV2, MastodonNotFoundError
 
 from homeassistant.core import HomeAssistant
 
@@ -33,10 +33,10 @@ def get_diagnostics(
     """Get mastodon diagnostics."""
     client = config_entry.runtime_data.client
 
-    if client.mastodon_api_version == 1:
-        instance = client.instance_v1()
-    else:
+    try:
         instance = client.instance_v2()
+    except MastodonNotFoundError:
+        instance = client.instance_v1()
     account = client.account_verify_credentials()
 
     return instance, account

--- a/tests/components/mastodon/conftest.py
+++ b/tests/components/mastodon/conftest.py
@@ -32,12 +32,16 @@ def mock_mastodon_client() -> Generator[AsyncMock]:
         ) as mock_client,
     ):
         client = mock_client.return_value
-        client.instance.return_value = InstanceV2.from_json(
+        client.instance_v1.return_value = InstanceV2.from_json(
+            load_fixture("instance.json", DOMAIN)
+        )
+        client.instance_v2.return_value = InstanceV2.from_json(
             load_fixture("instance.json", DOMAIN)
         )
         client.account_verify_credentials.return_value = Account.from_json(
             load_fixture("account_verify_credentials.json", DOMAIN)
         )
+        client.mastodon_api_version = 2
         client.status_post.return_value = None
         yield client
 

--- a/tests/components/mastodon/snapshots/test_diagnostics.ambr
+++ b/tests/components/mastodon/snapshots/test_diagnostics.ambr
@@ -83,3 +83,87 @@
     }),
   })
 # ---
+# name: test_entry_diagnostics_fallback_to_instance_v1
+  dict({
+    'account': dict({
+      'acct': 'trwnh',
+      'avatar': 'https://files.mastodon.social/accounts/avatars/000/014/715/original/051c958388818705.png',
+      'avatar_static': 'https://files.mastodon.social/accounts/avatars/000/014/715/original/051c958388818705.png',
+      'bot': True,
+      'created_at': '2016-11-24T00:00:00+00:00',
+      'discoverable': True,
+      'display_name': 'infinite love ⴳ',
+      'emojis': list([
+      ]),
+      'fields': list([
+        dict({
+          'name': 'Website',
+          'value': '<a href="https://trwnh.com" target="_blank" rel="nofollow noopener me" translate="no"><span class="invisible">https://</span><span class="">trwnh.com</span><span class="invisible"></span></a>',
+          'verified_at': '2019-08-29T04:14:55.571+00:00',
+        }),
+        dict({
+          'name': 'Portfolio',
+          'value': '<a href="https://abdullahtarawneh.com" target="_blank" rel="nofollow noopener me" translate="no"><span class="invisible">https://</span><span class="">abdullahtarawneh.com</span><span class="invisible"></span></a>',
+          'verified_at': '2021-02-11T20:34:13.574+00:00',
+        }),
+        dict({
+          'name': 'Fan of:',
+          'value': 'Punk-rock and post-hardcore (Circa Survive, letlive., La Dispute, THE FEVER 333)Manga (Yu-Gi-Oh!, One Piece, JoJo&#39;s Bizarre Adventure, Death Note, Shaman King)Platformers and RPGs (Banjo-Kazooie, Boktai, Final Fantasy Crystal Chronicles)',
+          'verified_at': None,
+        }),
+        dict({
+          'name': 'What to expect:',
+          'value': 'talking about various things i find interesting, and otherwise being a genuine and decent wholesome poster. i&#39;m just here to hang out and talk to cool people! and to spill my thoughts.',
+          'verified_at': None,
+        }),
+      ]),
+      'followers_count': 3169,
+      'following_count': 328,
+      'group': False,
+      'header': 'https://files.mastodon.social/accounts/headers/000/014/715/original/5c6fc24edb3bb873.jpg',
+      'header_static': 'https://files.mastodon.social/accounts/headers/000/014/715/original/5c6fc24edb3bb873.jpg',
+      'hide_collections': True,
+      'id': '14715',
+      'indexable': False,
+      'last_status_at': '2025-03-04T00:00:00',
+      'limited': None,
+      'locked': False,
+      'memorial': None,
+      'moved': None,
+      'moved_to_account': None,
+      'mute_expires_at': None,
+      'noindex': False,
+      'note': '<p>i have approximate knowledge of many things. perpetual student. (nb/ace/they)</p><p>xmpp/email: a@trwnh.com<br /><a href="https://trwnh.com" target="_blank" rel="nofollow noopener" translate="no"><span class="invisible">https://</span><span class="">trwnh.com</span><span class="invisible"></span></a><br />help me live:<br />- <a href="https://donate.stripe.com/4gwcPCaMpcQ19RC4gg" target="_blank" rel="nofollow noopener" translate="no"><span class="invisible">https://</span><span class="ellipsis">donate.stripe.com/4gwcPCaMpcQ1</span><span class="invisible">9RC4gg</span></a><br />- <a href="https://liberapay.com/trwnh" target="_blank" rel="nofollow noopener" translate="no"><span class="invisible">https://</span><span class="">liberapay.com/trwnh</span><span class="invisible"></span></a></p><p>notes:<br />- my triggers are moths and glitter<br />- i have all notifs except mentions turned off, so please interact if you wanna be friends! i literally will not notice otherwise<br />- dm me if i did something wrong, so i can improve<br />- purest person on fedi, do not lewd in my presence</p>',
+      'role': None,
+      'roles': list([
+      ]),
+      'source': None,
+      'statuses_count': 69523,
+      'suspended': None,
+      'uri': 'https://mastodon.social/users/trwnh',
+      'url': 'https://mastodon.social/@trwnh',
+      'username': 'trwnh',
+    }),
+    'instance': dict({
+      'api_versions': None,
+      'configuration': None,
+      'contact': None,
+      'description': 'The original server operated by the Mastodon gGmbH non-profit',
+      'domain': 'mastodon.social',
+      'icon': None,
+      'languages': None,
+      'registrations': None,
+      'rules': None,
+      'source_url': 'https://github.com/mastodon/mastodon',
+      'thumbnail': None,
+      'title': 'Mastodon',
+      'uri': 'mastodon.social',
+      'usage': dict({
+        'users': dict({
+          'active_month': 380143,
+        }),
+      }),
+      'version': '4.4.0-nightly.2025-02-07',
+    }),
+  })
+# ---

--- a/tests/components/mastodon/test_diagnostics.py
+++ b/tests/components/mastodon/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+from mastodon.Mastodon import MastodonNotFoundError
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
@@ -26,3 +27,26 @@ async def test_entry_diagnostics(
         await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
         == snapshot
     )
+
+
+async def test_entry_diagnostics_fallback_to_instance_v1(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_mastodon_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics with fallback to instance_v1 when instance_v2 raises MastodonNotFoundError."""
+    mock_mastodon_client.instance_v2.side_effect = MastodonNotFoundError(
+        "Instance v2 not found"
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    diagnostics_result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    mock_mastodon_client.instance_v1.assert_called()
+
+    assert diagnostics_result == snapshot

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -39,7 +39,8 @@ async def test_initialization_failure(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test initialization failure."""
-    mock_mastodon_client.instance.side_effect = MastodonError
+    mock_mastodon_client.instance_v1.side_effect = MastodonError
+    mock_mastodon_client.instance_v2.side_effect = MastodonError
 
     await setup_integration(hass, mock_config_entry)
 

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from mastodon.Mastodon import MastodonError
+from mastodon.Mastodon import MastodonNotFoundError
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.mastodon.config_flow import MastodonConfigFlow
@@ -39,8 +39,8 @@ async def test_initialization_failure(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test initialization failure."""
-    mock_mastodon_client.instance_v1.side_effect = MastodonError
-    mock_mastodon_client.instance_v2.side_effect = MastodonError
+    mock_mastodon_client.instance_v1.side_effect = MastodonNotFoundError
+    mock_mastodon_client.instance_v2.side_effect = MastodonNotFoundError
 
     await setup_integration(hass, mock_config_entry)
 

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -47,6 +47,22 @@ async def test_initialization_failure(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_setup_integration_fallback_to_instance_v1(
+    hass: HomeAssistant,
+    mock_mastodon_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test full flow where instance_v2 fails and falls back to instance_v1."""
+    mock_mastodon_client.instance_v2.side_effect = MastodonNotFoundError(
+        "Instance API v2 not found"
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    mock_mastodon_client.instance_v2.assert_called_once()
+    mock_mastodon_client.instance_v1.assert_called_once()
+
+
 async def test_migrate(
     hass: HomeAssistant,
     mock_mastodon_client: AsyncMock,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The recent update to Mastodon.py in 2025.9.0b0 has introduced a warning

`MastodonDeprecationWarning: Endpoint /api/v1/instance/ is marked as deprecated and may be removed in future Mastodon versions.`

This PR explicitly calls v2 instance, falling back to v1 if it is not found (Mastodon v4, released in 2022 supports v2, so unlikely few instances will be around needing the fall back)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
