### PR TITLE
Fix Yale Access Bluetooth key discovery timing issues

### DIFF
--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import CONF_ADDRESS, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import CALLBACK_TYPE, CoreState, Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
-from .config_cache import async_get_config
+from .config_cache import async_get_validated_config
 from .const import (
     CONF_ALWAYS_CONNECTED,
     CONF_KEY,
@@ -50,7 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: YALEXSBLEConfigEntry) ->
         # If the key was rotated, try to fetch the key and slot from the cache.
         address = entry.data[CONF_ADDRESS]
         if (
-            (validated_config := async_get_config(hass, address))
+            (validated_config := async_get_validated_config(hass, address))
             and validated_config.key != entry.data[CONF_KEY]
             and validated_config.slot != entry.data[CONF_SLOT]
             and await _async_try_setup_entry(

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -51,8 +51,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: YALEXSBLEConfigEntry) ->
         address = entry.data[CONF_ADDRESS]
         if (
             (validated_config := async_get_validated_config(hass, address))
-            and validated_config.key != entry.data[CONF_KEY]
-            and validated_config.slot != entry.data[CONF_SLOT]
+            and (
+                validated_config.key != entry.data[CONF_KEY]
+                or validated_config.slot != entry.data[CONF_SLOT]
+            )
             and await _async_try_setup_entry(
                 hass, entry, validated_config.key, validated_config.slot
             )
@@ -61,6 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: YALEXSBLEConfigEntry) ->
             hass.config_entries.async_update_entry(
                 entry,
                 data={
+                    **entry.data,
                     CONF_KEY: validated_config.key,
                     CONF_SLOT: validated_config.slot,
                 },

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -58,9 +58,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: YALEXSBLEConfigEntry) ->
             )
         ):
             # If we can use the cached key and slot, update the entry.
-            hass.config_entries.async_update_entry(
-                entry,
                 data={
+                    **entry.data,
                     CONF_KEY: validated_config.key,
                     CONF_SLOT: validated_config.slot,
                 },

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -105,7 +105,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: YALEXSBLEConfigEntry) ->
             validated_config.key != entry.data[CONF_KEY]
             or validated_config.slot != entry.data[CONF_SLOT]
         ):
+            assert shutdown_callback is not None
+            shutdown_callback()
             push_lock.set_lock_key(validated_config.key, validated_config.slot)
+            shutdown_callback = await push_lock.start()
             await _async_wait_for_first_update(push_lock, local_name)
             # If we can use the cached key and slot, update the entry.
             hass.config_entries.async_update_entry(

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -41,7 +41,7 @@ PLATFORMS: list[Platform] = [
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: YALEXSBLEConfigEntry) -> bool:
-    """Try to set up a Yale Access Bluetooth config entry."""
+    """Set up Yale Access Bluetooth from a config entry."""
     local_name = entry.data[CONF_LOCAL_NAME]
     address = entry.data[CONF_ADDRESS]
     key = entry.data[CONF_KEY]

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -58,8 +58,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: YALEXSBLEConfigEntry) ->
             )
         ):
             # If we can use the cached key and slot, update the entry.
+            hass.config_entries.async_update_entry(
+                entry,
                 data={
-                    **entry.data,
                     CONF_KEY: validated_config.key,
                     CONF_SLOT: validated_config.slot,
                 },

--- a/homeassistant/components/yalexs_ble/config_cache.py
+++ b/homeassistant/components/yalexs_ble/config_cache.py
@@ -1,0 +1,31 @@
+"""The Yale Access Bluetooth integration."""
+
+from __future__ import annotations
+
+from yalexs_ble import ValidatedLockConfig
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.util.hass_dict import HassKey
+
+CONFIG_CACHE: HassKey[dict[str, ValidatedLockConfig]] = HassKey(
+    "yalexs_ble_config_cache"
+)
+
+
+@callback
+def async_add_validated_config(
+    hass: HomeAssistant,
+    address: str,
+    config: ValidatedLockConfig,
+) -> None:
+    """Add a validated config."""
+    hass.data.setdefault(CONFIG_CACHE, {})[address] = config
+
+
+@callback
+def async_get_config(
+    hass: HomeAssistant,
+    address: str,
+) -> ValidatedLockConfig | None:
+    """Get the config for a specific address."""
+    return hass.data.get(CONFIG_CACHE, {}).get(address)

--- a/homeassistant/components/yalexs_ble/config_cache.py
+++ b/homeassistant/components/yalexs_ble/config_cache.py
@@ -23,7 +23,7 @@ def async_add_validated_config(
 
 
 @callback
-def async_get_config(
+def async_get_validated_config(
     hass: HomeAssistant,
     address: str,
 ) -> ValidatedLockConfig | None:

--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -249,10 +249,12 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
             if validated_config:
                 key = validated_config.key
                 slot = validated_config.slot
+                title = validated_config.name
             else:
                 assert user_input is not None
                 key = user_input[CONF_KEY]
                 slot = user_input[CONF_SLOT]
+                title = human_readable_name(None, local_name, address)
             await self.async_set_unique_id(address, raise_on_progress=False)
             self._abort_if_unique_id_configured()
             if not (
@@ -261,9 +263,7 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
             ):
                 return self.async_create_entry(
-                    title=validated_config.name
-                    if validated_config
-                    else human_readable_name(None, local_name, address),
+                    title=title,
                     data={
                         CONF_LOCAL_NAME: discovery_info.name,
                         CONF_ADDRESS: discovery_info.address,
@@ -347,11 +347,9 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
         if address in self._discovered_devices:
             service_info = self._discovered_devices[address]
             return f"{service_info.name} ({service_info.address})"
-        # If we have discovery info (from Bluetooth discovery), use that
-        if self._discovery_info and self._discovery_info.address == address:
-            return f"{self._discovery_info.name} ({address})"
-        # Fallback
-        return address
+        assert self._discovery_info is not None
+        assert self._discovery_info.address == address
+        return f"{self._discovery_info.name} ({address})"
 
     @staticmethod
     @callback

--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -33,7 +33,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .config_cache import async_add_validated_config, async_get_config
+from .config_cache import async_add_validated_config, async_get_validated_config
 from .const import CONF_ALWAYS_CONNECTED, CONF_KEY, CONF_LOCAL_NAME, CONF_SLOT, DOMAIN
 from .util import async_find_existing_service_info, human_readable_name
 
@@ -242,7 +242,7 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
         discovery_info = self._discovery_info
         assert discovery_info is not None
         address = discovery_info.address
-        validated_config = async_get_config(self.hass, address)
+        validated_config = async_get_validated_config(self.hass, address)
 
         if user_input is not None or validated_config:
             local_name = discovery_info.name
@@ -342,7 +342,7 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def _async_get_name_from_address(self, address: str) -> str:
         """Get the name of a device from its address."""
-        if validated_config := async_get_config(self.hass, address):
+        if validated_config := async_get_validated_config(self.hass, address):
             return f"{validated_config.name} ({address})"
         if address in self._discovered_devices:
             service_info = self._discovered_devices[address]

--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -78,6 +78,7 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._discovery_info: BluetoothServiceInfoBleak | None = None
         self._discovered_devices: dict[str, BluetoothServiceInfoBleak] = {}
+        self._lock_cfg: ValidatedLockConfig | None = None
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -92,7 +93,8 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
                 None, discovery_info.name, discovery_info.address
             ),
         }
-        if async_get_validated_config(self.hass, discovery_info.address):
+        if lock_cfg := async_get_validated_config(self.hass, discovery_info.address):
+            self._lock_cfg = lock_cfg
             return await self.async_step_integration_discovery_confirm()
         return await self.async_step_key_slot()
 
@@ -140,6 +142,7 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
         if self.hass.config_entries.flow.async_has_matching_flow(self):
             raise AbortFlow("already_in_progress")
 
+        self._lock_cfg = lock_cfg
         self.context["title_placeholders"] = {
             "name": human_readable_name(
                 lock_cfg.name, lock_cfg.local_name, self._discovery_info.address
@@ -170,16 +173,15 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a confirmation of discovered integration."""
         assert self._discovery_info is not None
-        lock_cfg = async_get_validated_config(self.hass, self._discovery_info.address)
-        assert lock_cfg is not None
+        assert self._lock_cfg is not None
         if user_input is not None:
             return self.async_create_entry(
-                title=lock_cfg.name,
+                title=self._lock_cfg.name,
                 data={
                     CONF_LOCAL_NAME: self._discovery_info.name,
                     CONF_ADDRESS: self._discovery_info.address,
-                    CONF_KEY: lock_cfg.key,
-                    CONF_SLOT: lock_cfg.slot,
+                    CONF_KEY: self._lock_cfg.key,
+                    CONF_SLOT: self._lock_cfg.slot,
                 },
             )
 
@@ -187,7 +189,7 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="integration_discovery_confirm",
             description_placeholders={
-                "name": lock_cfg.name,
+                "name": self._lock_cfg.name,
                 "address": self._discovery_info.address,
             },
         )

--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -93,6 +93,9 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
                 None, discovery_info.name, discovery_info.address
             ),
         }
+        if lock_cfg := async_get_validated_config(self.hass, discovery_info.address):
+            self._lock_cfg = lock_cfg
+            return await self.async_step_integration_discovery_confirm()
         return await self.async_step_key_slot()
 
     async def async_step_integration_discovery(

--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -33,6 +33,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.typing import DiscoveryInfoType
 
+from .config_cache import async_add_validated_config, async_get_config
 from .const import CONF_ALWAYS_CONNECTED, CONF_KEY, CONF_LOCAL_NAME, CONF_SLOT, DOMAIN
 from .util import async_find_existing_service_info, human_readable_name
 
@@ -105,6 +106,7 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
             discovery_info["key"],
             discovery_info["slot"],
         )
+        async_add_validated_config(self.hass, lock_cfg.address, lock_cfg)
 
         address = lock_cfg.address
         self.local_name = lock_cfg.local_name
@@ -232,6 +234,59 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_key_slot(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the key and slot step."""
+        errors: dict[str, str] = {}
+        discovery_info = self._discovery_info
+        assert discovery_info is not None
+        address = discovery_info.address
+        validated_config = async_get_config(self.hass, address)
+
+        if user_input is not None or validated_config:
+            local_name = discovery_info.name
+            if validated_config:
+                key = validated_config.key
+                slot = validated_config.slot
+            else:
+                assert user_input is not None
+                key = user_input[CONF_KEY]
+                slot = user_input[CONF_SLOT]
+            await self.async_set_unique_id(address, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            if not (
+                errors := await async_validate_lock_or_error(
+                    local_name, discovery_info.device, key, slot
+                )
+            ):
+                return self.async_create_entry(
+                    title=validated_config.name
+                    if validated_config
+                    else human_readable_name(None, local_name, address),
+                    data={
+                        CONF_LOCAL_NAME: discovery_info.name,
+                        CONF_ADDRESS: discovery_info.address,
+                        CONF_KEY: key,
+                        CONF_SLOT: slot,
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="key_slot",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_KEY): str,
+                    vol.Required(CONF_SLOT): int,
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "address": address,
+                "title": self._async_get_name_from_address(address),
+            },
+        )
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -241,38 +296,25 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self.active = True
             address = user_input[CONF_ADDRESS]
-            discovery_info = self._discovered_devices[address]
-            local_name = discovery_info.name
-            key = user_input[CONF_KEY]
-            slot = user_input[CONF_SLOT]
-            await self.async_set_unique_id(
-                discovery_info.address, raise_on_progress=False
-            )
-            self._abort_if_unique_id_configured()
-            if not (
-                errors := await async_validate_lock_or_error(
-                    local_name, discovery_info.device, key, slot
-                )
-            ):
-                return self.async_create_entry(
-                    title=local_name,
-                    data={
-                        CONF_LOCAL_NAME: discovery_info.name,
-                        CONF_ADDRESS: discovery_info.address,
-                        CONF_KEY: key,
-                        CONF_SLOT: slot,
-                    },
-                )
+            self._discovery_info = self._discovered_devices[address]
+            return await self.async_step_key_slot()
 
         if discovery := self._discovery_info:
             self._discovered_devices[discovery.address] = discovery
         else:
             current_addresses = self._async_current_ids(include_ignore=False)
+            _LOGGER.warning(
+                "No user input provided, current addresses: %s", current_addresses
+            )
             current_unique_names = {
                 entry.data.get(CONF_LOCAL_NAME)
                 for entry in self._async_current_entries()
                 if local_name_is_unique(entry.data.get(CONF_LOCAL_NAME))
             }
+            _LOGGER.warning(
+                "No unique local names found, current unique names: %s",
+                current_unique_names,
+            )
             for discovery in async_discovered_service_info(self.hass):
                 if (
                     discovery.address in current_addresses
@@ -290,14 +332,12 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_ADDRESS): vol.In(
                     {
-                        service_info.address: (
-                            f"{service_info.name} ({service_info.address})"
+                        service_info.address: self._async_get_name_from_address(
+                            service_info.address
                         )
                         for service_info in self._discovered_devices.values()
                     }
-                ),
-                vol.Required(CONF_KEY): str,
-                vol.Required(CONF_SLOT): int,
+                )
             }
         )
         return self.async_show_form(
@@ -305,6 +345,14 @@ class YalexsConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
             errors=errors,
         )
+
+    @callback
+    def _async_get_name_from_address(self, address: str) -> str:
+        """Get the name of a device from its address."""
+        if validated_config := async_get_config(self.hass, address):
+            return f"{validated_config.name} ({address})"
+        service_info = self._discovered_devices[address]
+        return f"{service_info.name} ({service_info.address})"
 
     @staticmethod
     @callback

--- a/homeassistant/components/yalexs_ble/strings.json
+++ b/homeassistant/components/yalexs_ble/strings.json
@@ -3,18 +3,23 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "description": "Check the documentation for how to find the offline key. If you are using the August cloud integration to obtain the key, you may need to reload the August cloud integration while the lock is in Bluetooth range.",
+        "description": "Select the device you want to set up over Bluetooth.",
         "data": {
-          "address": "Bluetooth address",
+          "address": "Bluetooth address"
+        }
+      },
+      "key_slot": {
+        "description": "Enter the key for the {title} lock with address {address}. If you are using the August or Yale cloud integration to obtain the key, you may be able to avoid this manual setup by reloading the August or Yale cloud integration while the lock is in Bluetooth range.",
+        "data": {
           "key": "Offline Key (32-byte hex string)",
           "slot": "Offline Key Slot (Integer between 0 and 255)"
         }
       },
       "reauth_validate": {
-        "description": "Enter the updated key for the {title} lock with address {address}. If you are using the August cloud integration to obtain the key, you may be able to avoid manual reauthentication by reloading the August cloud integration while the lock is in Bluetooth range.",
+        "description": "Enter the updated key for the {title} lock with address {address}. If you are using the August or Yale cloud integration to obtain the key, you may be able to avoid manual re-authentication by reloading the August or Yale cloud integration while the lock is in Bluetooth range.",
         "data": {
-          "key": "[%key:component::yalexs_ble::config::step::user::data::key%]",
-          "slot": "[%key:component::yalexs_ble::config::step::user::data::slot%]"
+          "key": "[%key:component::yalexs_ble::config::step::key_slot::data::key%]",
+          "slot": "[%key:component::yalexs_ble::config::step::key_slot::data::slot%]"
         }
       },
       "integration_discovery_confirm": {

--- a/tests/components/yalexs_ble/test_config_flow.py
+++ b/tests/components/yalexs_ble/test_config_flow.py
@@ -1088,6 +1088,75 @@ async def test_reauth(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_user_step_with_cached_config(hass: HomeAssistant) -> None:
+    """Test user step when config is already cached from integration discovery."""
+    # First, simulate integration discovery to populate the cache
+    discovery_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={
+            "name": "Front Door",
+            "address": YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+            "key": "2fd51b8621c6a139eaffbedcb846b60f",
+            "slot": 66,
+            "serial": "M1XXX012LU",
+        },
+    )
+    assert discovery_result["type"] is FlowResultType.ABORT
+    assert discovery_result["reason"] == "no_devices_found"
+
+    # Now start a user flow - it should use the cached config
+    with patch(
+        "homeassistant.components.yalexs_ble.config_flow.async_discovered_service_info",
+        return_value=[YALE_ACCESS_LOCK_DISCOVERY_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # The dropdown should show "Front Door (AA:BB:CC:DD:EE:FF)" from cached config
+    # This is the line 346 case we're testing
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "key_slot"
+
+    # The key_slot step should auto-complete with cached values
+    # When no user input is provided, it should use the cached config
+    with (
+        patch(
+            "homeassistant.components.yalexs_ble.config_flow.PushLock.validate",
+        ),
+        patch(
+            "homeassistant.components.yalexs_ble.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        # No user input triggers using cached config
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            None,  # None triggers checking for cached config
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "Front Door"  # Uses the name from cached config
+    assert result3["data"] == {
+        CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
+        CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+        CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
+        CONF_SLOT: 66,
+    }
+    assert result3["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
 async def test_options(hass: HomeAssistant) -> None:
     """Test options."""
     entry = MockConfigEntry(

--- a/tests/components/yalexs_ble/test_config_flow.py
+++ b/tests/components/yalexs_ble/test_config_flow.py
@@ -61,6 +61,16 @@ async def test_user_step_success(hass: HomeAssistant, slot: int) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "key_slot"
+    assert result2["errors"] == {}
+
     with (
         patch(
             "homeassistant.components.yalexs_ble.config_flow.PushLock.validate",
@@ -70,25 +80,24 @@ async def test_user_step_success(hass: HomeAssistant, slot: int) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: slot,
             },
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == YALE_ACCESS_LOCK_DISCOVERY_INFO.name
-    assert result2["data"] == {
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} (EEFF)"
+    assert result3["data"] == {
         CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
         CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
         CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
         CONF_SLOT: slot,
     }
-    assert result2["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
+    assert result3["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -113,6 +122,16 @@ async def test_user_step_from_ignored(hass: HomeAssistant, slot: int) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "key_slot"
+    assert result2["errors"] == {}
+
     with (
         patch(
             "homeassistant.components.yalexs_ble.config_flow.PushLock.validate",
@@ -122,25 +141,24 @@ async def test_user_step_from_ignored(hass: HomeAssistant, slot: int) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: slot,
             },
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == YALE_ACCESS_LOCK_DISCOVERY_INFO.name
-    assert result2["data"] == {
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} (EEFF)"
+    assert result3["data"] == {
         CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
         CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
         CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
         CONF_SLOT: slot,
     }
-    assert result2["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
+    assert result3["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -198,37 +216,44 @@ async def test_user_step_invalid_keys(hass: HomeAssistant) -> None:
         result["flow_id"],
         {
             CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
-            CONF_KEY: "dog",
-            CONF_SLOT: 66,
         },
     )
     assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {CONF_KEY: "invalid_key_format"}
+    assert result2["step_id"] == "key_slot"
+    assert result2["errors"] == {}
 
     result3 = await hass.config_entries.flow.async_configure(
         result2["flow_id"],
         {
-            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
-            CONF_KEY: "qfd51b8621c6a139eaffbedcb846b60f",
+            CONF_KEY: "dog",
             CONF_SLOT: 66,
         },
     )
     assert result3["type"] is FlowResultType.FORM
-    assert result3["step_id"] == "user"
+    assert result3["step_id"] == "key_slot"
     assert result3["errors"] == {CONF_KEY: "invalid_key_format"}
 
     result4 = await hass.config_entries.flow.async_configure(
         result3["flow_id"],
         {
-            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+            CONF_KEY: "qfd51b8621c6a139eaffbedcb846b60f",
+            CONF_SLOT: 66,
+        },
+    )
+    assert result4["type"] is FlowResultType.FORM
+    assert result4["step_id"] == "key_slot"
+    assert result4["errors"] == {CONF_KEY: "invalid_key_format"}
+
+    result5 = await hass.config_entries.flow.async_configure(
+        result4["flow_id"],
+        {
             CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
             CONF_SLOT: 999,
         },
     )
-    assert result4["type"] is FlowResultType.FORM
-    assert result4["step_id"] == "user"
-    assert result4["errors"] == {CONF_SLOT: "invalid_key_index"}
+    assert result5["type"] is FlowResultType.FORM
+    assert result5["step_id"] == "key_slot"
+    assert result5["errors"] == {CONF_SLOT: "invalid_key_index"}
 
     with (
         patch(
@@ -239,25 +264,24 @@ async def test_user_step_invalid_keys(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result5 = await hass.config_entries.flow.async_configure(
-            result4["flow_id"],
+        result6 = await hass.config_entries.flow.async_configure(
+            result5["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: 66,
             },
         )
         await hass.async_block_till_done()
 
-    assert result5["type"] is FlowResultType.CREATE_ENTRY
-    assert result5["title"] == YALE_ACCESS_LOCK_DISCOVERY_INFO.name
-    assert result5["data"] == {
+    assert result6["type"] is FlowResultType.CREATE_ENTRY
+    assert result6["title"] == f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} (EEFF)"
+    assert result6["data"] == {
         CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
         CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
         CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
         CONF_SLOT: 66,
     }
-    assert result5["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
+    assert result6["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -274,23 +298,32 @@ async def test_user_step_cannot_connect(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "key_slot"
+    assert result2["errors"] == {}
+
     with patch(
         "homeassistant.components.yalexs_ble.config_flow.PushLock.validate",
         side_effect=BleakError,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: 66,
             },
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["step_id"] == "key_slot"
+    assert result3["errors"] == {"base": "cannot_connect"}
 
     with (
         patch(
@@ -301,25 +334,24 @@ async def test_user_step_cannot_connect(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: 66,
             },
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == YALE_ACCESS_LOCK_DISCOVERY_INFO.name
-    assert result3["data"] == {
+    assert result4["type"] is FlowResultType.CREATE_ENTRY
+    assert result4["title"] == f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} (EEFF)"
+    assert result4["data"] == {
         CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
         CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
         CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
         CONF_SLOT: 66,
     }
-    assert result3["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
+    assert result4["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -336,23 +368,32 @@ async def test_user_step_auth_exception(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "key_slot"
+    assert result2["errors"] == {}
+
     with patch(
         "homeassistant.components.yalexs_ble.config_flow.PushLock.validate",
         side_effect=AuthError,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: 66,
             },
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {CONF_KEY: "invalid_auth"}
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["step_id"] == "key_slot"
+    assert result3["errors"] == {CONF_KEY: "invalid_auth"}
 
     with (
         patch(
@@ -363,25 +404,24 @@ async def test_user_step_auth_exception(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: 66,
             },
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == YALE_ACCESS_LOCK_DISCOVERY_INFO.name
-    assert result3["data"] == {
+    assert result4["type"] is FlowResultType.CREATE_ENTRY
+    assert result4["title"] == f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} (EEFF)"
+    assert result4["data"] == {
         CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
         CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
         CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
         CONF_SLOT: 66,
     }
-    assert result3["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
+    assert result4["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -398,23 +438,32 @@ async def test_user_step_unknown_exception(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "key_slot"
+    assert result2["errors"] == {}
+
     with patch(
         "homeassistant.components.yalexs_ble.config_flow.PushLock.validate",
         side_effect=RuntimeError,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: 66,
             },
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {"base": "unknown"}
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["step_id"] == "key_slot"
+    assert result3["errors"] == {"base": "unknown"}
 
     with (
         patch(
@@ -425,25 +474,24 @@ async def test_user_step_unknown_exception(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: 66,
             },
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == YALE_ACCESS_LOCK_DISCOVERY_INFO.name
-    assert result3["data"] == {
+    assert result4["type"] is FlowResultType.CREATE_ENTRY
+    assert result4["title"] == f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} (EEFF)"
+    assert result4["data"] == {
         CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
         CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
         CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
         CONF_SLOT: 66,
     }
-    assert result3["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
+    assert result4["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -455,7 +503,7 @@ async def test_bluetooth_step_success(hass: HomeAssistant) -> None:
         data=YALE_ACCESS_LOCK_DISCOVERY_INFO,
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "key_slot"
     assert result["errors"] == {}
 
     with (
@@ -470,7 +518,6 @@ async def test_bluetooth_step_success(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                 CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                 CONF_SLOT: 66,
             },
@@ -478,7 +525,7 @@ async def test_bluetooth_step_success(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == YALE_ACCESS_LOCK_DISCOVERY_INFO.name
+    assert result2["title"] == f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} (EEFF)"
     assert result2["data"] == {
         CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
         CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
@@ -563,7 +610,7 @@ async def test_integration_discovery_takes_precedence_over_bluetooth(
         data=YALE_ACCESS_LOCK_DISCOVERY_INFO,
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "key_slot"
     assert result["errors"] == {}
     flows = list(hass.config_entries.flow._handler_progress_index[DOMAIN])
     assert len(flows) == 1
@@ -774,7 +821,7 @@ async def test_integration_discovery_takes_precedence_over_bluetooth_uuid_addres
         data=LOCK_DISCOVERY_INFO_UUID_ADDRESS,
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "key_slot"
     assert result["errors"] == {}
     flows = list(hass.config_entries.flow._handler_progress_index[DOMAIN])
     assert len(flows) == 1
@@ -850,7 +897,7 @@ async def test_integration_discovery_takes_precedence_over_bluetooth_non_unique_
         data=OLD_FIRMWARE_LOCK_DISCOVERY_INFO,
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "key_slot"
     assert result["errors"] == {}
     flows = list(hass.config_entries.flow._handler_progress_index[DOMAIN])
     assert len(flows) == 1
@@ -907,6 +954,15 @@ async def test_user_is_setting_up_lock_and_discovery_happens_in_the_middle(
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "key_slot"
+
     user_flow_event = asyncio.Event()
     valdidate_started = asyncio.Event()
 
@@ -926,9 +982,8 @@ async def test_user_is_setting_up_lock_and_discovery_happens_in_the_middle(
     ):
         user_flow_task = asyncio.create_task(
             hass.config_entries.flow.async_configure(
-                result["flow_id"],
+                result2["flow_id"],
                 {
-                    CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
                     CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
                     CONF_SLOT: 66,
                 },
@@ -959,7 +1014,7 @@ async def test_user_is_setting_up_lock_and_discovery_happens_in_the_middle(
         user_flow_result = await user_flow_task
 
     assert user_flow_result["type"] is FlowResultType.CREATE_ENTRY
-    assert user_flow_result["title"] == YALE_ACCESS_LOCK_DISCOVERY_INFO.name
+    assert user_flow_result["title"] == f"{YALE_ACCESS_LOCK_DISCOVERY_INFO.name} (EEFF)"
     assert user_flow_result["data"] == {
         CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
         CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,

--- a/tests/components/yalexs_ble/test_config_flow.py
+++ b/tests/components/yalexs_ble/test_config_flow.py
@@ -676,6 +676,60 @@ async def test_integration_discovery_takes_precedence_over_bluetooth(
     assert len(flows) == 0
 
 
+async def test_bluetooth_discovery_with_cached_config(
+    hass: HomeAssistant,
+) -> None:
+    """Test bluetooth discovery when validated config is already in cache."""
+    # First, populate the cache via integration discovery
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={
+            "name": "Front Door",
+            "address": YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+            "key": "2fd51b8621c6a139eaffbedcb846b60f",
+            "slot": 66,
+            "serial": "M1XXX012LU",
+        },
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+
+    # Now do bluetooth discovery with the cached config
+    with patch(
+        "homeassistant.components.yalexs_ble.PushLock.validate",
+        return_value=None,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_BLUETOOTH},
+            data=YALE_ACCESS_LOCK_DISCOVERY_INFO,
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "integration_discovery_confirm"
+    assert result["description_placeholders"] == {
+        "name": "Front Door",
+        "address": YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+    }
+
+    # Confirm the discovery
+    with patch(
+        "homeassistant.components.yalexs_ble.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Front Door"
+    assert result["data"] == {
+        CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
+        CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+        CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
+        CONF_SLOT: 66,
+    }
+
+
 async def test_integration_discovery_updates_key_unique_local_name(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes an issue where Yale Access Bluetooth (yalexs_ble) integration fails to automatically use keys discovered by the August/Yale cloud integrations when the lock is temporarily out of Bluetooth range during key discovery.

The problem occurs because key discovery is timing-dependent - if the lock isn't in Bluetooth range at the exact moment the cloud integration discovers the key, that key is lost and users must manually enter it. This leads to frustration when keys rotate or when setting up Bluetooth after cloud integration.

The fix implements a persistent cache for discovered lock keys that solves two critical timing issues:
1. **Lock out of range during discovery** - Keys discovered by cloud integrations are cached and automatically used when the lock comes back into Bluetooth range, even hours or days later
2. **Key rotation** - When keys rotate for security, the new keys are cached and automatically applied to existing Bluetooth connections that fail with old keys at setup time (if they change later after its setup we still don't update them, but that would be too invasive a change for a bug fix).

Changes:
- Added config cache that stores validated lock configurations when discovered by cloud integrations
- Automatic key refresh from cache when authentication fails due to rotated keys
- Use of cached keys during initial setup flow to avoid manual entry
- Improved config flow that separates device selection from key entry - only prompts for keys when not already cached, avoiding unnecessary manual entry
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #149690
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr