### PR TITLE
Fix KNX Light - individual color initialisation from UI config

### DIFF
--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -285,13 +285,19 @@ def _create_ui_light(xknx: XKNX, knx_config: ConfigType, name: str) -> XknxLight
         group_address_switch_green_state=conf.get_state_and_passive(
             CONF_COLOR, CONF_GA_GREEN_SWITCH
         ),
-        group_address_brightness_green=conf.get_write(CONF_GA_GREEN_BRIGHTNESS),
+        group_address_brightness_green=conf.get_write(
+            CONF_COLOR, CONF_GA_GREEN_BRIGHTNESS
+        ),
         group_address_brightness_green_state=conf.get_state_and_passive(
             CONF_COLOR, CONF_GA_GREEN_BRIGHTNESS
         ),
-        group_address_switch_blue=conf.get_write(CONF_GA_BLUE_SWITCH),
-        group_address_switch_blue_state=conf.get_state_and_passive(CONF_GA_BLUE_SWITCH),
-        group_address_brightness_blue=conf.get_write(CONF_GA_BLUE_BRIGHTNESS),
+        group_address_switch_blue=conf.get_write(CONF_COLOR, CONF_GA_BLUE_SWITCH),
+        group_address_switch_blue_state=conf.get_state_and_passive(
+            CONF_COLOR, CONF_GA_BLUE_SWITCH
+        ),
+        group_address_brightness_blue=conf.get_write(
+            CONF_COLOR, CONF_GA_BLUE_BRIGHTNESS
+        ),
         group_address_brightness_blue_state=conf.get_state_and_passive(
             CONF_COLOR, CONF_GA_BLUE_BRIGHTNESS
         ),

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -240,18 +240,18 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
                             write_required=True, valid_dpt="5.001"
                         ),
                         "section_blue": KNXSectionFlat(),
-                        vol.Required(CONF_GA_BLUE_BRIGHTNESS): GASelector(
-                            write_required=True, valid_dpt="5.001"
-                        ),
                         vol.Optional(CONF_GA_BLUE_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
                         ),
-                        "section_white": KNXSectionFlat(),
-                        vol.Optional(CONF_GA_WHITE_BRIGHTNESS): GASelector(
+                        vol.Required(CONF_GA_BLUE_BRIGHTNESS): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
+                        "section_white": KNXSectionFlat(),
                         vol.Optional(CONF_GA_WHITE_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
+                        ),
+                        vol.Optional(CONF_GA_WHITE_BRIGHTNESS): GASelector(
+                            write_required=True, valid_dpt="5.001"
                         ),
                     },
                 ),

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -575,26 +575,6 @@
                 'type': 'knx_section_flat',
               }),
               dict({
-                'name': 'ga_blue_brightness',
-                'options': dict({
-                  'passive': True,
-                  'state': dict({
-                    'required': False,
-                  }),
-                  'validDPTs': list([
-                    dict({
-                      'main': 5,
-                      'sub': 1,
-                    }),
-                  ]),
-                  'write': dict({
-                    'required': True,
-                  }),
-                }),
-                'required': True,
-                'type': 'knx_group_address',
-              }),
-              dict({
                 'name': 'ga_blue_switch',
                 'optional': True,
                 'options': dict({
@@ -616,14 +596,7 @@
                 'type': 'knx_group_address',
               }),
               dict({
-                'collapsible': False,
-                'name': 'section_white',
-                'required': False,
-                'type': 'knx_section_flat',
-              }),
-              dict({
-                'name': 'ga_white_brightness',
-                'optional': True,
+                'name': 'ga_blue_brightness',
                 'options': dict({
                   'passive': True,
                   'state': dict({
@@ -639,8 +612,14 @@
                     'required': True,
                   }),
                 }),
-                'required': False,
+                'required': True,
                 'type': 'knx_group_address',
+              }),
+              dict({
+                'collapsible': False,
+                'name': 'section_white',
+                'required': False,
+                'type': 'knx_section_flat',
               }),
               dict({
                 'name': 'ga_white_switch',
@@ -658,6 +637,27 @@
                   ]),
                   'write': dict({
                     'required': False,
+                  }),
+                }),
+                'required': False,
+                'type': 'knx_group_address',
+              }),
+              dict({
+                'name': 'ga_white_brightness',
+                'optional': True,
+                'options': dict({
+                  'passive': True,
+                  'state': dict({
+                    'required': False,
+                  }),
+                  'validDPTs': list([
+                    dict({
+                      'main': 5,
+                      'sub': 1,
+                    }),
+                  ]),
+                  'write': dict({
+                    'required': True,
                   }),
                 }),
                 'required': False,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Individual color lights configured in UI were wrongly initialised. The config parameters of blue and green weren't sourced from subkey and thus ignored.
- Fix selector order of individual color configuration to have consistent switch, brightness order for all colours.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://community.home-assistant.io/t/knx-rgbw-control-acting-crazy/926812
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
