### PR TITLE
Fix Sonos Dialog Select type conversion

### DIFF
--- a/homeassistant/components/sonos/select.py
+++ b/homeassistant/components/sonos/select.py
@@ -61,8 +61,15 @@ async def async_setup_entry(
                 if (
                     state := getattr(speaker.soco, select_data.soco_attribute, None)
                 ) is not None:
-                    setattr(speaker, select_data.speaker_attribute, state)
-                    features.append(select_data)
+                    try:
+                        setattr(speaker, select_data.speaker_attribute, int(state))
+                        features.append(select_data)
+                    except ValueError:
+                        _LOGGER.error(
+                            "Invalid value for %s %s",
+                            select_data.speaker_attribute,
+                            state,
+                        )
         return features
 
     async def _async_create_entities(speaker: SonosSpeaker) -> None:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -599,7 +599,12 @@ class SonosSpeaker:
 
         for enum_var in (ATTR_DIALOG_LEVEL,):
             if enum_var in variables:
-                setattr(self, f"{enum_var}_enum", variables[enum_var])
+                try:
+                    setattr(self, f"{enum_var}_enum", int(variables[enum_var]))
+                except ValueError:
+                    _LOGGER.error(
+                        "Invalid value for %s %s", enum_var, variables[enum_var]
+                    )
 
         self.async_write_entity_states()
 

--- a/tests/components/sonos/test_select.py
+++ b/tests/components/sonos/test_select.py
@@ -38,9 +38,9 @@ async def platform_binary_sensor_fixture():
     [
         (0, "off"),
         (1, "low"),
-        (2, "medium"),
-        (3, "high"),
-        (4, "max"),
+        ("2", "medium"),
+        ("3", "high"),
+        ("4", "max"),
     ],
 )
 async def test_select_dialog_level(
@@ -49,7 +49,7 @@ async def test_select_dialog_level(
     soco,
     entity_registry: er.EntityRegistry,
     speaker_info: dict[str, str],
-    level: int,
+    level: int | str,
     result: str,
 ) -> None:
     """Test dialog level select entity."""


### PR DESCRIPTION
## Proposed change

Fix issue with dialog mode select entity new feature.

Sonos sends dialog mode levels as string and the integration was expecting these all to be integers.  Fix by converting to integers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151526
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
