### PR TITLE
Catch more invalid themes in validation

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -90,7 +90,7 @@ THEME_SCHEMA = vol.Schema(
     }
 )
 
-THEMES_SCHEMA = vol.Schema({cv.string: (THEME_SCHEMA)})
+THEMES_SCHEMA = vol.Schema({cv.string: THEME_SCHEMA})
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -75,7 +75,7 @@ PRIMARY_COLOR = "primary-color"
 
 _LOGGER = logging.getLogger(__name__)
 
-EXTENDED_THEME_SCHEMA = vol.Schema(
+THEME_SCHEMA = vol.Schema(
     {
         # Theme variables that apply to all modes
         cv.string: cv.string,
@@ -90,14 +90,14 @@ EXTENDED_THEME_SCHEMA = vol.Schema(
     }
 )
 
-THEME_SCHEMA = vol.Schema({cv.string: (EXTENDED_THEME_SCHEMA)})
+THEMES_SCHEMA = vol.Schema({cv.string: (THEME_SCHEMA)})
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
                 vol.Optional(CONF_FRONTEND_REPO): cv.isdir,
-                vol.Optional(CONF_THEMES): THEME_SCHEMA,
+                vol.Optional(CONF_THEMES): THEMES_SCHEMA,
                 vol.Optional(CONF_EXTRA_MODULE_URL): vol.All(
                     cv.ensure_list, [cv.string]
                 ),

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterator
 from functools import lru_cache, partial
 import logging
 import os
@@ -75,32 +75,17 @@ PRIMARY_COLOR = "primary-color"
 
 _LOGGER = logging.getLogger(__name__)
 
-
-def _not_modes_string_key(key: str) -> str:
-    if key == CONF_THEMES_MODES:
-        raise vol.Invalid("Key 'modes' must not be a string value")
-    return key
-
-
-def _at_least_one_mode(value: Mapping[str, Any]) -> Mapping[str, Any]:
-    if CONF_THEMES_LIGHT not in value and CONF_THEMES_DARK not in value:
-        raise vol.Invalid("At least one of 'light' or 'dark' modes must be present")
-    return value
-
-
 EXTENDED_THEME_SCHEMA = vol.Schema(
     {
         # Theme variables that apply to all modes
-        vol.All(cv.string, _not_modes_string_key): cv.string,
+        cv.string: cv.string,
         # Mode specific theme variables
         vol.Optional(CONF_THEMES_MODES): vol.All(
-            vol.Schema(
-                {
-                    vol.Optional(CONF_THEMES_LIGHT): vol.Schema({cv.string: cv.string}),
-                    vol.Optional(CONF_THEMES_DARK): vol.Schema({cv.string: cv.string}),
-                }
-            ),
-            _at_least_one_mode,
+            {
+                vol.Optional(CONF_THEMES_LIGHT): vol.Schema({cv.string: cv.string}),
+                vol.Optional(CONF_THEMES_DARK): vol.Schema({cv.string: cv.string}),
+            },
+            cv.has_at_least_one_key(CONF_THEMES_LIGHT, CONF_THEMES_DARK),
         ),
     }
 )

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -536,7 +536,7 @@ async def _async_setup_themes(
         new_themes = config.get(DOMAIN, {}).get(CONF_THEMES, {})
 
         try:
-            THEME_SCHEMA(new_themes)
+            THEMES_SCHEMA(new_themes)
         except vol.Invalid as err:
             raise HomeAssistantError(f"Failed to reload themes: {err}") from err
 

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -410,8 +410,64 @@ async def test_themes_reload_themes(
 
 
 @pytest.mark.usefixtures("frontend")
+@pytest.mark.parametrize(
+    ("invalid_theme", "error"),
+    [
+        (
+            {
+                "invalid0": "blue",
+            },
+            "expected a dictionary",
+        ),
+        (
+            {
+                "invalid1": {
+                    "primary-color": "black",
+                    "modes": "light:{} dark:{}",
+                }
+            },
+            "expected a dictionary.*modes",
+        ),
+        (
+            {
+                "invalid2": None,
+            },
+            "expected a dictionary",
+        ),
+        (
+            {
+                "invalid3": {
+                    "primary-color": "black",
+                    "modes": {},
+                }
+            },
+            "At least one of 'light' or 'dark'",
+        ),
+        (
+            {
+                "invalid4": {
+                    "primary-color": "black",
+                    "modes": None,
+                }
+            },
+            "expected a dictionary.*modes",
+        ),
+        (
+            {
+                "invalid5": {
+                    "primary-color": "black",
+                    "modes": {"light": {}, "dank": {}},
+                }
+            },
+            "extra keys not allowed.*dank",
+        ),
+    ],
+)
 async def test_themes_reload_invalid(
-    hass: HomeAssistant, themes_ws_client: MockHAClientWebSocket
+    hass: HomeAssistant,
+    themes_ws_client: MockHAClientWebSocket,
+    invalid_theme: dict,
+    error: str,
 ) -> None:
     """Test frontend.reload_themes service with an invalid theme."""
 
@@ -424,9 +480,9 @@ async def test_themes_reload_invalid(
     with (
         patch(
             "homeassistant.components.frontend.async_hass_config_yaml",
-            return_value={DOMAIN: {CONF_THEMES: {"sad": "blue"}}},
+            return_value={DOMAIN: {CONF_THEMES: invalid_theme}},
         ),
-        pytest.raises(HomeAssistantError, match="Failed to reload themes"),
+        pytest.raises(HomeAssistantError, match=rf"Failed to reload themes.*{error}"),
     ):
         await hass.services.async_call(DOMAIN, "reload_themes", blocking=True)
 

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -441,7 +441,7 @@ async def test_themes_reload_themes(
                     "modes": {},
                 }
             },
-            "At least one of 'light' or 'dark'",
+            "at least one of light, dark.*modes",
         ),
         (
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Some malformed themes that may have been previously accepted (but not correctly working) will now generate an error. 


## Proposed change
Themes validation is a bit looser than it could be and it leads to some potential frontend bugs, we can be a bit more strict.

1. There may potentially be some old themes floating around that have the following code (this came up in an actual bug report):
```
modes:
  light:{}
  dark:{}
```

Despite that this looks kinda like an object, it is actually a string `"light:{} dark:{}"`, as yaml requires a space after the colon. Frontend expects this key to be an object and some components choke on it if modes is encountered as a string in 2025.9.

2. modes: is currently accepted with an empty object, which is a bit non-sensical, as that would imply it doesn't support light or dark mode. This change requires at least one of 'light' or 'dark' to be present, if modes is present. 


Adds testcases for these and a few other invalid conditions which were not tested.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/issues/26884
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
