### PR TITLE
Add service `modbus.read_registers`

### DIFF
--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -106,6 +106,8 @@ UDP = "udp"
 
 # service call attributes
 ATTR_ADDRESS = CONF_ADDRESS
+ATTR_COUNT = "count"
+ATTR_TYPE = "type"
 ATTR_HUB = "hub"
 ATTR_UNIT = "unit"
 ATTR_SLAVE = "slave"
@@ -143,6 +145,7 @@ CALL_TYPE_X_REGISTER_HOLDINGS = "holdings"
 # service calls
 SERVICE_WRITE_COIL = "write_coil"
 SERVICE_WRITE_REGISTER = "write_register"
+SERVICE_READ_REGISTERS = "read_registers"
 SERVICE_STOP = "stop"
 SERVICE_RESTART = "restart"
 

--- a/homeassistant/components/modbus/icons.json
+++ b/homeassistant/components/modbus/icons.json
@@ -9,6 +9,9 @@
     "write_register": {
       "service": "mdi:database-edit"
     },
+    "read_registers": {
+      "service": "mdi:database-search"
+    },
     "stop": {
       "service": "mdi:stop"
     },

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -183,9 +183,9 @@ async def async_modbus_setup(
     def _resolve_slave(data: dict[str, Any]) -> int:
         slave = 1
         if ATTR_UNIT in data:
-            slave = int(float(data[ATTR_UNIT]))
+            slave = data[ATTR_UNIT]
         if ATTR_SLAVE in data:
-            slave = int(float(data[ATTR_SLAVE]))
+            slave = data[ATTR_SLAVE]
         return slave
 
     async def async_write_register(service: ServiceCall) -> None:

--- a/homeassistant/components/modbus/services.yaml
+++ b/homeassistant/components/modbus/services.yaml
@@ -47,6 +47,39 @@ write_register:
       default: "modbus_hub"
       selector:
         text:
+read_registers:
+  fields:
+    address:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 65535
+    count:
+      required: false
+      default: 1
+      selector:
+        number:
+          min: 1
+          max: 125
+    type:
+      required: true
+      selector:
+        select:
+          options:
+            - "input"
+            - "holding"
+    slave:
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 255
+    hub:
+      example: "hub1"
+      default: "modbus_hub"
+      selector:
+        text:
 stop:
   fields:
     hub:

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -48,6 +48,32 @@
         }
       }
     },
+    "read_registers": {
+      "name": "Read registers",
+      "description": "Reads one or more Modbus input or holding registers.",
+      "fields": {
+        "address": {
+          "name": "[%key:component::modbus::services::write_coil::fields::address::name%]",
+          "description": "Address of the first register."
+        },
+        "count": {
+          "name": "Count",
+          "description": "Number of registers to read."
+        },
+        "type": {
+          "name": "Type",
+          "description": "Type of registers to read."
+        },
+        "slave": {
+          "name": "[%key:component::modbus::services::write_coil::fields::slave::name%]",
+          "description": "[%key:component::modbus::services::write_coil::fields::slave::description%]"
+        },
+        "hub": {
+          "name": "[%key:component::modbus::services::write_coil::fields::hub::name%]",
+          "description": "[%key:component::modbus::services::write_coil::fields::hub::description%]"
+        }
+      }
+    },
     "stop": {
       "name": "[%key:common::action::stop%]",
       "description": "Stops a Modbus hub.",

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -908,47 +908,59 @@ async def test_pb_service_write(
     "do_read",
     [
         {
-            ATTR_ADDRESS: 14,
-            ATTR_COUNT: 1,
-            ATTR_TYPE: CALL_TYPE_REGISTER_INPUT,
+            DATA: {
+                ATTR_ADDRESS: 14,
+                ATTR_COUNT: 1,
+                ATTR_TYPE: CALL_TYPE_REGISTER_INPUT,
+            },
             FUNC: CALL_TYPE_REGISTER_INPUT,
             RETURN_VALUE: ReadResult([0x0001]),
             EXPECTED_RESULT: {"values": [0x0001]},
         },
         {
-            ATTR_ADDRESS: 15,
-            ATTR_TYPE: CALL_TYPE_REGISTER_INPUT,
+            DATA: {
+                ATTR_ADDRESS: 15,
+                ATTR_TYPE: CALL_TYPE_REGISTER_INPUT,
+            },
             FUNC: CALL_TYPE_REGISTER_INPUT,
             RETURN_VALUE: ReadResult([0x1000]),
             EXPECTED_RESULT: {"values": [0x1000]},
         },
         {
-            ATTR_ADDRESS: 16,
-            ATTR_COUNT: 2,
-            ATTR_TYPE: CALL_TYPE_REGISTER_INPUT,
+            DATA: {
+                ATTR_ADDRESS: 16,
+                ATTR_COUNT: 2,
+                ATTR_TYPE: CALL_TYPE_REGISTER_INPUT,
+            },
             FUNC: CALL_TYPE_REGISTER_INPUT,
             RETURN_VALUE: ReadResult([0x0003, 0x0002]),
             EXPECTED_RESULT: {"values": [0x0003, 0x0002]},
         },
         {
-            ATTR_ADDRESS: 17,
-            ATTR_COUNT: 1,
-            ATTR_TYPE: CALL_TYPE_REGISTER_HOLDING,
+            DATA: {
+                ATTR_ADDRESS: 17,
+                ATTR_COUNT: 1,
+                ATTR_TYPE: CALL_TYPE_REGISTER_HOLDING,
+            },
             FUNC: CALL_TYPE_REGISTER_HOLDING,
             RETURN_VALUE: ReadResult([0x0004]),
             EXPECTED_RESULT: {"values": [0x0004]},
         },
         {
-            ATTR_ADDRESS: 18,
-            ATTR_TYPE: CALL_TYPE_REGISTER_HOLDING,
+            DATA: {
+                ATTR_ADDRESS: 18,
+                ATTR_TYPE: CALL_TYPE_REGISTER_HOLDING,
+            },
             FUNC: CALL_TYPE_REGISTER_HOLDING,
             RETURN_VALUE: ReadResult([0x0005]),
             EXPECTED_RESULT: {"values": [0x0005]},
         },
         {
-            ATTR_ADDRESS: 19,
-            ATTR_COUNT: 2,
-            ATTR_TYPE: CALL_TYPE_REGISTER_HOLDING,
+            DATA: {
+                ATTR_ADDRESS: 19,
+                ATTR_COUNT: 2,
+                ATTR_TYPE: CALL_TYPE_REGISTER_HOLDING,
+            },
             FUNC: CALL_TYPE_REGISTER_HOLDING,
             RETURN_VALUE: ReadResult([0x0006, 0x0007]),
             EXPECTED_RESULT: {"values": [0x0006, 0x0007]},
@@ -988,11 +1000,11 @@ async def test_pb_service_read(
     data = {
         ATTR_HUB: TEST_MODBUS_NAME,
         do_slave: 17,
-        ATTR_ADDRESS: do_read[ATTR_ADDRESS],
-        ATTR_TYPE: do_read[ATTR_TYPE],
+        ATTR_ADDRESS: do_read[DATA][ATTR_ADDRESS],
+        ATTR_TYPE: do_read[DATA][ATTR_TYPE],
     }
-    if ATTR_COUNT in do_read:
-        data[ATTR_COUNT] = do_read[ATTR_COUNT]
+    if ATTR_COUNT in do_read[DATA]:
+        data[ATTR_COUNT] = do_read[DATA][ATTR_COUNT]
     mock_modbus_with_pymodbus.reset_mock()
     caplog.clear()
     caplog.set_level(logging.DEBUG)

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -13,7 +13,6 @@ This file is responsible for testing:
 It uses binary_sensors/sensors to do black box testing of the read calls.
 """
 
-from contextlib import nullcontext as does_not_raise
 from datetime import timedelta
 import logging
 from unittest import mock
@@ -1014,8 +1013,16 @@ async def test_pb_service_read(
     func_name[do_read[FUNC]].return_value = return_value
 
     error_expected = bool(do_return[DATA])
-    ctx = pytest.raises(HomeAssistantError) if error_expected else does_not_raise()
-    with ctx:
+    if error_expected:
+        with pytest.raises(HomeAssistantError):
+            service_result = await hass.services.async_call(
+                DOMAIN,
+                SERVICE_READ_REGISTERS,
+                data,
+                blocking=True,
+                return_response=True,
+            )
+    else:
         service_result = await hass.services.async_call(
             DOMAIN, SERVICE_READ_REGISTERS, data, blocking=True, return_response=True
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes it is useful to be able to read input or holding registers without creating a new entity with polling for them. Examples include peeking at configuration registers that only need to be read once during the commissioning of a new device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40744
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
