### PR TITLE
litterrobot: LR4 Hopper low, dispense events, and hopper metrics

### DIFF
--- a/homeassistant/components/litterrobot/binary_sensor.py
+++ b/homeassistant/components/litterrobot/binary_sensor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Generic
 
 from pylitterbot import LitterRobot, LitterRobot4, Robot
+from pylitterbot.robot.litterrobot4 import HopperStatus
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -54,6 +55,12 @@ BINARY_SENSOR_MAP: dict[type[Robot], tuple[RobotBinarySensorEntityDescription, .
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
             entity_registry_enabled_default=False,
             is_on_fn=lambda robot: not robot.is_hopper_removed,
+        ),
+        RobotBinarySensorEntityDescription[LitterRobot4](
+            key="hopper_low",
+            translation_key="hopper_low",
+            entity_registry_enabled_default=True,
+            is_on_fn=lambda robot: robot.hopper_status == HopperStatus.EMPTY,
         ),
     ),
     Robot: (  # type: ignore[type-abstract]  # only used for isinstance check

--- a/homeassistant/components/litterrobot/coordinator.py
+++ b/homeassistant/components/litterrobot/coordinator.py
@@ -7,17 +7,14 @@ from datetime import timedelta
 import logging
 
 from pylitterbot import Account, FeederRobot, LitterRobot
-from pylitterbot.robot.litterrobot4 import LitterRobot4
 from pylitterbot.exceptions import LitterRobotException, LitterRobotLoginException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import storage
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 
@@ -46,113 +43,18 @@ class LitterRobotDataUpdateCoordinator(DataUpdateCoordinator[None]):
         )
 
         self.account = Account(websession=async_get_clientsession(hass))
-        # Per-robot hopper metrics and last seen event timestamp
-        self.hopper_metrics: dict[str, dict[str, float | int | None]] = {}
-        self._last_hopper_event_ts: dict[str, float] = {}
-        self._hopper_totals: dict[str, float] = {}
-        self._store: storage.Store | None = None
 
     async def _async_update_data(self) -> None:
         """Update all device states from the Litter-Robot API."""
         await self.account.refresh_robots()
         await self.account.load_pets()
         for pet in self.account.pets:
-            # Need to fetch weight history for `get_visits_since`
+            # Fetch weight history for `get_visits_since` sensor
             await pet.fetch_weight_history()
-
-        # Update LR4 hopper metrics and fire events for new dispenses
-        updated_persist = False
-        for robot in (r for r in self.account.robots if isinstance(r, LitterRobot4)):
-            try:
-                activities = await robot.get_activity_history(limit=50)
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Failed fetching activity for %s: %s", robot.serial, err)
-                continue
-
-            today_start = dt_util.start_of_local_day()
-            # Normalize to monotonic increasing events
-            hopper_events = [
-                a for a in activities if str(a.action).startswith("Litter Dispensed")
-            ]
-            hopper_events.sort(key=lambda a: a.timestamp)
-
-            # Fire events for new activities
-            last_ts = self._last_hopper_event_ts.get(robot.serial, 0.0)
-            newest_ts = last_ts
-            for ev in hopper_events:
-                ev_ts = ev.timestamp.timestamp() if hasattr(ev.timestamp, "timestamp") else 0.0
-                # Parse numeric value from "Litter Dispensed: <value>"
-                value_str = str(ev.action).split(":", 1)[-1].strip() if ":" in str(ev.action) else None
-                try:
-                    value = float(value_str) if value_str is not None else None
-                except ValueError:
-                    value = None
-                if ev_ts > last_ts:
-                    self.hass.bus.async_fire(
-                        "litterrobot_hopper_dispensed",
-                        {
-                            "serial": robot.serial,
-                            "name": robot.name,
-                            "timestamp": ev.timestamp.isoformat(),
-                            "value": value,
-                        },
-                    )
-                    if value is not None:
-                        total = self._hopper_totals.get(robot.serial, 0.0) + value
-                        self._hopper_totals[robot.serial] = total
-                        updated_persist = True
-                if ev_ts > newest_ts:
-                    newest_ts = ev_ts
-            if newest_ts > 0:
-                if self._last_hopper_event_ts.get(robot.serial) != newest_ts:
-                    self._last_hopper_event_ts[robot.serial] = newest_ts
-                    updated_persist = True
-
-            # Compute daily metrics
-            sum_today = 0.0
-            count_today = 0
-            last_value: float | None = None
-            if hopper_events:
-                # Last event value
-                last_ev = hopper_events[-1]
-                lv_str = str(last_ev.action).split(":", 1)[-1].strip() if ":" in str(last_ev.action) else None
-                try:
-                    last_value = float(lv_str) if lv_str is not None else None
-                except ValueError:
-                    last_value = None
-            for ev in hopper_events:
-                if ev.timestamp >= today_start:
-                    count_today += 1
-                    val_str = str(ev.action).split(":", 1)[-1].strip() if ":" in str(ev.action) else None
-                    try:
-                        sum_today += float(val_str) if val_str is not None else 0.0
-                    except ValueError:
-                        pass
-
-            self.hopper_metrics[robot.serial] = {
-                "sum_today": sum_today,
-                "count_today": count_today,
-                "last_value": last_value,
-                "total": self._hopper_totals.get(robot.serial, 0.0),
-            }
-
-        if updated_persist and self._store is not None:
-            await self._store.async_save(
-                {
-                    "last_ts": self._last_hopper_event_ts,
-                    "totals": self._hopper_totals,
-                }
-            )
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         try:
-            # Load persisted hopper totals and last timestamps
-            self._store = storage.Store(self.hass, 1, f"{DOMAIN}_hopper_metrics")
-            stored = await self._store.async_load() or {}
-            self._last_hopper_event_ts = stored.get("last_ts", {})
-            self._hopper_totals = stored.get("totals", {})
-
             await self.account.connect(
                 username=self.config_entry.data[CONF_USERNAME],
                 password=self.config_entry.data[CONF_PASSWORD],

--- a/homeassistant/components/litterrobot/coordinator.py
+++ b/homeassistant/components/litterrobot/coordinator.py
@@ -7,14 +7,17 @@ from datetime import timedelta
 import logging
 
 from pylitterbot import Account, FeederRobot, LitterRobot
+from pylitterbot.robot.litterrobot4 import LitterRobot4
 from pylitterbot.exceptions import LitterRobotException, LitterRobotLoginException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import storage
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 
@@ -43,6 +46,11 @@ class LitterRobotDataUpdateCoordinator(DataUpdateCoordinator[None]):
         )
 
         self.account = Account(websession=async_get_clientsession(hass))
+        # Per-robot hopper metrics and last seen event timestamp
+        self.hopper_metrics: dict[str, dict[str, float | int | None]] = {}
+        self._last_hopper_event_ts: dict[str, float] = {}
+        self._hopper_totals: dict[str, float] = {}
+        self._store: storage.Store | None = None
 
     async def _async_update_data(self) -> None:
         """Update all device states from the Litter-Robot API."""
@@ -52,9 +60,99 @@ class LitterRobotDataUpdateCoordinator(DataUpdateCoordinator[None]):
             # Need to fetch weight history for `get_visits_since`
             await pet.fetch_weight_history()
 
+        # Update LR4 hopper metrics and fire events for new dispenses
+        updated_persist = False
+        for robot in (r for r in self.account.robots if isinstance(r, LitterRobot4)):
+            try:
+                activities = await robot.get_activity_history(limit=50)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("Failed fetching activity for %s: %s", robot.serial, err)
+                continue
+
+            today_start = dt_util.start_of_local_day()
+            # Normalize to monotonic increasing events
+            hopper_events = [
+                a for a in activities if str(a.action).startswith("Litter Dispensed")
+            ]
+            hopper_events.sort(key=lambda a: a.timestamp)
+
+            # Fire events for new activities
+            last_ts = self._last_hopper_event_ts.get(robot.serial, 0.0)
+            newest_ts = last_ts
+            for ev in hopper_events:
+                ev_ts = ev.timestamp.timestamp() if hasattr(ev.timestamp, "timestamp") else 0.0
+                # Parse numeric value from "Litter Dispensed: <value>"
+                value_str = str(ev.action).split(":", 1)[-1].strip() if ":" in str(ev.action) else None
+                try:
+                    value = float(value_str) if value_str is not None else None
+                except ValueError:
+                    value = None
+                if ev_ts > last_ts:
+                    self.hass.bus.async_fire(
+                        "litterrobot_hopper_dispensed",
+                        {
+                            "serial": robot.serial,
+                            "name": robot.name,
+                            "timestamp": ev.timestamp.isoformat(),
+                            "value": value,
+                        },
+                    )
+                    if value is not None:
+                        total = self._hopper_totals.get(robot.serial, 0.0) + value
+                        self._hopper_totals[robot.serial] = total
+                        updated_persist = True
+                if ev_ts > newest_ts:
+                    newest_ts = ev_ts
+            if newest_ts > 0:
+                if self._last_hopper_event_ts.get(robot.serial) != newest_ts:
+                    self._last_hopper_event_ts[robot.serial] = newest_ts
+                    updated_persist = True
+
+            # Compute daily metrics
+            sum_today = 0.0
+            count_today = 0
+            last_value: float | None = None
+            if hopper_events:
+                # Last event value
+                last_ev = hopper_events[-1]
+                lv_str = str(last_ev.action).split(":", 1)[-1].strip() if ":" in str(last_ev.action) else None
+                try:
+                    last_value = float(lv_str) if lv_str is not None else None
+                except ValueError:
+                    last_value = None
+            for ev in hopper_events:
+                if ev.timestamp >= today_start:
+                    count_today += 1
+                    val_str = str(ev.action).split(":", 1)[-1].strip() if ":" in str(ev.action) else None
+                    try:
+                        sum_today += float(val_str) if val_str is not None else 0.0
+                    except ValueError:
+                        pass
+
+            self.hopper_metrics[robot.serial] = {
+                "sum_today": sum_today,
+                "count_today": count_today,
+                "last_value": last_value,
+                "total": self._hopper_totals.get(robot.serial, 0.0),
+            }
+
+        if updated_persist and self._store is not None:
+            await self._store.async_save(
+                {
+                    "last_ts": self._last_hopper_event_ts,
+                    "totals": self._hopper_totals,
+                }
+            )
+
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         try:
+            # Load persisted hopper totals and last timestamps
+            self._store = storage.Store(self.hass, 1, f"{DOMAIN}_hopper_metrics")
+            stored = await self._store.async_load() or {}
+            self._last_hopper_event_ts = stored.get("last_ts", {})
+            self._hopper_totals = stored.get("totals", {})
+
             await self.account.connect(
                 username=self.config_entry.data[CONF_USERNAME],
                 password=self.config_entry.data[CONF_PASSWORD],

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -216,64 +216,6 @@ async def async_setup_entry(
         for pet in coordinator.account.pets
         for description in PET_SENSORS
     )
-    # Add LR4 hopper daily sum and event count sensors
-    for robot in coordinator.account.robots:
-        if isinstance(robot, LitterRobot4):
-            entities.append(
-                LitterHopperMetricSensor(
-                    robot,
-                    coordinator,
-                    RobotSensorEntityDescription[LitterRobot4](
-                        key="hopper_dispensed_today",
-                        translation_key="hopper_dispensed_today",
-                        state_class=SensorStateClass.TOTAL,
-                        last_reset_fn=dt_util.start_of_local_day,
-                        value_fn=lambda r: None,  # unused in custom entity
-                    ),
-                    metric_key="sum_today",
-                )
-            )
-            entities.append(
-                LitterHopperMetricSensor(
-                    robot,
-                    coordinator,
-                    RobotSensorEntityDescription[LitterRobot4](
-                        key="hopper_dispense_events_today",
-                        translation_key="hopper_dispense_events_today",
-                        state_class=SensorStateClass.TOTAL,
-                        last_reset_fn=dt_util.start_of_local_day,
-                        value_fn=lambda r: None,  # unused in custom entity
-                    ),
-                    metric_key="count_today",
-                )
-            )
-            entities.append(
-                LitterHopperMetricSensor(
-                    robot,
-                    coordinator,
-                    RobotSensorEntityDescription[LitterRobot4](
-                        key="hopper_dispensed_last",
-                        translation_key="hopper_dispensed_last",
-                        state_class=SensorStateClass.MEASUREMENT,
-                        value_fn=lambda r: None,  # unused in custom entity
-                    ),
-                    metric_key="last_value",
-                )
-            )
-            entities.append(
-                LitterHopperMetricSensor(
-                    robot,
-                    coordinator,
-                    RobotSensorEntityDescription[LitterRobot4](
-                        key="hopper_dispensed_total",
-                        translation_key="hopper_dispensed_total",
-                        state_class=SensorStateClass.TOTAL_INCREASING,
-                        value_fn=lambda r: None,  # unused in custom entity
-                    ),
-                    metric_key="total",
-                )
-            )
-
     async_add_entities(entities)
 
 
@@ -300,15 +242,4 @@ class LitterRobotSensorEntity(LitterRobotEntity[_WhiskerEntityT], SensorEntity):
         return self.entity_description.last_reset_fn() or super().last_reset
 
 
-class LitterHopperMetricSensor(LitterRobotSensorEntity):
-    """Custom sensor reading LR4 hopper metrics computed by the coordinator."""
-
-    def __init__(self, robot: LitterRobot4, coordinator, description: RobotSensorEntityDescription, metric_key: str) -> None:  # type: ignore[no-untyped-def]
-        super().__init__(robot=robot, coordinator=coordinator, description=description)
-        self._metric_key = metric_key
-
-    @property
-    def native_value(self) -> float | int | None:
-        metrics = self.coordinator.hopper_metrics.get(self.robot.serial, {})  # type: ignore[attr-defined]
-        value = metrics.get(self._metric_key)
-        return value  # type: ignore[return-value]
+    

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -161,6 +161,7 @@ ROBOT_SENSOR_MAP: dict[type[Robot], list[RobotSensorEntityDescription]] = {
             state_class=SensorStateClass.MEASUREMENT,
             value_fn=lambda robot: robot.pet_weight,
         ),
+        # Additional LR4 hopper metrics are provided via custom entities below
     ],
     FeederRobot: [
         RobotSensorEntityDescription[FeederRobot](
@@ -215,6 +216,64 @@ async def async_setup_entry(
         for pet in coordinator.account.pets
         for description in PET_SENSORS
     )
+    # Add LR4 hopper daily sum and event count sensors
+    for robot in coordinator.account.robots:
+        if isinstance(robot, LitterRobot4):
+            entities.append(
+                LitterHopperMetricSensor(
+                    robot,
+                    coordinator,
+                    RobotSensorEntityDescription[LitterRobot4](
+                        key="hopper_dispensed_today",
+                        translation_key="hopper_dispensed_today",
+                        state_class=SensorStateClass.TOTAL,
+                        last_reset_fn=dt_util.start_of_local_day,
+                        value_fn=lambda r: None,  # unused in custom entity
+                    ),
+                    metric_key="sum_today",
+                )
+            )
+            entities.append(
+                LitterHopperMetricSensor(
+                    robot,
+                    coordinator,
+                    RobotSensorEntityDescription[LitterRobot4](
+                        key="hopper_dispense_events_today",
+                        translation_key="hopper_dispense_events_today",
+                        state_class=SensorStateClass.TOTAL,
+                        last_reset_fn=dt_util.start_of_local_day,
+                        value_fn=lambda r: None,  # unused in custom entity
+                    ),
+                    metric_key="count_today",
+                )
+            )
+            entities.append(
+                LitterHopperMetricSensor(
+                    robot,
+                    coordinator,
+                    RobotSensorEntityDescription[LitterRobot4](
+                        key="hopper_dispensed_last",
+                        translation_key="hopper_dispensed_last",
+                        state_class=SensorStateClass.MEASUREMENT,
+                        value_fn=lambda r: None,  # unused in custom entity
+                    ),
+                    metric_key="last_value",
+                )
+            )
+            entities.append(
+                LitterHopperMetricSensor(
+                    robot,
+                    coordinator,
+                    RobotSensorEntityDescription[LitterRobot4](
+                        key="hopper_dispensed_total",
+                        translation_key="hopper_dispensed_total",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        value_fn=lambda r: None,  # unused in custom entity
+                    ),
+                    metric_key="total",
+                )
+            )
+
     async_add_entities(entities)
 
 
@@ -239,3 +298,17 @@ class LitterRobotSensorEntity(LitterRobotEntity[_WhiskerEntityT], SensorEntity):
     def last_reset(self) -> datetime | None:
         """Return the time when the sensor was last reset, if any."""
         return self.entity_description.last_reset_fn() or super().last_reset
+
+
+class LitterHopperMetricSensor(LitterRobotSensorEntity):
+    """Custom sensor reading LR4 hopper metrics computed by the coordinator."""
+
+    def __init__(self, robot: LitterRobot4, coordinator, description: RobotSensorEntityDescription, metric_key: str) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(robot=robot, coordinator=coordinator, description=description)
+        self._metric_key = metric_key
+
+    @property
+    def native_value(self) -> float | int | None:
+        metrics = self.coordinator.hopper_metrics.get(self.robot.serial, {})  # type: ignore[attr-defined]
+        value = metrics.get(self._metric_key)
+        return value  # type: ignore[return-value]

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -76,19 +76,6 @@
           "empty": "[%key:common::state::empty%]"
         }
       },
-      "hopper_dispensed_today": {
-        "name": "Litter dispensed today"
-      },
-      "hopper_dispense_events_today": {
-        "name": "Hopper dispense events today",
-        "unit_of_measurement": "events"
-      },
-      "hopper_dispensed_last": {
-        "name": "Last litter dispensed"
-      },
-      "hopper_dispensed_total": {
-        "name": "Litter dispensed (total)"
-      },
       "last_seen": {
         "name": "Last seen"
       },

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -37,6 +37,9 @@
       "hopper_connected": {
         "name": "Hopper connected"
       },
+      "hopper_low": {
+        "name": "Hopper low"
+      },
       "sleeping": {
         "name": "Sleeping"
       },
@@ -72,6 +75,19 @@
           "motor_disconnected": "Motor disconnected",
           "empty": "[%key:common::state::empty%]"
         }
+      },
+      "hopper_dispensed_today": {
+        "name": "Litter dispensed today"
+      },
+      "hopper_dispense_events_today": {
+        "name": "Hopper dispense events today",
+        "unit_of_measurement": "events"
+      },
+      "hopper_dispensed_last": {
+        "name": "Last litter dispensed"
+      },
+      "hopper_dispensed_total": {
+        "name": "Litter dispensed (total)"
       },
       "last_seen": {
         "name": "Last seen"


### PR DESCRIPTION
Adds LR4 hopper support: hopper_low binary sensor, event fired on 'Litter Dispensed', and sensors for daily sum, daily count, last, and total dispensed. Includes persistence for total.