### PR TITLE
fix zhong_hong climate component fan_mode attribute definition

### DIFF
--- a/homeassistant/components/zhong_hong/climate.py
+++ b/homeassistant/components/zhong_hong/climate.py
@@ -65,6 +65,25 @@ MODE_TO_STATE = {
     ZHONG_HONG_MODE_FAN_ONLY: HVACMode.FAN_ONLY,
 }
 
+# HA → zhong_hong
+FAN_MODE_MAP = {
+    "low": "LOW",
+    "medium": "MID",
+    "high": "HIGH",
+    "auto": "MIDHIGH",
+    "top": "HIGH",
+    "middle": "MID",
+    "focus": "MIDHIGH",
+    "diffuse": "MIDLOW",
+}
+# zhong_hong → HA
+FAN_MODE_REVERSE_MAP = {
+    "LOW": "low",
+    "MID": "medium",
+    "HIGH": "high",
+    "MIDHIGH": "auto",
+    "MIDLOW": "diffuse",
+}
 
 def setup_platform(
     hass: HomeAssistant,
@@ -208,12 +227,20 @@ class ZhongHongClimate(ClimateEntity):
     @property
     def fan_mode(self):
         """Return the fan setting."""
-        return self._current_fan_mode
+        if not self._current_fan_mode:
+        	return None
+        return FAN_MODE_REVERSE_MAP.get(
+        	self._current_fan_mode.upper(), self._current_fan_mode.lower()
+        )
 
     @property
     def fan_modes(self):
         """Return the list of available fan modes."""
-        return self._device.fan_list
+        if not self._device.fan_list:
+        	return []
+        return list(
+        	{FAN_MODE_REVERSE_MAP.get(x.upper(), x.lower()) for x in self._device.fan_list}
+        )
 
     @property
     def min_temp(self) -> float:
@@ -255,4 +282,7 @@ class ZhongHongClimate(ClimateEntity):
 
     def set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        self._device.set_fan_mode(fan_mode)
+        mapped_mode = FAN_MODE_MAP.get(fan_mode.lower())
+        if not mapped_mode:
+        	raise ValueError(f"Unsupported fan mode: {fan_mode}")
+        self._device.set_fan_mode(mapped_mode)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The original integrated fan_mode definition uses the fan_mode enumeration in ZhongHongHVAC, which is defined in uppercase. However, the enumeration definition in homeassistant is all lowercase. As a result, the parameter fan_mode in service.set_fan_mode needs to pass the value HIGH instead of high, which does not meet the standard. In addition, the fan speed mode can no longer be displayed normally on homeassistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
