### PR TITLE
Allow port and SNMP community configuration for Brother printer

### DIFF
--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from brother import Brother, SnmpError
 
 from homeassistant.components.snmp import async_get_snmp_engine
-from homeassistant.const import CONF_HOST, CONF_TYPE, Platform
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
+from .const import CONF_COMMUNITY, DEFAULT_COMMUNITY, DEFAULT_PORT, DOMAIN
 from .coordinator import BrotherConfigEntry, BrotherDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -18,12 +18,14 @@ PLATFORMS = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> bool:
     """Set up Brother from a config entry."""
     host = entry.data[CONF_HOST]
+    port = entry.data.get(CONF_PORT, DEFAULT_PORT)
+    community = entry.data.get(CONF_COMMUNITY, DEFAULT_COMMUNITY)
     printer_type = entry.data[CONF_TYPE]
 
     snmp_engine = await async_get_snmp_engine(hass)
     try:
         brother = await Brother.create(
-            host, printer_type=printer_type, snmp_engine=snmp_engine
+            host, port, community, printer_type=printer_type, snmp_engine=snmp_engine
         )
     except (ConnectionError, SnmpError, TimeoutError) as error:
         raise ConfigEntryNotReady(

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -17,9 +17,16 @@ PLATFORMS = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> bool:
     """Set up Brother from a config entry."""
+    # Update config entry to ensure COMMUNITY and PORT are present
+    if CONF_COMMUNITY not in entry.data:
+        new_data = entry.data.copy()
+        new_data[CONF_COMMUNITY] = DEFAULT_COMMUNITY
+        new_data[CONF_PORT] = DEFAULT_PORT
+        hass.config_entries.async_update_entry(entry, data=new_data)
+
     host = entry.data[CONF_HOST]
-    port = entry.data.get(CONF_PORT, DEFAULT_PORT)
-    community = entry.data.get(CONF_COMMUNITY, DEFAULT_COMMUNITY)
+    port = entry.data[CONF_PORT]
+    community = entry.data[CONF_COMMUNITY]
     printer_type = entry.data[CONF_TYPE]
 
     snmp_engine = await async_get_snmp_engine(hass)

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -9,7 +9,13 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import CONF_COMMUNITY, DEFAULT_COMMUNITY, DEFAULT_PORT, DOMAIN
+from .const import (
+    CONF_COMMUNITY,
+    DEFAULT_COMMUNITY,
+    DEFAULT_PORT,
+    DOMAIN,
+    SECTION_ADVANCED_SETTINGS,
+)
 from .coordinator import BrotherConfigEntry, BrotherDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -18,15 +24,17 @@ PLATFORMS = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> bool:
     """Set up Brother from a config entry."""
     # Update config entry to ensure COMMUNITY and PORT are present
-    if CONF_COMMUNITY not in entry.data:
+    if SECTION_ADVANCED_SETTINGS not in entry.data:
         new_data = entry.data.copy()
-        new_data[CONF_COMMUNITY] = DEFAULT_COMMUNITY
-        new_data[CONF_PORT] = DEFAULT_PORT
+        new_data[SECTION_ADVANCED_SETTINGS] = {
+            CONF_PORT: DEFAULT_PORT,
+            CONF_COMMUNITY: DEFAULT_COMMUNITY,
+        }
         hass.config_entries.async_update_entry(entry, data=new_data)
 
     host = entry.data[CONF_HOST]
-    port = entry.data[CONF_PORT]
-    community = entry.data[CONF_COMMUNITY]
+    port = entry.data[SECTION_ADVANCED_SETTINGS][CONF_PORT]
+    community = entry.data[SECTION_ADVANCED_SETTINGS][CONF_COMMUNITY]
     printer_type = entry.data[CONF_TYPE]
 
     snmp_engine = await async_get_snmp_engine(hass)

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -9,21 +9,42 @@ import voluptuous as vol
 
 from homeassistant.components.snmp import async_get_snmp_engine
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_TYPE
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util.network import is_host_valid
 
-from .const import DOMAIN, PRINTER_TYPES
+from .const import (
+    CONF_COMMUNITY,
+    DEFAULT_COMMUNITY,
+    DEFAULT_PORT,
+    DOMAIN,
+    PRINTER_TYPES,
+)
 
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): str,
         vol.Optional(CONF_TYPE, default="laser"): vol.In(PRINTER_TYPES),
     }
 )
-RECONFIGURE_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+ZEROCONF_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): str,
+        vol.Optional(CONF_TYPE, default="laser"): vol.In(PRINTER_TYPES),
+    }
+)
+RECONFIGURE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): str,
+    }
+)
 
 
 async def validate_input(
@@ -35,7 +56,12 @@ async def validate_input(
 
     snmp_engine = await async_get_snmp_engine(hass)
 
-    brother = await Brother.create(user_input[CONF_HOST], snmp_engine=snmp_engine)
+    brother = await Brother.create(
+        user_input[CONF_HOST],
+        user_input[CONF_PORT],
+        user_input[CONF_COMMUNITY],
+        snmp_engine=snmp_engine,
+    )
     await brother.async_update()
 
     if expected_mac is not None and brother.serial.lower() != expected_mac:
@@ -126,13 +152,11 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
             title = f"{self.brother.model} {self.brother.serial}"
             return self.async_create_entry(
                 title=title,
-                data={CONF_HOST: self.host, CONF_TYPE: user_input[CONF_TYPE]},
+                data={CONF_HOST: self.host, **user_input},
             )
         return self.async_show_form(
             step_id="zeroconf_confirm",
-            data_schema=vol.Schema(
-                {vol.Optional(CONF_TYPE, default="laser"): vol.In(PRINTER_TYPES)}
-            ),
+            data_schema=ZEROCONF_SCHEMA,
             description_placeholders={
                 "serial_number": self.brother.serial,
                 "model": self.brother.model,
@@ -160,7 +184,7 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 return self.async_update_reload_and_abort(
                     entry,
-                    data_updates={CONF_HOST: user_input[CONF_HOST]},
+                    data_updates=user_input,
                 )
 
         return self.async_show_form(

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.snmp import async_get_snmp_engine
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import section
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util.network import is_host_valid
@@ -21,28 +22,50 @@ from .const import (
     DEFAULT_PORT,
     DOMAIN,
     PRINTER_TYPES,
+    SECTION_ADVANCED_SETTINGS,
 )
 
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
-        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-        vol.Required(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): str,
         vol.Optional(CONF_TYPE, default="laser"): vol.In(PRINTER_TYPES),
+        vol.Required(SECTION_ADVANCED_SETTINGS): section(
+            vol.Schema(
+                {
+                    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+                    vol.Required(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): str,
+                },
+            ),
+            {"collapsed": True},
+        ),
     }
 )
 ZEROCONF_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-        vol.Required(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): str,
         vol.Optional(CONF_TYPE, default="laser"): vol.In(PRINTER_TYPES),
+        vol.Required(SECTION_ADVANCED_SETTINGS): section(
+            vol.Schema(
+                {
+                    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+                    vol.Required(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): str,
+                },
+            ),
+            {"collapsed": True},
+        ),
     }
 )
 RECONFIGURE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
-        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-        vol.Required(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): str,
+        vol.Required(SECTION_ADVANCED_SETTINGS): section(
+            vol.Schema(
+                {
+                    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+                    vol.Required(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): str,
+                },
+            ),
+            {"collapsed": True},
+        ),
     }
 )
 
@@ -58,8 +81,8 @@ async def validate_input(
 
     brother = await Brother.create(
         user_input[CONF_HOST],
-        user_input[CONF_PORT],
-        user_input[CONF_COMMUNITY],
+        user_input[SECTION_ADVANCED_SETTINGS][CONF_PORT],
+        user_input[SECTION_ADVANCED_SETTINGS][CONF_COMMUNITY],
         snmp_engine=snmp_engine,
     )
     await brother.async_update()

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -97,6 +97,7 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Brother Printer."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize."""

--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -10,3 +10,8 @@ DOMAIN: Final = "brother"
 PRINTER_TYPES: Final = ["laser", "ink"]
 
 UPDATE_INTERVAL = timedelta(seconds=30)
+
+CONF_COMMUNITY = "community"
+
+DEFAULT_COMMUNITY = "public"
+DEFAULT_PORT = 161

--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -11,6 +11,8 @@ PRINTER_TYPES: Final = ["laser", "ink"]
 
 UPDATE_INTERVAL = timedelta(seconds=30)
 
+SECTION_ADVANCED_SETTINGS = "advanced_settings"
+
 CONF_COMMUNITY = "community"
 
 DEFAULT_COMMUNITY = "public"

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -12,8 +12,8 @@
         "data_description": {
           "host": "The hostname or IP address of the Brother printer to control.",
           "port": "The SNMP port of the Brother printer.",
-          "community": "The SNMP Community string.",
-          "type": "Brother printer type."
+          "community": "A simple password for devices to communicate to each other.",
+          "type": "Brother printer type: ink or laser."
         }
       },
       "zeroconf_confirm": {

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -5,42 +5,69 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]",
-          "community": "SNMP Community",
           "type": "Type of the printer"
         },
         "data_description": {
           "host": "The hostname or IP address of the Brother printer to control.",
-          "port": "The SNMP port of the Brother printer.",
-          "community": "A simple password for devices to communicate to each other.",
           "type": "Brother printer type: ink or laser."
+        },
+        "sections": {
+          "advanced_settings": {
+            "name": "Advanced settings",
+            "data": {
+              "port": "[%key:common::config_flow::data::port%]",
+              "community": "SNMP Community"
+            },
+            "data_description": {
+              "port": "The SNMP port of the Brother printer.",
+              "community": "A simple password for devices to communicate to each other."
+            }
+          }
         }
       },
       "zeroconf_confirm": {
         "description": "Do you want to add the printer {model} with serial number `{serial_number}` to Home Assistant?",
         "title": "Discovered Brother Printer",
         "data": {
-          "port": "[%key:common::config_flow::data::port%]",
-          "community": "[%key:component::brother::config::step::user::data::community%]",
           "type": "[%key:component::brother::config::step::user::data::type%]"
         },
         "data_description": {
-          "port": "[%key:component::brother::config::step::user::data_description::port%]",
-          "community": "[%key:component::brother::config::step::user::data_description::community%]",
           "type": "[%key:component::brother::config::step::user::data_description::type%]"
+        },
+        "sections": {
+          "advanced_settings": {
+            "name": "Advanced settings",
+            "data": {
+              "port": "[%key:common::config_flow::data::port%]",
+              "community": "SNMP Community"
+            },
+            "data_description": {
+              "port": "The SNMP port of the Brother printer.",
+              "community": "A simple password for devices to communicate to each other."
+            }
+          }
         }
       },
       "reconfigure": {
         "description": "Update configuration for {printer_name}.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]",
-          "community": "[%key:component::brother::config::step::user::data::community%]"
+          "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "[%key:component::brother::config::step::user::data_description::host%]",
-          "port": "[%key:component::brother::config::step::user::data_description::port%]",
-          "community": "[%key:component::brother::config::step::user::data_description::community%]"
+          "host": "[%key:component::brother::config::step::user::data_description::host%]"
+        },
+        "sections": {
+          "advanced_settings": {
+            "name": "Advanced settings",
+            "data": {
+              "port": "[%key:common::config_flow::data::port%]",
+              "community": "SNMP Community"
+            },
+            "data_description": {
+              "port": "The SNMP port of the Brother printer.",
+              "community": "A simple password for devices to communicate to each other."
+            }
+          }
         }
       }
     },

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -5,26 +5,44 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "community": "SNMP Community",
           "type": "Type of the printer"
         },
         "data_description": {
-          "host": "The hostname or IP address of the Brother printer to control."
+          "host": "The hostname or IP address of the Brother printer to control.",
+          "port": "The SNMP port of your printer.",
+          "community": "The SNMP community string.",
+          "type": "Brother printer type."
         }
       },
       "zeroconf_confirm": {
         "description": "Do you want to add the printer {model} with serial number `{serial_number}` to Home Assistant?",
         "title": "Discovered Brother Printer",
         "data": {
+          "port": "[%key:common::config_flow::data::port%]",
+          "community": "[%key:component::brother::config::step::user::data::community%]",
           "type": "[%key:component::brother::config::step::user::data::type%]"
+        },
+        "data_description": {
+          "host": "[%key:component::brother::config::step::user::data_description::host%]",
+          "port": "[%key:component::brother::config::step::user::data_description::port%]",
+          "community": "[%key:component::brother::config::step::user::data_description::community%]",
+          "type": "[%key:component::brother::config::step::user::data_description::type%]"
         }
       },
       "reconfigure": {
         "description": "Update configuration for {printer_name}.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "community": "[%key:component::brother::config::step::user::data::community%]"
         },
         "data_description": {
-          "host": "[%key:component::brother::config::step::user::data_description::host%]"
+          "host": "[%key:component::brother::config::step::user::data_description::host%]",
+          "port": "[%key:component::brother::config::step::user::data_description::port%]",
+          "community": "[%key:component::brother::config::step::user::data_description::community%]",
+          "type": "[%key:component::brother::config::step::user::data_description::type%]"
         }
       }
     },

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -11,8 +11,8 @@
         },
         "data_description": {
           "host": "The hostname or IP address of the Brother printer to control.",
-          "port": "The SNMP port of your printer.",
-          "community": "The SNMP community string.",
+          "port": "The SNMP port of the Brother printer.",
+          "community": "The SNMP Community string.",
           "type": "Brother printer type."
         }
       },

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -25,7 +25,6 @@
           "type": "[%key:component::brother::config::step::user::data::type%]"
         },
         "data_description": {
-          "host": "[%key:component::brother::config::step::user::data_description::host%]",
           "port": "[%key:component::brother::config::step::user::data_description::port%]",
           "community": "[%key:component::brother::config::step::user::data_description::community%]",
           "type": "[%key:component::brother::config::step::user::data_description::type%]"
@@ -41,8 +40,7 @@
         "data_description": {
           "host": "[%key:component::brother::config::step::user::data_description::host%]",
           "port": "[%key:component::brother::config::step::user::data_description::port%]",
-          "community": "[%key:component::brother::config::step::user::data_description::community%]",
-          "type": "[%key:component::brother::config::step::user::data_description::type%]"
+          "community": "[%key:component::brother::config::step::user::data_description::community%]"
         }
       }
     },

--- a/tests/components/brother/conftest.py
+++ b/tests/components/brother/conftest.py
@@ -7,8 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from brother import BrotherSensors
 import pytest
 
-from homeassistant.components.brother.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_TYPE
+from homeassistant.components.brother.const import (
+    CONF_COMMUNITY,
+    DOMAIN,
+    SECTION_ADVANCED_SETTINGS,
+)
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 
 from tests.common import MockConfigEntry
 
@@ -122,5 +126,10 @@ def mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         title="HL-L2340DW 0123456789",
         unique_id="0123456789",
-        data={CONF_HOST: "localhost", CONF_TYPE: "laser"},
+        data={
+            CONF_HOST: "localhost",
+            CONF_TYPE: "laser",
+            SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        },
+        minor_version=2,
     )

--- a/tests/components/brother/snapshots/test_diagnostics.ambr
+++ b/tests/components/brother/snapshots/test_diagnostics.ambr
@@ -66,9 +66,11 @@
     }),
     'firmware': '1.2.3',
     'info': dict({
-      'community': 'public',
+      'advanced_settings': dict({
+        'community': 'public',
+        'port': 161,
+      }),
       'host': 'localhost',
-      'port': 161,
       'type': 'laser',
     }),
     'model': 'HL-L2340DW',

--- a/tests/components/brother/snapshots/test_diagnostics.ambr
+++ b/tests/components/brother/snapshots/test_diagnostics.ambr
@@ -66,7 +66,9 @@
     }),
     'firmware': '1.2.3',
     'info': dict({
+      'community': 'public',
       'host': 'localhost',
+      'port': 161,
       'type': 'laser',
     }),
     'model': 'HL-L2340DW',

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, patch
 from brother import SnmpError, UnsupportedModelError
 import pytest
 
-from homeassistant.components.brother.const import CONF_COMMUNITY, DOMAIN
+from homeassistant.components.brother.const import (
+    CONF_COMMUNITY,
+    DOMAIN,
+    SECTION_ADVANCED_SETTINGS,
+)
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
@@ -19,9 +23,8 @@ from tests.common import MockConfigEntry
 
 CONFIG = {
     CONF_HOST: "127.0.0.1",
-    CONF_PORT: 161,
-    CONF_COMMUNITY: "public",
     CONF_TYPE: "laser",
+    SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
 }
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry", "mock_unload_entry")
@@ -54,9 +57,9 @@ async def test_create_entry(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "HL-L2340DW 0123456789"
     assert result["data"][CONF_HOST] == host
-    assert result["data"][CONF_PORT] == 161
-    assert result["data"][CONF_COMMUNITY] == "public"
     assert result["data"][CONF_TYPE] == "laser"
+    assert result["data"][SECTION_ADVANCED_SETTINGS][CONF_PORT] == 161
+    assert result["data"][SECTION_ADVANCED_SETTINGS][CONF_COMMUNITY] == "public"
 
 
 async def test_invalid_hostname(hass: HomeAssistant) -> None:
@@ -66,9 +69,8 @@ async def test_invalid_hostname(hass: HomeAssistant) -> None:
         context={"source": SOURCE_USER},
         data={
             CONF_HOST: "invalid/hostname",
-            CONF_PORT: 161,
-            CONF_COMMUNITY: "public",
             CONF_TYPE: "laser",
+            SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
         },
     )
 
@@ -257,15 +259,18 @@ async def test_zeroconf_confirm_create_entry(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_PORT: 161, CONF_COMMUNITY: "public", CONF_TYPE: "laser"},
+        user_input={
+            CONF_TYPE: "laser",
+            SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "HL-L2340DW 0123456789"
     assert result["data"][CONF_HOST] == "127.0.0.1"
-    assert result["data"][CONF_PORT] == 161
-    assert result["data"][CONF_COMMUNITY] == "public"
     assert result["data"][CONF_TYPE] == "laser"
+    assert result["data"][SECTION_ADVANCED_SETTINGS][CONF_PORT] == 161
+    assert result["data"][SECTION_ADVANCED_SETTINGS][CONF_COMMUNITY] == "public"
 
 
 async def test_reconfigure_successful(
@@ -283,16 +288,18 @@ async def test_reconfigure_successful(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_HOST: "10.10.10.10", CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        user_input={
+            CONF_HOST: "10.10.10.10",
+            SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        },
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert mock_config_entry.data == {
         CONF_HOST: "10.10.10.10",
-        CONF_PORT: 161,
-        CONF_COMMUNITY: "public",
         CONF_TYPE: "laser",
+        SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
     }
 
 
@@ -323,7 +330,10 @@ async def test_reconfigure_not_successful(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_HOST: "10.10.10.10", CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        user_input={
+            CONF_HOST: "10.10.10.10",
+            SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        },
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -334,16 +344,18 @@ async def test_reconfigure_not_successful(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_HOST: "10.10.10.10", CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        user_input={
+            CONF_HOST: "10.10.10.10",
+            SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        },
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert mock_config_entry.data == {
         CONF_HOST: "10.10.10.10",
-        CONF_PORT: 161,
-        CONF_COMMUNITY: "public",
         CONF_TYPE: "laser",
+        SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
     }
 
 
@@ -364,8 +376,7 @@ async def test_reconfigure_invalid_hostname(
         result["flow_id"],
         user_input={
             CONF_HOST: "invalid/hostname",
-            CONF_PORT: 161,
-            CONF_COMMUNITY: "public",
+            SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
         },
     )
 
@@ -391,7 +402,10 @@ async def test_reconfigure_not_the_same_device(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_HOST: "10.10.10.10", CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        user_input={
+            CONF_HOST: "10.10.10.10",
+            SECTION_ADVANCED_SETTINGS: {CONF_PORT: 161, CONF_COMMUNITY: "public"},
+        },
     )
 
     assert result["type"] is FlowResultType.FORM

--- a/tests/components/brother/test_init.py
+++ b/tests/components/brother/test_init.py
@@ -5,8 +5,13 @@ from unittest.mock import AsyncMock, patch
 from brother import SnmpError
 import pytest
 
-from homeassistant.components.brother.const import DOMAIN
+from homeassistant.components.brother.const import (
+    CONF_COMMUNITY,
+    DOMAIN,
+    SECTION_ADVANCED_SETTINGS,
+)
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
 
 from . import init_integration
@@ -68,3 +73,26 @@ async def test_unload_entry(
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
+
+
+async def test_migrate_entry(
+    hass: HomeAssistant,
+    mock_brother_client: AsyncMock,
+) -> None:
+    """Test entry migration to minor_version=2."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="HL-L2340DW 0123456789",
+        unique_id="0123456789",
+        data={CONF_HOST: "localhost", CONF_TYPE: "laser"},
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.minor_version == 2
+    assert config_entry.data[SECTION_ADVANCED_SETTINGS][CONF_PORT] == 161
+    assert config_entry.data[SECTION_ADVANCED_SETTINGS][CONF_COMMUNITY] == "public"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Relates to https://github.com/orgs/home-assistant/discussions/763

Adds the ability to use custom port and SNMP community in Brother integration.

Port and community configuration have been placed in the advanced settings section because they will not be used by most users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40680
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
