### PR TITLE
Remove Kodi media player platform yaml support

### DIFF
--- a/homeassistant/components/kodi/config_flow.py
+++ b/homeassistant/components/kodi/config_flow.py
@@ -233,28 +233,6 @@ class KodiConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self._show_ws_port_form(errors)
 
-    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
-        """Handle import from YAML."""
-        reason = None
-        try:
-            await validate_http(self.hass, import_data)
-            await validate_ws(self.hass, import_data)
-        except InvalidAuth:
-            _LOGGER.exception("Invalid Kodi credentials")
-            reason = "invalid_auth"
-        except CannotConnect:
-            _LOGGER.exception("Cannot connect to Kodi")
-            reason = "cannot_connect"
-        except Exception:
-            _LOGGER.exception("Unexpected exception")
-            reason = "unknown"
-        else:
-            return self.async_create_entry(
-                title=import_data[CONF_NAME], data=import_data
-            )
-
-        return self.async_abort(reason=reason)
-
     @callback
     def _show_credentials_form(
         self, errors: dict[str, str] | None = None

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -15,7 +15,6 @@ import voluptuous as vol
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
-    PLATFORM_SCHEMA as MEDIA_PLAYER_PLATFORM_SCHEMA,
     BrowseError,
     BrowseMedia,
     MediaPlayerEntity,
@@ -24,19 +23,11 @@ from homeassistant.components.media_player import (
     MediaType,
     async_process_play_media_url,
 )
-from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DEVICE_ID,
-    CONF_HOST,
     CONF_NAME,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_PROXY_SSL,
-    CONF_SSL,
-    CONF_TIMEOUT,
     CONF_TYPE,
-    CONF_USERNAME,
     EVENT_HOMEASSISTANT_STARTED,
 )
 from homeassistant.core import CoreState, HomeAssistant, callback
@@ -46,13 +37,10 @@ from homeassistant.helpers import (
     entity_platform,
 )
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import (
-    AddConfigEntryEntitiesCallback,
-    AddEntitiesCallback,
-)
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.network import is_internal_request
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, VolDictType
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.util import dt as dt_util
 
 from . import KodiConfigEntry
@@ -62,34 +50,11 @@ from .browse_media import (
     library_payload,
     media_source_content_filter,
 )
-from .const import (
-    CONF_WS_PORT,
-    DEFAULT_PORT,
-    DEFAULT_SSL,
-    DEFAULT_TIMEOUT,
-    DEFAULT_WS_PORT,
-    DOMAIN,
-    EVENT_TURN_OFF,
-    EVENT_TURN_ON,
-)
+from .const import DOMAIN, EVENT_TURN_OFF, EVENT_TURN_ON
 
 _LOGGER = logging.getLogger(__name__)
 
 EVENT_KODI_CALL_METHOD_RESULT = "kodi_call_method_result"
-
-CONF_TCP_PORT = "tcp_port"
-CONF_TURN_ON_ACTION = "turn_on_action"
-CONF_TURN_OFF_ACTION = "turn_off_action"
-CONF_ENABLE_WEBSOCKET = "enable_websocket"
-
-DEPRECATED_TURN_OFF_ACTIONS = {
-    None: None,
-    "quit": "Application.Quit",
-    "hibernate": "System.Hibernate",
-    "suspend": "System.Suspend",
-    "reboot": "System.Reboot",
-    "shutdown": "System.Shutdown",
-}
 
 WEBSOCKET_WATCHDOG_INTERVAL = timedelta(seconds=10)
 
@@ -120,25 +85,6 @@ MAP_KODI_MEDIA_TYPES: dict[MediaType | str, str] = {
 }
 
 
-PLATFORM_SCHEMA = MEDIA_PLAYER_PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_TCP_PORT, default=DEFAULT_WS_PORT): cv.port,
-        vol.Optional(CONF_PROXY_SSL, default=DEFAULT_SSL): cv.boolean,
-        vol.Optional(CONF_TURN_ON_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(CONF_TURN_OFF_ACTION): vol.Any(
-            cv.SCRIPT_SCHEMA, vol.In(DEPRECATED_TURN_OFF_ACTIONS)
-        ),
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-        vol.Inclusive(CONF_USERNAME, "auth"): cv.string,
-        vol.Inclusive(CONF_PASSWORD, "auth"): cv.string,
-        vol.Optional(CONF_ENABLE_WEBSOCKET, default=True): cv.boolean,
-    }
-)
-
-
 SERVICE_ADD_MEDIA = "add_to_playlist"
 SERVICE_CALL_METHOD = "call_method"
 
@@ -159,50 +105,6 @@ KODI_ADD_MEDIA_SCHEMA: VolDictType = {
 KODI_CALL_METHOD_SCHEMA = cv.make_entity_service_schema(
     {vol.Required(ATTR_METHOD): cv.string}, extra=vol.ALLOW_EXTRA
 )
-
-
-def find_matching_config_entries_for_host(hass, host):
-    """Search existing config entries for one matching the host."""
-    for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.data[CONF_HOST] == host:
-            return entry
-    return None
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the Kodi platform."""
-    if discovery_info:
-        # Now handled by zeroconf in the config flow
-        return
-
-    host = config[CONF_HOST]
-    if find_matching_config_entries_for_host(hass, host):
-        return
-
-    websocket = config.get(CONF_ENABLE_WEBSOCKET)
-    ws_port = config.get(CONF_TCP_PORT) if websocket else None
-
-    entry_data = {
-        CONF_NAME: config.get(CONF_NAME, host),
-        CONF_HOST: host,
-        CONF_PORT: config.get(CONF_PORT),
-        CONF_WS_PORT: ws_port,
-        CONF_USERNAME: config.get(CONF_USERNAME),
-        CONF_PASSWORD: config.get(CONF_PASSWORD),
-        CONF_SSL: config.get(CONF_PROXY_SSL),
-        CONF_TIMEOUT: config.get(CONF_TIMEOUT),
-    }
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=entry_data
-        )
-    )
 
 
 async def async_setup_entry(

--- a/tests/components/kodi/test_config_flow.py
+++ b/tests/components/kodi/test_config_flow.py
@@ -18,7 +18,6 @@ from .util import (
     TEST_DISCOVERY,
     TEST_DISCOVERY_WO_UUID,
     TEST_HOST,
-    TEST_IMPORT,
     TEST_WS_PORT,
     UUID,
     MockConnection,
@@ -666,99 +665,3 @@ async def test_discovery_without_unique_id(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_uuid"
-
-
-async def test_form_import(hass: HomeAssistant) -> None:
-    """Test we get the form with import source."""
-    with (
-        patch(
-            "homeassistant.components.kodi.config_flow.Kodi.ping",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.kodi.config_flow.get_kodi_connection",
-            return_value=MockConnection(),
-        ),
-        patch(
-            "homeassistant.components.kodi.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=TEST_IMPORT,
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == TEST_IMPORT["name"]
-    assert result["data"] == TEST_IMPORT
-
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_form_import_invalid_auth(hass: HomeAssistant) -> None:
-    """Test we handle invalid auth on import."""
-    with (
-        patch(
-            "homeassistant.components.kodi.config_flow.Kodi.ping",
-            side_effect=InvalidAuthError,
-        ),
-        patch(
-            "homeassistant.components.kodi.config_flow.get_kodi_connection",
-            return_value=MockConnection(),
-        ),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=TEST_IMPORT,
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "invalid_auth"
-
-
-async def test_form_import_cannot_connect(hass: HomeAssistant) -> None:
-    """Test we handle cannot connect on import."""
-    with (
-        patch(
-            "homeassistant.components.kodi.config_flow.Kodi.ping",
-            side_effect=CannotConnectError,
-        ),
-        patch(
-            "homeassistant.components.kodi.config_flow.get_kodi_connection",
-            return_value=MockConnection(),
-        ),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=TEST_IMPORT,
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
-
-
-async def test_form_import_exception(hass: HomeAssistant) -> None:
-    """Test we handle unknown exception on import."""
-    with (
-        patch(
-            "homeassistant.components.kodi.config_flow.Kodi.ping",
-            side_effect=Exception,
-        ),
-        patch(
-            "homeassistant.components.kodi.config_flow.get_kodi_connection",
-            return_value=MockConnection(),
-        ),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=TEST_IMPORT,
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Kodi media player is no longer configurable through a YAML platform.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Kodi media player has config flow since 5 years ago, support was implemented in #38551 and the configuration was imported, but there was no repair issue, so the code still exists.
I propose to just remove the legacy yaml support since it's been a long time. Alternatively we can raise a repair issue and wait additional deprecation period.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
