### PR TITLE
Sort template config menu step by user language

### DIFF
--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -514,7 +514,7 @@ TEMPLATE_TYPES = [
 ]
 
 CONFIG_FLOW = {
-    "user": SchemaFlowMenuStep(TEMPLATE_TYPES),
+    "user": SchemaFlowMenuStep(TEMPLATE_TYPES, True),
     Platform.ALARM_CONTROL_PANEL: SchemaFlowFormStep(
         config_schema(Platform.ALARM_CONTROL_PANEL),
         preview="template",

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -378,25 +378,8 @@
         "title": "Template sensor"
       },
       "user": {
-        "description": "This helper allows you to create helper entities that define their state using a template.",
+        "description": "This helper allows you to create helper entities that define their state using a template. What kind of template would you like to create?",
         "menu_options": {
-          "alarm_control_panel": "Template an alarm control panel",
-          "binary_sensor": "Template a binary sensor",
-          "button": "Template a button",
-          "cover": "Template a cover",
-          "event": "Template an event",
-          "fan": "Template a fan",
-          "image": "Template an image",
-          "light": "Template a light",
-          "lock": "Template a lock",
-          "number": "Template a number",
-          "select": "Template a select",
-          "sensor": "Template a sensor",
-          "switch": "Template a switch",
-          "update": "Template an update",
-          "vacuum": "Template a vacuum"
-        },
-        "menu_sort_values": {
           "alarm_control_panel": "[%key:component::alarm_control_panel::title%]",
           "binary_sensor": "[%key:component::binary_sensor::title%]",
           "button": "[%key:component::button::title%]",

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -396,6 +396,23 @@
           "update": "Template an update",
           "vacuum": "Template a vacuum"
         },
+        "menu_sort_values": {
+          "alarm_control_panel": "[%key:component::alarm_control_panel::title%]",
+          "binary_sensor": "[%key:component::binary_sensor::title%]",
+          "button": "[%key:component::button::title%]",
+          "cover": "[%key:component::cover::title%]",
+          "event": "[%key:component::event::title%]",
+          "fan": "[%key:component::fan::title%]",
+          "image": "[%key:component::image::title%]",
+          "light": "[%key:component::light::title%]",
+          "lock": "[%key:component::lock::title%]",
+          "number": "[%key:component::number::title%]",
+          "select": "[%key:component::select::title%]",
+          "sensor": "[%key:component::sensor::title%]",
+          "switch": "[%key:component::switch::title%]",
+          "update": "[%key:component::update::title%]",
+          "vacuum": "[%key:component::vacuum::title%]"
+        },
         "title": "Template helper"
       },
       "switch": {

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -142,6 +142,7 @@ class FlowResult(TypedDict, Generic[_FlowContextT, _HandlerT], total=False):
     progress_task: asyncio.Task[Any] | None
     reason: str
     required: bool
+    sort: bool
     step_id: str
     title: str
     translation_domain: str
@@ -854,6 +855,7 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         *,
         step_id: str | None = None,
         menu_options: Container[str],
+        sort: bool,
         description_placeholders: Mapping[str, str] | None = None,
     ) -> _FlowResultT:
         """Show a navigation menu to the user.
@@ -868,6 +870,8 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             menu_options=menu_options,
             description_placeholders=description_placeholders,
         )
+        if sort:
+            flow_result["sort"] = sort
         if step_id is not None:
             flow_result["step_id"] = step_id
         return flow_result

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -855,7 +855,7 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         *,
         step_id: str | None = None,
         menu_options: Container[str],
-        sort: bool,
+        sort: bool = False,
         description_placeholders: Mapping[str, str] | None = None,
     ) -> _FlowResultT:
         """Show a navigation menu to the user.

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -117,6 +117,11 @@ class SchemaFlowMenuStep(SchemaFlowStep):
     `SchemaCommonFlowHandler`.
     """
 
+    sort: bool = False
+    """If true, menu options will be sorted in the user's language, by the
+      'menu_sort_values' key (if defined), otherwise by the option label.
+    """
+
 
 class SchemaCommonFlowHandler:
     """Handle a schema based config or options flow."""
@@ -269,6 +274,7 @@ class SchemaCommonFlowHandler:
             return self._handler.async_show_menu(
                 step_id=next_step_id,
                 menu_options=await self._get_options(menu_step),
+                sort=menu_step.sort,
             )
 
         form_step = cast(SchemaFlowFormStep, self._flow[next_step_id])
@@ -322,6 +328,7 @@ class SchemaCommonFlowHandler:
         return self._handler.async_show_menu(
             step_id=step_id,
             menu_options=await self._get_options(menu_step),
+            sort=menu_step.sort,
         )
 
 

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -118,8 +118,7 @@ class SchemaFlowMenuStep(SchemaFlowStep):
     """
 
     sort: bool = False
-    """If true, menu options will be sorted in the user's language, by the
-      'menu_sort_values' key (if defined), otherwise by the option label.
+    """If true, menu options will be alphabetically sorted by the option label.
     """
 
 

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -170,6 +170,7 @@ def gen_data_entry_schema(
                 vol.Optional("data"): {str: translation_value_validator},
                 vol.Optional("data_description"): {str: translation_value_validator},
                 vol.Optional("menu_options"): {str: translation_value_validator},
+                vol.Optional("menu_sort_values"): {str: translation_value_validator},
                 vol.Optional("submit"): translation_value_validator,
                 vol.Optional("sections"): {
                     str: {

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -173,7 +173,6 @@ def gen_data_entry_schema(
                 vol.Optional("menu_option_descriptions"): {
                     str: translation_value_validator
                 },
-                vol.Optional("menu_sort_values"): {str: translation_value_validator},
                 vol.Optional("submit"): translation_value_validator,
                 vol.Optional("sections"): {
                     str: {

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -173,7 +173,7 @@ def gen_data_entry_schema(
                 vol.Optional("menu_option_descriptions"): {
                     str: translation_value_validator
                 },
-                vol.Optional("menu_sort_values"): {str: translation_value_validator},              
+                vol.Optional("menu_sort_values"): {str: translation_value_validator},
                 vol.Optional("submit"): translation_value_validator,
                 vol.Optional("sections"): {
                     str: {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change proposes to add a new `sort` option to StepFlowMenu, which will instruct the frontend to sort the menu items based on the translated language. 

It uses this option for the create template config flow, which requires user to pick a template domain to create using a menu, and the list is quite long and getting longer as more template types are added. 

In English the list is sorted in nice alphabetical order, but in other languages the items appear to be sorted in random order, and it makes it harder than necessary to find and pick an item.

~~In addition to adding the sort option, this also adds a separate class of translation key for each step option, which will not be displayed, but is used for sorting. This might be overkill but it seemed useful in this situation, as the menu step labels themselves were not _directly_ sortable because they use natural language sentences and include articles like `a` and `an` before the actual template type, which would throw off their sort order. Or possibly in other languages things there would be other irregularities that make sorting the sentences directly incorrect.~~

~~So this will keep the same sort order as currently in English, (sorted by template domain), instead of sorting on the string prefix `Template a...` or `Template an...`~~

~~If we were willing to change these keys we could potentially add sorting without introducing a new `menu_sort_values` key, but for now I have added it pending further opinions, as it provides greater flexibility for the future.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/26398
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2773
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/26845

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
