### PR TITLE
Bump airOS to 0.5.1

### DIFF
--- a/homeassistant/components/airos/__init__.py
+++ b/homeassistant/components/airos/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from airos.airos8 import AirOS
+from airos.airos8 import AirOS8
 
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
@@ -23,7 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> boo
     # with no option in the web UI to change or upload a custom certificate.
     session = async_get_clientsession(hass, verify_ssl=False)
 
-    airos_device = AirOS(
+    airos_device = AirOS8(
         host=entry.data[CONF_HOST],
         username=entry.data[CONF_USERNAME],
         password=entry.data[CONF_PASSWORD],

--- a/homeassistant/components/airos/binary_sensor.py
+++ b/homeassistant/components/airos/binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import AirOSConfigEntry, AirOSData, AirOSDataUpdateCoordinator
+from .coordinator import AirOS8Data, AirOSConfigEntry, AirOSDataUpdateCoordinator
 from .entity import AirOSEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ PARALLEL_UPDATES = 0
 class AirOSBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describe an AirOS binary sensor."""
 
-    value_fn: Callable[[AirOSData], bool]
+    value_fn: Callable[[AirOS8Data], bool]
 
 
 BINARY_SENSORS: tuple[AirOSBinarySensorEntityDescription, ...] = (

--- a/homeassistant/components/airos/config_flow.py
+++ b/homeassistant/components/airos/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
-from .coordinator import AirOS
+from .coordinator import AirOS8
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class AirOSConfigFlow(ConfigFlow, domain=DOMAIN):
             # with no option in the web UI to change or upload a custom certificate.
             session = async_get_clientsession(self.hass, verify_ssl=False)
 
-            airos_device = AirOS(
+            airos_device = AirOS8(
                 host=user_input[CONF_HOST],
                 username=user_input[CONF_USERNAME],
                 password=user_input[CONF_PASSWORD],

--- a/homeassistant/components/airos/coordinator.py
+++ b/homeassistant/components/airos/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from airos.airos8 import AirOS, AirOSData
+from airos.airos8 import AirOS8, AirOS8Data
 from airos.exceptions import (
     AirOSConnectionAuthenticationError,
     AirOSConnectionSetupError,
@@ -24,13 +24,13 @@ _LOGGER = logging.getLogger(__name__)
 type AirOSConfigEntry = ConfigEntry[AirOSDataUpdateCoordinator]
 
 
-class AirOSDataUpdateCoordinator(DataUpdateCoordinator[AirOSData]):
+class AirOSDataUpdateCoordinator(DataUpdateCoordinator[AirOS8Data]):
     """Class to manage fetching AirOS data from single endpoint."""
 
     config_entry: AirOSConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: AirOSConfigEntry, airos_device: AirOS
+        self, hass: HomeAssistant, config_entry: AirOSConfigEntry, airos_device: AirOS8
     ) -> None:
         """Initialize the coordinator."""
         self.airos_device = airos_device
@@ -42,7 +42,7 @@ class AirOSDataUpdateCoordinator(DataUpdateCoordinator[AirOSData]):
             update_interval=SCAN_INTERVAL,
         )
 
-    async def _async_update_data(self) -> AirOSData:
+    async def _async_update_data(self) -> AirOS8Data:
         """Fetch data from AirOS."""
         try:
             await self.airos_device.login()

--- a/homeassistant/components/airos/manifest.json
+++ b/homeassistant/components/airos/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airos",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["airos==0.4.4"]
+  "requirements": ["airos==0.5.1"]
 }

--- a/homeassistant/components/airos/sensor.py
+++ b/homeassistant/components/airos/sensor.py
@@ -26,7 +26,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .coordinator import AirOSConfigEntry, AirOSData, AirOSDataUpdateCoordinator
+from .coordinator import AirOS8Data, AirOSConfigEntry, AirOSDataUpdateCoordinator
 from .entity import AirOSEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ PARALLEL_UPDATES = 0
 class AirOSSensorEntityDescription(SensorEntityDescription):
     """Describe an AirOS sensor."""
 
-    value_fn: Callable[[AirOSData], StateType]
+    value_fn: Callable[[AirOS8Data], StateType]
 
 
 SENSORS: tuple[AirOSSensorEntityDescription, ...] = (

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -453,7 +453,7 @@ airgradient==0.9.2
 airly==1.1.0
 
 # homeassistant.components.airos
-airos==0.4.4
+airos==0.5.1
 
 # homeassistant.components.airthings_ble
 airthings-ble==0.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -435,7 +435,7 @@ airgradient==0.9.2
 airly==1.1.0
 
 # homeassistant.components.airos
-airos==0.4.4
+airos==0.5.1
 
 # homeassistant.components.airthings_ble
 airthings-ble==0.9.2

--- a/tests/components/airos/conftest.py
+++ b/tests/components/airos/conftest.py
@@ -3,7 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
-from airos.airos8 import AirOSData
+from airos.airos8 import AirOS8Data
 import pytest
 
 from homeassistant.components.airos.const import DOMAIN
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 def ap_fixture():
     """Load fixture data for AP mode."""
     json_data = load_json_object_fixture("airos_loco5ac_ap-ptp.json", DOMAIN)
-    return AirOSData.from_dict(json_data)
+    return AirOS8Data.from_dict(json_data)
 
 
 @pytest.fixture
@@ -30,15 +30,15 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 @pytest.fixture
 def mock_airos_client(
-    request: pytest.FixtureRequest, ap_fixture: AirOSData
+    request: pytest.FixtureRequest, ap_fixture: AirOS8Data
 ) -> Generator[AsyncMock]:
     """Fixture to mock the AirOS API client."""
     with (
         patch(
-            "homeassistant.components.airos.config_flow.AirOS", autospec=True
+            "homeassistant.components.airos.config_flow.AirOS8", autospec=True
         ) as mock_airos,
-        patch("homeassistant.components.airos.coordinator.AirOS", new=mock_airos),
-        patch("homeassistant.components.airos.AirOS", new=mock_airos),
+        patch("homeassistant.components.airos.coordinator.AirOS8", new=mock_airos),
+        patch("homeassistant.components.airos.AirOS8", new=mock_airos),
     ):
         client = mock_airos.return_value
         client.status.return_value = ap_fixture

--- a/tests/components/airos/test_diagnostics.py
+++ b/tests/components/airos/test_diagnostics.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.airos.coordinator import AirOSData
+from homeassistant.components.airos.coordinator import AirOS8Data
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
@@ -19,7 +19,7 @@ async def test_diagnostics(
     hass_client: ClientSessionGenerator,
     mock_airos_client: MagicMock,
     mock_config_entry: MockConfigEntry,
-    ap_fixture: AirOSData,
+    ap_fixture: AirOS8Data,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Bump airOS to 0.5.1 paving the way for initial firmware v6 support (which is sufficient for binary_sensor/sensor currently available from HA). 

Outlook: Before v6 can be introduced there needs to be a migration (v6 doesn't have `device_id` property which I didn't change to `mac`-address for both entity and binary_sensor. This is not (yet) included to remain just a dependency update.

[Markdown changelo](https://github.com/CoMPaTech/python-airos/blob/main/CHANGELOG.md) - [Github release changelog](https://github.com/CoMPaTech/python-airos/compare/v0.4.4...v0.5.1) - readers notes 0.5.0 potentially introduced mypy issues within HA, hence never released).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/151348
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
