### PR TITLE
Add Hot Water+ Level select entity to A. O. Smith integration

### DIFF
--- a/homeassistant/components/aosmith/__init__.py
+++ b/homeassistant/components/aosmith/__init__.py
@@ -16,7 +16,7 @@ from .coordinator import (
     AOSmithStatusCoordinator,
 )
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.WATER_HEATER]
+PLATFORMS: list[Platform] = [Platform.SELECT, Platform.SENSOR, Platform.WATER_HEATER]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AOSmithConfigEntry) -> bool:

--- a/homeassistant/components/aosmith/icons.json
+++ b/homeassistant/components/aosmith/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "select": {
+      "hot_water_plus_level": {
+        "default": "mdi:water-plus"
+      }
+    },
     "sensor": {
       "hot_water_availability": {
         "default": "mdi:water-thermometer"

--- a/homeassistant/components/aosmith/select.py
+++ b/homeassistant/components/aosmith/select.py
@@ -60,12 +60,11 @@ class AOSmithHotWaterPlusSelectEntity(AOSmithStatusEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Set the Hot Water+ mode."""
-        aosmith_hwp_level = HWP_LEVEL_HA_TO_AOSMITH.get(option)
-        if aosmith_hwp_level is not None:
-            await self.client.update_mode(
-                junction_id=self.junction_id,
-                mode=self.device.status.current_mode,
-                hot_water_plus_level=aosmith_hwp_level,
-            )
+        aosmith_hwp_level = HWP_LEVEL_HA_TO_AOSMITH[option]
+        await self.client.update_mode(
+            junction_id=self.junction_id,
+            mode=self.device.status.current_mode,
+            hot_water_plus_level=aosmith_hwp_level,
+        )
 
-            await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/aosmith/select.py
+++ b/homeassistant/components/aosmith/select.py
@@ -2,8 +2,7 @@
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AOSmithConfigEntry
 from .coordinator import AOSmithStatusCoordinator
@@ -17,13 +16,11 @@ HWP_LEVEL_HA_TO_AOSMITH = {
 }
 HWP_LEVEL_AOSMITH_TO_HA = {value: key for key, value in HWP_LEVEL_HA_TO_AOSMITH.items()}
 
-x = list(HWP_LEVEL_AOSMITH_TO_HA)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AOSmithConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up A. O. Smith select platform."""
     data = entry.runtime_data
@@ -40,8 +37,9 @@ async def async_setup_entry(
 class AOSmithHotWaterPlusSelectEntity(AOSmithStatusEntity, SelectEntity):
     """Class for the Hot Water+ select entity."""
 
+    _attr_translation_key = "hot_water_plus_level"
+    _attr_icon = "mdi:water-plus"
     _attr_options = list(HWP_LEVEL_HA_TO_AOSMITH)
-    _attr_translation_key = "hot_water_plus"
 
     def __init__(self, coordinator: AOSmithStatusCoordinator, junction_id: str) -> None:
         """Initialize the entity."""
@@ -49,15 +47,22 @@ class AOSmithHotWaterPlusSelectEntity(AOSmithStatusEntity, SelectEntity):
         self._attr_unique_id = junction_id
 
     @property
+    def suggested_object_id(self) -> str | None:
+        """Override the suggested object id to make '+' get converted to 'plus' in the entity id."""
+        return "hot_water_plus_level"
+
+    @property
     def current_option(self) -> str | None:
         """Return the current Hot Water+ mode."""
-        return HWP_LEVEL_HA_TO_AOSMITH.get(self.device.status.hot_water_plus_level)
+        hot_water_plus_level = self.device.status.hot_water_plus_level
+        return (
+            None
+            if hot_water_plus_level is None
+            else HWP_LEVEL_AOSMITH_TO_HA.get(hot_water_plus_level)
+        )
 
     async def async_select_option(self, option: str) -> None:
         """Set the Hot Water+ mode."""
-        if option not in self.options:
-            raise HomeAssistantError(f"Invalid option: {option}")
-
         aosmith_hwp_level = HWP_LEVEL_HA_TO_AOSMITH.get(option)
         if aosmith_hwp_level is not None:
             await self.client.update_mode(
@@ -67,8 +72,3 @@ class AOSmithHotWaterPlusSelectEntity(AOSmithStatusEntity, SelectEntity):
             )
 
             await self.coordinator.async_request_refresh()
-
-    @property
-    def options(self) -> list[str]:
-        """Return the list of available operation modes."""
-        return [mode.original_name for mode in self.device.supported_modes]

--- a/homeassistant/components/aosmith/select.py
+++ b/homeassistant/components/aosmith/select.py
@@ -9,10 +9,10 @@ from .coordinator import AOSmithStatusCoordinator
 from .entity import AOSmithStatusEntity
 
 HWP_LEVEL_HA_TO_AOSMITH = {
-    "Off": 0,
-    "1": 1,
-    "2": 2,
-    "3": 3,
+    "off": 0,
+    "level1": 1,
+    "level2": 2,
+    "level3": 3,
 }
 HWP_LEVEL_AOSMITH_TO_HA = {value: key for key, value in HWP_LEVEL_HA_TO_AOSMITH.items()}
 
@@ -26,11 +26,9 @@ async def async_setup_entry(
     data = entry.runtime_data
 
     async_add_entities(
-        [
-            AOSmithHotWaterPlusSelectEntity(data.status_coordinator, device.junction_id)
-            for device in data.status_coordinator.data.values()
-            if device.supports_hot_water_plus
-        ]
+        AOSmithHotWaterPlusSelectEntity(data.status_coordinator, device.junction_id)
+        for device in data.status_coordinator.data.values()
+        if device.supports_hot_water_plus
     )
 
 
@@ -38,13 +36,12 @@ class AOSmithHotWaterPlusSelectEntity(AOSmithStatusEntity, SelectEntity):
     """Class for the Hot Water+ select entity."""
 
     _attr_translation_key = "hot_water_plus_level"
-    _attr_icon = "mdi:water-plus"
     _attr_options = list(HWP_LEVEL_HA_TO_AOSMITH)
 
     def __init__(self, coordinator: AOSmithStatusCoordinator, junction_id: str) -> None:
         """Initialize the entity."""
         super().__init__(coordinator, junction_id)
-        self._attr_unique_id = junction_id
+        self._attr_unique_id = f"hot_water_plus_level_{junction_id}"
 
     @property
     def suggested_object_id(self) -> str | None:

--- a/homeassistant/components/aosmith/select.py
+++ b/homeassistant/components/aosmith/select.py
@@ -1,0 +1,74 @@
+"""The select platform for the A. O. Smith integration."""
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import AOSmithConfigEntry
+from .coordinator import AOSmithStatusCoordinator
+from .entity import AOSmithStatusEntity
+
+HWP_LEVEL_HA_TO_AOSMITH = {
+    "Off": 0,
+    "1": 1,
+    "2": 2,
+    "3": 3,
+}
+HWP_LEVEL_AOSMITH_TO_HA = {value: key for key, value in HWP_LEVEL_HA_TO_AOSMITH.items()}
+
+x = list(HWP_LEVEL_AOSMITH_TO_HA)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: AOSmithConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up A. O. Smith select platform."""
+    data = entry.runtime_data
+
+    async_add_entities(
+        [
+            AOSmithHotWaterPlusSelectEntity(data.status_coordinator, device.junction_id)
+            for device in data.status_coordinator.data.values()
+            if device.supports_hot_water_plus
+        ]
+    )
+
+
+class AOSmithHotWaterPlusSelectEntity(AOSmithStatusEntity, SelectEntity):
+    """Class for the Hot Water+ select entity."""
+
+    _attr_options = list(HWP_LEVEL_HA_TO_AOSMITH)
+    _attr_translation_key = "hot_water_plus"
+
+    def __init__(self, coordinator: AOSmithStatusCoordinator, junction_id: str) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator, junction_id)
+        self._attr_unique_id = junction_id
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current Hot Water+ mode."""
+        return HWP_LEVEL_HA_TO_AOSMITH.get(self.device.status.hot_water_plus_level)
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the Hot Water+ mode."""
+        if option not in self.options:
+            raise HomeAssistantError(f"Invalid option: {option}")
+
+        aosmith_hwp_level = HWP_LEVEL_HA_TO_AOSMITH.get(option)
+        if aosmith_hwp_level is not None:
+            await self.client.update_mode(
+                junction_id=self.junction_id,
+                mode=self.device.status.current_mode,
+                hot_water_plus_level=aosmith_hwp_level,
+            )
+
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def options(self) -> list[str]:
+        """Return the list of available operation modes."""
+        return [mode.original_name for mode in self.device.supported_modes]

--- a/homeassistant/components/aosmith/strings.json
+++ b/homeassistant/components/aosmith/strings.json
@@ -28,7 +28,13 @@
   "entity": {
     "select": {
       "hot_water_plus_level": {
-        "name": "Hot Water+ level"
+        "name": "Hot Water+ level",
+        "state": {
+          "off": "[%key:common::state::off%]",
+          "level1": "Level 1",
+          "level2": "Level 2",
+          "level3": "Level 3"
+        }
       }
     },
     "sensor": {

--- a/homeassistant/components/aosmith/strings.json
+++ b/homeassistant/components/aosmith/strings.json
@@ -33,6 +33,11 @@
       "energy_usage": {
         "name": "Energy usage"
       }
+    },
+    "select": {
+      "hot_water_plus": {
+        "name": "Hot Water+"
+      }
     }
   }
 }

--- a/homeassistant/components/aosmith/strings.json
+++ b/homeassistant/components/aosmith/strings.json
@@ -26,17 +26,17 @@
     }
   },
   "entity": {
+    "select": {
+      "hot_water_plus_level": {
+        "name": "Hot Water+ level"
+      }
+    },
     "sensor": {
       "hot_water_availability": {
         "name": "Hot water availability"
       },
       "energy_usage": {
         "name": "Energy usage"
-      }
-    },
-    "select": {
-      "hot_water_plus": {
-        "name": "Hot Water+"
       }
     }
   }

--- a/tests/components/aosmith/conftest.py
+++ b/tests/components/aosmith/conftest.py
@@ -29,7 +29,11 @@ FIXTURE_USER_INPUT = {
 
 
 def build_device_fixture(
-    heat_pump: bool, mode_pending: bool, setpoint_pending: bool, has_vacation_mode: bool
+    heat_pump: bool,
+    mode_pending: bool,
+    setpoint_pending: bool,
+    has_vacation_mode: bool,
+    supports_hot_water_plus: bool,
 ):
     """Build a fixture for a device."""
     supported_modes: list[SupportedOperationModeInfo] = [

--- a/tests/components/aosmith/conftest.py
+++ b/tests/components/aosmith/conftest.py
@@ -41,7 +41,7 @@ def build_device_fixture(
             mode=OperationMode.ELECTRIC,
             original_name="ELECTRIC",
             has_day_selection=True,
-            supports_hot_water_plus=False,
+            supports_hot_water_plus=supports_hot_water_plus,
         ),
     ]
 
@@ -51,7 +51,7 @@ def build_device_fixture(
                 mode=OperationMode.HYBRID,
                 original_name="HYBRID",
                 has_day_selection=False,
-                supports_hot_water_plus=False,
+                supports_hot_water_plus=supports_hot_water_plus,
             )
         )
         supported_modes.append(
@@ -59,7 +59,7 @@ def build_device_fixture(
                 mode=OperationMode.HEAT_PUMP,
                 original_name="HEAT_PUMP",
                 has_day_selection=False,
-                supports_hot_water_plus=False,
+                supports_hot_water_plus=supports_hot_water_plus,
             )
         )
 
@@ -73,17 +73,18 @@ def build_device_fixture(
             )
         )
 
-    device_type = (
-        DeviceType.NEXT_GEN_HEAT_PUMP if heat_pump else DeviceType.RE3_CONNECTED
-    )
-
     current_mode = OperationMode.HEAT_PUMP if heat_pump else OperationMode.ELECTRIC
 
-    model = "HPTS-50 200 202172000" if heat_pump else "EE12-50H55DVF 100,3806368"
+    if heat_pump and supports_hot_water_plus:
+        device_type = DeviceType.RE3_PREMIUM
+    elif heat_pump:
+        device_type = DeviceType.NEXT_GEN_HEAT_PUMP
+    else:
+        device_type = DeviceType.RE3_CONNECTED
 
     return Device(
         brand="aosmith",
-        model=model,
+        model="Example model",
         device_type=device_type,
         dsn="dsn",
         junction_id="junctionId",
@@ -91,7 +92,7 @@ def build_device_fixture(
         serial="serial",
         install_location="Basement",
         supported_modes=supported_modes,
-        supports_hot_water_plus=False,
+        supports_hot_water_plus=supports_hot_water_plus,
         status=DeviceStatus(
             firmware_version="2.14",
             is_online=True,
@@ -102,7 +103,7 @@ def build_device_fixture(
             temperature_setpoint_previous=130,
             temperature_setpoint_maximum=130,
             hot_water_status=90,
-            hot_water_plus_level=None,
+            hot_water_plus_level=1 if supports_hot_water_plus else None,
         ),
     )
 
@@ -170,12 +171,19 @@ def get_devices_fixture_has_vacation_mode() -> bool:
 
 
 @pytest.fixture
+def get_devices_fixture_supports_hot_water_plus() -> bool:
+    """Return whether to include hot water plus support in the get_devices fixture."""
+    return False
+
+
+@pytest.fixture
 async def mock_client(
     hass: HomeAssistant,
     get_devices_fixture_heat_pump: bool,
     get_devices_fixture_mode_pending: bool,
     get_devices_fixture_setpoint_pending: bool,
     get_devices_fixture_has_vacation_mode: bool,
+    get_devices_fixture_supports_hot_water_plus: bool,
 ) -> Generator[MagicMock]:
     """Return a mocked client."""
     get_devices_fixture = [
@@ -184,6 +192,7 @@ async def mock_client(
             mode_pending=get_devices_fixture_mode_pending,
             setpoint_pending=get_devices_fixture_setpoint_pending,
             has_vacation_mode=get_devices_fixture_has_vacation_mode,
+            supports_hot_water_plus=get_devices_fixture_supports_hot_water_plus,
         )
     ]
     get_all_device_info_fixture = await async_load_json_object_fixture(

--- a/tests/components/aosmith/snapshots/test_device.ambr
+++ b/tests/components/aosmith/snapshots/test_device.ambr
@@ -20,7 +20,7 @@
     'labels': set({
     }),
     'manufacturer': 'A. O. Smith',
-    'model': 'HPTS-50 200 202172000',
+    'model': 'Example model',
     'model_id': None,
     'name': 'My water heater',
     'name_by_user': None,

--- a/tests/components/aosmith/snapshots/test_select.ambr
+++ b/tests/components/aosmith/snapshots/test_select.ambr
@@ -6,10 +6,10 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'Off',
-        '1',
-        '2',
-        '3',
+        'off',
+        'level1',
+        'level2',
+        'level3',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -30,14 +30,14 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:water-plus',
+    'original_icon': None,
     'original_name': 'Hot Water+ level',
     'platform': 'aosmith',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'hot_water_plus_level',
-    'unique_id': 'junctionId',
+    'unique_id': 'hot_water_plus_level_junctionId',
     'unit_of_measurement': None,
   })
 # ---
@@ -45,12 +45,11 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'My water heater Hot Water+ level',
-      'icon': 'mdi:water-plus',
       'options': list([
-        'Off',
-        '1',
-        '2',
-        '3',
+        'off',
+        'level1',
+        'level2',
+        'level3',
       ]),
     }),
     'context': <ANY>,
@@ -58,6 +57,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1',
+    'state': 'level1',
   })
 # ---

--- a/tests/components/aosmith/snapshots/test_select.ambr
+++ b/tests/components/aosmith/snapshots/test_select.ambr
@@ -1,0 +1,63 @@
+# serializer version: 1
+# name: test_state[True][select.my_water_heater_hot_water_plus_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'Off',
+        '1',
+        '2',
+        '3',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.my_water_heater_hot_water_plus_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water-plus',
+    'original_name': 'Hot Water+ level',
+    'platform': 'aosmith',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'hot_water_plus_level',
+    'unique_id': 'junctionId',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_state[True][select.my_water_heater_hot_water_plus_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'My water heater Hot Water+ level',
+      'icon': 'mdi:water-plus',
+      'options': list([
+        'Off',
+        '1',
+        '2',
+        '3',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.my_water_heater_hot_water_plus_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---

--- a/tests/components/aosmith/test_init.py
+++ b/tests/components/aosmith/test_init.py
@@ -56,6 +56,7 @@ async def test_config_entry_not_ready_get_energy_use_data_error(
             mode_pending=False,
             setpoint_pending=False,
             has_vacation_mode=True,
+            supports_hot_water_plus=False,
         )
     ]
 

--- a/tests/components/aosmith/test_select.py
+++ b/tests/components/aosmith/test_select.py
@@ -46,10 +46,10 @@ async def test_state(
 @pytest.mark.parametrize(
     ("hass_level", "aosmith_level"),
     [
-        ("Off", 0),
-        ("1", 1),
-        ("2", 2),
-        ("3", 3),
+        ("off", 0),
+        ("level1", 1),
+        ("level2", 2),
+        ("level3", 3),
     ],
 )
 async def test_set_hot_water_plus_level(

--- a/tests/components/aosmith/test_select.py
+++ b/tests/components/aosmith/test_select.py
@@ -57,9 +57,9 @@ async def test_set_hot_water_plus_level(
     mock_client: MagicMock,
     init_integration: MockConfigEntry,
     hass_level: str,
-    aosmith_level: str,
+    aosmith_level: int,
 ) -> None:
-    """Test setting the operation mode."""
+    """Test setting the Hot Water+ level."""
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,

--- a/tests/components/aosmith/test_select.py
+++ b/tests/components/aosmith/test_select.py
@@ -1,0 +1,77 @@
+"""Tests for the select platform of the A. O. Smith integration."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock, patch
+
+from py_aosmith.models import OperationMode
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+async def platforms() -> AsyncGenerator[None]:
+    """Return the platforms to be loaded for this test."""
+    with patch("homeassistant.components.aosmith.PLATFORMS", [Platform.SELECT]):
+        yield
+
+
+@pytest.mark.parametrize(
+    ("get_devices_fixture_supports_hot_water_plus"),
+    [True],
+)
+async def test_state(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the state of the select entity."""
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("get_devices_fixture_supports_hot_water_plus"),
+    [True],
+)
+@pytest.mark.parametrize(
+    ("hass_level", "aosmith_level"),
+    [
+        ("Off", 0),
+        ("1", 1),
+        ("2", 2),
+        ("3", 3),
+    ],
+)
+async def test_set_hot_water_plus_level(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    init_integration: MockConfigEntry,
+    hass_level: str,
+    aosmith_level: str,
+) -> None:
+    """Test setting the operation mode."""
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.my_water_heater_hot_water_plus_level",
+            ATTR_OPTION: hass_level,
+        },
+    )
+    await hass.async_block_till_done()
+
+    mock_client.update_mode.assert_called_once_with(
+        junction_id="junctionId",
+        mode=OperationMode.HEAT_PUMP,
+        hot_water_plus_level=aosmith_level,
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement the select platform for the A. O. Smith integration, with a single entity to set the level of the "Hot Water+" feature supported by RE3Premium device types ([newly supported in py-aosmith 1.0.14](https://github.com/home-assistant/core/pull/151597)).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40691
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
