### PR TITLE
Bump aioautomower to v2.3.1

### DIFF
--- a/homeassistant/components/husqvarna_automower/coordinator.py
+++ b/homeassistant/components/husqvarna_automower/coordinator.py
@@ -182,14 +182,6 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
                 "Failed to listen to websocket. Trying to reconnect: %s",
                 err,
             )
-        if not hass.is_stopping:
-            await asyncio.sleep(self.reconnect_time)
-            self.reconnect_time = min(self.reconnect_time * 2, MAX_WS_RECONNECT_TIME)
-            entry.async_create_background_task(
-                hass,
-                self.client_listen(hass, entry, automower_client),
-                "reconnect_task",
-            )
 
     def _should_poll(self) -> bool:
         """Return True if at least one mower is connected and at least one is not OFF."""

--- a/homeassistant/components/husqvarna_automower/coordinator.py
+++ b/homeassistant/components/husqvarna_automower/coordinator.py
@@ -39,6 +39,7 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
     """Class to manage fetching Husqvarna data."""
 
     config_entry: AutomowerConfigEntry
+    _reconnecting: bool = False
 
     def __init__(
         self,
@@ -63,6 +64,7 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
         self.websocket_alive: bool = False
         self.websocket_callbacks: list[Callable[[bool], None]] = []
         self._watchdog_task: asyncio.Task | None = None
+        self._proactive_reconnect_task: asyncio.Task | None = None
 
     @override
     @callback
@@ -166,11 +168,21 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
         entry: AutomowerConfigEntry,
         automower_client: AutomowerSession,
     ) -> None:
-        """Listen with the client."""
+        """Listen with the client, reconnecting proactively and on errors."""
         try:
             await automower_client.auth.websocket_connect()
-            # Reset reconnect time after successful connection
             self.reconnect_time = DEFAULT_RECONNECT_TIME
+            if (
+                self._proactive_reconnect_task is None
+                or self._proactive_reconnect_task.done()
+            ):
+                _LOGGER.debug("Starting proactive reconnect task")
+                self._proactive_reconnect_task = entry.async_create_background_task(
+                    hass,
+                    self._proactive_reconnect(automower_client),
+                    name="proactive_reconnect_task",
+                )
+
             await automower_client.start_listening()
         except (HusqvarnaWSServerHandshakeError, HusqvarnaWSClientError) as err:
             _LOGGER.debug(
@@ -191,6 +203,41 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
                 "reconnect_task",
             )
 
+    async def _proactive_reconnect(self, automower_client: AutomowerSession) -> None:
+        """Proactive reconnect: first after 1h59min30s, then every 1h59min58s."""
+        try:
+            # Wait 1h59min30s to unsync with _pong_watchdog
+            await asyncio.sleep(7167)
+            while True:
+                _LOGGER.debug("Proactive reconnect triggered")
+                self._reconnecting = True
+                try:
+                    old_ws_close_task = asyncio.create_task(
+                        automower_client.auth.websocket_close()
+                    )
+                    new_ws_task = asyncio.create_task(
+                        automower_client.auth.websocket_connect()
+                    )
+                    await old_ws_close_task
+                    await new_ws_task
+                    _LOGGER.debug(
+                        "Proactive reconnect completed: WS switched without downtime"
+                    )
+                except (ApiError, OSError, RuntimeError) as err:
+                    _LOGGER.warning(
+                        "Proactive reconnect failed, watchdog will take over: %s", err
+                    )
+                    if self.update_interval is None:
+                        self.update_interval = SCAN_INTERVAL
+                        self.hass.async_create_task(self.async_request_refresh())
+                finally:
+                    self._reconnecting = False
+
+                # Wait 1h59min57s to to reconnect
+                await asyncio.sleep(7197)
+        except asyncio.CancelledError:
+            _LOGGER.debug("Proactive reconnect task cancelled")
+
     def _should_poll(self) -> bool:
         """Return True if at least one mower is connected and at least one is not OFF."""
         return any(mower.metadata.connected for mower in self.data.values()) and any(
@@ -198,25 +245,31 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
         )
 
     async def _pong_watchdog(self) -> None:
-        """Watchdog to check for pong messages."""
+        """Watchdog: ping WebSocket periodically and restart polling if necessary."""
         _LOGGER.debug("Watchdog started")
         try:
             while True:
-                _LOGGER.debug("Sending ping")
-                is_alive = await self.api.send_empty_message()
-                _LOGGER.debug("Ping result: %s", is_alive)
-                if self.websocket_alive != is_alive:
-                    self.websocket_alive = is_alive
-                    for ws_callback in self.websocket_callbacks:
-                        ws_callback(is_alive)
+                if self._reconnecting:
+                    _LOGGER.debug("Skipping ping: proactive reconnect in progress")
+                else:
+                    _LOGGER.debug("Sending ping")
+                    is_alive = await self.api.send_empty_message()
+                    _LOGGER.debug("Ping result: %s", is_alive)
+
+                    # Nur bei Statusänderung Callbacks feuern
+                    if self.websocket_alive != is_alive:
+                        self.websocket_alive = is_alive
+                        for ws_callback in self.websocket_callbacks:
+                            ws_callback(is_alive)
+
+                    # Polling wieder aktivieren, falls WebSocket tot
+                    if not self.websocket_alive and self.update_interval is None:
+                        _LOGGER.debug("No pong received → restart polling")
+                        self.update_interval = SCAN_INTERVAL
+                        await self.async_request_refresh()
 
                 await asyncio.sleep(PING_INTERVAL)
                 _LOGGER.debug("Websocket alive %s", self.websocket_alive)
-                if not self.websocket_alive:
-                    _LOGGER.debug("No pong received → restart polling")
-                    if self.update_interval is None:
-                        self.update_interval = SCAN_INTERVAL
-                        await self.async_request_refresh()
         except asyncio.CancelledError:
             _LOGGER.debug("Watchdog cancelled")
 

--- a/homeassistant/components/husqvarna_automower/manifest.json
+++ b/homeassistant/components/husqvarna_automower/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "loggers": ["aioautomower"],
   "quality_scale": "silver",
-  "requirements": ["aioautomower==2.3.0b2"]
+  "requirements": ["aioautomower==2.3.0"]
 }

--- a/homeassistant/components/husqvarna_automower/manifest.json
+++ b/homeassistant/components/husqvarna_automower/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "loggers": ["aioautomower"],
   "quality_scale": "silver",
-  "requirements": ["aioautomower==2.2.1"]
+  "requirements": ["aioautomower==2.3.0b2"]
 }

--- a/homeassistant/components/husqvarna_automower/manifest.json
+++ b/homeassistant/components/husqvarna_automower/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "loggers": ["aioautomower"],
   "quality_scale": "silver",
-  "requirements": ["aioautomower==2.3.0"]
+  "requirements": ["aioautomower==2.3.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -204,7 +204,7 @@ aioaseko==1.0.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2.3.0b2
+aioautomower==2.3.0
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -204,7 +204,7 @@ aioaseko==1.0.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2.3.0
+aioautomower==2.3.1
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -204,7 +204,7 @@ aioaseko==1.0.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2.2.1
+aioautomower==2.3.0b2
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -192,7 +192,7 @@ aioaseko==1.0.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2.2.1
+aioautomower==2.3.0b2
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -192,7 +192,7 @@ aioaseko==1.0.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2.3.0
+aioautomower==2.3.1
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -192,7 +192,7 @@ aioaseko==1.0.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2.3.0b2
+aioautomower==2.3.0
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.2

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -192,17 +192,11 @@ async def test_websocket_not_available(
     await hass.async_block_till_done()
     assert f"{error_msg} Trying to reconnect: Boom" in caplog.text
 
-    # Simulate a successful connection
     caplog.clear()
-    await mock_called.wait()
-    mock_called.clear()
-    await hass.async_block_till_done()
-    assert mock.call_count == 2
-    assert "Trying to reconnect: Boom" not in caplog.text
 
     # Simulate hass shutting down
     await hass.async_stop()
-    assert mock.call_count == 2
+    assert mock.call_count == 1
 
 
 async def test_device_info(

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -684,60 +684,14 @@ async def test_websocket_watchdog(
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
+    assert mock_automower_client.get_status.call_count == 0
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
     assert mock_automower_client.get_status.call_count == 1
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert mock_automower_client.get_status.call_count == 2
-
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    assert mock_automower_client.get_status.call_count == 3
-
-
-async def test_proactive_reconnect(
-    hass: HomeAssistant,
-    mock_automower_client,
-    mock_config_entry,
-    freezer: FrozenDateTimeFactory,
-    values: dict[str, MowerAttributes],
-) -> None:
-    """Test that the ws_ready_callback triggers an attempt to start the Watchdog task.
-
-    and that the pong callback stops polling when all mowers are inactive.
-    """
-    callback_holder: dict[str, Callable] = {}
-
-    @callback
-    def fake_register_websocket_response(
-        cb: Callable[[dict[str, MowerAttributes]], None],
-    ) -> None:
-        callback_holder["data_cb"] = cb
-
-    mock_automower_client.register_data_callback.side_effect = (
-        fake_register_websocket_response
-    )
-    ws_ready_callbacks: list[Callable[[], None]] = []
-
-    @callback
-    def fake_register_ws_ready_callback(cb: Callable[[], None]) -> None:
-        ws_ready_callbacks.append(cb)
-
-    mock_automower_client.register_ws_ready_callback.side_effect = (
-        fake_register_ws_ready_callback
-    )
-
-    await setup_integration(hass, mock_config_entry)
-
-    for cb in ws_ready_callbacks:
-        cb()
-
-    await hass.async_block_till_done()
-    assert mock_automower_client.auth.websocket_connect.call_count == 1
-
-    freezer.tick(timedelta(seconds=7167))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    assert mock_automower_client.auth.websocket_connect.call_count == 2

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -684,14 +684,60 @@ async def test_websocket_watchdog(
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert mock_automower_client.get_status.call_count == 0
-
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
     assert mock_automower_client.get_status.call_count == 1
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert mock_automower_client.get_status.call_count == 2
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert mock_automower_client.get_status.call_count == 3
+
+
+async def test_proactive_reconnect(
+    hass: HomeAssistant,
+    mock_automower_client,
+    mock_config_entry,
+    freezer: FrozenDateTimeFactory,
+    values: dict[str, MowerAttributes],
+) -> None:
+    """Test that the ws_ready_callback triggers an attempt to start the Watchdog task.
+
+    and that the pong callback stops polling when all mowers are inactive.
+    """
+    callback_holder: dict[str, Callable] = {}
+
+    @callback
+    def fake_register_websocket_response(
+        cb: Callable[[dict[str, MowerAttributes]], None],
+    ) -> None:
+        callback_holder["data_cb"] = cb
+
+    mock_automower_client.register_data_callback.side_effect = (
+        fake_register_websocket_response
+    )
+    ws_ready_callbacks: list[Callable[[], None]] = []
+
+    @callback
+    def fake_register_ws_ready_callback(cb: Callable[[], None]) -> None:
+        ws_ready_callbacks.append(cb)
+
+    mock_automower_client.register_ws_ready_callback.side_effect = (
+        fake_register_ws_ready_callback
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    for cb in ws_ready_callbacks:
+        cb()
+
+    await hass.async_block_till_done()
+    assert mock_automower_client.auth.websocket_connect.call_count == 1
+
+    freezer.tick(timedelta(seconds=7167))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert mock_automower_client.auth.websocket_connect.call_count == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps aioautomower to 2.3.1 and fixes and allows a proactive reconnect of the websocket inside the library. Therefore the reconnect in HA has to be removed.

Please include in next patch release.

Release notes: https://github.com/Thomas55555/aioautomower/releases/tag/v2.3.0
Release notes: https://github.com/Thomas55555/aioautomower/releases/tag/v2.3.1
diff: https://github.com/Thomas55555/aioautomower/compare/v2.2.2...v2.3.1

Currently the websocket gets disconnected every 2h which makes the event entity unavailable.
This leads to unnice switches in the logbook from available to unavailable
![proactive_reconnect](https://github.com/user-attachments/assets/9b2aea7a-3f2b-4df0-ab8f-2fe75519e932)

With this PR we proactively reconnect the websocket, before it gets closed.

Note: In the picture you see before 22:00 the old behavior. And after that the new behaviour.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #152374
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
