### PR TITLE
Improve HassLightSet intent definition

### DIFF
--- a/homeassistant/components/light/intent.py
+++ b/homeassistant/components/light/intent.py
@@ -27,6 +27,9 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             INTENT_SET,
             DOMAIN,
             SERVICE_TURN_ON,
+            required_slots={
+                vol.Any("color", "temperature", "brightness"): object,
+            },
             optional_slots={
                 "color": intent.IntentSlotInfo(
                     service_data_name=ATTR_RGB_COLOR,

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -146,7 +146,9 @@ async def async_handle(
         result = await handler.async_handle(intent)
     except vol.Invalid as err:
         _LOGGER.warning("Received invalid slot info for %s: %s", intent_type, err)
-        raise InvalidSlotInfo(f"Received invalid slot info for {intent_type}") from err
+        raise InvalidSlotInfo(
+            f"Received invalid slot info for {intent_type}: {err}"
+        ) from err
     except IntentError:
         raise  # bubble up intent related errors
     except Exception as err:
@@ -1180,6 +1182,8 @@ class DynamicServiceIntentHandler(IntentHandler):
         service_data: dict[str, Any] = {ATTR_ENTITY_ID: state.entity_id}
         if self.required_slots:
             for key, slot_info in self.required_slots.items():
+                if isinstance(key, vol.Any):
+                    continue
                 service_data[slot_info.service_data_name or key] = intent_obj.slots[
                     key
                 ]["value"]

--- a/tests/components/light/test_intent.py
+++ b/tests/components/light/test_intent.py
@@ -1,10 +1,12 @@
 """Tests for the light intents."""
 
+import pytest
+
 from homeassistant.components import light
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode, intent
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.intent import async_handle
+from homeassistant.helpers.intent import InvalidSlotInfo, async_handle
 
 from tests.common import async_mock_service
 
@@ -89,3 +91,66 @@ async def test_intent_set_temperature(hass: HomeAssistant) -> None:
     assert call.service == SERVICE_TURN_ON
     assert call.data.get(ATTR_ENTITY_ID) == "light.test"
     assert call.data.get(light.ATTR_COLOR_TEMP_KELVIN) == 2000
+
+
+async def test_intent_set_missing_required_slots(hass: HomeAssistant) -> None:
+    """Test that the intent fails when none of the required slots (color, temperature, brightness) are provided."""
+    hass.states.async_set(
+        "light.test", "off", {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.HS]}
+    )
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    # Test with only name - should fail because none of color, temperature, brightness are provided
+    with pytest.raises(InvalidSlotInfo) as exc_info:
+        await async_handle(
+            hass,
+            "test",
+            intent.INTENT_SET,
+            {"name": {"value": "Test"}},
+        )
+
+    # Verify the error message indicates that at least one of the required slots is needed
+    error_message = str(exc_info.value)
+    assert "color" in error_message or "temperature" in error_message or "brightness" in error_message
+
+    # Test with empty slots - should also fail
+    with pytest.raises(InvalidSlotInfo) as exc_info:
+        await async_handle(
+            hass,
+            "test",
+            intent.INTENT_SET,
+            {},
+        )
+
+    # Verify no service calls were made since validation failed
+    assert len(calls) == 0
+
+
+async def test_intent_set_with_required_slots_passes(hass: HomeAssistant) -> None:
+    """Test that the intent succeeds when at least one required slot is provided."""
+    hass.states.async_set(
+        "light.test", "off", {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.BRIGHTNESS]}
+    )
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    # Test with brightness only - should pass
+    await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET,
+        {
+            "name": {"value": "Test"},
+            "brightness": {"value": "50"},
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Verify service was called successfully
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == light.DOMAIN
+    assert call.service == SERVICE_TURN_ON
+    assert call.data.get(ATTR_ENTITY_ID) == "light.test"
+    assert call.data.get(light.ATTR_BRIGHTNESS_PCT) == 50


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Unsure, but I'd say no. This PR changes the OpenAPI definition of the HassLightSet intent to be more exhaustive, but that's not used directly by users.


## Proposed change

While technically color, temperature and brightness are optional, al least one of those three must be provided, otherwise nothing is being set. I noticed this because my LLM was making tool calls HassLightSet without any argument, which is obviously wrong.

This should make the OpenAPI json schema generated by voluptuous_openapi express that at least one is required.

It does so by using `required(anyOf(...))`, which voluptuous_openapi already supports.
Hopefully this helps LLMs make less mistakes calling tools.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
