### PR TITLE
Add secondary wake word and pipeline to ESPHome voice satellites

### DIFF
--- a/homeassistant/components/assist_pipeline/select.py
+++ b/homeassistant/components/assist_pipeline/select.py
@@ -72,7 +72,7 @@ class AssistPipelineSelect(SelectEntity, restore_state.RestoreEntity):
         """Initialize a pipeline selector."""
         self._domain = domain
         self._unique_id_prefix = unique_id_prefix
-        self._attr_unique_id = f"{unique_id_prefix}-pipeline"
+        self._attr_unique_id = f"{unique_id_prefix}-{self.entity_description.key}"
         self.hass = hass
         self._update_options()
 
@@ -133,16 +133,6 @@ class AssistSecondaryPipelineSelect(AssistPipelineSelect):
         translation_key="pipeline_2",
         entity_category=EntityCategory.CONFIG,
     )
-
-    def __init__(self, hass: HomeAssistant, domain: str, unique_id_prefix: str) -> None:
-        """Initialize a secondary pipeline selector."""
-        super().__init__(hass, domain, unique_id_prefix)
-
-        self._domain = domain
-        self._unique_id_prefix = unique_id_prefix
-        self._attr_unique_id = f"{unique_id_prefix}-pipeline-2"
-        self.hass = hass
-        self._update_options()
 
 
 class VadSensitivitySelect(SelectEntity, restore_state.RestoreEntity):

--- a/homeassistant/components/assist_pipeline/select.py
+++ b/homeassistant/components/assist_pipeline/select.py
@@ -78,11 +78,18 @@ class AssistPipelineSelect(SelectEntity, restore_state.RestoreEntity):
         index: int = 0,
     ) -> None:
         """Initialize a pipeline selector."""
-        key_suffix = "" if index < 1 else f"_{index + 1}"
+        if index < 1:
+            # Keep compatibility
+            key_suffix = ""
+            placeholder = ""
+        else:
+            key_suffix = f"_{index + 1}"
+            placeholder = f" {index + 1}"
+
         self.entity_description = replace(
             self.entity_description,
             key=f"pipeline{key_suffix}",
-            translation_placeholders={"index": str(index + 1)},
+            translation_placeholders={"index": placeholder},
         )
 
         self._domain = domain

--- a/homeassistant/components/assist_pipeline/select.py
+++ b/homeassistant/components/assist_pipeline/select.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import replace
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory, Platform
@@ -64,12 +65,26 @@ class AssistPipelineSelect(SelectEntity, restore_state.RestoreEntity):
         translation_key="pipeline",
         entity_category=EntityCategory.CONFIG,
     )
+
     _attr_should_poll = False
     _attr_current_option = OPTION_PREFERRED
     _attr_options = [OPTION_PREFERRED]
 
-    def __init__(self, hass: HomeAssistant, domain: str, unique_id_prefix: str) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        domain: str,
+        unique_id_prefix: str,
+        index: int = 0,
+    ) -> None:
         """Initialize a pipeline selector."""
+        key_suffix = "" if index < 1 else f"_{index + 1}"
+        self.entity_description = replace(
+            self.entity_description,
+            key=f"pipeline{key_suffix}",
+            translation_placeholders={"index": str(index + 1)},
+        )
+
         self._domain = domain
         self._unique_id_prefix = unique_id_prefix
         self._attr_unique_id = f"{unique_id_prefix}-{self.entity_description.key}"
@@ -123,16 +138,6 @@ class AssistPipelineSelect(SelectEntity, restore_state.RestoreEntity):
 
         if self._attr_current_option not in options:
             self._attr_current_option = OPTION_PREFERRED
-
-
-class AssistSecondaryPipelineSelect(AssistPipelineSelect):
-    """Entity to represent a secondary pipeline selector."""
-
-    entity_description = SelectEntityDescription(
-        key="pipeline_2",
-        translation_key="pipeline_2",
-        entity_category=EntityCategory.CONFIG,
-    )
 
 
 class VadSensitivitySelect(SelectEntity, restore_state.RestoreEntity):

--- a/homeassistant/components/assist_pipeline/select.py
+++ b/homeassistant/components/assist_pipeline/select.py
@@ -125,6 +125,26 @@ class AssistPipelineSelect(SelectEntity, restore_state.RestoreEntity):
             self._attr_current_option = OPTION_PREFERRED
 
 
+class AssistSecondaryPipelineSelect(AssistPipelineSelect):
+    """Entity to represent a secondary pipeline selector."""
+
+    entity_description = SelectEntityDescription(
+        key="pipeline_2",
+        translation_key="pipeline_2",
+        entity_category=EntityCategory.CONFIG,
+    )
+
+    def __init__(self, hass: HomeAssistant, domain: str, unique_id_prefix: str) -> None:
+        """Initialize a secondary pipeline selector."""
+        super().__init__(hass, domain, unique_id_prefix)
+
+        self._domain = domain
+        self._unique_id_prefix = unique_id_prefix
+        self._attr_unique_id = f"{unique_id_prefix}-pipeline-2"
+        self.hass = hass
+        self._update_options()
+
+
 class VadSensitivitySelect(SelectEntity, restore_state.RestoreEntity):
     """Entity to represent VAD sensitivity."""
 

--- a/homeassistant/components/assist_pipeline/strings.json
+++ b/homeassistant/components/assist_pipeline/strings.json
@@ -13,7 +13,7 @@
         }
       },
       "pipeline_2": {
-        "name": "Secondary Assistant",
+        "name": "Secondary assistant",
         "state": {
           "preferred": "Preferred"
         }

--- a/homeassistant/components/assist_pipeline/strings.json
+++ b/homeassistant/components/assist_pipeline/strings.json
@@ -13,10 +13,7 @@
         }
       },
       "pipeline_2": {
-        "name": "Secondary assistant",
-        "state": {
-          "preferred": "Preferred"
-        }
+        "name": "Secondary assistant"
       },
       "vad_sensitivity": {
         "name": "Finished speaking detection",

--- a/homeassistant/components/assist_pipeline/strings.json
+++ b/homeassistant/components/assist_pipeline/strings.json
@@ -7,7 +7,7 @@
     },
     "select": {
       "pipeline": {
-        "name": "Assistant {index}",
+        "name": "Assistant{index}",
         "state": {
           "preferred": "Preferred"
         }

--- a/homeassistant/components/assist_pipeline/strings.json
+++ b/homeassistant/components/assist_pipeline/strings.json
@@ -12,6 +12,12 @@
           "preferred": "Preferred"
         }
       },
+      "pipeline_2": {
+        "name": "Secondary Assistant",
+        "state": {
+          "preferred": "Preferred"
+        }
+      },
       "vad_sensitivity": {
         "name": "Finished speaking detection",
         "state": {

--- a/homeassistant/components/assist_pipeline/strings.json
+++ b/homeassistant/components/assist_pipeline/strings.json
@@ -7,13 +7,10 @@
     },
     "select": {
       "pipeline": {
-        "name": "Assistant",
+        "name": "Assistant {index}",
         "state": {
           "preferred": "Preferred"
         }
-      },
-      "pipeline_2": {
-        "name": "Secondary assistant"
       },
       "vad_sensitivity": {
         "name": "Finished speaking detection",

--- a/homeassistant/components/esphome/assist_satellite.py
+++ b/homeassistant/components/esphome/assist_satellite.py
@@ -152,7 +152,7 @@ class EsphomeAssistSatellite(
     @property
     def secondary_pipeline_entity_id(self) -> str | None:
         """Return the entity ID of the secondary pipeline to use for the next conversation."""
-        return self._get_entity_id("pipeline-2")
+        return self._get_entity_id("pipeline_2")
 
     @property
     def wake_word_entity_id(self) -> str | None:
@@ -162,7 +162,7 @@ class EsphomeAssistSatellite(
     @property
     def secondary_wake_word_entity_id(self) -> str | None:
         """Return the entity ID of the secondary wake word select."""
-        return self._get_entity_id("wake_word-2")
+        return self._get_entity_id("wake_word_2")
 
     @property
     def vad_sensitivity_entity_id(self) -> str | None:

--- a/homeassistant/components/esphome/const.py
+++ b/homeassistant/components/esphome/const.py
@@ -25,3 +25,5 @@ PROJECT_URLS = {
 # ESPHome always uses .0 for the changelog URL
 STABLE_BLE_URL_VERSION = f"{STABLE_BLE_VERSION.major}.{STABLE_BLE_VERSION.minor}.0"
 DEFAULT_URL = f"https://esphome.io/changelog/{STABLE_BLE_URL_VERSION}.html"
+
+NO_WAKE_WORD: Final[str] = "no_wake_word"

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -180,7 +180,7 @@ class RuntimeEntryData:
     assist_satellite_set_wake_words_callbacks: list[Callable[[list[str]], None]] = (
         field(default_factory=list)
     )
-    assist_satellite_active_wake_words: dict[int, str] = field(default_factory=dict)
+    assist_satellite_wake_words: dict[int, str] = field(default_factory=dict)
     device_id_to_name: dict[int, str] = field(default_factory=dict)
     entity_removal_callbacks: dict[EntityInfoKey, list[CALLBACK_TYPE]] = field(
         default_factory=dict
@@ -516,11 +516,11 @@ class RuntimeEntryData:
     ) -> None:
         """Notify listeners that the Assist satellite wake words have been set."""
         if wake_word_id:
-            self.assist_satellite_active_wake_words[wake_word_index] = wake_word_id
+            self.assist_satellite_wake_words[wake_word_index] = wake_word_id
         else:
-            self.assist_satellite_active_wake_words.pop(wake_word_index, None)
+            self.assist_satellite_wake_words.pop(wake_word_index, None)
 
-        wake_word_ids = list(self.assist_satellite_active_wake_words.values())
+        wake_word_ids = list(self.assist_satellite_wake_words.values())
 
         for callback_ in self.assist_satellite_set_wake_words_callbacks.copy():
             callback_(wake_word_ids)

--- a/homeassistant/components/esphome/icons.json
+++ b/homeassistant/components/esphome/icons.json
@@ -9,10 +9,16 @@
       "pipeline": {
         "default": "mdi:filter-outline"
       },
+      "pipeline_2": {
+        "default": "mdi:filter-outline"
+      },
       "vad_sensitivity": {
         "default": "mdi:volume-high"
       },
       "wake_word": {
+        "default": "mdi:microphone"
+      },
+      "wake_word_2": {
         "default": "mdi:microphone"
       }
     }

--- a/homeassistant/components/esphome/select.py
+++ b/homeassistant/components/esphome/select.py
@@ -163,7 +163,7 @@ class EsphomeAssistSatelliteWakeWordSelect(
         self._attr_current_option = option
         self.async_write_ha_state()
 
-        wake_word_id = self._wake_words.get(option, NO_WAKE_WORD)
+        wake_word_id = self._wake_words.get(option)
         self._entry_data.async_assist_satellite_set_wake_word(
             self._wake_word_index, wake_word_id
         )

--- a/homeassistant/components/esphome/select.py
+++ b/homeassistant/components/esphome/select.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Final
+
 from aioesphomeapi import EntityInfo, SelectInfo, SelectState
 
 from homeassistant.components.assist_pipeline.select import (
     AssistPipelineSelect,
+    AssistSecondaryPipelineSelect,
     VadSensitivitySelect,
 )
 from homeassistant.components.assist_satellite import AssistSatelliteConfiguration
@@ -26,6 +29,7 @@ from .entity import (
 from .entry_data import ESPHomeConfigEntry, RuntimeEntryData
 
 PARALLEL_UPDATES = 0
+NO_WAKE_WORD: Final[str] = "no_wake_word"
 
 
 async def async_setup_entry(
@@ -51,8 +55,10 @@ async def async_setup_entry(
         async_add_entities(
             [
                 EsphomeAssistPipelineSelect(hass, entry_data),
+                EsphomeSecondaryAssistPipelineSelect(hass, entry_data),
                 EsphomeVadSensitivitySelect(hass, entry_data),
                 EsphomeAssistSatelliteWakeWordSelect(entry_data),
+                EsphomeSecondaryAssistSatelliteWakeWordSelect(entry_data),
             ]
         )
 
@@ -90,6 +96,19 @@ class EsphomeAssistPipelineSelect(EsphomeAssistEntity, AssistPipelineSelect):
         AssistPipelineSelect.__init__(self, hass, DOMAIN, self._device_info.mac_address)
 
 
+class EsphomeSecondaryAssistPipelineSelect(
+    EsphomeAssistEntity, AssistSecondaryPipelineSelect
+):
+    """Secondary pipeline selector for esphome devices."""
+
+    def __init__(self, hass: HomeAssistant, entry_data: RuntimeEntryData) -> None:
+        """Initialize a secondary pipeline selector."""
+        EsphomeAssistEntity.__init__(self, entry_data)
+        AssistSecondaryPipelineSelect.__init__(
+            self, hass, DOMAIN, self._device_info.mac_address
+        )
+
+
 class EsphomeVadSensitivitySelect(EsphomeAssistEntity, VadSensitivitySelect):
     """VAD sensitivity selector for ESPHome devices."""
 
@@ -110,9 +129,9 @@ class EsphomeAssistSatelliteWakeWordSelect(
         entity_category=EntityCategory.CONFIG,
     )
     _attr_current_option: str | None = None
-    _attr_options: list[str] = []
+    _attr_options: list[str] = [NO_WAKE_WORD]
 
-    def __init__(self, entry_data: RuntimeEntryData) -> None:
+    def __init__(self, entry_data: RuntimeEntryData, wake_word_index: int = 0) -> None:
         """Initialize a wake word selector."""
         EsphomeAssistEntity.__init__(self, entry_data)
 
@@ -121,15 +140,19 @@ class EsphomeAssistSatelliteWakeWordSelect(
 
         # name -> id
         self._wake_words: dict[str, str] = {}
+        self._wake_word_index = wake_word_index
 
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return bool(self._attr_options)
+        return len(self._attr_options) > 1  # more than just NO_WAKE_WORD
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
+
+        if last_state := await self.async_get_last_state():
+            self._attr_current_option = last_state.state
 
         # Update options when config is updated
         self.async_on_remove(
@@ -140,33 +163,57 @@ class EsphomeAssistSatelliteWakeWordSelect(
 
     async def async_select_option(self, option: str) -> None:
         """Select an option."""
-        if wake_word_id := self._wake_words.get(option):
-            # _attr_current_option will be updated on
-            # async_satellite_config_updated after the device sets the wake
-            # word.
-            self._entry_data.async_assist_satellite_set_wake_word(wake_word_id)
+        self._attr_current_option = option
+        self.async_write_ha_state()
+
+        wake_word_id = self._wake_words.get(option, NO_WAKE_WORD)
+        self._entry_data.async_assist_satellite_set_wake_word(
+            self._wake_word_index, wake_word_id
+        )
 
     def async_satellite_config_updated(
         self, config: AssistSatelliteConfiguration
     ) -> None:
         """Update options with available wake words."""
         if (not config.available_wake_words) or (config.max_active_wake_words < 1):
-            self._attr_current_option = None
+            # No wake words
             self._wake_words.clear()
+            self._attr_current_option = NO_WAKE_WORD
+            self._attr_options = [NO_WAKE_WORD]
             self.async_write_ha_state()
             return
 
         self._wake_words = {w.wake_word: w.id for w in config.available_wake_words}
-        self._attr_options = sorted(self._wake_words)
+        self._attr_options = [NO_WAKE_WORD, *sorted(self._wake_words)]
 
+        option = NO_WAKE_WORD
         if config.active_wake_words:
-            # Select first active wake word
-            wake_word_id = config.active_wake_words[0]
-            for wake_word in config.available_wake_words:
-                if wake_word.id == wake_word_id:
-                    self._attr_current_option = wake_word.wake_word
-        else:
-            # Select first available wake word
-            self._attr_current_option = config.available_wake_words[0].wake_word
+            for active_wake_word_id in config.active_wake_words:
+                for wake_word, wake_word_id in self._wake_words.items():
+                    if (wake_word_id == active_wake_word_id) and (
+                        self._attr_current_option == wake_word
+                    ):
+                        option = wake_word
+                        break
 
+        self._attr_current_option = option
         self.async_write_ha_state()
+
+
+class EsphomeSecondaryAssistSatelliteWakeWordSelect(
+    EsphomeAssistSatelliteWakeWordSelect
+):
+    """Secondary wake word selector for esphome devices."""
+
+    entity_description = SelectEntityDescription(
+        key="wake_word_2",
+        translation_key="wake_word_2",
+        entity_category=EntityCategory.CONFIG,
+    )
+
+    def __init__(self, entry_data: RuntimeEntryData) -> None:
+        """Initialize a secondary wake word selector."""
+        EsphomeAssistSatelliteWakeWordSelect.__init__(self, entry_data, 1)
+
+        unique_id_prefix = self._device_info.mac_address
+        self._attr_unique_id = f"{unique_id_prefix}-wake_word-2"

--- a/homeassistant/components/esphome/select.py
+++ b/homeassistant/components/esphome/select.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Final
-
 from aioesphomeapi import EntityInfo, SelectInfo, SelectState
 
 from homeassistant.components.assist_pipeline.select import (
@@ -18,7 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import restore_state
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, NO_WAKE_WORD
 from .entity import (
     EsphomeAssistEntity,
     EsphomeEntity,
@@ -29,7 +27,6 @@ from .entity import (
 from .entry_data import ESPHomeConfigEntry, RuntimeEntryData
 
 PARALLEL_UPDATES = 0
-NO_WAKE_WORD: Final[str] = "no_wake_word"
 
 
 async def async_setup_entry(

--- a/homeassistant/components/esphome/select.py
+++ b/homeassistant/components/esphome/select.py
@@ -123,11 +123,18 @@ class EsphomeAssistSatelliteWakeWordSelect(
 
     def __init__(self, entry_data: RuntimeEntryData, index: int = 0) -> None:
         """Initialize a wake word selector."""
-        key_suffix = "" if index < 1 else f"_{index + 1}"
+        if index < 1:
+            # Keep compatibility
+            key_suffix = ""
+            placeholder = ""
+        else:
+            key_suffix = f"_{index + 1}"
+            placeholder = f" {index + 1}"
+
         self.entity_description = replace(
             self.entity_description,
             key=f"wake_word{key_suffix}",
-            translation_placeholders={"index": str(index + 1)},
+            translation_placeholders={"index": placeholder},
         )
 
         EsphomeAssistEntity.__init__(self, entry_data)

--- a/homeassistant/components/esphome/select.py
+++ b/homeassistant/components/esphome/select.py
@@ -177,6 +177,9 @@ class EsphomeAssistSatelliteWakeWordSelect(
             self._wake_words.clear()
             self._attr_current_option = NO_WAKE_WORD
             self._attr_options = [NO_WAKE_WORD]
+            self._entry_data.assist_satellite_wake_words.pop(
+                self._wake_word_index, None
+            )
             self.async_write_ha_state()
             return
 
@@ -185,7 +188,7 @@ class EsphomeAssistSatelliteWakeWordSelect(
 
         option = self._attr_current_option
         if (
-            (not option)
+            (option is None)
             or ((wake_word_id := self._wake_words.get(option)) is None)
             or (wake_word_id not in config.active_wake_words)
         ):
@@ -196,10 +199,10 @@ class EsphomeAssistSatelliteWakeWordSelect(
 
         # Keep entry data in sync
         if wake_word_id := self._wake_words.get(option):
-            self._entry_data.assist_satellite_active_wake_words[
-                self._wake_word_index
-            ] = wake_word_id
+            self._entry_data.assist_satellite_wake_words[self._wake_word_index] = (
+                wake_word_id
+            )
         else:
-            self._entry_data.assist_satellite_active_wake_words.pop(
+            self._entry_data.assist_satellite_wake_words.pop(
                 self._wake_word_index, None
             )

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -119,7 +119,7 @@
         }
       },
       "wake_word": {
-        "name": "Wake word {index}",
+        "name": "Wake word{index}",
         "state": {
           "no_wake_word": "No wake word",
           "okay_nabu": "Okay Nabu"

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -113,7 +113,7 @@
       "pipeline_2": {
         "name": "[%key:component::assist_pipeline::entity::select::pipeline_2::name%]",
         "state": {
-          "preferred": "[%key:component::assist_pipeline::entity::select::pipeline_2::state::preferred%]"
+          "preferred": "[%key:component::assist_pipeline::entity::select::pipeline::state::preferred%]"
         }
       },
       "vad_sensitivity": {
@@ -134,7 +134,7 @@
       "wake_word_2": {
         "name": "Secondary wake word",
         "state": {
-          "no_wake_word": "No wake word"
+          "no_wake_word": "[%key:component::esphome::entity::select::wake_word::state::no_wake_word%]"
         }
       }
     },

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -110,12 +110,6 @@
           "preferred": "[%key:component::assist_pipeline::entity::select::pipeline::state::preferred%]"
         }
       },
-      "pipeline_2": {
-        "name": "[%key:component::assist_pipeline::entity::select::pipeline_2::name%]",
-        "state": {
-          "preferred": "[%key:component::assist_pipeline::entity::select::pipeline::state::preferred%]"
-        }
-      },
       "vad_sensitivity": {
         "name": "[%key:component::assist_pipeline::entity::select::vad_sensitivity::name%]",
         "state": {
@@ -125,16 +119,10 @@
         }
       },
       "wake_word": {
-        "name": "Wake word",
+        "name": "Wake word {index}",
         "state": {
           "no_wake_word": "No wake word",
           "okay_nabu": "Okay Nabu"
-        }
-      },
-      "wake_word_2": {
-        "name": "Secondary wake word",
-        "state": {
-          "no_wake_word": "[%key:component::esphome::entity::select::wake_word::state::no_wake_word%]"
         }
       }
     },

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -110,6 +110,12 @@
           "preferred": "[%key:component::assist_pipeline::entity::select::pipeline::state::preferred%]"
         }
       },
+      "pipeline_2": {
+        "name": "[%key:component::assist_pipeline::entity::select::pipeline_2::name%]",
+        "state": {
+          "preferred": "[%key:component::assist_pipeline::entity::select::pipeline_2::state::preferred%]"
+        }
+      },
       "vad_sensitivity": {
         "name": "[%key:component::assist_pipeline::entity::select::vad_sensitivity::name%]",
         "state": {
@@ -121,7 +127,14 @@
       "wake_word": {
         "name": "Wake word",
         "state": {
+          "no_wake_word": "No wake word",
           "okay_nabu": "Okay Nabu"
+        }
+      },
+      "wake_word_2": {
+        "name": "Secondary wake word",
+        "state": {
+          "no_wake_word": "No wake word"
         }
       }
     },

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -28,6 +28,7 @@ from homeassistant.components import (
     tts,
 )
 from homeassistant.components.assist_pipeline import PipelineEvent, PipelineEventType
+from homeassistant.components.assist_pipeline.pipeline import KEY_ASSIST_PIPELINE
 from homeassistant.components.assist_satellite import (
     AssistSatelliteConfiguration,
     AssistSatelliteEntityFeature,
@@ -46,6 +47,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, intent as intent_helper
 from homeassistant.helpers.network import get_url
+from homeassistant.setup import async_setup_component
 
 from .common import get_satellite_entity
 from .conftest import MockESPHomeDeviceType
@@ -1738,7 +1740,7 @@ async def test_get_set_configuration(
             AssistSatelliteWakeWord("5678", "hey jarvis", ["en"]),
         ],
         active_wake_words=["1234"],
-        max_active_wake_words=1,
+        max_active_wake_words=2,
     )
     mock_client.get_voice_assistant_configuration.return_value = expected_config
 
@@ -1858,7 +1860,7 @@ async def test_wake_word_select(
             AssistSatelliteWakeWord("hey_mycroft", "Hey Mycroft", ["en"]),
         ],
         active_wake_words=["hey_jarvis"],
-        max_active_wake_words=1,
+        max_active_wake_words=2,
     )
     mock_client.get_voice_assistant_configuration.return_value = device_config
 
@@ -1952,3 +1954,119 @@ async def test_wake_word_select(
 
     # Only primary wake word remains
     assert satellite.async_get_configuration().active_wake_words == ["okay_nabu"]
+
+
+async def test_secondary_pipeline(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test that the secondary pipeline is used when the secondary wake word is given."""
+    assert await async_setup_component(hass, "assist_pipeline", {})
+    pipeline_data = hass.data[KEY_ASSIST_PIPELINE]
+    pipeline_id_to_name: dict[str, str] = {}
+    for pipeline_name in ("Primary Pipeline", "Secondary Pipeline"):
+        pipeline = await pipeline_data.pipeline_store.async_create_item(
+            {
+                "name": pipeline_name,
+                "language": "en-US",
+                "conversation_engine": None,
+                "conversation_language": "en-US",
+                "tts_engine": None,
+                "tts_language": None,
+                "tts_voice": None,
+                "stt_engine": None,
+                "stt_language": None,
+                "wake_word_entity": None,
+                "wake_word_id": None,
+            }
+        )
+        pipeline_id_to_name[pipeline.id] = pipeline_name
+
+    device_config = AssistSatelliteConfiguration(
+        available_wake_words=[
+            AssistSatelliteWakeWord("okay_nabu", "Okay Nabu", ["en"]),
+            AssistSatelliteWakeWord("hey_jarvis", "Hey Jarvis", ["en"]),
+            AssistSatelliteWakeWord("hey_mycroft", "Hey Mycroft", ["en"]),
+        ],
+        active_wake_words=["hey_jarvis"],
+        max_active_wake_words=2,
+    )
+    mock_client.get_voice_assistant_configuration.return_value = device_config
+
+    # Wrap mock so we can tell when it's done
+    configuration_set = asyncio.Event()
+
+    async def wrapper(*args, **kwargs):
+        # Update device config because entity will request it after update
+        device_config.active_wake_words = kwargs["active_wake_words"]
+        configuration_set.set()
+
+    mock_client.set_voice_assistant_configuration = AsyncMock(side_effect=wrapper)
+
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        device_info={
+            "voice_assistant_feature_flags": VoiceAssistantFeature.VOICE_ASSISTANT
+            | VoiceAssistantFeature.ANNOUNCE
+        },
+    )
+    await hass.async_block_till_done()
+
+    satellite = get_satellite_entity(hass, mock_device.device_info.mac_address)
+    assert satellite is not None
+
+    # Set primary/secondary wake words and assistants
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: "select.test_wake_word", "option": "Okay Nabu"},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: "select.test_assistant", "option": "Primary Pipeline"},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: "select.test_secondary_wake_word", "option": "Hey Jarvis"},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.test_secondary_assistant",
+            "option": "Secondary Pipeline",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    async def get_pipeline(wake_word_phrase):
+        with patch(
+            "homeassistant.components.assist_satellite.entity.async_pipeline_from_audio_stream",
+        ) as mock_pipeline_from_audio_stream:
+            await satellite.handle_pipeline_start(
+                conversation_id="",
+                flags=0,
+                audio_settings=VoiceAssistantAudioSettings(),
+                wake_word_phrase=wake_word_phrase,
+            )
+
+            mock_pipeline_from_audio_stream.assert_called_once()
+            kwargs = mock_pipeline_from_audio_stream.call_args_list[0].kwargs
+            return pipeline_id_to_name[kwargs["pipeline_id"]]
+
+    # Primary pipeline is the default
+    for wake_word_phrase in (None, "Okay Nabu"):
+        assert (await get_pipeline(wake_word_phrase)) == "Primary Pipeline"
+
+    # Secondary pipeline requires secondary wake word
+    assert (await get_pipeline("Hey Jarvis")) == "Secondary Pipeline"
+
+    # Primary pipeline should be restored after
+    assert (await get_pipeline(None)) == "Primary Pipeline"

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -37,6 +37,7 @@ from homeassistant.components.assist_satellite import (
 # pylint: disable-next=hass-component-root-import
 from homeassistant.components.assist_satellite.entity import AssistSatelliteState
 from homeassistant.components.esphome.assist_satellite import VoiceAssistantUDPServer
+from homeassistant.components.esphome.const import NO_WAKE_WORD
 from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
@@ -1884,10 +1885,10 @@ async def test_wake_word_select(
     assert satellite is not None
     assert satellite.async_get_configuration().active_wake_words == ["hey_jarvis"]
 
-    # Active wake word should be selected
+    # No wake word should be selected by default
     state = hass.states.get("select.test_wake_word")
     assert state is not None
-    assert state.state == "Hey Jarvis"
+    assert state.state == NO_WAKE_WORD
 
     # Changing the select should set the active wake word
     await hass.services.async_call(

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -1913,7 +1913,7 @@ async def test_wake_word_select(
     assert satellite.async_get_configuration().active_wake_words == ["okay_nabu"]
 
     # No secondary wake word should be selected by default
-    state = hass.states.get("select.test_secondary_wake_word")
+    state = hass.states.get("select.test_wake_word_2")
     assert state is not None
     assert state.state == NO_WAKE_WORD
 
@@ -1921,12 +1921,12 @@ async def test_wake_word_select(
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: "select.test_secondary_wake_word", "option": "Hey Jarvis"},
+        {ATTR_ENTITY_ID: "select.test_wake_word_2", "option": "Hey Jarvis"},
         blocking=True,
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("select.test_secondary_wake_word")
+    state = hass.states.get("select.test_wake_word_2")
     assert state is not None
     assert state.state == "Hey Jarvis"
 
@@ -1944,7 +1944,7 @@ async def test_wake_word_select(
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: "select.test_secondary_wake_word", "option": NO_WAKE_WORD},
+        {ATTR_ENTITY_ID: "select.test_wake_word_2", "option": NO_WAKE_WORD},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -2032,14 +2032,14 @@ async def test_secondary_pipeline(
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: "select.test_secondary_wake_word", "option": "Hey Jarvis"},
+        {ATTR_ENTITY_ID: "select.test_wake_word_2", "option": "Hey Jarvis"},
         blocking=True,
     )
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {
-            ATTR_ENTITY_ID: "select.test_secondary_assistant",
+            ATTR_ENTITY_ID: "select.test_assistant_2",
             "option": "Secondary Pipeline",
         },
         blocking=True,

--- a/tests/components/esphome/test_select.py
+++ b/tests/components/esphome/test_select.py
@@ -9,6 +9,7 @@ from homeassistant.components.assist_satellite import (
     AssistSatelliteConfiguration,
     AssistSatelliteWakeWord,
 )
+from homeassistant.components.esphome.const import NO_WAKE_WORD
 from homeassistant.components.select import (
     ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
@@ -186,7 +187,7 @@ async def test_wake_word_select_no_active_wake_words(
     assert satellite is not None
     assert not satellite.async_get_configuration().active_wake_words
 
-    # First available wake word should be selected
+    # No wake word should be selected
     state = hass.states.get("select.test_wake_word")
     assert state is not None
-    assert state.state == "Okay Nabu"
+    assert state.state == NO_WAKE_WORD

--- a/tests/components/esphome/test_select.py
+++ b/tests/components/esphome/test_select.py
@@ -39,7 +39,7 @@ async def test_secondary_pipeline_selector(
 ) -> None:
     """Test secondary assist pipeline selector."""
 
-    state = hass.states.get("select.test_secondary_assistant")
+    state = hass.states.get("select.test_assistant_2")
     assert state is not None
     assert state.state == "preferred"
 
@@ -73,7 +73,7 @@ async def test_secondary_wake_word_select(
     hass: HomeAssistant,
 ) -> None:
     """Test that secondary wake word select is unavailable initially."""
-    state = hass.states.get("select.test_secondary_wake_word")
+    state = hass.states.get("select.test_wake_word_2")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
@@ -140,7 +140,7 @@ async def test_wake_word_select_no_wake_words(
     assert not satellite.async_get_configuration().available_wake_words
 
     # Selects should be unavailable
-    for entity_id in ("select.test_wake_word", "select.test_secondary_wake_word"):
+    for entity_id in ("select.test_wake_word", "select.test_wake_word_2"):
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_UNAVAILABLE
@@ -175,7 +175,7 @@ async def test_wake_word_select_zero_max_wake_words(
     assert satellite.async_get_configuration().max_active_wake_words == 0
 
     # Selects should be unavailable
-    for entity_id in ("select.test_wake_word", "select.test_secondary_wake_word"):
+    for entity_id in ("select.test_wake_word", "select.test_wake_word_2"):
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_UNAVAILABLE
@@ -211,7 +211,7 @@ async def test_wake_word_select_no_active_wake_words(
     assert not satellite.async_get_configuration().active_wake_words
 
     # No wake words should be selected
-    for entity_id in ("select.test_wake_word", "select.test_secondary_wake_word"):
+    for entity_id in ("select.test_wake_word", "select.test_wake_word_2"):
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == NO_WAKE_WORD

--- a/tests/components/esphome/test_select.py
+++ b/tests/components/esphome/test_select.py
@@ -34,6 +34,17 @@ async def test_pipeline_selector(
 
 
 @pytest.mark.usefixtures("mock_voice_assistant_v1_entry")
+async def test_secondary_pipeline_selector(
+    hass: HomeAssistant,
+) -> None:
+    """Test secondary assist pipeline selector."""
+
+    state = hass.states.get("select.test_secondary_assistant")
+    assert state is not None
+    assert state.state == "preferred"
+
+
+@pytest.mark.usefixtures("mock_voice_assistant_v1_entry")
 async def test_vad_sensitivity_select(
     hass: HomeAssistant,
 ) -> None:
@@ -53,6 +64,16 @@ async def test_wake_word_select(
 ) -> None:
     """Test that wake word select is unavailable initially."""
     state = hass.states.get("select.test_wake_word")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("mock_voice_assistant_v1_entry")
+async def test_secondary_wake_word_select(
+    hass: HomeAssistant,
+) -> None:
+    """Test that secondary wake word select is unavailable initially."""
+    state = hass.states.get("select.test_secondary_wake_word")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
@@ -118,10 +139,11 @@ async def test_wake_word_select_no_wake_words(
     assert satellite is not None
     assert not satellite.async_get_configuration().available_wake_words
 
-    # Select should be unavailable
-    state = hass.states.get("select.test_wake_word")
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    # Selects should be unavailable
+    for entity_id in ("select.test_wake_word", "select.test_secondary_wake_word"):
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_UNAVAILABLE
 
 
 async def test_wake_word_select_zero_max_wake_words(
@@ -152,10 +174,11 @@ async def test_wake_word_select_zero_max_wake_words(
     assert satellite is not None
     assert satellite.async_get_configuration().max_active_wake_words == 0
 
-    # Select should be unavailable
-    state = hass.states.get("select.test_wake_word")
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    # Selects should be unavailable
+    for entity_id in ("select.test_wake_word", "select.test_secondary_wake_word"):
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_UNAVAILABLE
 
 
 async def test_wake_word_select_no_active_wake_words(
@@ -187,7 +210,8 @@ async def test_wake_word_select_no_active_wake_words(
     assert satellite is not None
     assert not satellite.async_get_configuration().active_wake_words
 
-    # No wake word should be selected
-    state = hass.states.get("select.test_wake_word")
-    assert state is not None
-    assert state.state == NO_WAKE_WORD
+    # No wake words should be selected
+    for entity_id in ("select.test_wake_word", "select.test_secondary_wake_word"):
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == NO_WAKE_WORD


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
ESPHome voice satellites internally support multiple wake words, but this hasn't been exposed through the UI yet. Rather than supporting an arbitrary number of wake words and pipelines, we have decided to just expose a second wake word/pipeline for multilingual households. In this case, the second wake word would run a pipeline (voice assistant) with a different language than the primary wake word/pipeline.

This PR adds "Secondary wake word" and "Secondary assistant" entities, and uses the secondary assistant (pipeline) instead when the secondary wake word is used.

A "No wake word" option has also been added, allowing users to disable the secondary wake word. As a side benefit, this also lets users disable the primary wake word (a requested feature for users wanting to only use a button).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
