### PR TITLE
Fix exception countries migration for Alexa Devices

### DIFF
--- a/homeassistant/components/alexa_devices/__init__.py
+++ b/homeassistant/components/alexa_devices/__init__.py
@@ -48,7 +48,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> 
         )
 
         # Convert country in domain
-        country = entry.data[CONF_COUNTRY]
+        country = entry.data[CONF_COUNTRY].lower()
         domain = COUNTRY_DOMAINS.get(country, country)
 
         # Add site to login data

--- a/homeassistant/components/alexa_devices/const.py
+++ b/homeassistant/components/alexa_devices/const.py
@@ -7,21 +7,21 @@ _LOGGER = logging.getLogger(__package__)
 DOMAIN = "alexa_devices"
 CONF_LOGIN_DATA = "login_data"
 
-DEFAULT_DOMAIN = {"domain": "com"}
+DEFAULT_DOMAIN = "com"
 COUNTRY_DOMAINS = {
     "ar": DEFAULT_DOMAIN,
     "at": DEFAULT_DOMAIN,
-    "au": {"domain": "com.au"},
-    "be": {"domain": "com.be"},
+    "au": "com.au",
+    "be": "com.be",
     "br": DEFAULT_DOMAIN,
-    "gb": {"domain": "co.uk"},
+    "gb": "co.uk",
     "il": DEFAULT_DOMAIN,
-    "jp": {"domain": "co.jp"},
-    "mx": {"domain": "com.mx"},
+    "jp": "co.jp",
+    "mx": "com.mx",
     "no": DEFAULT_DOMAIN,
-    "nz": {"domain": "com.au"},
+    "nz": "com.au",
     "pl": DEFAULT_DOMAIN,
-    "tr": {"domain": "com.tr"},
+    "tr": "com.tr",
     "us": DEFAULT_DOMAIN,
-    "za": {"domain": "co.za"},
+    "za": "co.za",
 }

--- a/tests/components/alexa_devices/const.py
+++ b/tests/components/alexa_devices/const.py
@@ -1,7 +1,6 @@
 """Alexa Devices tests const."""
 
 TEST_CODE = "023123"
-TEST_COUNTRY = "IT"
 TEST_PASSWORD = "fake_password"
 TEST_SERIAL_NUMBER = "echo_test_serial_number"
 TEST_USERNAME = "fake_email@gmail.com"

--- a/tests/components/alexa_devices/test_init.py
+++ b/tests/components/alexa_devices/test_init.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
-from .const import TEST_COUNTRY, TEST_PASSWORD, TEST_SERIAL_NUMBER, TEST_USERNAME
+from .const import TEST_PASSWORD, TEST_SERIAL_NUMBER, TEST_USERNAME
 
 from tests.common import MockConfigEntry
 
@@ -42,7 +42,7 @@ async def test_migrate_entry(
         domain=DOMAIN,
         title="Amazon Test Account",
         data={
-            CONF_COUNTRY: TEST_COUNTRY,
+            CONF_COUNTRY: "US",  # country should be in COUNTRY_DOMAINS exceptions
             CONF_USERNAME: TEST_USERNAME,
             CONF_PASSWORD: TEST_PASSWORD,
             CONF_LOGIN_DATA: {"session": "test-session"},
@@ -58,7 +58,4 @@ async def test_migrate_entry(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.minor_version == 2
-    assert (
-        config_entry.data[CONF_LOGIN_DATA]["site"]
-        == f"https://www.amazon.{TEST_COUNTRY}"
-    )
+    assert config_entry.data[CONF_LOGIN_DATA]["site"] == "https://www.amazon.com"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix exception countries migration for Alexa Devices

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151279
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
