### PR TITLE
Drop Tuya compatibility code for mqtt

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, NamedTuple
-from urllib.parse import urlsplit
+from typing import Any, NamedTuple
 
 from tuya_sharing import (
     CustomerDevice,
@@ -12,7 +11,6 @@ from tuya_sharing import (
     SharingDeviceListener,
     SharingTokenListener,
 )
-from tuya_sharing.mq import SharingMQ, SharingMQConfig
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -47,81 +45,13 @@ class HomeAssistantTuyaData(NamedTuple):
     listener: SharingDeviceListener
 
 
-if TYPE_CHECKING:
-    import paho.mqtt.client as mqtt
-
-
-class ManagerCompat(Manager):
-    """Extended Manager class from the Tuya device sharing SDK.
-
-    The extension ensures compatibility a paho-mqtt client version >= 2.1.0.
-    It overrides extend refresh_mq method to ensure correct paho.mqtt client calls.
-
-    This code can be removed when a version of tuya-device-sharing with
-    https://github.com/tuya/tuya-device-sharing-sdk/pull/25 is available.
-    """
-
-    def refresh_mq(self):
-        """Refresh the MQTT connection."""
-        if self.mq is not None:
-            self.mq.stop()
-            self.mq = None
-
-        home_ids = [home.id for home in self.user_homes]
-        device = [
-            device
-            for device in self.device_map.values()
-            if hasattr(device, "id") and getattr(device, "set_up", False)
-        ]
-
-        sharing_mq = SharingMQCompat(self.customer_api, home_ids, device)
-        sharing_mq.start()
-        sharing_mq.add_message_listener(self.on_message)
-        self.mq = sharing_mq
-
-
-class SharingMQCompat(SharingMQ):
-    """Extended SharingMQ class from the Tuya device sharing SDK.
-
-    The extension ensures compatibility a paho-mqtt client version >= 2.1.0.
-    It overrides _start method to ensure correct paho.mqtt client calls.
-
-    This code can be removed when a version of tuya-device-sharing with
-    https://github.com/tuya/tuya-device-sharing-sdk/pull/25 is available.
-    """
-
-    def _start(self, mq_config: SharingMQConfig) -> mqtt.Client:
-        """Start the MQTT client."""
-        # We don't import on the top because some integrations
-        # should be able to optionally rely on MQTT.
-        import paho.mqtt.client as mqtt  # noqa: PLC0415
-
-        mqttc = mqtt.Client(client_id=mq_config.client_id)
-        mqttc.username_pw_set(mq_config.username, mq_config.password)
-        mqttc.user_data_set({"mqConfig": mq_config})
-        mqttc.on_connect = self._on_connect
-        mqttc.on_message = self._on_message
-        mqttc.on_subscribe = self._on_subscribe
-        mqttc.on_log = self._on_log
-        mqttc.on_disconnect = self._on_disconnect
-
-        url = urlsplit(mq_config.url)
-        if url.scheme == "ssl":
-            mqttc.tls_set()
-
-        mqttc.connect(url.hostname, url.port)
-
-        mqttc.loop_start()
-        return mqttc
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool:
     """Async setup hass config entry."""
     if CONF_APP_TYPE in entry.data:
         raise ConfigEntryAuthFailed("Authentication failed. Please re-authenticate.")
 
     token_listener = TokenListener(hass, entry)
-    manager = ManagerCompat(
+    manager = Manager(
         TUYA_CLIENT_ID,
         entry.data[CONF_USER_CODE],
         entry.data[CONF_TERMINAL_ID],

--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import DeviceListener, ManagerCompat
+from homeassistant.components.tuya import DeviceListener
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -264,7 +264,7 @@ class MockDeviceListener(DeviceListener):
 
 async def initialize_entry(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: CustomerDevice | list[CustomerDevice],
 ) -> None:
@@ -277,8 +277,6 @@ async def initialize_entry(
     mock_config_entry.add_to_hass(hass)
 
     # Initialize the component
-    with patch(
-        "homeassistant.components.tuya.ManagerCompat", return_value=mock_manager
-    ):
+    with patch("homeassistant.components.tuya.Manager", return_value=mock_manager):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -6,9 +6,14 @@ from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
-from tuya_sharing import CustomerApi, CustomerDevice, DeviceFunction, DeviceStatusRange
+from tuya_sharing import (
+    CustomerApi,
+    CustomerDevice,
+    DeviceFunction,
+    DeviceStatusRange,
+    Manager,
+)
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.components.tuya.const import (
     CONF_APP_TYPE,
     CONF_ENDPOINT,
@@ -56,7 +61,7 @@ def mock_config_entry() -> MockConfigEntry:
 @pytest.fixture
 async def mock_loaded_entry(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> MockConfigEntry:
@@ -69,7 +74,7 @@ async def mock_loaded_entry(
 
     # Initialize the component
     with (
-        patch("homeassistant.components.tuya.ManagerCompat", return_value=mock_manager),
+        patch("homeassistant.components.tuya.Manager", return_value=mock_manager),
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
@@ -114,9 +119,9 @@ def mock_tuya_login_control() -> Generator[MagicMock]:
 
 
 @pytest.fixture
-def mock_manager() -> ManagerCompat:
+def mock_manager() -> Manager:
     """Mock Tuya Manager."""
-    manager = MagicMock(spec=ManagerCompat)
+    manager = MagicMock(spec=Manager)
     manager.device_map = {}
     manager.mq = MagicMock()
     manager.mq.client = MagicMock()
@@ -209,9 +214,7 @@ async def _create_device(hass: HomeAssistant, mock_device_code: str) -> Customer
 
 
 @pytest.fixture
-def mock_listener(
-    hass: HomeAssistant, mock_manager: ManagerCompat
-) -> MockDeviceListener:
+def mock_listener(hass: HomeAssistant, mock_manager: Manager) -> MockDeviceListener:
     """Create a DeviceListener for testing."""
     listener = MockDeviceListener(hass, mock_manager)
     mock_manager.add_device_listener(listener)

--- a/tests/components/tuya/test_alarm_control_panel.py
+++ b/tests/components/tuya/test_alarm_control_panel.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -20,7 +19,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.ALARM_CONTROL_PANEL])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,

--- a/tests/components/tuya/test_binary_sensor.py
+++ b/tests/components/tuya/test_binary_sensor.py
@@ -6,9 +6,8 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -22,7 +21,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
@@ -51,7 +50,7 @@ async def test_platform_setup_and_discovery(
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.BINARY_SENSOR])
 async def test_bitmap(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
     mock_listener: MockDeviceListener,

--- a/tests/components/tuya/test_button.py
+++ b/tests/components/tuya/test_button.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -20,7 +19,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.BUTTON])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,

--- a/tests/components/tuya/test_camera.py
+++ b/tests/components/tuya/test_camera.py
@@ -6,9 +6,8 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -31,7 +30,7 @@ def mock_getrandbits():
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.CAMERA])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.climate import (
     ATTR_FAN_MODE,
@@ -17,7 +17,6 @@ from homeassistant.components.climate import (
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_TEMPERATURE,
 )
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotSupported
@@ -31,7 +30,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.CLIMATE])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
@@ -49,7 +48,7 @@ async def test_platform_setup_and_discovery(
 )
 async def test_set_temperature(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -79,7 +78,7 @@ async def test_set_temperature(
 )
 async def test_fan_mode_windspeed(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -110,7 +109,7 @@ async def test_fan_mode_windspeed(
 )
 async def test_fan_mode_no_valid_code(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -144,7 +143,7 @@ async def test_fan_mode_no_valid_code(
 )
 async def test_set_humidity_not_supported(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:

--- a/tests/components/tuya/test_cover.py
+++ b/tests/components/tuya/test_cover.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
@@ -18,7 +18,6 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
 )
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceNotSupported
@@ -32,7 +31,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.COVER])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
@@ -51,7 +50,7 @@ async def test_platform_setup_and_discovery(
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.COVER])
 async def test_open_service(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -85,7 +84,7 @@ async def test_open_service(
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.COVER])
 async def test_close_service(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -118,7 +117,7 @@ async def test_close_service(
 )
 async def test_set_position(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -160,7 +159,7 @@ async def test_set_position(
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.COVER])
 async def test_percent_state_on_cover(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
     percent_control: int,
@@ -185,7 +184,7 @@ async def test_percent_state_on_cover(
 )
 async def test_set_tilt_position_not_supported(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:

--- a/tests/components/tuya/test_diagnostics.py
+++ b/tests/components/tuya/test_diagnostics.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.components.tuya.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -25,7 +24,7 @@ from tests.typing import ClientSessionGenerator
 @pytest.mark.parametrize("mock_device_code", ["rqbj_4iqe2hsfyd86kwwc"])
 async def test_entry_diagnostics(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
     hass_client: ClientSessionGenerator,
@@ -46,7 +45,7 @@ async def test_entry_diagnostics(
 @pytest.mark.parametrize("mock_device_code", ["rqbj_4iqe2hsfyd86kwwc"])
 async def test_device_diagnostics(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
     hass_client: ClientSessionGenerator,

--- a/tests/components/tuya/test_event.py
+++ b/tests/components/tuya/test_event.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -20,7 +19,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.EVENT])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,

--- a/tests/components/tuya/test_fan.py
+++ b/tests/components/tuya/test_fan.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -20,7 +19,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.FAN])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,

--- a/tests/components/tuya/test_humidifier.py
+++ b/tests/components/tuya/test_humidifier.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.humidifier import (
     ATTR_HUMIDITY,
@@ -15,7 +15,6 @@ from homeassistant.components.humidifier import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
@@ -29,7 +28,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.HUMIDIFIER])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
@@ -47,7 +46,7 @@ async def test_platform_setup_and_discovery(
 )
 async def test_turn_on(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -74,7 +73,7 @@ async def test_turn_on(
 )
 async def test_turn_off(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -101,7 +100,7 @@ async def test_turn_off(
 )
 async def test_set_humidity(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -131,7 +130,7 @@ async def test_set_humidity(
 )
 async def test_turn_on_unsupported(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -166,7 +165,7 @@ async def test_turn_on_unsupported(
 )
 async def test_turn_off_unsupported(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -201,7 +200,7 @@ async def test_turn_off_unsupported(
 )
 async def test_set_humidity_unsupported(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.components.tuya.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -17,7 +16,7 @@ from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 async def test_device_registry(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: CustomerDevice,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/tuya/test_light.py
+++ b/tests/components/tuya/test_light.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -16,7 +16,6 @@ from homeassistant.components.light import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -29,7 +28,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.LIGHT])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
@@ -92,7 +91,7 @@ async def test_platform_setup_and_discovery(
 )
 async def test_turn_on_white(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
     turn_on_input: dict[str, Any],
@@ -125,7 +124,7 @@ async def test_turn_on_white(
 )
 async def test_turn_off(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:

--- a/tests/components/tuya/test_number.py
+++ b/tests/components/tuya/test_number.py
@@ -6,14 +6,13 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.number import (
     ATTR_VALUE,
     DOMAIN as NUMBER_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
@@ -27,7 +26,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.NUMBER])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
@@ -45,7 +44,7 @@ async def test_platform_setup_and_discovery(
 )
 async def test_set_value(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -75,7 +74,7 @@ async def test_set_value(
 )
 async def test_set_value_no_function(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:

--- a/tests/components/tuya/test_select.py
+++ b/tests/components/tuya/test_select.py
@@ -6,14 +6,13 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.select import (
     ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
@@ -27,7 +26,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.SELECT])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
@@ -45,7 +44,7 @@ async def test_platform_setup_and_discovery(
 )
 async def test_select_option(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -75,7 +74,7 @@ async def test_select_option(
 )
 async def test_select_invalid_option(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:

--- a/tests/components/tuya/test_sensor.py
+++ b/tests/components/tuya/test_sensor.py
@@ -6,9 +6,8 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -22,7 +21,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,

--- a/tests/components/tuya/test_siren.py
+++ b/tests/components/tuya/test_siren.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -20,7 +19,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.SIREN])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,

--- a/tests/components/tuya/test_switch.py
+++ b/tests/components/tuya/test_switch.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -20,7 +19,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.SWITCH])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,

--- a/tests/components/tuya/test_vacuum.py
+++ b/tests/components/tuya/test_vacuum.py
@@ -6,9 +6,8 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.components.vacuum import (
     DOMAIN as VACUUM_DOMAIN,
     SERVICE_RETURN_TO_BASE,
@@ -25,7 +24,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.VACUUM])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
@@ -43,7 +42,7 @@ async def test_platform_setup_and_discovery(
 )
 async def test_return_home(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:

--- a/tests/components/tuya/test_valve.py
+++ b/tests/components/tuya/test_valve.py
@@ -6,9 +6,8 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from tuya_sharing import CustomerDevice
+from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.components.tuya import ManagerCompat
 from homeassistant.components.valve import (
     DOMAIN as VALVE_DOMAIN,
     SERVICE_CLOSE_VALVE,
@@ -26,7 +25,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.VALVE])
 async def test_platform_setup_and_discovery(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_devices: list[CustomerDevice],
     entity_registry: er.EntityRegistry,
@@ -44,7 +43,7 @@ async def test_platform_setup_and_discovery(
 )
 async def test_open_valve(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:
@@ -73,7 +72,7 @@ async def test_open_valve(
 )
 async def test_close_valve(
     hass: HomeAssistant,
-    mock_manager: ManagerCompat,
+    mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
     mock_device: CustomerDevice,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reverse #139518
~Needs #151659~ (merged)

cc @jbouwh

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
