### PR TITLE
Miele refrigerators cause index out of range errors when offline

### DIFF
--- a/tests/components/miele/fixtures/action_offline.json
+++ b/tests/components/miele/fixtures/action_offline.json
@@ -1,0 +1,15 @@
+{
+  "processAction": [],
+  "light": [],
+  "ambientLight": [],
+  "startTime": [],
+  "ventilationStep": [],
+  "programId": [],
+  "targetTemperature": [],
+  "deviceName": false,
+  "powerOn": false,
+  "powerOff": false,
+  "colors": [],
+  "modes": [],
+  "runOnTime": []
+}

--- a/tests/components/miele/fixtures/fridge_freezer.json
+++ b/tests/components/miele/fixtures/fridge_freezer.json
@@ -111,7 +111,7 @@
       "batteryLevel": null
     }
   },
-  "**DummyAppliance_Fridge_Freezer_Offline": {
+  "DummyAppliance_Fridge_Freezer_Offline": {
     "ident": {
       "type": {
         "key_localized": "Device type",

--- a/tests/components/miele/fixtures/fridge_freezer.json
+++ b/tests/components/miele/fixtures/fridge_freezer.json
@@ -110,5 +110,82 @@
       "ecoFeedback": null,
       "batteryLevel": null
     }
+  },
+  "**DummyAppliance_Fridge_Freezer_Offline": {
+    "ident": {
+      "type": {
+        "key_localized": "Device type",
+        "value_raw": 21,
+        "value_localized": "Fridge freezer"
+      },
+      "deviceName": "",
+      "protocolVersion": 203,
+      "deviceIdentLabel": {
+        "fabNumber": "**REDACTED**",
+        "fabIndex": "00",
+        "techType": "KFN 7734 C",
+        "matNumber": "12336150",
+        "swids": []
+      },
+      "xkmIdentLabel": {
+        "techType": "EK037LHBM",
+        "releaseVersion": "32.33"
+      }
+    },
+    "state": {
+      "ProgramID": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Program name"
+      },
+      "status": {
+        "value_raw": 255,
+        "value_localized": "Not connected",
+        "key_localized": "status"
+      },
+      "programType": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Program type"
+      },
+      "programPhase": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Program phase"
+      },
+      "remainingTime": [],
+      "startTime": [],
+      "targetTemperature": [],
+      "coreTargetTemperature": [],
+      "temperature": [],
+      "coreTemperature": [],
+      "remoteEnable": {
+        "fullRemoteControl": false,
+        "smartGrid": false,
+        "mobileStart": null
+      },
+      "ambientLight": null,
+      "light": null,
+      "elapsedTime": [],
+      "spinningSpeed": {
+        "unit": "rpm",
+        "value_raw": null,
+        "value_localized": null,
+        "key_localized": "Spin speed"
+      },
+      "dryingStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Drying level"
+      },
+      "ventilationStep": {
+        "value_raw": null,
+        "value_localized": "",
+        "key_localized": "Fan level"
+      },
+      "plateStep": [],
+      "ecoFeedback": null,
+      "batteryLevel": null
+    }
   }
 }

--- a/tests/components/miele/snapshots/test_climate.ambr
+++ b/tests/components/miele/snapshots/test_climate.ambr
@@ -357,7 +357,7 @@
     'suggested_object_id': None,
     'supported_features': <ClimateEntityFeature: 1>,
     'translation_key': 'freezer',
-    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-thermostat2-2',
+    'unique_id': 'DummyAppliance_Fridge_Freezer_Offline-thermostat2-2',
     'unit_of_measurement': None,
   })
 # ---
@@ -485,7 +485,7 @@
     'suggested_object_id': None,
     'supported_features': <ClimateEntityFeature: 1>,
     'translation_key': 'refrigerator',
-    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-thermostat-1',
+    'unique_id': 'DummyAppliance_Fridge_Freezer_Offline-thermostat-1',
     'unit_of_measurement': None,
   })
 # ---
@@ -613,7 +613,7 @@
     'suggested_object_id': None,
     'supported_features': <ClimateEntityFeature: 1>,
     'translation_key': 'zone_3',
-    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-thermostat3-3',
+    'unique_id': 'DummyAppliance_Fridge_Freezer_Offline-thermostat3-3',
     'unit_of_measurement': None,
   })
 # ---
@@ -627,6 +627,390 @@
       ]),
       'max_temp': -15,
       'min_temp': -30,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 1.0,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.fridge_freezer_zone_3_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_freezer-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.fridge_freezer_freezer',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Freezer',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': 'freezer',
+    'unique_id': 'DummyAppliance_Fridge_Freezer-thermostat2-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_freezer-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': -18,
+      'friendly_name': 'Fridge freezer Freezer',
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 1.0,
+      'temperature': -18,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.fridge_freezer_freezer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_freezer_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.fridge_freezer_freezer_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Freezer',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': 'freezer',
+    'unique_id': 'DummyAppliance_Fridge_Freezer_Offline-thermostat2-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_freezer_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': None,
+      'friendly_name': 'Fridge freezer Freezer',
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 1.0,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.fridge_freezer_freezer_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_refrigerator-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.fridge_freezer_refrigerator',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Refrigerator',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': 'refrigerator',
+    'unique_id': 'DummyAppliance_Fridge_Freezer-thermostat-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_refrigerator-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 4,
+      'friendly_name': 'Fridge freezer Refrigerator',
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 1.0,
+      'temperature': 4,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.fridge_freezer_refrigerator',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_refrigerator_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.fridge_freezer_refrigerator_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Refrigerator',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': 'refrigerator',
+    'unique_id': 'DummyAppliance_Fridge_Freezer_Offline-thermostat-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_refrigerator_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': None,
+      'friendly_name': 'Fridge freezer Refrigerator',
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 1.0,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.fridge_freezer_refrigerator_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_zone_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.fridge_freezer_zone_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone 3',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': 'zone_3',
+    'unique_id': 'DummyAppliance_Fridge_Freezer-thermostat3-3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_zone_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': -28,
+      'friendly_name': 'Fridge freezer Zone 3',
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 1.0,
+      'temperature': -25,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.fridge_freezer_zone_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_zone_3_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.fridge_freezer_zone_3_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone 3',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': 'zone_3',
+    'unique_id': 'DummyAppliance_Fridge_Freezer_Offline-thermostat3-3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_states_offline[fridge_freezer_offline-fridge_freezer.json-platforms0][climate.fridge_freezer_zone_3_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': None,
+      'friendly_name': 'Fridge freezer Zone 3',
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 35,
+      'min_temp': 7,
       'supported_features': <ClimateEntityFeature: 1>,
       'target_temp_step': 1.0,
       'temperature': None,

--- a/tests/components/miele/snapshots/test_climate.ambr
+++ b/tests/components/miele/snapshots/test_climate.ambr
@@ -319,6 +319,70 @@
     'state': 'cool',
   })
 # ---
+# name: test_climate_states_mulizone[fridge_freezer-fridge_freezer.json-platforms0][climate.fridge_freezer_freezer_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': -14,
+      'min_temp': -28,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.fridge_freezer_freezer_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Freezer',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': 'freezer',
+    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-thermostat2-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_states_mulizone[fridge_freezer-fridge_freezer.json-platforms0][climate.fridge_freezer_freezer_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': None,
+      'friendly_name': 'Fridge freezer Freezer',
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': -14,
+      'min_temp': -28,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 1.0,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.fridge_freezer_freezer_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
 # name: test_climate_states_mulizone[fridge_freezer-fridge_freezer.json-platforms0][climate.fridge_freezer_refrigerator-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -383,6 +447,70 @@
     'state': 'cool',
   })
 # ---
+# name: test_climate_states_mulizone[fridge_freezer-fridge_freezer.json-platforms0][climate.fridge_freezer_refrigerator_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 9,
+      'min_temp': 1,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.fridge_freezer_refrigerator_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Refrigerator',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': 'refrigerator',
+    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-thermostat-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_states_mulizone[fridge_freezer-fridge_freezer.json-platforms0][climate.fridge_freezer_refrigerator_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': None,
+      'friendly_name': 'Fridge freezer Refrigerator',
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 9,
+      'min_temp': 1,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 1.0,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.fridge_freezer_refrigerator_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
 # name: test_climate_states_mulizone[fridge_freezer-fridge_freezer.json-platforms0][climate.fridge_freezer_zone_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -441,6 +569,70 @@
     }),
     'context': <ANY>,
     'entity_id': 'climate.fridge_freezer_zone_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_climate_states_mulizone[fridge_freezer-fridge_freezer.json-platforms0][climate.fridge_freezer_zone_3_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': -15,
+      'min_temp': -30,
+      'target_temp_step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.fridge_freezer_zone_3_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone 3',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': 'zone_3',
+    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-thermostat3-3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_states_mulizone[fridge_freezer-fridge_freezer.json-platforms0][climate.fridge_freezer_zone_3_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': None,
+      'friendly_name': 'Fridge freezer Zone 3',
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': -15,
+      'min_temp': -30,
+      'supported_features': <ClimateEntityFeature: 1>,
+      'target_temp_step': 1.0,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.fridge_freezer_zone_3_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/miele/snapshots/test_sensor.ambr
+++ b/tests/components/miele/snapshots/test_sensor.ambr
@@ -1595,6 +1595,97 @@
     'state': 'in_use',
   })
 # ---
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.fridge_freezer_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'autocleaning',
+        'failure',
+        'idle',
+        'in_use',
+        'not_connected',
+        'off',
+        'on',
+        'pause',
+        'program_ended',
+        'program_interrupted',
+        'programmed',
+        'rinse_hold',
+        'service',
+        'supercooling',
+        'supercooling_superfreezing',
+        'superfreezing',
+        'superheating',
+        'waiting_to_start',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.fridge_freezer_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': 'mdi:fridge-outline',
+    'original_name': None,
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'status',
+    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-state_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.fridge_freezer_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Fridge freezer',
+      'icon': 'mdi:fridge-outline',
+      'options': list([
+        'autocleaning',
+        'failure',
+        'idle',
+        'in_use',
+        'not_connected',
+        'off',
+        'on',
+        'pause',
+        'program_ended',
+        'program_interrupted',
+        'programmed',
+        'rinse_hold',
+        'service',
+        'supercooling',
+        'supercooling_superfreezing',
+        'superfreezing',
+        'superheating',
+        'waiting_to_start',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.fridge_freezer_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_connected',
+  })
+# ---
 # name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.fridge_freezer_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -1649,6 +1740,62 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '4.0',
+  })
+# ---
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.fridge_freezer_temperature_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.fridge_freezer_temperature_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'miele',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-state_temperature_1',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.fridge_freezer_temperature_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Fridge freezer Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.fridge_freezer_temperature_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
   })
 # ---
 # name: test_fridge_freezer_sensor_states[platforms0-fridge_freezer.json][sensor.fridge_freezer_temperature_zone_2-entry]

--- a/tests/components/miele/snapshots/test_sensor.ambr
+++ b/tests/components/miele/snapshots/test_sensor.ambr
@@ -1647,7 +1647,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'status',
-    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-state_status',
+    'unique_id': 'DummyAppliance_Fridge_Freezer_Offline-state_status',
     'unit_of_measurement': None,
   })
 # ---
@@ -1778,7 +1778,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '**DummyAppliance_Fridge_Freezer_Offline-state_temperature_1',
+    'unique_id': 'DummyAppliance_Fridge_Freezer_Offline-state_temperature_1',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---

--- a/tests/components/miele/test_climate.py
+++ b/tests/components/miele/test_climate.py
@@ -36,6 +36,22 @@ async def test_climate_states(
 
 @pytest.mark.parametrize("load_device_file", ["fridge_freezer.json"])
 @pytest.mark.parametrize(
+    "load_action_file", ["action_offline.json"], ids=["fridge_freezer_offline"]
+)
+async def test_climate_states_offline(
+    hass: HomeAssistant,
+    mock_miele_client: MagicMock,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    setup_platform: MockConfigEntry,
+) -> None:
+    """Test climate entity state."""
+
+    await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
+
+
+@pytest.mark.parametrize("load_device_file", ["fridge_freezer.json"])
+@pytest.mark.parametrize(
     "load_action_file", ["action_fridge_freezer.json"], ids=["fridge_freezer"]
 )
 async def test_climate_states_mulizone(


### PR DESCRIPTION
## Proposed change
When Miele refrigerators are offline, there are many `IndexError: list index out of range` on temperature reads for `climate` entities.

For example:
```
2025-08-28 09:00:43.208 ERROR (MainThread) [homeassistant.components.climate] Error while setting up miele platform for climate: list index out of range
Traceback (most recent call last):
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity_platform.py", line 451, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/workspaces/home-assistant-core/homeassistant/components/miele/climate.py", line 159, in async_setup_entry
    _async_add_new_devices()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/workspaces/home-assistant-core/homeassistant/components/miele/climate.py", line 144, in _async_add_new_devices
    async_add_entities(
    ~~~~~~~~~~~~~~~~~~^
        MieleClimate(coordinator, device_id, definition.description)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
        )
        ^
    )
    ^
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity_platform.py", line 570, in _async_schedule_add_entities_for_entry
    new_entities if type(new_entities) is list else list(new_entities)
                                                    ~~~~^^^^^^^^^^^^^^
  File "/workspaces/home-assistant-core/homeassistant/components/miele/climate.py", line 152, in <genexpr>
    definition.description.value_fn(device)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/workspaces/home-assistant-core/homeassistant/components/miele/climate.py", line 65, in <lambda>
    lambda value: cast(int, value.state_temperatures[0].temperature) / 100.0
                            ~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
