### PR TITLE
Use motor rotation mode in Tuya clkg covers (curtain)

### DIFF
--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -257,14 +257,12 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             self._motor_reverse_mode_enum = enum_type
 
     @property
-    def _is_motor_reverse_mode(self) -> bool:
+    def _is_motor_forward(self) -> bool:
         """Check if the cover direction should be reversed based on motor_reverse_mode."""
-        if (
+        return not (
             self._motor_reverse_mode_enum
             and self.device.status.get(self._motor_reverse_mode_enum.dpcode) == "back"
-        ):
-            return False
-        return True
+        )
 
     @property
     def current_cover_position(self) -> int | None:
@@ -277,7 +275,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
         return round(
             self._current_position.remap_value_to(
-                position, 0, 100, reverse=self._is_motor_reverse_mode
+                position, 0, 100, reverse=self._is_motor_forward
             )
         )
 
@@ -334,7 +332,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                     "code": self._set_position.dpcode,
                     "value": round(
                         self._set_position.remap_value_from(
-                            100, 0, 100, reverse=self._is_motor_reverse_mode
+                            100, 0, 100, reverse=self._is_motor_forward
                         ),
                     ),
                 }
@@ -360,7 +358,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                     "code": self._set_position.dpcode,
                     "value": round(
                         self._set_position.remap_value_from(
-                            0, 0, 100, reverse=self._is_motor_reverse_mode
+                            0, 0, 100, reverse=self._is_motor_forward
                         ),
                     ),
                 }
@@ -383,7 +381,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                             kwargs[ATTR_POSITION],
                             0,
                             100,
-                            reverse=self._is_motor_reverse_mode,
+                            reverse=self._is_motor_forward,
                         )
                     ),
                 }
@@ -416,7 +414,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                             kwargs[ATTR_TILT_POSITION],
                             0,
                             100,
-                            reverse=self._is_motor_reverse_mode,
+                            reverse=self._is_motor_forward,
                         )
                     ),
                 }

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DPCode, DPType
 from .entity import TuyaEntity
-from .models import IntegerTypeData
+from .models import EnumTypeData, IntegerTypeData
 from .util import get_dpcode
 
 
@@ -37,6 +37,7 @@ class TuyaCoverEntityDescription(CoverEntityDescription):
     open_instruction_value: str = "open"
     close_instruction_value: str = "close"
     stop_instruction_value: str = "stop"
+    motor_reverse_mode: DPCode | None = None
 
 
 COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
@@ -124,6 +125,7 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             translation_key="curtain",
             current_position=DPCode.PERCENT_CONTROL,
             set_position=DPCode.PERCENT_CONTROL,
+            motor_reverse_mode=DPCode.CONTROL_BACK_MODE,
             device_class=CoverDeviceClass.CURTAIN,
         ),
         TuyaCoverEntityDescription(
@@ -132,6 +134,7 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             translation_placeholders={"index": "2"},
             current_position=DPCode.PERCENT_CONTROL_2,
             set_position=DPCode.PERCENT_CONTROL_2,
+            motor_reverse_mode=DPCode.CONTROL_BACK_MODE,
             device_class=CoverDeviceClass.CURTAIN,
         ),
     ),
@@ -188,6 +191,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
     _current_position: IntegerTypeData | None = None
     _set_position: IntegerTypeData | None = None
     _tilt: IntegerTypeData | None = None
+    _motor_reverse_mode_enum: EnumTypeData | None = None
     entity_description: TuyaCoverEntityDescription
 
     def __init__(
@@ -242,6 +246,26 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             self._attr_supported_features |= CoverEntityFeature.SET_TILT_POSITION
             self._tilt = int_type
 
+        # Determine type to use for checking motor reverse mode
+        if (motor_mode := description.motor_reverse_mode) and (
+            enum_type := self.find_dpcode(
+                motor_mode,
+                dptype=DPType.ENUM,
+                prefer_function=True,
+            )
+        ):
+            self._motor_reverse_mode_enum = enum_type
+
+    @property
+    def _is_motor_reverse_mode(self) -> bool:
+        """Check if the cover direction should be reversed based on motor_reverse_mode."""
+        if (
+            self._motor_reverse_mode_enum
+            and self.device.status.get(self._motor_reverse_mode_enum.dpcode) == "back"
+        ):
+            return False
+        return True
+
     @property
     def current_cover_position(self) -> int | None:
         """Return cover current position."""
@@ -252,7 +276,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             return None
 
         return round(
-            self._current_position.remap_value_to(position, 0, 100, reverse=True)
+            self._current_position.remap_value_to(
+                position, 0, 100, reverse=self._is_motor_reverse_mode
+            )
         )
 
     @property
@@ -307,7 +333,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                 {
                     "code": self._set_position.dpcode,
                     "value": round(
-                        self._set_position.remap_value_from(100, 0, 100, reverse=True),
+                        self._set_position.remap_value_from(
+                            100, 0, 100, reverse=self._is_motor_reverse_mode
+                        ),
                     ),
                 }
             )
@@ -331,7 +359,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                 {
                     "code": self._set_position.dpcode,
                     "value": round(
-                        self._set_position.remap_value_from(0, 0, 100, reverse=True),
+                        self._set_position.remap_value_from(
+                            0, 0, 100, reverse=self._is_motor_reverse_mode
+                        ),
                     ),
                 }
             )
@@ -350,7 +380,10 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                     "code": self._set_position.dpcode,
                     "value": round(
                         self._set_position.remap_value_from(
-                            kwargs[ATTR_POSITION], 0, 100, reverse=True
+                            kwargs[ATTR_POSITION],
+                            0,
+                            100,
+                            reverse=self._is_motor_reverse_mode,
                         )
                     ),
                 }
@@ -380,7 +413,10 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                     "code": self._tilt.dpcode,
                     "value": round(
                         self._tilt.remap_value_from(
-                            kwargs[ATTR_TILT_POSITION], 0, 100, reverse=True
+                            kwargs[ATTR_TILT_POSITION],
+                            0,
+                            100,
+                            reverse=self._is_motor_reverse_mode,
                         )
                     ),
                 }

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -258,7 +258,10 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
     @property
     def _is_motor_forward(self) -> bool:
-        """Check if the cover direction should be reversed based on motor_reverse_mode."""
+        """Check if the cover direction should be reversed based on motor_reverse_mode.
+
+        If the motor is "forward" (=default) then the positions need to be reversed.
+        """
         return not (
             self._motor_reverse_mode_enum
             and self.device.status.get(self._motor_reverse_mode_enum.dpcode) == "back"

--- a/tests/components/tuya/snapshots/test_cover.ambr
+++ b/tests/components/tuya/snapshots/test_cover.ambr
@@ -393,7 +393,7 @@
 # name: test_platform_setup_and_discovery[cover.roller_shutter_living_room_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 25,
+      'current_position': 75,
       'device_class': 'curtain',
       'friendly_name': 'Roller shutter Living Room Curtain',
       'supported_features': <CoverEntityFeature: 15>,

--- a/tests/components/tuya/test_cover.py
+++ b/tests/components/tuya/test_cover.py
@@ -213,11 +213,11 @@ async def test_set_tilt_position_not_supported(
 @pytest.mark.parametrize(
     ("initial_percent_control", "expected_state", "expected_position"),
     [
-        (0, "open", 100),  # Should be closed/0
-        (25, "open", 75),  # Should be open/25
+        (0, "closed", 0),
+        (25, "open", 25),
         (50, "open", 50),
-        (75, "open", 25),  # Should be open/75
-        (100, "closed", 0),  # Should be open/100
+        (75, "open", 75),
+        (100, "open", 100),
     ],
 )
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.COVER])
@@ -259,16 +259,14 @@ async def test_clkg_wltqkykhni0papzj_state(
             {},
             [
                 {"code": "control", "value": "open"},
-                # Should be sending 100
-                {"code": "percent_control", "value": 0},
+                {"code": "percent_control", "value": 100},
             ],
         ),
         (
             SERVICE_SET_COVER_POSITION,
             {ATTR_POSITION: 25},
             [
-                # Should be sending 25
-                {"code": "percent_control", "value": 75},
+                {"code": "percent_control", "value": 25},
             ],
         ),
         (
@@ -276,8 +274,7 @@ async def test_clkg_wltqkykhni0papzj_state(
             {},
             [
                 {"code": "control", "value": "close"},
-                # Should be sending 0
-                {"code": "percent_control", "value": 100},
+                {"code": "percent_control", "value": 0},
             ],
         ),
     ],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on issue #151635, and initial work from @FredrikM97

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151635
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
