### PR TITLE
Reconfiguration support for webhook flow helper

### DIFF
--- a/homeassistant/components/dialogflow/strings.json
+++ b/homeassistant/components/dialogflow/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen the [webhook service of Dialogflow]({dialogflow_url}).\n\nUpdate the webhook with following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to the [webhook service of Dialogflow]({dialogflow_url}) and update the webhook with following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },

--- a/homeassistant/components/dialogflow/strings.json
+++ b/homeassistant/components/dialogflow/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen the [webhook service of Dialogflow]({dialogflow_url}).\n\nUpdate the webhook with following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -9,6 +10,10 @@
       "default": "To send events to Home Assistant, you will need to set up the [webhook service of Dialogflow]({dialogflow_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) for further details."
     },
     "step": {
+      "reconfigure": {
+        "description": "Are you sure you want to re-configure Dialogflow?",
+        "title": "Re-configure Dialogflow webhook"
+      },
       "user": {
         "description": "Are you sure you want to set up Dialogflow?",
         "title": "Set up the Dialogflow webhook"

--- a/homeassistant/components/dialogflow/strings.json
+++ b/homeassistant/components/dialogflow/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to the [webhook service of Dialogflow]({dialogflow_url}) and update the webhook with following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Reconfiguration was successful**\n\nGo to the [webhook service of Dialogflow]({dialogflow_url}) and update the webhook with following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -11,8 +11,8 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Are you sure you want to re-configure Dialogflow?",
-        "title": "Re-configure Dialogflow webhook"
+        "description": "Are you sure you want to reconfigure Dialogflow?",
+        "title": "Reconfigure Dialogflow webhook"
       },
       "user": {
         "description": "Are you sure you want to set up Dialogflow?",

--- a/homeassistant/components/geofency/strings.json
+++ b/homeassistant/components/geofency/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen the webhook feature in Geofency.\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to the webhook feature in Geofency and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },

--- a/homeassistant/components/geofency/strings.json
+++ b/homeassistant/components/geofency/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen the webhook feature in Geofency.\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -9,6 +10,10 @@
       "default": "To send events to Home Assistant, you will need to set up the webhook feature in Geofency.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."
     },
     "step": {
+      "reconfigure": {
+        "description": "Are you sure you want to re-configure the Geofency webhook?",
+        "title": "Re-configure Geofency webhook"
+      },
       "user": {
         "description": "Are you sure you want to set up the Geofency webhook?",
         "title": "Set up the Geofency webhook"

--- a/homeassistant/components/geofency/strings.json
+++ b/homeassistant/components/geofency/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to the webhook feature in Geofency and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Reconfiguration was successful**\n\nGo to the webhook feature in Geofency and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -11,8 +11,8 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Are you sure you want to re-configure the Geofency webhook?",
-        "title": "Re-configure Geofency webhook"
+        "description": "Are you sure you want to reconfigure the Geofency webhook?",
+        "title": "Reconfigure Geofency webhook"
       },
       "user": {
         "description": "Are you sure you want to set up the Geofency webhook?",

--- a/homeassistant/components/gpslogger/strings.json
+++ b/homeassistant/components/gpslogger/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen the webhook feature in GPSLogger.\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to the webhook feature in GPSLogger and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },

--- a/homeassistant/components/gpslogger/strings.json
+++ b/homeassistant/components/gpslogger/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen the webhook feature in GPSLogger.\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -9,6 +10,10 @@
       "default": "To send events to Home Assistant, you will need to set up the webhook feature in GPSLogger.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."
     },
     "step": {
+      "reconfigure": {
+        "description": "Are you sure you want to re-configure the GPSLogger webhook?",
+        "title": "Re-configure GPSLogger webhook"
+      },
       "user": {
         "description": "Are you sure you want to set up the GPSLogger webhook?",
         "title": "Set up the GPSLogger webhook"

--- a/homeassistant/components/gpslogger/strings.json
+++ b/homeassistant/components/gpslogger/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to the webhook feature in GPSLogger and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Reconfiguration was successful**\n\nGo to the webhook feature in GPSLogger and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -11,8 +11,8 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Are you sure you want to re-configure the GPSLogger webhook?",
-        "title": "Re-configure GPSLogger webhook"
+        "description": "Are you sure you want to reconfigure the GPSLogger webhook?",
+        "title": "Reconfigure GPSLogger webhook"
       },
       "user": {
         "description": "Are you sure you want to set up the GPSLogger webhook?",

--- a/homeassistant/components/ifttt/strings.json
+++ b/homeassistant/components/ifttt/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen the \"Make a web request\" action from the [IFTTT webhook applet]({applet_url}).\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to the \"Make a web request\" action from the [IFTTT webhook applet]({applet_url}) and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },

--- a/homeassistant/components/ifttt/strings.json
+++ b/homeassistant/components/ifttt/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen the \"Make a web request\" action from the [IFTTT webhook applet]({applet_url}).\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -9,6 +10,10 @@
       "default": "To send events to Home Assistant, you will need to use the \"Make a web request\" action from the [IFTTT webhook applet]({applet_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."
     },
     "step": {
+      "reconfigure": {
+        "description": "Are you sure you want to re-configure IFTTT?",
+        "title": "Re-configure IFTTT webhook applet"
+      },
       "user": {
         "description": "Are you sure you want to set up IFTTT?",
         "title": "Set up the IFTTT webhook applet"

--- a/homeassistant/components/ifttt/strings.json
+++ b/homeassistant/components/ifttt/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to the \"Make a web request\" action from the [IFTTT webhook applet]({applet_url}) and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
+      "reconfigure_successful": "**Reconfiguration was successful**\n\nGo to the \"Make a web request\" action from the [IFTTT webhook applet]({applet_url}) and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -11,8 +11,8 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Are you sure you want to re-configure IFTTT?",
-        "title": "Re-configure IFTTT webhook applet"
+        "description": "Are you sure you want to reconfigure IFTTT?",
+        "title": "Reconfigure IFTTT webhook applet"
       },
       "user": {
         "description": "Are you sure you want to set up IFTTT?",

--- a/homeassistant/components/locative/strings.json
+++ b/homeassistant/components/locative/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen webhooks in the Locative app.\n\nUpdate webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to webhooks in the Locative app and update webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },

--- a/homeassistant/components/locative/strings.json
+++ b/homeassistant/components/locative/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen webhooks in the Locative app.\n\nUpdate webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -9,6 +10,10 @@
       "default": "To send locations to Home Assistant, you will need to set up the webhook feature in the Locative app.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."
     },
     "step": {
+      "reconfigure": {
+        "description": "Do you want to start re-configuration?",
+        "title": "Re-configure Locative webhook"
+      },
       "user": {
         "description": "[%key:common::config_flow::description::confirm_setup%]",
         "title": "Set up the Locative webhook"

--- a/homeassistant/components/locative/strings.json
+++ b/homeassistant/components/locative/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to webhooks in the Locative app and update webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Reconfiguration was successful**\n\nGo to webhooks in the Locative app and update webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -11,8 +11,8 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Do you want to start re-configuration?",
-        "title": "Re-configure Locative webhook"
+        "description": "Do you want to start reconfiguration?",
+        "title": "Reconfigure Locative webhook"
       },
       "user": {
         "description": "[%key:common::config_flow::description::confirm_setup%]",

--- a/homeassistant/components/mailgun/strings.json
+++ b/homeassistant/components/mailgun/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen [webhooks in Mailgun]({mailgun_url}).\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to [webhooks in Mailgun]({mailgun_url}) and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },

--- a/homeassistant/components/mailgun/strings.json
+++ b/homeassistant/components/mailgun/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen [webhooks in Mailgun]({mailgun_url}).\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -9,6 +10,10 @@
       "default": "To send events to Home Assistant, you will need to set up a [webhook with Mailgun]({mailgun_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."
     },
     "step": {
+      "reconfigure": {
+        "description": "Are you sure you want to re-configure Mailgun?",
+        "title": "Re-configure Mailgun webhook"
+      },
       "user": {
         "description": "Are you sure you want to set up Mailgun?",
         "title": "Set up the Mailgun webhook"

--- a/homeassistant/components/mailgun/strings.json
+++ b/homeassistant/components/mailgun/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to [webhooks in Mailgun]({mailgun_url}) and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
+      "reconfigure_successful": "**Reconfiguration was successful**\n\nGo to [webhooks in Mailgun]({mailgun_url}) and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -11,8 +11,8 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Are you sure you want to re-configure Mailgun?",
-        "title": "Re-configure Mailgun webhook"
+        "description": "Are you sure you want to reconfigure Mailgun?",
+        "title": "Reconfigure Mailgun webhook"
       },
       "user": {
         "description": "Are you sure you want to set up Mailgun?",

--- a/homeassistant/components/sleep_as_android/config_flow.py
+++ b/homeassistant/components/sleep_as_android/config_flow.py
@@ -11,4 +11,5 @@ config_entry_flow.register_webhook_flow(
     "Sleep as Android",
     {"docs_url": "https://www.home-assistant.io/integrations/sleep_as_android"},
     allow_multiple=True,
+    reconfigure=True,
 )

--- a/homeassistant/components/sleep_as_android/config_flow.py
+++ b/homeassistant/components/sleep_as_android/config_flow.py
@@ -11,5 +11,4 @@ config_entry_flow.register_webhook_flow(
     "Sleep as Android",
     {"docs_url": "https://www.home-assistant.io/integrations/sleep_as_android"},
     allow_multiple=True,
-    reconfigure=True,
 )

--- a/homeassistant/components/sleep_as_android/strings.json
+++ b/homeassistant/components/sleep_as_android/strings.json
@@ -1,24 +1,18 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "title": "Set up Sleep as Android",
-        "description": "Are you sure you want to set up the Sleep as Android integration?"
-      },
-      "reconfigure": {
-        "title": "Re-configure Sleep as Android",
-        "description": "Are you sure you want to re-configure the Sleep as Android integration?"
-      }
-    },
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen Sleep as Android and go to *Settings → Services → Automation → Webhooks*\n\nUpdate the URL field with the following webhook:\n\n`{webhook_url}`"
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen Sleep as Android and go to *Settings → Services → Automation → Webhooks*\n\nUpdate the URL field with the following webhook:\n\n`{webhook_url}`",
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to set up a webhook.\n\nOpen Sleep as Android and go to *Settings → Services → Automation → Webhooks*\n\nEnable *Webhooks* and fill in the following webhook in the URL field:\n\n`{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details."
     },
     "step": {
+      "reconfigure": {
+        "description": "Are you sure you want to re-configure the Sleep as Android integration?",
+        "title": "Re-configure Sleep as Android"
+      },
       "user": {
         "description": "Are you sure you want to set up the Sleep as Android integration?",
         "title": "Set up Sleep as Android"

--- a/homeassistant/components/sleep_as_android/strings.json
+++ b/homeassistant/components/sleep_as_android/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen Sleep as Android and go to *Settings → Services → Automation → Webhooks*\n\nUpdate the URL field with the following webhook:\n\n`{webhook_url}`",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nIn Sleep as Android go to *Settings → Services → Automation → Webhooks* and update the webhook with the following URL:\n\n`{webhook_url}`",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {

--- a/homeassistant/components/sleep_as_android/strings.json
+++ b/homeassistant/components/sleep_as_android/strings.json
@@ -1,8 +1,19 @@
 {
   "config": {
+    "step": {
+      "user": {
+        "title": "Set up Sleep as Android",
+        "description": "Are you sure you want to set up the Sleep as Android integration?"
+      },
+      "reconfigure": {
+        "title": "Re-configure Sleep as Android",
+        "description": "Are you sure you want to re-configure the Sleep as Android integration?"
+      }
+    },
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]",
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen Sleep as Android and go to *Settings → Services → Automation → Webhooks*\n\nUpdate the URL field with the following webhook:\n\n`{webhook_url}`"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to set up a webhook.\n\nOpen Sleep as Android and go to *Settings → Services → Automation → Webhooks*\n\nEnable *Webhooks* and fill in the following webhook in the URL field:\n\n`{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/sleep_as_android/strings.json
+++ b/homeassistant/components/sleep_as_android/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nIn Sleep as Android go to *Settings → Services → Automation → Webhooks* and update the webhook with the following URL:\n\n`{webhook_url}`",
+      "reconfigure_successful": "**Reconfiguration was successful**\n\nIn Sleep as Android go to *Settings → Services → Automation → Webhooks* and update the webhook with the following URL:\n\n`{webhook_url}`",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
@@ -10,8 +10,8 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Are you sure you want to re-configure the Sleep as Android integration?",
-        "title": "Re-configure Sleep as Android"
+        "description": "Are you sure you want to reconfigure the Sleep as Android integration?",
+        "title": "Reconfigure Sleep as Android"
       },
       "user": {
         "description": "Are you sure you want to set up the Sleep as Android integration?",

--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen webhooks in the Traccar Client.\n\nUpdate webhook with the following URL: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -9,6 +10,10 @@
       "default": "To send events to Home Assistant, you will need to set up the webhook feature in Traccar Client.\n\nUse the following URL: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details."
     },
     "step": {
+      "reconfigure": {
+        "description": "Are you sure you want to re-configure the Traccar Client?",
+        "title": "Re-configure Traccar Client"
+      },
       "user": {
         "description": "Are you sure you want to set up Traccar Client?",
         "title": "Set up Traccar Client"

--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to webhooks in the Traccar Client and pdate the webhook with the following URL: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to webhooks in the Traccar Client and update the webhook with the following URL: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },

--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen webhooks in the Traccar Client.\n\nUpdate webhook with the following URL: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to webhooks in the Traccar Client and pdate the webhook with the following URL: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },

--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to webhooks in the Traccar Client and update the webhook with the following URL: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details.",
+      "reconfigure_successful": "**Reconfiguration was successful**\n\nGo to webhooks in the Traccar Client and update the webhook with the following URL: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -11,8 +11,8 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Are you sure you want to re-configure the Traccar Client?",
-        "title": "Re-configure Traccar Client"
+        "description": "Are you sure you want to reconfigure the Traccar Client?",
+        "title": "Reconfigure Traccar Client"
       },
       "user": {
         "description": "Are you sure you want to set up Traccar Client?",

--- a/homeassistant/components/twilio/strings.json
+++ b/homeassistant/components/twilio/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "Re-configuration was successful\n\nOpen [webhooks in Twilio]({twilio_url}).\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
+      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to [webhooks in Twilio]({twilio_url}) and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },

--- a/homeassistant/components/twilio/strings.json
+++ b/homeassistant/components/twilio/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
+      "reconfigure_successful": "Re-configuration was successful\n\nOpen [webhooks in Twilio]({twilio_url}).\n\nUpdate the webhook with the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -9,6 +10,10 @@
       "default": "To send events to Home Assistant, you will need to set up a [webhook with Twilio]({twilio_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."
     },
     "step": {
+      "reconfigure": {
+        "description": "Do you want to start re-configuration?",
+        "title": "Re-configure Twilio webhook"
+      },
       "user": {
         "description": "[%key:common::config_flow::description::confirm_setup%]",
         "title": "Set up the Twilio webhook"

--- a/homeassistant/components/twilio/strings.json
+++ b/homeassistant/components/twilio/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "reconfigure_successful": "**Re-configuration was successful**\n\nGo to [webhooks in Twilio]({twilio_url}) and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
+      "reconfigure_successful": "**Reconfiguration was successful**\n\nGo to [webhooks in Twilio]({twilio_url}) and update the webhook with the following settings:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
@@ -11,8 +11,8 @@
     },
     "step": {
       "reconfigure": {
-        "description": "Do you want to start re-configuration?",
-        "title": "Re-configure Twilio webhook"
+        "description": "Do you want to start reconfiguration?",
+        "title": "Reconfigure Twilio webhook"
       },
       "user": {
         "description": "[%key:common::config_flow::description::confirm_setup%]",

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -215,11 +215,19 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
         """Handle a user initiated set up flow to create a webhook."""
-        if not self._allow_multiple and self._async_current_entries():
+        if (
+            not self._allow_multiple
+            and self._async_current_entries()
+            and self.source != config_entries.SOURCE_RECONFIGURE
+        ):
             return self.async_abort(reason="single_instance_allowed")
 
         if user_input is None:
-            return self.async_show_form(step_id="user")
+            return self.async_show_form(
+                step_id="reconfigure"
+                if self.source == config_entries.SOURCE_RECONFIGURE
+                else "user"
+            )
 
         # Local import to be sure cloud is loaded and setup
         from homeassistant.components.cloud import (  # noqa: PLC0415
@@ -234,7 +242,11 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
             async_generate_url,
         )
 
-        webhook_id = async_generate_id()
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            entry = self._get_reconfigure_entry()
+            webhook_id = entry.data["webhook_id"]
+        else:
+            webhook_id = async_generate_id()
 
         if "cloud" in self.hass.config.components and async_active_subscription(
             self.hass
@@ -250,6 +262,17 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
 
         self._description_placeholder["webhook_url"] = webhook_url
 
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            if self.hass.config_entries.async_update_entry(
+                entry=entry,
+                data={"webhook_id": webhook_id, "cloudhook": cloudhook},
+            ):
+                self.hass.config_entries.async_schedule_reload(entry.entry_id)
+            return self.async_abort(
+                reason="reconfigure_successful",
+                description_placeholders=self._description_placeholder,
+            )
+
         return self.async_create_entry(
             title=self._title,
             data={"webhook_id": webhook_id, "cloudhook": cloudhook},
@@ -258,7 +281,11 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
 
 
 def register_webhook_flow(
-    domain: str, title: str, description_placeholder: dict, allow_multiple: bool = False
+    domain: str,
+    title: str,
+    description_placeholder: dict,
+    allow_multiple: bool = False,
+    reconfigure: bool = False,
 ) -> None:
     """Register flow for webhook integrations."""
 
@@ -267,6 +294,9 @@ def register_webhook_flow(
 
         def __init__(self) -> None:
             super().__init__(domain, title, description_placeholder, allow_multiple)
+
+        if reconfigure:
+            async_step_reconfigure = WebhookFlowHandler.async_step_user
 
     config_entries.HANDLERS.register(domain)(WebhookFlow)
 

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -279,13 +279,16 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
             description_placeholders=self._description_placeholder,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle a user initiated flow to re-configure a webhook."""
+
+        return await self.async_step_user(user_input)
+
 
 def register_webhook_flow(
-    domain: str,
-    title: str,
-    description_placeholder: dict,
-    allow_multiple: bool = False,
-    reconfigure: bool = False,
+    domain: str, title: str, description_placeholder: dict, allow_multiple: bool = False
 ) -> None:
     """Register flow for webhook integrations."""
 
@@ -294,9 +297,6 @@ def register_webhook_flow(
 
         def __init__(self) -> None:
             super().__init__(domain, title, description_placeholder, allow_multiple)
-
-        if reconfigure:
-            async_step_reconfigure = WebhookFlowHandler.async_step_user
 
     config_entries.HANDLERS.register(domain)(WebhookFlow)
 

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -61,6 +61,9 @@ def webhook_flow_conf(hass: HomeAssistant) -> Generator[None]:
         config_entry_flow.register_webhook_flow(
             "test_multiple", "Test Multiple", {}, True
         )
+        config_entry_flow.register_webhook_flow(
+            "test_reconfigure", "Test Reconfigure", {}, False, True
+        )
         yield
 
 
@@ -510,3 +513,90 @@ async def test_webhook_create_cloudhook_aborts_not_connected(
 
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "cloud_not_connected"
+
+
+async def test_webhook_reconfigure_flow(
+    hass: HomeAssistant, webhook_flow_conf: None
+) -> None:
+    """Test webhook reconfigure flow."""
+    config_entry = MockConfigEntry(
+        domain="test_reconfigure", data={"webhook_id": "12345", "cloudhook": False}
+    )
+    config_entry.add_to_hass(hass)
+
+    flow = config_entries.HANDLERS["test_reconfigure"]()
+    flow.hass = hass
+    flow.context = {
+        "source": config_entries.SOURCE_RECONFIGURE,
+        "entry_id": config_entry.entry_id,
+    }
+
+    await async_process_ha_core_config(
+        hass,
+        {"external_url": "https://example.com"},
+    )
+
+    result = await flow.async_step_reconfigure()
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await flow.async_step_reconfigure(user_input={})
+
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert result["description_placeholders"] == {
+        "webhook_url": "https://example.com/api/webhook/12345"
+    }
+    assert config_entry.data["webhook_id"] == "12345"
+    assert config_entry.data["cloudhook"] is False
+
+
+async def test_webhook_reconfigure_cloudhook(
+    hass: HomeAssistant, webhook_flow_conf: None
+) -> None:
+    """Test reconfigure updates to cloudhook if subscribed."""
+    assert await setup.async_setup_component(hass, "cloud", {})
+
+    config_entry = MockConfigEntry(
+        domain="test_reconfigure", data={"webhook_id": "12345", "cloudhook": False}
+    )
+    config_entry.add_to_hass(hass)
+
+    flow = config_entries.HANDLERS["test_reconfigure"]()
+    flow.hass = hass
+    flow.context = {
+        "source": config_entries.SOURCE_RECONFIGURE,
+        "entry_id": config_entry.entry_id,
+    }
+
+    result = await flow.async_step_reconfigure()
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    with (
+        patch(
+            "hass_nabucasa.cloudhooks.Cloudhooks.async_create",
+            return_value={"cloudhook_url": "https://example.com"},
+        ) as mock_create,
+        patch(
+            "hass_nabucasa.Cloud.subscription_expired",
+            new_callable=PropertyMock(return_value=False),
+        ),
+        patch(
+            "hass_nabucasa.Cloud.is_logged_in",
+            new_callable=PropertyMock(return_value=True),
+        ),
+        patch(
+            "hass_nabucasa.iot_base.BaseIoT.connected",
+            new_callable=PropertyMock(return_value=True),
+        ),
+    ):
+        result = await flow.async_step_reconfigure(user_input={})
+
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert result["description_placeholders"] == {"webhook_url": "https://example.com"}
+    assert len(mock_create.mock_calls) == 1
+
+    assert config_entry.data["webhook_id"] == "12345"
+    assert config_entry.data["cloudhook"] is True

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -61,9 +61,6 @@ def webhook_flow_conf(hass: HomeAssistant) -> Generator[None]:
         config_entry_flow.register_webhook_flow(
             "test_multiple", "Test Multiple", {}, True
         )
-        config_entry_flow.register_webhook_flow(
-            "test_reconfigure", "Test Reconfigure", {}, False, True
-        )
         yield
 
 
@@ -520,11 +517,11 @@ async def test_webhook_reconfigure_flow(
 ) -> None:
     """Test webhook reconfigure flow."""
     config_entry = MockConfigEntry(
-        domain="test_reconfigure", data={"webhook_id": "12345", "cloudhook": False}
+        domain="test_single", data={"webhook_id": "12345", "cloudhook": False}
     )
     config_entry.add_to_hass(hass)
 
-    flow = config_entries.HANDLERS["test_reconfigure"]()
+    flow = config_entries.HANDLERS["test_single"]()
     flow.hass = hass
     flow.context = {
         "source": config_entries.SOURCE_RECONFIGURE,
@@ -558,11 +555,11 @@ async def test_webhook_reconfigure_cloudhook(
     assert await setup.async_setup_component(hass, "cloud", {})
 
     config_entry = MockConfigEntry(
-        domain="test_reconfigure", data={"webhook_id": "12345", "cloudhook": False}
+        domain="test_single", data={"webhook_id": "12345", "cloudhook": False}
     )
     config_entry.add_to_hass(hass)
 
-    flow = config_entries.HANDLERS["test_reconfigure"]()
+    flow = config_entries.HANDLERS["test_single"]()
     flow.hass = hass
     flow.context = {
         "source": config_entries.SOURCE_RECONFIGURE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for reconfiguration to the webhook flow helper

This allows users to re-run the setup flow for webhook-based integrations, which would be useful in the following scenarios:

- The webhook URL needs to be retrieved again (currently only shown once during initial setup).
- The target device/service has lost the stored webhook URL (e.g., after a reset, reinstallation, or firmware/software update).
- The Home Assistant instance configuration has changed, such as:
  - Remote access being enabled after initial setup (via external URL or Home Assistant Cloud subscription).
  - The address of the instance being modified.

During reconfiguration, if a Home Assistant Cloud subscription is active, the `cloudhook` flag will be enabled. Otherwise, only a new webhook URL is generated.

To add a reconfigure flow to a webhook-based integration the following translation strings are required:

```json
{
"config": {
   "step": {
      "reconfigure": {
        "title": "Re-configure Sleep as Android",
        "description": "Are you sure you want to re-configure the Sleep as Android integration?"
      }
    },
    "abort": {
      "reconfigure_successful": "Re-configuration was successful\n\nOpen Sleep as Android and go to *Settings → Services → Automation → Webhooks*\n\nUpdate the URL field with the following webhook:\n\n`{webhook_url}`"
    }
}
```
 In the abort string the same translation placeholders as in the user flow will available.

<img width="619" height="414" alt="image" src="https://github.com/user-attachments/assets/24b5d132-7f03-47be-b6c6-44277531a0e8" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2948
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
