### PR TITLE
Avoid blocking IO in TRIGGERcmd

### DIFF
--- a/homeassistant/components/triggercmd/__init__.py
+++ b/homeassistant/components/triggercmd/__init__.py
@@ -21,8 +21,9 @@ type TriggercmdConfigEntry = ConfigEntry[ha.Hub]
 async def async_setup_entry(hass: HomeAssistant, entry: TriggercmdConfigEntry) -> bool:
     """Set up TRIGGERcmd from a config entry."""
     hub = ha.Hub(entry.data[CONF_TOKEN])
+    await hub.async_init(hass)
 
-    status_code = await client.async_connection_test(entry.data[CONF_TOKEN])
+    status_code = await client.async_connection_test(entry.data[CONF_TOKEN], hass)
     if status_code != 200:
         raise ConfigEntryNotReady
 

--- a/homeassistant/components/triggercmd/__init__.py
+++ b/homeassistant/components/triggercmd/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import httpx_client
 
 from .const import CONF_TOKEN
 
@@ -20,10 +21,12 @@ type TriggercmdConfigEntry = ConfigEntry[ha.Hub]
 
 async def async_setup_entry(hass: HomeAssistant, entry: TriggercmdConfigEntry) -> bool:
     """Set up TRIGGERcmd from a config entry."""
+    hass_client = httpx_client.get_async_client(hass)
     hub = ha.Hub(entry.data[CONF_TOKEN])
-    await hub.async_init(hass)
-
-    status_code = await client.async_connection_test(entry.data[CONF_TOKEN], hass)
+    await hub.async_init(hass_client)
+    status_code = await client.async_connection_test(
+        entry.data[CONF_TOKEN], hass_client
+    )
     if status_code != 200:
         raise ConfigEntryNotReady
 

--- a/homeassistant/components/triggercmd/config_flow.py
+++ b/homeassistant/components/triggercmd/config_flow.py
@@ -33,8 +33,8 @@ async def validate_input(hass: HomeAssistant, data: dict) -> str:
     if not token_data["id"]:
         raise InvalidToken
 
+    hass_client = httpx_client.get_async_client(hass)
     try:
-        hass_client = httpx_client.get_async_client(hass)
         await client.async_connection_test(data[CONF_TOKEN], hass_client)
     except Exception as e:
         raise TRIGGERcmdConnectionError from e

--- a/homeassistant/components/triggercmd/config_flow.py
+++ b/homeassistant/components/triggercmd/config_flow.py
@@ -33,7 +33,7 @@ async def validate_input(hass: HomeAssistant, data: dict) -> str:
         raise InvalidToken
 
     try:
-        await client.async_connection_test(data[CONF_TOKEN])
+        await client.async_connection_test(data[CONF_TOKEN], hass)
     except Exception as e:
         raise TRIGGERcmdConnectionError from e
     else:

--- a/homeassistant/components/triggercmd/config_flow.py
+++ b/homeassistant/components/triggercmd/config_flow.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import httpx_client
 
 from .const import CONF_TOKEN, DOMAIN
 
@@ -33,7 +34,8 @@ async def validate_input(hass: HomeAssistant, data: dict) -> str:
         raise InvalidToken
 
     try:
-        await client.async_connection_test(data[CONF_TOKEN], hass)
+        hass_client = httpx_client.get_async_client(hass)
+        await client.async_connection_test(data[CONF_TOKEN], hass_client)
     except Exception as e:
         raise TRIGGERcmdConnectionError from e
     else:

--- a/homeassistant/components/triggercmd/manifest.json
+++ b/homeassistant/components/triggercmd/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/triggercmd",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["triggercmd==0.0.27"]
+  "requirements": ["triggercmd==0.0.33"]
 }

--- a/homeassistant/components/triggercmd/manifest.json
+++ b/homeassistant/components/triggercmd/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/triggercmd",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["triggercmd==0.0.35"]
+  "requirements": ["triggercmd==0.0.36"]
 }

--- a/homeassistant/components/triggercmd/manifest.json
+++ b/homeassistant/components/triggercmd/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/triggercmd",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["triggercmd==0.0.33"]
+  "requirements": ["triggercmd==0.0.35"]
 }

--- a/homeassistant/components/triggercmd/switch.py
+++ b/homeassistant/components/triggercmd/switch.py
@@ -82,6 +82,6 @@ class TRIGGERcmdSwitch(SwitchEntity):
                 "params": params,
                 "sender": "Home Assistant",
             },
-            self._switch.hub.hass,
+            self._switch.hub.hass_client,
         )
         _LOGGER.debug("TRIGGERcmd trigger response: %s", r.json())

--- a/homeassistant/components/triggercmd/switch.py
+++ b/homeassistant/components/triggercmd/switch.py
@@ -82,5 +82,6 @@ class TRIGGERcmdSwitch(SwitchEntity):
                 "params": params,
                 "sender": "Home Assistant",
             },
+            self._switch.hub.hass,
         )
         _LOGGER.debug("TRIGGERcmd trigger response: %s", r.json())

--- a/homeassistant/components/triggercmd/switch.py
+++ b/homeassistant/components/triggercmd/switch.py
@@ -82,6 +82,6 @@ class TRIGGERcmdSwitch(SwitchEntity):
                 "params": params,
                 "sender": "Home Assistant",
             },
-            self._switch.hub.hass_client,
+            self._switch.hub.httpx_client,
         )
         _LOGGER.debug("TRIGGERcmd trigger response: %s", r.json())

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2978,7 +2978,7 @@ tplink-omada-client==1.4.4
 transmission-rpc==7.0.3
 
 # homeassistant.components.triggercmd
-triggercmd==0.0.33
+triggercmd==0.0.35
 
 # homeassistant.components.twinkly
 ttls==1.8.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2978,7 +2978,7 @@ tplink-omada-client==1.4.4
 transmission-rpc==7.0.3
 
 # homeassistant.components.triggercmd
-triggercmd==0.0.35
+triggercmd==0.0.36
 
 # homeassistant.components.twinkly
 ttls==1.8.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2978,7 +2978,7 @@ tplink-omada-client==1.4.4
 transmission-rpc==7.0.3
 
 # homeassistant.components.triggercmd
-triggercmd==0.0.27
+triggercmd==0.0.33
 
 # homeassistant.components.twinkly
 ttls==1.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2452,7 +2452,7 @@ tplink-omada-client==1.4.4
 transmission-rpc==7.0.3
 
 # homeassistant.components.triggercmd
-triggercmd==0.0.33
+triggercmd==0.0.35
 
 # homeassistant.components.twinkly
 ttls==1.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2452,7 +2452,7 @@ tplink-omada-client==1.4.4
 transmission-rpc==7.0.3
 
 # homeassistant.components.triggercmd
-triggercmd==0.0.35
+triggercmd==0.0.36
 
 # homeassistant.components.twinkly
 ttls==1.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2452,7 +2452,7 @@ tplink-omada-client==1.4.4
 transmission-rpc==7.0.3
 
 # homeassistant.components.triggercmd
-triggercmd==0.0.27
+triggercmd==0.0.33
 
 # homeassistant.components.twinkly
 ttls==1.8.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Solves: Blocking I/O inside the event loop (Issue #151324)
I used the solution on this page of the HA developer docs:
https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_verify_locations
Specifically, the one for httpx under load_default_certs: 
homeassistant.helpers.httpx_client.get_async_client to create the httpx.AsyncClient.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151324

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
Existing tests are adequate.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
This commit shows the changes in the triggercmd module:
https://github.com/rvmey/triggercmd-python-agent/commit/62a7f004115536fbd987e69a918c741cb77fb1d7#diff-a0572e2c7cb2b9343cc2d2d403c5e692ab13453e9279aa899ce6b2879fdff0c5

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
