### PR TITLE
Prevent multiple Home Assistant instances from running with the same config directory

### DIFF
--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -3,10 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Generator
+from contextlib import contextmanager
 import dataclasses
+from datetime import UTC, datetime
+import fcntl
+from io import TextIOWrapper
+import json
 import logging
+import os
+from pathlib import Path
 import subprocess
+import sys
 import threading
+import time
 from time import monotonic
 import traceback
 from typing import Any
@@ -14,6 +24,7 @@ from typing import Any
 import packaging.tags
 
 from . import bootstrap
+from .const import __version__
 from .core import callback
 from .helpers.frame import warn_use
 from .util.executor import InterruptibleThreadPoolExecutor
@@ -33,7 +44,108 @@ from .util.thread import deadlock_safe_shutdown
 MAX_EXECUTOR_WORKERS = 64
 TASK_CANCELATION_TIMEOUT = 5
 
+# Lock file configuration
+LOCK_FILE_NAME = "ha_run.lock"
+LOCK_FILE_VERSION = 1  # Increment if format changes
+
 _LOGGER = logging.getLogger(__name__)
+
+
+class SingleExecutionLock:
+    """Context object for single execution lock."""
+
+    def __init__(self) -> None:
+        """Initialize the lock context."""
+        self.exit_code: int | None = None
+
+
+def _write_lock_info(lock_file: TextIOWrapper) -> None:
+    """Write current instance information to the lock file.
+
+    Args:
+        lock_file: The open lock file handle.
+    """
+    lock_file.seek(0)
+    lock_file.truncate()
+
+    instance_info = {
+        "pid": os.getpid(),
+        "version": LOCK_FILE_VERSION,
+        "ha_version": __version__,
+        "start_ts": time.time(),
+    }
+    json.dump(instance_info, lock_file)
+    lock_file.flush()
+
+
+def _report_existing_instance(lock_file_path: Path, config_dir: str) -> None:
+    """Report that another instance is already running.
+
+    Attempts to read the lock file to provide details about the running instance.
+    """
+    error_msg: list[str] = []
+    error_msg.append("Error: Another Home Assistant instance is already running!")
+
+    # Try to read information about the existing instance
+    try:
+        with open(lock_file_path, encoding="utf-8") as f:
+            content = f.read()
+            if (
+                content.strip()
+            ):  # Check for non-empty content after stripping whitespace
+                existing_info = json.loads(content)
+                start_time = datetime.fromtimestamp(
+                    existing_info["start_ts"], tz=UTC
+                ).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+                error_msg.append(f"  PID: {existing_info['pid']}")
+                error_msg.append(f"  Version: {existing_info['ha_version']}")
+                error_msg.append(f"  Started: {start_time}")
+            else:
+                error_msg.append("  Unable to read lock file details.")
+    except Exception:  # noqa: BLE001
+        error_msg.append("  Unable to read lock file details.")
+
+    error_msg.append(f"  Config directory: {config_dir}")
+    error_msg.append("")
+    error_msg.append("Please stop the existing instance before starting a new one.")
+
+    for line in error_msg:
+        print(line, file=sys.stderr)  # noqa: T201
+
+
+@contextmanager
+def ensure_single_execution(config_dir: str) -> Generator[SingleExecutionLock]:
+    """Ensure only one Home Assistant instance runs per config directory.
+
+    Uses file locking to prevent multiple instances from running with the
+    same configuration directory, which can cause data corruption.
+
+    Returns a context object with exit_code attribute that will be set
+    if another instance is already running.
+    """
+    lock_file_path = Path(config_dir) / LOCK_FILE_NAME
+    lock_context = SingleExecutionLock()
+
+    # Open with 'a+' mode to avoid truncating existing content
+    # This allows us to read existing content if lock fails
+    with open(lock_file_path, "a+", encoding="utf-8") as lock_file:
+        # Try to acquire an exclusive, non-blocking lock
+        # This will raise BlockingIOError if lock is already held
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            # Another instance is already running
+            _report_existing_instance(lock_file_path, config_dir)
+            lock_context.exit_code = 1
+            yield lock_context
+            return  # Exit early since we couldn't get the lock
+
+        # If we got the lock (no exception), write our instance info
+        _write_lock_info(lock_file)
+
+        # Yield the context - lock will be released when the with statement closes the file
+        yield lock_context
 
 
 @dataclasses.dataclass(slots=True)

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Generator
 from contextlib import contextmanager
 import dataclasses
-from datetime import UTC, datetime
+from datetime import datetime
 import fcntl
 from io import TextIOWrapper
 import json
@@ -94,9 +94,14 @@ def _report_existing_instance(lock_file_path: Path, config_dir: str) -> None:
                 content.strip()
             ):  # Check for non-empty content after stripping whitespace
                 existing_info = json.loads(content)
-                start_time = datetime.fromtimestamp(
-                    existing_info["start_ts"], tz=UTC
-                ).strftime("%Y-%m-%d %H:%M:%S UTC")
+                start_dt = datetime.fromtimestamp(existing_info["start_ts"])
+                # Format with timezone abbreviation (e.g., PST, EST, CET)
+                start_time = start_dt.strftime("%Y-%m-%d %H:%M:%S %Z")
+                # If no timezone name available, add local time indicator
+                if not start_dt.strftime("%Z"):
+                    start_time = (
+                        start_dt.strftime("%Y-%m-%d %H:%M:%S") + " (local time)"
+                    )
 
                 error_msg.append(f"  PID: {existing_info['pid']}")
                 error_msg.append(f"  Version: {existing_info['ha_version']}")

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -51,12 +51,11 @@ LOCK_FILE_VERSION = 1  # Increment if format changes
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass
 class SingleExecutionLock:
     """Context object for single execution lock."""
 
-    def __init__(self) -> None:
-        """Initialize the lock context."""
-        self.exit_code: int | None = None
+    exit_code: int | None = None
 
 
 def _write_lock_info(lock_file: TextIOWrapper) -> None:

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -95,10 +95,10 @@ def _report_existing_instance(lock_file_path: Path, config_dir: str) -> None:
             ):  # Check for non-empty content after stripping whitespace
                 existing_info = json.loads(content)
                 start_dt = datetime.fromtimestamp(existing_info["start_ts"])
-                # Format with timezone abbreviation (e.g., PST, EST, CET)
-                start_time = start_dt.strftime("%Y-%m-%d %H:%M:%S %Z")
-                # If no timezone name available, add local time indicator
-                if not start_dt.strftime("%Z"):
+                # Format with timezone abbreviation if available, otherwise add local time indicator
+                if tz_abbr := start_dt.strftime("%Z"):
+                    start_time = start_dt.strftime(f"%Y-%m-%d %H:%M:%S {tz_abbr}")
+                else:
                     start_time = (
                         start_dt.strftime("%Y-%m-%d %H:%M:%S") + " (local time)"
                     )

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -88,10 +88,7 @@ def _report_existing_instance(lock_file_path: Path, config_dir: str) -> None:
     # Try to read information about the existing instance
     try:
         with open(lock_file_path, encoding="utf-8") as f:
-            content = f.read()
-            if (
-                content.strip()
-            ):  # Check for non-empty content after stripping whitespace
+            if content := f.read().strip():
                 existing_info = json.loads(content)
                 start_dt = datetime.fromtimestamp(existing_info["start_ts"])
                 # Format with timezone abbreviation if available, otherwise add local time indicator

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -45,7 +45,7 @@ MAX_EXECUTOR_WORKERS = 64
 TASK_CANCELATION_TIMEOUT = 5
 
 # Lock file configuration
-LOCK_FILE_NAME = "ha_run.lock"
+LOCK_FILE_NAME = ".ha_run.lock"
 LOCK_FILE_VERSION = 1  # Increment if format changes
 
 _LOGGER = logging.getLogger(__name__)
@@ -146,6 +146,8 @@ def ensure_single_execution(config_dir: str) -> Generator[SingleExecutionLock]:
         _write_lock_info(lock_file)
 
         # Yield the context - lock will be released when the with statement closes the file
+        # IMPORTANT: We don't unlink the file to avoid races where multiple processes
+        # could create different lock files
         yield lock_context
 
 

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -104,8 +104,8 @@ def _report_existing_instance(lock_file_path: Path, config_dir: str) -> None:
                 error_msg.append(f"  Started: {start_time}")
             else:
                 error_msg.append("  Unable to read lock file details.")
-    except Exception:  # noqa: BLE001
-        error_msg.append("  Unable to read lock file details.")
+    except (json.JSONDecodeError, OSError) as ex:
+        error_msg.append(f"  Unable to read lock file details: {ex}")
 
     error_msg.append(f"  Config directory: {config_dir}")
     error_msg.append("")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -249,6 +249,10 @@ def test_ensure_single_execution_blocked(
         assert "Another Home Assistant instance is already running!" in captured.err
         assert "PID: 12345" in captured.err
         assert "Version: 2025.1.0" in captured.err
+        assert "Started: " in captured.err
+        assert (
+            "(local time)" in captured.err
+        )  # Should show local time since naive datetime
         assert f"Config directory: {config_dir}" in captured.err
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -268,7 +268,7 @@ def test_ensure_single_execution_corrupt_lock_file(
         # Check error output
         captured = capfd.readouterr()
         assert "Another Home Assistant instance is already running!" in captured.err
-        assert "Unable to read lock file details." in captured.err
+        assert "Unable to read lock file details:" in captured.err
         assert f"Config directory: {config_dir}" in captured.err
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -250,9 +250,8 @@ def test_ensure_single_execution_blocked(
         assert "PID: 12345" in captured.err
         assert "Version: 2025.1.0" in captured.err
         assert "Started: " in captured.err
-        assert (
-            "(local time)" in captured.err
-        )  # Should show local time since naive datetime
+        # Should show local time since naive datetime
+        assert "(local time)" in captured.err
         assert f"Config directory: {config_dir}" in captured.err
 
 
@@ -316,12 +315,12 @@ def test_ensure_single_execution_with_timezone(
     with open(lock_file_path, "w+", encoding="utf-8") as lock_file:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
 
-        # Write mock instance info
+        # Write mock instance info (started 2 hours ago)
         instance_info = {
             "pid": 54321,
             "version": 1,
             "ha_version": "2025.2.0",
-            "start_ts": time.time() - 7200,  # Started 2 hours ago
+            "start_ts": time.time() - 7200,
         }
         json.dump(instance_info, lock_file)
         lock_file.flush()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -352,7 +352,7 @@ def test_ensure_single_execution_sequential_runs(tmp_path: Path) -> None:
             first_data = json.load(f)
 
     # Small delay to ensure different timestamp
-    time.sleep(0.01)
+    time.sleep(0.00001)
 
     # Second instance should work after first is done
     with runner.ensure_single_execution(config_dir) as lock:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,8 +2,13 @@
 
 import asyncio
 from collections.abc import Iterator
+import fcntl
+import json
+import os
+from pathlib import Path
 import subprocess
 import threading
+import time
 from unittest.mock import patch
 
 import packaging.tags
@@ -11,6 +16,7 @@ import py
 import pytest
 
 from homeassistant import core, runner
+from homeassistant.const import __version__
 from homeassistant.core import HomeAssistant
 from homeassistant.util import executor, thread
 
@@ -187,3 +193,133 @@ def test_enable_posix_spawn() -> None:
     ):
         runner._enable_posix_spawn()
         assert subprocess._USE_POSIX_SPAWN is False
+
+
+def test_ensure_single_execution_success(tmp_path: Path) -> None:
+    """Test successful single instance execution."""
+    config_dir = str(tmp_path)
+    lock_file_path = tmp_path / runner.LOCK_FILE_NAME
+
+    # Should be able to acquire lock and write instance info
+    with runner.ensure_single_execution(config_dir) as lock:
+        # Should not have an exit code when successful
+        assert lock.exit_code is None
+        assert lock_file_path.exists()
+
+        # Verify lock file contains correct information
+        with open(lock_file_path, encoding="utf-8") as f:
+            data = json.load(f)
+            assert data["pid"] == os.getpid()
+            assert data["version"] == runner.LOCK_FILE_VERSION
+            assert data["ha_version"] == __version__
+            assert "start_ts" in data
+            assert isinstance(data["start_ts"], float)
+
+    # Lock file should still exist but be unlocked after context exit
+    assert lock_file_path.exists()
+
+
+def test_ensure_single_execution_blocked(
+    tmp_path: Path, capfd: pytest.CaptureFixture[str]
+) -> None:
+    """Test that second instance is blocked when lock exists."""
+    config_dir = str(tmp_path)
+    lock_file_path = tmp_path / runner.LOCK_FILE_NAME
+
+    # Create and lock the file to simulate another instance
+    with open(lock_file_path, "w+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        # Write mock instance info
+        instance_info = {
+            "pid": 12345,
+            "version": 1,
+            "ha_version": "2025.1.0",
+            "start_ts": time.time() - 3600,  # Started 1 hour ago
+        }
+        json.dump(instance_info, lock_file)
+        lock_file.flush()
+
+        # Try to acquire lock (should set exit_code but not raise)
+        with runner.ensure_single_execution(config_dir) as lock:
+            assert lock.exit_code == 1
+
+        # Check error output
+        captured = capfd.readouterr()
+        assert "Another Home Assistant instance is already running!" in captured.err
+        assert "PID: 12345" in captured.err
+        assert "Version: 2025.1.0" in captured.err
+        assert f"Config directory: {config_dir}" in captured.err
+
+
+def test_ensure_single_execution_corrupt_lock_file(
+    tmp_path: Path, capfd: pytest.CaptureFixture[str]
+) -> None:
+    """Test handling of corrupted lock file."""
+    config_dir = str(tmp_path)
+    lock_file_path = tmp_path / runner.LOCK_FILE_NAME
+
+    # Create and lock the file with corrupt content
+    with open(lock_file_path, "w+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        lock_file.write("not valid json{]")
+        lock_file.flush()
+
+        # Try to acquire lock (should set exit_code but handle corrupt file gracefully)
+        with runner.ensure_single_execution(config_dir) as lock:
+            assert lock.exit_code == 1
+
+        # Check error output
+        captured = capfd.readouterr()
+        assert "Another Home Assistant instance is already running!" in captured.err
+        assert "Unable to read lock file details." in captured.err
+        assert f"Config directory: {config_dir}" in captured.err
+
+
+def test_ensure_single_execution_empty_lock_file(
+    tmp_path: Path, capfd: pytest.CaptureFixture[str]
+) -> None:
+    """Test handling of empty lock file."""
+    config_dir = str(tmp_path)
+    lock_file_path = tmp_path / runner.LOCK_FILE_NAME
+
+    # Create and lock an empty file
+    with open(lock_file_path, "w+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        # Don't write anything - leave it empty
+        lock_file.flush()
+
+        # Try to acquire lock (should set exit_code but handle empty file gracefully)
+        with runner.ensure_single_execution(config_dir) as lock:
+            assert lock.exit_code == 1
+
+        # Check error output
+        captured = capfd.readouterr()
+        assert "Another Home Assistant instance is already running!" in captured.err
+        assert "Unable to read lock file details." in captured.err
+
+
+def test_ensure_single_execution_sequential_runs(tmp_path: Path) -> None:
+    """Test that sequential runs work correctly after lock is released."""
+    config_dir = str(tmp_path)
+    lock_file_path = tmp_path / runner.LOCK_FILE_NAME
+
+    # First instance
+    with runner.ensure_single_execution(config_dir) as lock:
+        assert lock.exit_code is None
+        assert lock_file_path.exists()
+        with open(lock_file_path, encoding="utf-8") as f:
+            first_data = json.load(f)
+
+    # Small delay to ensure different timestamp
+    time.sleep(0.01)
+
+    # Second instance should work after first is done
+    with runner.ensure_single_execution(config_dir) as lock:
+        assert lock.exit_code is None
+        assert lock_file_path.exists()
+        with open(lock_file_path, encoding="utf-8") as f:
+            second_data = json.load(f)
+            assert second_data["pid"] == os.getpid()
+            # Timestamp should be different
+            assert second_data["start_ts"] > first_data["start_ts"]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR implements a file-based lock mechanism using `fcntl.flock()` to ensure only one Home Assistant instance can run with a given configuration directory at a time. 

**Why this is critical:**
Running multiple Home Assistant instances with the same configuration directory is very unsafe as it can lead to corrupt storage - nothing in Home Assistant expects other instances to be running concurrently. This has been causing real issues for users, particularly with HomeKit integration failures. **This also explains many of the random corruption and failures we see in issue reports** - users unknowingly running duplicate instances has been a hidden root cause of numerous seemingly unrelated problems.

**The problem has become significant:**
Previously I thought this wasn't worth implementing, but as I'm now spending time investigating why HomeKit doesn't work at least once a month where multiple instances turns out to be the problem, it's clear this issue has risen to the level where it needs to be addressed.

**How easy it is to make this mistake:**
It's sadly a relatively easy mistake to make - users can accidentally run Home Assistant OS or container twice pointing to the same directory. I even do this myself when testing with venv installs because I forget I have it running in another window.

**What this PR does:**
- Creates a lock file (`.ha_run.lock` - hidden file) in the config directory when Home Assistant starts
- Uses OS-level file locking (`fcntl.flock`) to prevent other instances from starting
- If another instance is already running, displays helpful error message with:
  - PID of the running instance
  - Home Assistant version
  - When the instance was started (in local time)
  - The config directory path
- Automatically releases the lock when the process exits (even on crash)
- Uses `print` to stderr for error messages (not logger) because this check happens before logging is initialized

**Example error message:**
```
Error: Another Home Assistant instance is already running!
  PID: 12345
  Version: 2025.10.0
  Started: 2025-09-03 10:30:45 (local time)
  Config directory: /config

Please stop the existing instance before starting a new one.
```

**Testing performed:**
- Comprehensive unit tests with 100% code coverage (note that `__main__.py` does not have coverage but the change is trivial there)
- Tested with Python subprocess spawning multiple instances
- Verified with Docker containers sharing the same config volume
- Manually tested with `hass -c config` in venv
- Confirmed the second instance is properly blocked and shows the helpful error message

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151016
- This PR is related to issue: Multiple issues with HomeKit and storage corruption caused by duplicate instances
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr