### PR TITLE
Use new method to get the access token in the Volvo integration

### DIFF
--- a/homeassistant/components/volvo/api.py
+++ b/homeassistant/components/volvo/api.py
@@ -6,8 +6,8 @@ from typing import cast
 from aiohttp import ClientSession
 from volvocarsapi.auth import AccessTokenManager
 
-from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+from homeassistant.helpers.redact import async_redact_data
 
 _LOGGER = logging.getLogger(__name__)
 _TO_REDACT = ["access_token", "id_token", "refresh_token"]

--- a/homeassistant/components/volvo/api.py
+++ b/homeassistant/components/volvo/api.py
@@ -1,11 +1,16 @@
 """API for Volvo bound to Home Assistant OAuth."""
 
+import logging
 from typing import cast
 
 from aiohttp import ClientSession
 from volvocarsapi.auth import AccessTokenManager
 
+from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+
+_LOGGER = logging.getLogger(__name__)
+_TO_REDACT = ["access_token", "id_token", "refresh_token"]
 
 
 class VolvoAuth(AccessTokenManager):
@@ -18,7 +23,20 @@ class VolvoAuth(AccessTokenManager):
 
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
+        current_access_token = self._oauth_session.token["access_token"]
+        current_refresh_token = self._oauth_session.token["refresh_token"]
+
         await self._oauth_session.async_ensure_token_valid()
+
+        _LOGGER.debug(
+            "Token: %s", async_redact_data(self._oauth_session.token, _TO_REDACT)
+        )
+        _LOGGER.debug(
+            "Token changed: access %s, refresh %s",
+            current_access_token != self._oauth_session.token["access_token"],
+            current_refresh_token != self._oauth_session.token["refresh_token"],
+        )
+
         return cast(str, self._oauth_session.token["access_token"])
 
 

--- a/homeassistant/components/volvo/manifest.json
+++ b/homeassistant/components/volvo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Volvo",
   "codeowners": ["@thomasddn"],
   "config_flow": true,
-  "dependencies": ["application_credentials", "diagnostics"],
+  "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/volvo",
   "integration_type": "device",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/volvo/manifest.json
+++ b/homeassistant/components/volvo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Volvo",
   "codeowners": ["@thomasddn"],
   "config_flow": true,
-  "dependencies": ["application_credentials"],
+  "dependencies": ["application_credentials", "diagnostics"],
   "documentation": "https://www.home-assistant.io/integrations/volvo",
   "integration_type": "device",
   "iot_class": "cloud_polling",

--- a/tests/components/volvo/conftest.py
+++ b/tests/components/volvo/conftest.py
@@ -1,6 +1,7 @@
 """Define fixtures for Volvo unit tests."""
 
 from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -9,6 +10,7 @@ from volvocarsapi.auth import TOKEN_URL
 from volvocarsapi.models import (
     VolvoCarsAvailableCommand,
     VolvoCarsLocation,
+    VolvoCarsValueField,
     VolvoCarsValueStatusField,
     VolvoCarsVehicle,
 )
@@ -17,10 +19,16 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
+from homeassistant.components.volvo.api import VolvoAuth
 from homeassistant.components.volvo.const import CONF_VIN, DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_TOKEN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    OAuth2Session,
+    async_get_config_entry_implementation,
+)
 from homeassistant.setup import async_setup_component
+from homeassistant.util.json import JsonObjectType
 
 from . import async_load_fixture_as_json, async_load_fixture_as_value_field
 from .const import (
@@ -35,6 +43,30 @@ from .const import (
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+@dataclass
+class MockApiData:
+    """Container for mock API data."""
+
+    vehicle: VolvoCarsVehicle
+    commands: list[VolvoCarsAvailableCommand]
+    location: dict[str, VolvoCarsLocation]
+    availability: dict[str, VolvoCarsValueField]
+    brakes: dict[str, VolvoCarsValueField]
+    diagnostics: dict[str, VolvoCarsValueField]
+    doors: dict[str, VolvoCarsValueField]
+    energy_capabilities: JsonObjectType
+    energy_state: dict[str, VolvoCarsValueStatusField]
+    engine_status: dict[str, VolvoCarsValueField]
+    engine_warnings: dict[str, VolvoCarsValueField]
+    fuel_status: dict[str, VolvoCarsValueField]
+    odometer: dict[str, VolvoCarsValueField]
+    recharge_status: dict[str, VolvoCarsValueField]
+    statistics: dict[str, VolvoCarsValueField]
+    tyres: dict[str, VolvoCarsValueField]
+    warnings: dict[str, VolvoCarsValueField]
+    windows: dict[str, VolvoCarsValueField]
 
 
 @pytest.fixture(params=[DEFAULT_MODEL])
@@ -65,81 +97,62 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     return config_entry
 
 
-@pytest.fixture(autouse=True)
-async def mock_api(hass: HomeAssistant, full_model: str) -> AsyncGenerator[AsyncMock]:
+@pytest.fixture
+async def mock_api(
+    hass: HomeAssistant,
+    full_model: str,
+    mock_config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+    setup_credentials,
+) -> AsyncGenerator[VolvoCarsApi]:
     """Mock the Volvo API."""
+
+    mock_api_data = await _async_load_mock_api_data(hass, full_model)
+
+    implementation = await async_get_config_entry_implementation(
+        hass, mock_config_entry
+    )
+    oauth_session = OAuth2Session(hass, mock_config_entry, implementation)
+    auth = VolvoAuth(aioclient_mock, oauth_session)
+    api = VolvoCarsApi(
+        aioclient_mock,
+        auth,
+        mock_config_entry.data[CONF_API_KEY],
+        mock_config_entry.data[CONF_VIN],
+    )
+
     with patch(
         "homeassistant.components.volvo.VolvoCarsApi",
-        autospec=True,
-    ) as mock_api:
-        vehicle_data = await async_load_fixture_as_json(hass, "vehicle", full_model)
-        vehicle = VolvoCarsVehicle.from_dict(vehicle_data)
-
-        commands_data = (
-            await async_load_fixture_as_json(hass, "commands", full_model)
-        ).get("data")
-        commands = [VolvoCarsAvailableCommand.from_dict(item) for item in commands_data]
-
-        location_data = await async_load_fixture_as_json(hass, "location", full_model)
-        location = {"location": VolvoCarsLocation.from_dict(location_data)}
-
-        availability = await async_load_fixture_as_value_field(
-            hass, "availability", full_model
+        return_value=api,
+    ):
+        api.async_get_brakes_status = AsyncMock(return_value=mock_api_data.brakes)
+        api.async_get_command_accessibility = AsyncMock(
+            return_value=mock_api_data.availability
         )
-        brakes = await async_load_fixture_as_value_field(hass, "brakes", full_model)
-        diagnostics = await async_load_fixture_as_value_field(
-            hass, "diagnostics", full_model
+        api.async_get_commands = AsyncMock(return_value=mock_api_data.commands)
+        api.async_get_diagnostics = AsyncMock(return_value=mock_api_data.diagnostics)
+        api.async_get_doors_status = AsyncMock(return_value=mock_api_data.doors)
+        api.async_get_energy_capabilities = AsyncMock(
+            return_value=mock_api_data.energy_capabilities
         )
-        doors = await async_load_fixture_as_value_field(hass, "doors", full_model)
-        energy_capabilities = await async_load_fixture_as_json(
-            hass, "energy_capabilities", full_model
+        api.async_get_energy_state = AsyncMock(return_value=mock_api_data.energy_state)
+        api.async_get_engine_status = AsyncMock(
+            return_value=mock_api_data.engine_status
         )
-        energy_state_data = await async_load_fixture_as_json(
-            hass, "energy_state", full_model
+        api.async_get_engine_warnings = AsyncMock(
+            return_value=mock_api_data.engine_warnings
         )
-        energy_state = {
-            key: VolvoCarsValueStatusField.from_dict(value)
-            for key, value in energy_state_data.items()
-        }
-        engine_status = await async_load_fixture_as_value_field(
-            hass, "engine_status", full_model
+        api.async_get_fuel_status = AsyncMock(return_value=mock_api_data.fuel_status)
+        api.async_get_location = AsyncMock(return_value=mock_api_data.location)
+        api.async_get_odometer = AsyncMock(return_value=mock_api_data.odometer)
+        api.async_get_recharge_status = AsyncMock(
+            return_value=mock_api_data.recharge_status
         )
-        engine_warnings = await async_load_fixture_as_value_field(
-            hass, "engine_warnings", full_model
-        )
-        fuel_status = await async_load_fixture_as_value_field(
-            hass, "fuel_status", full_model
-        )
-        odometer = await async_load_fixture_as_value_field(hass, "odometer", full_model)
-        recharge_status = await async_load_fixture_as_value_field(
-            hass, "recharge_status", full_model
-        )
-        statistics = await async_load_fixture_as_value_field(
-            hass, "statistics", full_model
-        )
-        tyres = await async_load_fixture_as_value_field(hass, "tyres", full_model)
-        warnings = await async_load_fixture_as_value_field(hass, "warnings", full_model)
-        windows = await async_load_fixture_as_value_field(hass, "windows", full_model)
-
-        api: VolvoCarsApi = mock_api.return_value
-        api.async_get_brakes_status = AsyncMock(return_value=brakes)
-        api.async_get_command_accessibility = AsyncMock(return_value=availability)
-        api.async_get_commands = AsyncMock(return_value=commands)
-        api.async_get_diagnostics = AsyncMock(return_value=diagnostics)
-        api.async_get_doors_status = AsyncMock(return_value=doors)
-        api.async_get_energy_capabilities = AsyncMock(return_value=energy_capabilities)
-        api.async_get_energy_state = AsyncMock(return_value=energy_state)
-        api.async_get_engine_status = AsyncMock(return_value=engine_status)
-        api.async_get_engine_warnings = AsyncMock(return_value=engine_warnings)
-        api.async_get_fuel_status = AsyncMock(return_value=fuel_status)
-        api.async_get_location = AsyncMock(return_value=location)
-        api.async_get_odometer = AsyncMock(return_value=odometer)
-        api.async_get_recharge_status = AsyncMock(return_value=recharge_status)
-        api.async_get_statistics = AsyncMock(return_value=statistics)
-        api.async_get_tyre_states = AsyncMock(return_value=tyres)
-        api.async_get_vehicle_details = AsyncMock(return_value=vehicle)
-        api.async_get_warnings = AsyncMock(return_value=warnings)
-        api.async_get_window_states = AsyncMock(return_value=windows)
+        api.async_get_statistics = AsyncMock(return_value=mock_api_data.statistics)
+        api.async_get_tyre_states = AsyncMock(return_value=mock_api_data.tyres)
+        api.async_get_vehicle_details = AsyncMock(return_value=mock_api_data.vehicle)
+        api.async_get_warnings = AsyncMock(return_value=mock_api_data.warnings)
+        api.async_get_window_states = AsyncMock(return_value=mock_api_data.windows)
 
         yield api
 
@@ -183,3 +196,76 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         "homeassistant.components.volvo.async_setup_entry", return_value=True
     ) as mock_setup:
         yield mock_setup
+
+
+async def _async_load_mock_api_data(
+    hass: HomeAssistant, full_model: str
+) -> MockApiData:
+    """Load all mock API data from fixtures."""
+    vehicle_data = await async_load_fixture_as_json(hass, "vehicle", full_model)
+    vehicle = VolvoCarsVehicle.from_dict(vehicle_data)
+
+    commands_data = (
+        await async_load_fixture_as_json(hass, "commands", full_model)
+    ).get("data")
+    commands = [VolvoCarsAvailableCommand.from_dict(item) for item in commands_data]
+
+    location_data = await async_load_fixture_as_json(hass, "location", full_model)
+    location = {"location": VolvoCarsLocation.from_dict(location_data)}
+
+    availability = await async_load_fixture_as_value_field(
+        hass, "availability", full_model
+    )
+    brakes = await async_load_fixture_as_value_field(hass, "brakes", full_model)
+    diagnostics = await async_load_fixture_as_value_field(
+        hass, "diagnostics", full_model
+    )
+    doors = await async_load_fixture_as_value_field(hass, "doors", full_model)
+    energy_capabilities = await async_load_fixture_as_json(
+        hass, "energy_capabilities", full_model
+    )
+    energy_state_data = await async_load_fixture_as_json(
+        hass, "energy_state", full_model
+    )
+    energy_state = {
+        key: VolvoCarsValueStatusField.from_dict(value)
+        for key, value in energy_state_data.items()
+    }
+    engine_status = await async_load_fixture_as_value_field(
+        hass, "engine_status", full_model
+    )
+    engine_warnings = await async_load_fixture_as_value_field(
+        hass, "engine_warnings", full_model
+    )
+    fuel_status = await async_load_fixture_as_value_field(
+        hass, "fuel_status", full_model
+    )
+    odometer = await async_load_fixture_as_value_field(hass, "odometer", full_model)
+    recharge_status = await async_load_fixture_as_value_field(
+        hass, "recharge_status", full_model
+    )
+    statistics = await async_load_fixture_as_value_field(hass, "statistics", full_model)
+    tyres = await async_load_fixture_as_value_field(hass, "tyres", full_model)
+    warnings = await async_load_fixture_as_value_field(hass, "warnings", full_model)
+    windows = await async_load_fixture_as_value_field(hass, "windows", full_model)
+
+    return MockApiData(
+        vehicle=vehicle,
+        commands=commands,
+        location=location,
+        availability=availability,
+        brakes=brakes,
+        diagnostics=diagnostics,
+        doors=doors,
+        energy_capabilities=energy_capabilities,
+        energy_state=energy_state,
+        engine_status=engine_status,
+        engine_warnings=engine_warnings,
+        fuel_status=fuel_status,
+        odometer=odometer,
+        recharge_status=recharge_status,
+        statistics=statistics,
+        tyres=tyres,
+        warnings=warnings,
+        windows=windows,
+    )

--- a/tests/components/volvo/conftest.py
+++ b/tests/components/volvo/conftest.py
@@ -129,7 +129,7 @@ async def mock_api(
         api.async_get_command_accessibility = AsyncMock(
             return_value=mock_api_data.availability
         )
-        api.async_get_commands = AsyncMock(return_value=mock_api_data.commands)
+        api.async_get_commands.return_value = mock_api_data.commands
         api.async_get_diagnostics = AsyncMock(return_value=mock_api_data.diagnostics)
         api.async_get_doors_status = AsyncMock(return_value=mock_api_data.doors)
         api.async_get_energy_capabilities = AsyncMock(

--- a/tests/components/volvo/conftest.py
+++ b/tests/components/volvo/conftest.py
@@ -129,7 +129,7 @@ async def mock_api(
         api.async_get_command_accessibility = AsyncMock(
             return_value=mock_api_data.availability
         )
-        api.async_get_commands.return_value = mock_api_data.commands
+        api.async_get_commands = AsyncMock(return_value=mock_api_data.commands)
         api.async_get_diagnostics = AsyncMock(return_value=mock_api_data.diagnostics)
         api.async_get_doors_status = AsyncMock(return_value=mock_api_data.doors)
         api.async_get_energy_capabilities = AsyncMock(

--- a/tests/components/volvo/test_binary_sensor.py
+++ b/tests/components/volvo/test_binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("mock_api", "full_model")
 @pytest.mark.parametrize(
     "full_model",
     ["ex30_2024", "s90_diesel_2018", "xc40_electric_2024", "xc90_petrol_2019"],

--- a/tests/components/volvo/test_sensor.py
+++ b/tests/components/volvo/test_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("mock_api", "full_model")
 @pytest.mark.parametrize(
     "full_model",
     [
@@ -38,6 +39,7 @@ async def test_sensor(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+@pytest.mark.usefixtures("mock_api", "full_model")
 @pytest.mark.parametrize(
     "full_model",
     ["xc40_electric_2024"],
@@ -54,6 +56,7 @@ async def test_distance_to_empty_battery(
     assert hass.states.get("sensor.volvo_xc40_distance_to_empty_battery").state == "250"
 
 
+@pytest.mark.usefixtures("mock_api", "full_model")
 @pytest.mark.parametrize(
     ("full_model", "short_model"),
     [("ex30_2024", "ex30"), ("xc60_phev_2020", "xc60")],
@@ -71,6 +74,7 @@ async def test_skip_invalid_api_fields(
     assert not hass.states.get(f"sensor.volvo_{short_model}_charging_current_limit")
 
 
+@pytest.mark.usefixtures("mock_api", "full_model")
 @pytest.mark.parametrize(
     "full_model",
     ["ex30_2024"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR request is related to #151062. Mind that the root cause has not been found yet ([comment](https://github.com/home-assistant/core/issues/151062#issuecomment-3241645281)).

With the bump of the `volvocarsapi` dependency (#151579), a new and better method is available to get the access token. This new method raises typed errors in case of failed token requests. This means the integration doesn't need to worry anymore about which possible http requests can be thrown.

As a consequence, unit tests had to be refactored, because `async_get_access_token()` on the `VolvoCarsApi` may not be mocked. Previously, the whole `VolvoCarsApi` was mocked, now only selective methods.

Additional logging has been added when requesting an access token to gather more information about the issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #151062
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
