### PR TITLE
Update py-aosmith to 1.0.14

### DIFF
--- a/homeassistant/components/aosmith/manifest.json
+++ b/homeassistant/components/aosmith/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aosmith",
   "iot_class": "cloud_polling",
-  "requirements": ["py-aosmith==1.0.12"]
+  "requirements": ["py-aosmith==1.0.14"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1743,7 +1743,7 @@ pushover_complete==1.2.0
 pvo==2.2.1
 
 # homeassistant.components.aosmith
-py-aosmith==1.0.12
+py-aosmith==1.0.14
 
 # homeassistant.components.canary
 py-canary==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1469,7 +1469,7 @@ pushover_complete==1.2.0
 pvo==2.2.1
 
 # homeassistant.components.aosmith
-py-aosmith==1.0.12
+py-aosmith==1.0.14
 
 # homeassistant.components.canary
 py-canary==0.5.4

--- a/tests/components/aosmith/conftest.py
+++ b/tests/components/aosmith/conftest.py
@@ -37,6 +37,7 @@ def build_device_fixture(
             mode=OperationMode.ELECTRIC,
             original_name="ELECTRIC",
             has_day_selection=True,
+            supports_hot_water_plus=False,
         ),
     ]
 
@@ -46,6 +47,7 @@ def build_device_fixture(
                 mode=OperationMode.HYBRID,
                 original_name="HYBRID",
                 has_day_selection=False,
+                supports_hot_water_plus=False,
             )
         )
         supported_modes.append(
@@ -53,6 +55,7 @@ def build_device_fixture(
                 mode=OperationMode.HEAT_PUMP,
                 original_name="HEAT_PUMP",
                 has_day_selection=False,
+                supports_hot_water_plus=False,
             )
         )
 
@@ -62,6 +65,7 @@ def build_device_fixture(
                 mode=OperationMode.VACATION,
                 original_name="VACATION",
                 has_day_selection=True,
+                supports_hot_water_plus=False,
             )
         )
 
@@ -83,6 +87,7 @@ def build_device_fixture(
         serial="serial",
         install_location="Basement",
         supported_modes=supported_modes,
+        supports_hot_water_plus=False,
         status=DeviceStatus(
             firmware_version="2.14",
             is_online=True,
@@ -93,6 +98,7 @@ def build_device_fixture(
             temperature_setpoint_previous=130,
             temperature_setpoint_maximum=130,
             hot_water_status=90,
+            hot_water_plus_level=None,
         ),
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update py-aosmith to 1.0.14. This introduces support for a new device type, referred to as 'RE3Premium'.

https://github.com/bdr99/py-aosmith/compare/1.0.12...1.0.14

Support for the new features of this device type will be added separately in https://github.com/home-assistant/core/pull/151548

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes https://github.com/home-assistant/core/issues/131774
  - fixes https://github.com/home-assistant/core/issues/131841
  - fixes https://github.com/home-assistant/core/issues/146051
  - fixes https://github.com/home-assistant/core/issues/151102
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
