### PR TITLE
Improve migration to entity registry version 1.18

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -79,7 +79,7 @@ EVENT_ENTITY_REGISTRY_UPDATED: EventType[EventEntityRegistryUpdatedData] = Event
 _LOGGER = logging.getLogger(__name__)
 
 STORAGE_VERSION_MAJOR = 1
-STORAGE_VERSION_MINOR = 18
+STORAGE_VERSION_MINOR = 19
 STORAGE_KEY = "core.entity_registry"
 
 CLEANUP_INTERVAL = 3600 * 24
@@ -159,6 +159,17 @@ def _protect_entity_options(
     data: EntityOptionsType | None,
 ) -> ReadOnlyEntityOptionsType:
     """Protect entity options from being modified."""
+    if data is None:
+        return ReadOnlyDict({})
+    return ReadOnlyDict({key: ReadOnlyDict(val) for key, val in data.items()})
+
+
+def _protect_optional_entity_options(
+    data: EntityOptionsType | UndefinedType | None,
+) -> ReadOnlyEntityOptionsType | UndefinedType:
+    """Protect entity options from being modified."""
+    if data is UNDEFINED:
+        return UNDEFINED
     if data is None:
         return ReadOnlyDict({})
     return ReadOnlyDict({key: ReadOnlyDict(val) for key, val in data.items()})
@@ -414,15 +425,17 @@ class DeletedRegistryEntry:
     config_subentry_id: str | None = attr.ib()
     created_at: datetime = attr.ib()
     device_class: str | None = attr.ib()
-    disabled_by: RegistryEntryDisabler | None = attr.ib()
+    disabled_by: RegistryEntryDisabler | UndefinedType | None = attr.ib()
     domain: str = attr.ib(init=False, repr=False)
-    hidden_by: RegistryEntryHider | None = attr.ib()
+    hidden_by: RegistryEntryHider | UndefinedType | None = attr.ib()
     icon: str | None = attr.ib()
     id: str = attr.ib()
     labels: set[str] = attr.ib()
     modified_at: datetime = attr.ib()
     name: str | None = attr.ib()
-    options: ReadOnlyEntityOptionsType = attr.ib(converter=_protect_entity_options)
+    options: ReadOnlyEntityOptionsType | UndefinedType = attr.ib(
+        converter=_protect_optional_entity_options
+    )
     orphaned_timestamp: float | None = attr.ib()
 
     _cache: dict[str, Any] = attr.ib(factory=dict, eq=False, init=False)
@@ -445,15 +458,22 @@ class DeletedRegistryEntry:
                     "config_subentry_id": self.config_subentry_id,
                     "created_at": self.created_at,
                     "device_class": self.device_class,
-                    "disabled_by": self.disabled_by,
+                    "disabled_by": self.disabled_by
+                    if self.disabled_by is not UNDEFINED
+                    else None,
+                    "disabled_by_undefined": self.disabled_by is UNDEFINED,
                     "entity_id": self.entity_id,
-                    "hidden_by": self.hidden_by,
+                    "hidden_by": self.hidden_by
+                    if self.hidden_by is not UNDEFINED
+                    else None,
+                    "hidden_by_undefined": self.hidden_by is UNDEFINED,
                     "icon": self.icon,
                     "id": self.id,
                     "labels": list(self.labels),
                     "modified_at": self.modified_at,
                     "name": self.name,
-                    "options": self.options,
+                    "options": self.options if self.options is not UNDEFINED else {},
+                    "options_undefined": self.options is UNDEFINED,
                     "orphaned_timestamp": self.orphaned_timestamp,
                     "platform": self.platform,
                     "unique_id": self.unique_id,
@@ -590,6 +610,14 @@ class EntityRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                     entity["labels"] = []
                     entity["name"] = None
                     entity["options"] = {}
+            if old_minor_version < 19:
+                # Version 1.19 adds undefined flags to deleted entities, this is a bugfix
+                # of version 1.18
+                set_to_undefined = old_minor_version < 18
+                for entity in data["deleted_entities"]:
+                    entity["disabled_by_undefined"] = set_to_undefined
+                    entity["hidden_by_undefined"] = set_to_undefined
+                    entity["options_undefined"] = set_to_undefined
 
         if old_major_version > 1:
             raise NotImplementedError
@@ -959,25 +987,30 @@ class EntityRegistry(BaseRegistry):
             categories = deleted_entity.categories
             created_at = deleted_entity.created_at
             device_class = deleted_entity.device_class
-            disabled_by = deleted_entity.disabled_by
-            # Adjust disabled_by based on config entry state
-            if config_entry and config_entry is not UNDEFINED:
-                if config_entry.disabled_by:
-                    if disabled_by is None:
-                        disabled_by = RegistryEntryDisabler.CONFIG_ENTRY
+            if deleted_entity.disabled_by is not UNDEFINED:
+                disabled_by = deleted_entity.disabled_by
+                # Adjust disabled_by based on config entry state
+                if config_entry and config_entry is not UNDEFINED:
+                    if config_entry.disabled_by:
+                        if disabled_by is None:
+                            disabled_by = RegistryEntryDisabler.CONFIG_ENTRY
+                    elif disabled_by == RegistryEntryDisabler.CONFIG_ENTRY:
+                        disabled_by = None
                 elif disabled_by == RegistryEntryDisabler.CONFIG_ENTRY:
                     disabled_by = None
-            elif disabled_by == RegistryEntryDisabler.CONFIG_ENTRY:
-                disabled_by = None
             # Restore entity_id if it's available
             if self._entity_id_available(deleted_entity.entity_id):
                 entity_id = deleted_entity.entity_id
             entity_registry_id = deleted_entity.id
-            hidden_by = deleted_entity.hidden_by
+            if deleted_entity.hidden_by is not UNDEFINED:
+                hidden_by = deleted_entity.hidden_by
             icon = deleted_entity.icon
             labels = deleted_entity.labels
             name = deleted_entity.name
-            options = deleted_entity.options
+            if deleted_entity.options is not UNDEFINED:
+                options = deleted_entity.options
+            else:
+                options = get_initial_options() if get_initial_options else None
         else:
             aliases = set()
             area_id = None
@@ -1530,6 +1563,20 @@ class EntityRegistry(BaseRegistry):
                     previous_unique_id=entity["previous_unique_id"],
                     unit_of_measurement=entity["unit_of_measurement"],
                 )
+
+            def get_optional_enum[_EnumT: StrEnum](
+                cls: type[_EnumT], value: str | None, undefined: bool
+            ) -> _EnumT | UndefinedType | None:
+                """Convert string to the passed enum, UNDEFINED or None."""
+                if undefined:
+                    return UNDEFINED
+                if value is None:
+                    return None
+                try:
+                    return cls(value)
+                except ValueError:
+                    return None
+
             for entity in data["deleted_entities"]:
                 try:
                     domain = split_entity_id(entity["entity_id"])[0]
@@ -1555,23 +1602,25 @@ class EntityRegistry(BaseRegistry):
                     config_subentry_id=entity["config_subentry_id"],
                     created_at=datetime.fromisoformat(entity["created_at"]),
                     device_class=entity["device_class"],
-                    disabled_by=(
-                        RegistryEntryDisabler(entity["disabled_by"])
-                        if entity["disabled_by"]
-                        else None
+                    disabled_by=get_optional_enum(
+                        RegistryEntryDisabler,
+                        entity["disabled_by"],
+                        entity["disabled_by_undefined"],
                     ),
                     entity_id=entity["entity_id"],
-                    hidden_by=(
-                        RegistryEntryHider(entity["hidden_by"])
-                        if entity["hidden_by"]
-                        else None
+                    hidden_by=get_optional_enum(
+                        RegistryEntryHider,
+                        entity["hidden_by"],
+                        entity["hidden_by_undefined"],
                     ),
                     icon=entity["icon"],
                     id=entity["id"],
                     labels=set(entity["labels"]),
                     modified_at=datetime.fromisoformat(entity["modified_at"]),
                     name=entity["name"],
-                    options=entity["options"],
+                    options=entity["options"]
+                    if not entity["options_undefined"]
+                    else UNDEFINED,
                     orphaned_timestamp=entity["orphaned_timestamp"],
                     platform=entity["platform"],
                     unique_id=entity["unique_id"],

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -20,6 +20,7 @@ from homeassistant.core import CoreState, Event, HomeAssistant, callback
 from homeassistant.exceptions import MaxLengthExceeded
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
+from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.util.dt import utc_from_timestamp, utcnow
 
 from tests.common import (
@@ -610,14 +611,17 @@ async def test_load_bad_data(
                     "created_at": "2024-02-14T12:00:00.900075+00:00",
                     "device_class": None,
                     "disabled_by": None,
+                    "disabled_by_undefined": False,
                     "entity_id": "test.test3",
                     "hidden_by": None,
+                    "hidden_by_undefined": False,
                     "icon": None,
                     "id": "00003",
                     "labels": [],
                     "modified_at": "2024-02-14T12:00:00.900075+00:00",
                     "name": None,
                     "options": None,
+                    "options_undefined": False,
                     "orphaned_timestamp": None,
                     "platform": "super_platform",
                     "unique_id": 234,  # Should not load
@@ -631,14 +635,17 @@ async def test_load_bad_data(
                     "created_at": "2024-02-14T12:00:00.900075+00:00",
                     "device_class": None,
                     "disabled_by": None,
+                    "disabled_by_undefined": False,
                     "entity_id": "test.test4",
                     "hidden_by": None,
+                    "hidden_by_undefined": False,
                     "icon": None,
                     "id": "00004",
                     "labels": [],
                     "modified_at": "2024-02-14T12:00:00.900075+00:00",
                     "name": None,
                     "options": None,
+                    "options_undefined": False,
                     "orphaned_timestamp": None,
                     "platform": "super_platform",
                     "unique_id": ["also", "not", "valid"],  # Should not load
@@ -962,9 +969,10 @@ async def test_migration_1_1(hass: HomeAssistant, hass_storage: dict[str, Any]) 
     assert entry.device_class is None
     assert entry.original_device_class == "best_class"
 
-    # Check we store migrated data
+    # Check migrated data
     await flush_store(registry._store)
-    assert hass_storage[er.STORAGE_KEY] == {
+    migrated_data = hass_storage[er.STORAGE_KEY]
+    assert migrated_data == {
         "version": er.STORAGE_VERSION_MAJOR,
         "minor_version": er.STORAGE_VERSION_MINOR,
         "key": er.STORAGE_KEY,
@@ -1006,6 +1014,11 @@ async def test_migration_1_1(hass: HomeAssistant, hass_storage: dict[str, Any]) 
             "deleted_entities": [],
         },
     }
+
+    # Serialize the migrated data again
+    registry.async_schedule_save()
+    await flush_store(registry._store)
+    assert hass_storage[er.STORAGE_KEY] == migrated_data
 
 
 @pytest.mark.parametrize("load_registries", [False])
@@ -1142,9 +1155,17 @@ async def test_migration_1_11(
     assert entry.device_class is None
     assert entry.original_device_class == "best_class"
 
+    deleted_entry = registry.deleted_entities[
+        ("test", "super_duper_platform", "very_very_unique")
+    ]
+    assert deleted_entry.disabled_by is UNDEFINED
+    assert deleted_entry.hidden_by is UNDEFINED
+    assert deleted_entry.options is UNDEFINED
+
     # Check migrated data
     await flush_store(registry._store)
-    assert hass_storage[er.STORAGE_KEY] == {
+    migrated_data = hass_storage[er.STORAGE_KEY]
+    assert migrated_data == {
         "version": er.STORAGE_VERSION_MAJOR,
         "minor_version": er.STORAGE_VERSION_MINOR,
         "key": er.STORAGE_KEY,
@@ -1193,6 +1214,87 @@ async def test_migration_1_11(
                     "created_at": "1970-01-01T00:00:00+00:00",
                     "device_class": None,
                     "disabled_by": None,
+                    "disabled_by_undefined": True,
+                    "entity_id": "test.deleted_entity",
+                    "hidden_by": None,
+                    "hidden_by_undefined": True,
+                    "icon": None,
+                    "id": "23456",
+                    "labels": [],
+                    "modified_at": "1970-01-01T00:00:00+00:00",
+                    "name": None,
+                    "options": {},
+                    "options_undefined": True,
+                    "orphaned_timestamp": None,
+                    "platform": "super_duper_platform",
+                    "unique_id": "very_very_unique",
+                }
+            ],
+        },
+    }
+
+    # Serialize the migrated data again
+    registry.async_schedule_save()
+    await flush_store(registry._store)
+    assert hass_storage[er.STORAGE_KEY] == migrated_data
+
+
+@pytest.mark.parametrize("load_registries", [False])
+async def test_migration_1_18(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Test migration from version 1.18.
+
+    This version has a flawed migration.
+    """
+    hass_storage[er.STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 18,
+        "data": {
+            "entities": [
+                {
+                    "aliases": [],
+                    "area_id": None,
+                    "capabilities": {},
+                    "categories": {},
+                    "config_entry_id": None,
+                    "config_subentry_id": None,
+                    "created_at": "1970-01-01T00:00:00+00:00",
+                    "device_id": None,
+                    "disabled_by": None,
+                    "entity_category": None,
+                    "entity_id": "test.entity",
+                    "has_entity_name": False,
+                    "hidden_by": None,
+                    "icon": None,
+                    "id": "12345",
+                    "labels": [],
+                    "modified_at": "1970-01-01T00:00:00+00:00",
+                    "name": None,
+                    "options": {},
+                    "original_device_class": "best_class",
+                    "original_icon": None,
+                    "original_name": None,
+                    "platform": "super_platform",
+                    "previous_unique_id": None,
+                    "suggested_object_id": None,
+                    "supported_features": 0,
+                    "translation_key": None,
+                    "unique_id": "very_unique",
+                    "unit_of_measurement": None,
+                    "device_class": None,
+                }
+            ],
+            "deleted_entities": [
+                {
+                    "aliases": [],
+                    "area_id": None,
+                    "categories": {},
+                    "config_entry_id": None,
+                    "config_subentry_id": None,
+                    "created_at": "1970-01-01T00:00:00+00:00",
+                    "device_class": None,
+                    "disabled_by": None,
                     "entity_id": "test.deleted_entity",
                     "hidden_by": None,
                     "icon": None,
@@ -1208,6 +1310,97 @@ async def test_migration_1_11(
             ],
         },
     }
+
+    await er.async_load(hass)
+    registry = er.async_get(hass)
+
+    entry = registry.async_get_or_create("test", "super_platform", "very_unique")
+
+    assert entry.device_class is None
+    assert entry.original_device_class == "best_class"
+
+    deleted_entry = registry.deleted_entities[
+        ("test", "super_duper_platform", "very_very_unique")
+    ]
+    assert deleted_entry.disabled_by is None
+    assert deleted_entry.hidden_by is None
+    assert deleted_entry.options == {}
+
+    # Check migrated data
+    await flush_store(registry._store)
+    migrated_data = hass_storage[er.STORAGE_KEY]
+    assert migrated_data == {
+        "version": er.STORAGE_VERSION_MAJOR,
+        "minor_version": er.STORAGE_VERSION_MINOR,
+        "key": er.STORAGE_KEY,
+        "data": {
+            "entities": [
+                {
+                    "aliases": [],
+                    "area_id": None,
+                    "capabilities": {},
+                    "categories": {},
+                    "config_entry_id": None,
+                    "config_subentry_id": None,
+                    "created_at": "1970-01-01T00:00:00+00:00",
+                    "device_id": None,
+                    "disabled_by": None,
+                    "entity_category": None,
+                    "entity_id": "test.entity",
+                    "has_entity_name": False,
+                    "hidden_by": None,
+                    "icon": None,
+                    "id": ANY,
+                    "labels": [],
+                    "modified_at": "1970-01-01T00:00:00+00:00",
+                    "name": None,
+                    "options": {},
+                    "original_device_class": "best_class",
+                    "original_icon": None,
+                    "original_name": None,
+                    "platform": "super_platform",
+                    "previous_unique_id": None,
+                    "suggested_object_id": None,
+                    "supported_features": 0,
+                    "translation_key": None,
+                    "unique_id": "very_unique",
+                    "unit_of_measurement": None,
+                    "device_class": None,
+                }
+            ],
+            "deleted_entities": [
+                {
+                    "aliases": [],
+                    "area_id": None,
+                    "categories": {},
+                    "config_entry_id": None,
+                    "config_subentry_id": None,
+                    "created_at": "1970-01-01T00:00:00+00:00",
+                    "device_class": None,
+                    "disabled_by": None,
+                    "disabled_by_undefined": False,
+                    "entity_id": "test.deleted_entity",
+                    "hidden_by": None,
+                    "hidden_by_undefined": False,
+                    "icon": None,
+                    "id": "23456",
+                    "labels": [],
+                    "modified_at": "1970-01-01T00:00:00+00:00",
+                    "name": None,
+                    "options": {},
+                    "options_undefined": False,
+                    "orphaned_timestamp": None,
+                    "platform": "super_duper_platform",
+                    "unique_id": "very_very_unique",
+                }
+            ],
+        },
+    }
+
+    # Serialize the migrated data again
+    registry.async_schedule_save()
+    await flush_store(registry._store)
+    assert hass_storage[er.STORAGE_KEY] == migrated_data
 
 
 async def test_update_entity_unique_id(
@@ -3148,6 +3341,366 @@ async def test_restore_entity(
     assert update_events[15].data == {"action": "remove", "entity_id": "light.custom_1"}
     # Restore entities the 3rd time
     assert update_events[16].data == {"action": "create", "entity_id": "light.hue_1234"}
+
+
+@pytest.mark.parametrize(
+    ("entity_disabled_by"),
+    [
+        None,
+        er.RegistryEntryDisabler.CONFIG_ENTRY,
+        er.RegistryEntryDisabler.DEVICE,
+        er.RegistryEntryDisabler.HASS,
+        er.RegistryEntryDisabler.INTEGRATION,
+        er.RegistryEntryDisabler.USER,
+    ],
+)
+@pytest.mark.usefixtures("freezer")
+async def test_restore_migrated_entity_disabled_by(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    entity_disabled_by: er.RegistryEntryDisabler | None,
+) -> None:
+    """Check how the disabled_by flag is treated when restoring an entity."""
+    update_events = async_capture_events(hass, er.EVENT_ENTITY_REGISTRY_UPDATED)
+    config_entry = MockConfigEntry(domain="light")
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entry = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "1234",
+        capabilities={"key1": "value1"},
+        config_entry=config_entry,
+        config_subentry_id=None,
+        device_id=device_entry.id,
+        disabled_by=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        get_initial_options=lambda: {"test_domain": {"key1": "value1"}},
+        has_entity_name=True,
+        hidden_by=er.RegistryEntryHider.INTEGRATION,
+        original_device_class="device_class_1",
+        original_icon="original_icon_1",
+        original_name="original_name_1",
+        suggested_object_id="hue_5678",
+        supported_features=1,
+        translation_key="translation_key_1",
+        unit_of_measurement="unit_1",
+    )
+
+    entity_registry.async_remove(entry.entity_id)
+    assert len(entity_registry.entities) == 0
+    assert len(entity_registry.deleted_entities) == 1
+
+    deleted_entry = entity_registry.deleted_entities[("light", "hue", "1234")]
+    entity_registry.deleted_entities[("light", "hue", "1234")] = attr.evolve(
+        deleted_entry, disabled_by=UNDEFINED
+    )
+
+    # Re-add entity, integration has changed
+    entry_restored = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "1234",
+        capabilities={"key2": "value2"},
+        config_entry=config_entry,
+        config_subentry_id=None,
+        device_id=device_entry.id,
+        disabled_by=entity_disabled_by,
+        entity_category=EntityCategory.CONFIG,
+        get_initial_options=lambda: {"test_domain": {"key2": "value2"}},
+        has_entity_name=False,
+        hidden_by=None,
+        original_device_class="device_class_2",
+        original_icon="original_icon_2",
+        original_name="original_name_2",
+        suggested_object_id="suggested_2",
+        supported_features=2,
+        translation_key="translation_key_2",
+        unit_of_measurement="unit_2",
+    )
+
+    assert len(entity_registry.entities) == 1
+    assert len(entity_registry.deleted_entities) == 0
+    assert entry != entry_restored
+    # entity_id and user customizations are restored. new integration options are
+    # respected.
+    assert entry_restored == er.RegistryEntry(
+        entity_id="light.hue_5678",
+        unique_id="1234",
+        platform="hue",
+        aliases=set(),
+        area_id=None,
+        categories={},
+        capabilities={"key2": "value2"},
+        config_entry_id=config_entry.entry_id,
+        config_subentry_id=None,
+        created_at=utcnow(),
+        device_class=None,
+        device_id=device_entry.id,
+        disabled_by=entity_disabled_by,
+        entity_category=EntityCategory.CONFIG,
+        has_entity_name=False,
+        hidden_by=er.RegistryEntryHider.INTEGRATION,
+        icon=None,
+        id=entry.id,
+        labels=set(),
+        modified_at=utcnow(),
+        name=None,
+        options={"test_domain": {"key1": "value1"}},
+        original_device_class="device_class_2",
+        original_icon="original_icon_2",
+        original_name="original_name_2",
+        suggested_object_id="suggested_2",
+        supported_features=2,
+        translation_key="translation_key_2",
+        unit_of_measurement="unit_2",
+    )
+
+    # Check the events
+    await hass.async_block_till_done()
+    assert len(update_events) == 3
+    assert update_events[0].data == {"action": "create", "entity_id": "light.hue_5678"}
+    assert update_events[1].data == {"action": "remove", "entity_id": "light.hue_5678"}
+    assert update_events[2].data == {"action": "create", "entity_id": "light.hue_5678"}
+
+
+@pytest.mark.parametrize(
+    ("entity_hidden_by"),
+    [
+        None,
+        er.RegistryEntryHider.INTEGRATION,
+        er.RegistryEntryHider.USER,
+    ],
+)
+@pytest.mark.usefixtures("freezer")
+async def test_restore_migrated_entity_hidden_by(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    entity_hidden_by: er.RegistryEntryHider | None,
+) -> None:
+    """Check how the hidden_by flag is treated when restoring an entity."""
+    update_events = async_capture_events(hass, er.EVENT_ENTITY_REGISTRY_UPDATED)
+    config_entry = MockConfigEntry(domain="light")
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entry = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "1234",
+        capabilities={"key1": "value1"},
+        config_entry=config_entry,
+        config_subentry_id=None,
+        device_id=device_entry.id,
+        disabled_by=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        get_initial_options=lambda: {"test_domain": {"key1": "value1"}},
+        has_entity_name=True,
+        hidden_by=er.RegistryEntryHider.INTEGRATION,
+        original_device_class="device_class_1",
+        original_icon="original_icon_1",
+        original_name="original_name_1",
+        suggested_object_id="hue_5678",
+        supported_features=1,
+        translation_key="translation_key_1",
+        unit_of_measurement="unit_1",
+    )
+
+    entity_registry.async_remove(entry.entity_id)
+    assert len(entity_registry.entities) == 0
+    assert len(entity_registry.deleted_entities) == 1
+
+    deleted_entry = entity_registry.deleted_entities[("light", "hue", "1234")]
+    entity_registry.deleted_entities[("light", "hue", "1234")] = attr.evolve(
+        deleted_entry, hidden_by=UNDEFINED
+    )
+
+    # Re-add entity, integration has changed
+    entry_restored = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "1234",
+        capabilities={"key2": "value2"},
+        config_entry=config_entry,
+        config_subentry_id=None,
+        device_id=device_entry.id,
+        disabled_by=None,
+        entity_category=EntityCategory.CONFIG,
+        get_initial_options=lambda: {"test_domain": {"key2": "value2"}},
+        has_entity_name=False,
+        hidden_by=entity_hidden_by,
+        original_device_class="device_class_2",
+        original_icon="original_icon_2",
+        original_name="original_name_2",
+        suggested_object_id="suggested_2",
+        supported_features=2,
+        translation_key="translation_key_2",
+        unit_of_measurement="unit_2",
+    )
+
+    assert len(entity_registry.entities) == 1
+    assert len(entity_registry.deleted_entities) == 0
+    assert entry != entry_restored
+    # entity_id and user customizations are restored. new integration options are
+    # respected.
+    assert entry_restored == er.RegistryEntry(
+        entity_id="light.hue_5678",
+        unique_id="1234",
+        platform="hue",
+        aliases=set(),
+        area_id=None,
+        categories={},
+        capabilities={"key2": "value2"},
+        config_entry_id=config_entry.entry_id,
+        config_subentry_id=None,
+        created_at=utcnow(),
+        device_class=None,
+        device_id=device_entry.id,
+        disabled_by=None,
+        entity_category=EntityCategory.CONFIG,
+        has_entity_name=False,
+        hidden_by=entity_hidden_by,
+        icon=None,
+        id=entry.id,
+        labels=set(),
+        modified_at=utcnow(),
+        name=None,
+        options={"test_domain": {"key1": "value1"}},
+        original_device_class="device_class_2",
+        original_icon="original_icon_2",
+        original_name="original_name_2",
+        suggested_object_id="suggested_2",
+        supported_features=2,
+        translation_key="translation_key_2",
+        unit_of_measurement="unit_2",
+    )
+
+    # Check the events
+    await hass.async_block_till_done()
+    assert len(update_events) == 3
+    assert update_events[0].data == {"action": "create", "entity_id": "light.hue_5678"}
+    assert update_events[1].data == {"action": "remove", "entity_id": "light.hue_5678"}
+    assert update_events[2].data == {"action": "create", "entity_id": "light.hue_5678"}
+
+
+@pytest.mark.usefixtures("freezer")
+async def test_restore_migrated_entity_initial_options(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Check how the initial options is treated when restoring an entity."""
+    update_events = async_capture_events(hass, er.EVENT_ENTITY_REGISTRY_UPDATED)
+    config_entry = MockConfigEntry(domain="light")
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entry = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "1234",
+        capabilities={"key1": "value1"},
+        config_entry=config_entry,
+        config_subentry_id=None,
+        device_id=device_entry.id,
+        disabled_by=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        get_initial_options=lambda: {"test_domain": {"key1": "value1"}},
+        has_entity_name=True,
+        hidden_by=er.RegistryEntryHider.INTEGRATION,
+        original_device_class="device_class_1",
+        original_icon="original_icon_1",
+        original_name="original_name_1",
+        suggested_object_id="hue_5678",
+        supported_features=1,
+        translation_key="translation_key_1",
+        unit_of_measurement="unit_1",
+    )
+
+    entity_registry.async_remove(entry.entity_id)
+    assert len(entity_registry.entities) == 0
+    assert len(entity_registry.deleted_entities) == 1
+
+    deleted_entry = entity_registry.deleted_entities[("light", "hue", "1234")]
+    entity_registry.deleted_entities[("light", "hue", "1234")] = attr.evolve(
+        deleted_entry, options=UNDEFINED
+    )
+
+    # Re-add entity, integration has changed
+    entry_restored = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "1234",
+        capabilities={"key2": "value2"},
+        config_entry=config_entry,
+        config_subentry_id=None,
+        device_id=device_entry.id,
+        disabled_by=None,
+        entity_category=EntityCategory.CONFIG,
+        get_initial_options=lambda: {"test_domain": {"key2": "value2"}},
+        has_entity_name=False,
+        hidden_by=None,
+        original_device_class="device_class_2",
+        original_icon="original_icon_2",
+        original_name="original_name_2",
+        suggested_object_id="suggested_2",
+        supported_features=2,
+        translation_key="translation_key_2",
+        unit_of_measurement="unit_2",
+    )
+
+    assert len(entity_registry.entities) == 1
+    assert len(entity_registry.deleted_entities) == 0
+    assert entry != entry_restored
+    # entity_id and user customizations are restored. new integration options are
+    # respected.
+    assert entry_restored == er.RegistryEntry(
+        entity_id="light.hue_5678",
+        unique_id="1234",
+        platform="hue",
+        aliases=set(),
+        area_id=None,
+        categories={},
+        capabilities={"key2": "value2"},
+        config_entry_id=config_entry.entry_id,
+        config_subentry_id=None,
+        created_at=utcnow(),
+        device_class=None,
+        device_id=device_entry.id,
+        disabled_by=None,
+        entity_category=EntityCategory.CONFIG,
+        has_entity_name=False,
+        hidden_by=er.RegistryEntryHider.INTEGRATION,
+        icon=None,
+        id=entry.id,
+        labels=set(),
+        modified_at=utcnow(),
+        name=None,
+        options={"test_domain": {"key2": "value2"}},
+        original_device_class="device_class_2",
+        original_icon="original_icon_2",
+        original_name="original_name_2",
+        suggested_object_id="suggested_2",
+        supported_features=2,
+        translation_key="translation_key_2",
+        unit_of_measurement="unit_2",
+    )
+
+    # Check the events
+    await hass.async_block_till_done()
+    assert len(update_events) == 3
+    assert update_events[0].data == {"action": "create", "entity_id": "light.hue_5678"}
+    assert update_events[1].data == {"action": "remove", "entity_id": "light.hue_5678"}
+    assert update_events[2].data == {"action": "create", "entity_id": "light.hue_5678"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve migration to entity registry version 1.18

With this change, entities which were deleted before `disabled_by`, `hidden_by` and `options` were stored in deleted entities will now have the `disabled_by`, `hidden_by` and `options` suggested by the integration when re-added instead of being treated as enabled / not hidden / no options.

This is an improved version of https://github.com/home-assistant/core/pull/151308 which was reverted by https://github.com/home-assistant/core/pull/151561

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
