### PR TITLE
Reduce log spam from unauthenticated websocket connections

### DIFF
--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import timedelta
+import logging
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -20,7 +21,11 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_call_logger_set_level, async_fire_time_changed
-from tests.typing import MockHAClientWebSocket, WebSocketGenerator
+from tests.typing import (
+    ClientSessionGenerator,
+    MockHAClientWebSocket,
+    WebSocketGenerator,
+)
 
 
 @pytest.fixture
@@ -398,6 +403,48 @@ async def test_prepare_fail_connection_reset(
         await hass_ws_client(hass)
 
     assert "Connection reset by peer while preparing WebSocket" in caplog.text
+
+
+async def test_auth_timeout_logs_at_debug(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test auth timeout is logged at debug level not warning."""
+    # Setup websocket API
+    assert await async_setup_component(hass, "websocket_api", {})
+
+    client = await hass_client()
+
+    # Patch the auth timeout to be very short (0.001 seconds)
+    with (
+        caplog.at_level(logging.DEBUG, "homeassistant.components.websocket_api"),
+        patch(
+            "homeassistant.components.websocket_api.http.AUTH_MESSAGE_TIMEOUT", 0.001
+        ),
+    ):
+        # Try to connect - will timeout quickly since we don't send auth
+        ws = await client.ws_connect("/api/websocket")
+        # Wait a bit for the timeout to trigger and cleanup to complete
+        await asyncio.sleep(0.1)
+        await ws.close()
+        await asyncio.sleep(0.1)
+
+        # Check that "Did not receive auth message" is logged at debug, not warning
+        debug_messages = [
+            r.message for r in caplog.records if r.levelno == logging.DEBUG
+        ]
+        assert any(
+            "Disconnected during auth phase: Did not receive auth message" in msg
+            for msg in debug_messages
+        )
+
+        # Check it's NOT logged at warning level
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        for msg in warning_messages:
+            assert "Did not receive auth message" not in msg
 
 
 async def test_enable_coalesce(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR reduces the logging level from WARNING to DEBUG for WebSocket connections that fail during the authentication phase. These failures commonly occur from port scanners, bots, and other non-legitimate connections from the public internet, creating unnecessary log noise that users cannot take action on.

The change specifically targets connections that timeout or disconnect before authenticating, while maintaining WARNING level logs for legitimate connections that disconnect after successful authentication.

This helps reduce log spam from transient connections that users have no control over, while still preserving visibility for actual issues with authenticated clients.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #126754
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Note: This PR addresses the specific case of "Did not receive auth message" errors mentioned in #126754. It doesn't fix all instances reported in that issue, but it significantly reduces log spam from connections that users cannot do anything about (random port scanners, bots, etc.).

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr