### PR TITLE
Add bluetooth websocket_api to subscribe to scanner state

### DIFF
--- a/homeassistant/components/bluetooth/websocket_api.py
+++ b/homeassistant/components/bluetooth/websocket_api.py
@@ -8,8 +8,10 @@ import time
 from typing import Any
 
 from habluetooth import (
+    BaseHaScanner,
     BluetoothScanningMode,
     HaBluetoothSlotAllocations,
+    HaScannerModeChange,
     HaScannerRegistration,
     HaScannerRegistrationEvent,
 )
@@ -28,11 +30,56 @@ from .util import InvalidConfigEntryID, InvalidSource, config_entry_id_to_source
 
 
 @callback
+def _async_get_source_from_config_entry(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg_id: int,
+    config_entry_id: str | None,
+    validate_source: bool = True,
+) -> str | None:
+    """Get source from config entry id.
+
+    Returns None if no config_entry_id provided or on error (after sending error response).
+    If validate_source is True, also validates that the scanner exists.
+    """
+    if not config_entry_id:
+        return None
+
+    if validate_source:
+        # Use the full validation that checks if scanner exists
+        try:
+            source = config_entry_id_to_source(hass, config_entry_id)
+        except InvalidConfigEntryID as err:
+            connection.send_error(msg_id, "invalid_config_entry_id", str(err))
+            return None
+        except InvalidSource as err:
+            connection.send_error(msg_id, "invalid_source", str(err))
+            return None
+    else:
+        # Just check if config entry exists and belongs to bluetooth
+        if (
+            not (entry := hass.config_entries.async_get_entry(config_entry_id))
+            or entry.domain != DOMAIN
+        ):
+            connection.send_error(
+                msg_id,
+                "invalid_config_entry_id",
+                f"Invalid config entry id: {config_entry_id}",
+            )
+            return None
+        assert entry.unique_id is not None
+        source = entry.unique_id
+
+    return source
+
+
+@callback
 def async_setup(hass: HomeAssistant) -> None:
     """Set up the bluetooth websocket API."""
     websocket_api.async_register_command(hass, ws_subscribe_advertisements)
     websocket_api.async_register_command(hass, ws_subscribe_connection_allocations)
     websocket_api.async_register_command(hass, ws_subscribe_scanner_details)
+    websocket_api.async_register_command(hass, ws_subscribe_scanner_state)
 
 
 @lru_cache(maxsize=1024)
@@ -180,16 +227,12 @@ async def ws_subscribe_connection_allocations(
 ) -> None:
     """Handle subscribe advertisements websocket command."""
     ws_msg_id = msg["id"]
-    source: str | None = None
-    if config_entry_id := msg.get("config_entry_id"):
-        try:
-            source = config_entry_id_to_source(hass, config_entry_id)
-        except InvalidConfigEntryID as err:
-            connection.send_error(ws_msg_id, "invalid_config_entry_id", str(err))
-            return
-        except InvalidSource as err:
-            connection.send_error(ws_msg_id, "invalid_source", str(err))
-            return
+    config_entry_id = msg.get("config_entry_id")
+    source = _async_get_source_from_config_entry(
+        hass, connection, ws_msg_id, config_entry_id
+    )
+    if config_entry_id and source is None:
+        return  # Error already sent by helper
 
     def _async_allocations_changed(allocations: HaBluetoothSlotAllocations) -> None:
         connection.send_message(
@@ -220,20 +263,12 @@ async def ws_subscribe_scanner_details(
 ) -> None:
     """Handle subscribe scanner details websocket command."""
     ws_msg_id = msg["id"]
-    source: str | None = None
-    if config_entry_id := msg.get("config_entry_id"):
-        if (
-            not (entry := hass.config_entries.async_get_entry(config_entry_id))
-            or entry.domain != DOMAIN
-        ):
-            connection.send_error(
-                ws_msg_id,
-                "invalid_config_entry_id",
-                f"Invalid config entry id: {config_entry_id}",
-            )
-            return
-        source = entry.unique_id
-        assert source is not None
+    config_entry_id = msg.get("config_entry_id")
+    source = _async_get_source_from_config_entry(
+        hass, connection, ws_msg_id, config_entry_id, validate_source=False
+    )
+    if config_entry_id and source is None:
+        return  # Error already sent by helper
 
     def _async_event_message(message: dict[str, Any]) -> None:
         connection.send_message(
@@ -260,3 +295,70 @@ async def ws_subscribe_scanner_details(
         ]
     ):
         _async_event_message({"add": matching_scanners})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "bluetooth/subscribe_scanner_state",
+        vol.Optional("config_entry_id"): str,
+    }
+)
+@websocket_api.async_response
+async def ws_subscribe_scanner_state(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Handle subscribe scanner state websocket command."""
+    ws_msg_id = msg["id"]
+    config_entry_id = msg.get("config_entry_id")
+    source = _async_get_source_from_config_entry(
+        hass, connection, ws_msg_id, config_entry_id
+    )
+    if config_entry_id and source is None:
+        return  # Error already sent by helper
+
+    @callback
+    def _async_send_scanner_state(
+        scanner: BaseHaScanner,
+        current_mode: BluetoothScanningMode | None,
+        requested_mode: BluetoothScanningMode | None,
+    ) -> None:
+        payload = {
+            "source": scanner.source,
+            "adapter": scanner.adapter,
+            "current_mode": current_mode.value if current_mode else None,
+            "requested_mode": requested_mode.value if requested_mode else None,
+        }
+        connection.send_message(
+            json_bytes(
+                websocket_api.event_message(
+                    ws_msg_id,
+                    payload,
+                )
+            )
+        )
+
+    @callback
+    def _async_scanner_state_changed(mode_change: HaScannerModeChange) -> None:
+        _async_send_scanner_state(
+            mode_change.scanner,
+            mode_change.current_mode,
+            mode_change.requested_mode,
+        )
+
+    manager = _get_manager(hass)
+    connection.subscriptions[ws_msg_id] = (
+        manager.async_register_scanner_mode_change_callback(
+            _async_scanner_state_changed, source
+        )
+    )
+    connection.send_message(json_bytes(websocket_api.result_message(ws_msg_id)))
+
+    # Send initial state for all matching scanners
+    for scanner in manager.async_current_scanners():
+        if source is None or scanner.source == source:
+            _async_send_scanner_state(
+                scanner,
+                scanner.current_mode,
+                scanner.requested_mode,
+            )

--- a/homeassistant/components/bluetooth/websocket_api.py
+++ b/homeassistant/components/bluetooth/websocket_api.py
@@ -64,7 +64,7 @@ def _async_get_source_from_config_entry(
         connection.send_error(
             msg_id,
             "invalid_config_entry_id",
-            f"Invalid config entry id: {config_entry_id}",
+            f"Config entry {config_entry_id} not found",
         )
         return None
     return entry.unique_id

--- a/homeassistant/components/bluetooth/websocket_api.py
+++ b/homeassistant/components/bluetooth/websocket_api.py
@@ -48,29 +48,26 @@ def _async_get_source_from_config_entry(
     if validate_source:
         # Use the full validation that checks if scanner exists
         try:
-            source = config_entry_id_to_source(hass, config_entry_id)
+            return config_entry_id_to_source(hass, config_entry_id)
         except InvalidConfigEntryID as err:
             connection.send_error(msg_id, "invalid_config_entry_id", str(err))
             return None
         except InvalidSource as err:
             connection.send_error(msg_id, "invalid_source", str(err))
             return None
-    else:
-        # Just check if config entry exists and belongs to bluetooth
-        if (
-            not (entry := hass.config_entries.async_get_entry(config_entry_id))
-            or entry.domain != DOMAIN
-        ):
-            connection.send_error(
-                msg_id,
-                "invalid_config_entry_id",
-                f"Invalid config entry id: {config_entry_id}",
-            )
-            return None
-        assert entry.unique_id is not None
-        source = entry.unique_id
 
-    return source
+    # Just check if config entry exists and belongs to bluetooth
+    if (
+        not (entry := hass.config_entries.async_get_entry(config_entry_id))
+        or entry.domain != DOMAIN
+    ):
+        connection.send_error(
+            msg_id,
+            "invalid_config_entry_id",
+            f"Invalid config entry id: {config_entry_id}",
+        )
+        return None
+    return entry.unique_id
 
 
 @callback

--- a/homeassistant/components/bluetooth/websocket_api.py
+++ b/homeassistant/components/bluetooth/websocket_api.py
@@ -308,6 +308,7 @@ async def ws_subscribe_scanner_state(
     """Handle subscribe scanner state websocket command."""
     ws_msg_id = msg["id"]
     config_entry_id = msg.get("config_entry_id")
+    source = _async_get_source_from_config_entry(
         hass, connection, ws_msg_id, config_entry_id, validate_source=False
     )
     if config_entry_id and source is None:

--- a/homeassistant/components/bluetooth/websocket_api.py
+++ b/homeassistant/components/bluetooth/websocket_api.py
@@ -308,8 +308,7 @@ async def ws_subscribe_scanner_state(
     """Handle subscribe scanner state websocket command."""
     ws_msg_id = msg["id"]
     config_entry_id = msg.get("config_entry_id")
-    source = _async_get_source_from_config_entry(
-        hass, connection, ws_msg_id, config_entry_id
+        hass, connection, ws_msg_id, config_entry_id, validate_source=False
     )
     if config_entry_id and source is None:
         return  # Error already sent by helper

--- a/tests/components/bluetooth/test_websocket_api.py
+++ b/tests/components/bluetooth/test_websocket_api.py
@@ -436,7 +436,7 @@ async def test_subscribe_scanner_details_invalid_config_entry_id(
         response = await client.receive_json()
     assert not response["success"]
     assert response["error"]["code"] == "invalid_config_entry_id"
-    assert response["error"]["message"] == "Invalid config entry id: non_existent"
+    assert response["error"]["message"] == "Config entry non_existent not found"
 
 
 @pytest.mark.usefixtures("enable_bluetooth")

--- a/tests/components/bluetooth/test_websocket_api.py
+++ b/tests/components/bluetooth/test_websocket_api.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, patch
 
 from bleak_retry_connector import Allocations
 from freezegun import freeze_time
+from habluetooth import BluetoothScanningMode
 import pytest
 
 from homeassistant.components.bluetooth import DOMAIN
@@ -436,3 +437,125 @@ async def test_subscribe_scanner_details_invalid_config_entry_id(
     assert not response["success"]
     assert response["error"]["code"] == "invalid_config_entry_id"
     assert response["error"]["message"] == "Invalid config entry id: non_existent"
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_subscribe_scanner_state(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test bluetooth subscribe_scanner_state."""
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "bluetooth/subscribe_scanner_state",
+        }
+    )
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["success"]
+
+    # Should receive initial state for existing scanner
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["event"] == {
+        "source": "00:00:00:00:00:01",
+        "adapter": "hci0",
+        "current_mode": "active",
+        "requested_mode": "active",
+    }
+
+    # Register a new scanner
+    manager = _get_manager()
+    hci3_scanner = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
+    cancel_hci3 = manager.async_register_hass_scanner(hci3_scanner)
+
+    # Simulate a mode change
+    hci3_scanner.current_mode = BluetoothScanningMode.ACTIVE
+    hci3_scanner.requested_mode = BluetoothScanningMode.ACTIVE
+    manager.scanner_mode_changed(hci3_scanner)
+
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["event"] == {
+        "source": "AA:BB:CC:DD:EE:33",
+        "adapter": "hci3",
+        "current_mode": "active",
+        "requested_mode": "active",
+    }
+
+    cancel_hci3()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_subscribe_scanner_state_specific_scanner(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test bluetooth subscribe_scanner_state for a specific source address."""
+    # Register the scanner first
+    manager = _get_manager()
+    hci3_scanner = FakeScanner("AA:BB:CC:DD:EE:33", "hci3")
+    cancel_hci3 = manager.async_register_hass_scanner(hci3_scanner)
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="AA:BB:CC:DD:EE:33")
+    entry.add_to_hass(hass)
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "bluetooth/subscribe_scanner_state",
+            "config_entry_id": entry.entry_id,
+        }
+    )
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["success"]
+
+    # Should receive initial state
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["event"] == {
+        "source": "AA:BB:CC:DD:EE:33",
+        "adapter": "hci3",
+        "current_mode": None,
+        "requested_mode": None,
+    }
+
+    # Simulate a mode change
+    hci3_scanner.current_mode = BluetoothScanningMode.PASSIVE
+    hci3_scanner.requested_mode = BluetoothScanningMode.ACTIVE
+    manager.scanner_mode_changed(hci3_scanner)
+
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert response["event"] == {
+        "source": "AA:BB:CC:DD:EE:33",
+        "adapter": "hci3",
+        "current_mode": "passive",
+        "requested_mode": "active",
+    }
+
+    cancel_hci3()
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_subscribe_scanner_state_invalid_config_entry_id(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test bluetooth subscribe_scanner_state for an invalid config entry id."""
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "bluetooth/subscribe_scanner_state",
+            "config_entry_id": "non_existent",
+        }
+    )
+    async with asyncio.timeout(1):
+        response = await client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "invalid_config_entry_id"
+    assert response["error"]["message"] == "Config entry non_existent not found"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The goal is to make it more obvious if the scanner is doing passive or active scans, and if there is a problem trying to start scans because the requested mode doesn't match the current mode.

`habluetooth` recently added support for watching / subscribing to mode changes so we can now get this into the UI.

frontend PR https://github.com/home-assistant/frontend/pull/26792

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
