### PR TITLE
Add event entity on websocket ready in Husqvarna Automower

### DIFF
--- a/homeassistant/components/husqvarna_automower/event.py
+++ b/homeassistant/components/husqvarna_automower/event.py
@@ -57,6 +57,7 @@ async def async_setup_entry(
             for mower_id in restored_mowers
             if mower_id in coordinator.data
         )
+        coordinator.api.unregister_ws_ready_callback(_on_ws_ready)
 
     coordinator.api.register_ws_ready_callback(_on_ws_ready)
 

--- a/homeassistant/components/husqvarna_automower/event.py
+++ b/homeassistant/components/husqvarna_automower/event.py
@@ -36,12 +36,13 @@ async def async_setup_entry(
     """Set up Automower message event entities.
 
     Entities are created dynamically based on messages received from the API,
-    but only for mowers that support message events.
+    but only for mowers that support message events after the WebSocket connection
+    is ready.
     """
     coordinator = config_entry.runtime_data
     entity_registry = er.async_get(hass)
 
-    restored_mowers = {
+    restored_mowers: set[str] = {
         entry.unique_id.removesuffix("_message")
         for entry in er.async_entries_for_config_entry(
             entity_registry, config_entry.entry_id
@@ -49,14 +50,19 @@ async def async_setup_entry(
         if entry.domain == EVENT_DOMAIN
     }
 
-    async_add_entities(
-        AutomowerMessageEventEntity(mower_id, coordinator)
-        for mower_id in restored_mowers
-        if mower_id in coordinator.data
-    )
+    @callback
+    def _on_ws_ready() -> None:
+        async_add_entities(
+            AutomowerMessageEventEntity(mower_id, coordinator, websocket_alive=True)
+            for mower_id in restored_mowers
+            if mower_id in coordinator.data
+        )
+
+    coordinator.api.register_ws_ready_callback(_on_ws_ready)
 
     @callback
     def _handle_message(msg: SingleMessageData) -> None:
+        """Add entity dynamically if a new mower sends messages."""
         if msg.id in restored_mowers:
             return
 
@@ -78,11 +84,17 @@ class AutomowerMessageEventEntity(AutomowerBaseEntity, EventEntity):
         self,
         mower_id: str,
         coordinator: AutomowerDataUpdateCoordinator,
+        *,
+        websocket_alive: bool | None = None,
     ) -> None:
         """Initialize Automower message event entity."""
         super().__init__(mower_id, coordinator)
         self._attr_unique_id = f"{mower_id}_message"
-        self.websocket_alive: bool = coordinator.websocket_alive
+        self.websocket_alive: bool = (
+            websocket_alive
+            if websocket_alive is not None
+            else coordinator.websocket_alive
+        )
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Needs: #151427
Currently the event entity is unavailable on startup. After the websocket connection is established it switches to available, which produces a log entry every time on startup. With this change des entity will be added after the websocket connection is established.

Please include in next patch release.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
