### PR TITLE
Use contact header for outgoing call transport

### DIFF
--- a/homeassistant/components/voip/__init__.py
+++ b/homeassistant/components/voip/__init__.py
@@ -61,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     sip_port = entry.options.get(CONF_SIP_PORT, SIP_PORT)
     devices = VoIPDevices(hass, entry)
-    devices.async_setup()
+    await devices.async_setup()
     transport, protocol = await _create_sip_server(
         hass,
         lambda: HassVoipDatagramProtocol(hass, devices),

--- a/homeassistant/components/voip/__init__.py
+++ b/homeassistant/components/voip/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_SIP_PORT, DOMAIN
 from .devices import VoIPDevices
+from .store import VoipStore
 from .voip import HassVoipDatagramProtocol
 
 PLATFORMS = (
@@ -35,6 +36,8 @@ __all__ = [
     "async_unload_entry",
 ]
 
+type VoipConfigEntry = ConfigEntry[VoipStore]
+
 
 @dataclass
 class DomainData:
@@ -45,7 +48,7 @@ class DomainData:
     devices: VoIPDevices
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: VoipConfigEntry) -> bool:
     """Set up VoIP integration from a config entry."""
     # Make sure there is a valid user ID for VoIP in the config entry
     if (
@@ -59,6 +62,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry, data={**entry.data, "user": voip_user.id}
         )
 
+    entry.runtime_data = VoipStore(hass, entry.entry_id)
     sip_port = entry.options.get(CONF_SIP_PORT, SIP_PORT)
     devices = VoIPDevices(hass, entry)
     await devices.async_setup()
@@ -102,7 +106,7 @@ async def _create_sip_server(
     return transport, protocol
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: VoipConfigEntry) -> bool:
     """Unload VoIP."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         _LOGGER.debug("Shutting down VoIP server")
@@ -121,9 +125,11 @@ async def async_remove_config_entry_device(
     return True
 
 
-async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_remove_entry(hass: HomeAssistant, entry: VoipConfigEntry) -> None:
     """Remove VoIP entry."""
     if "user" in entry.data and (
         user := await hass.auth.async_get_user(entry.data["user"])
     ):
         await hass.auth.async_remove_user(user)
+
+    await entry.runtime_data.async_remove()

--- a/homeassistant/components/voip/assist_satellite.py
+++ b/homeassistant/components/voip/assist_satellite.py
@@ -254,7 +254,7 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
         )
 
         try:
-            # VoIP ID is SIP header
+            # VoIP ID is SIP header - This represents what is set as the To header
             destination_endpoint = SipEndpoint(self.voip_device.voip_id)
         except ValueError:
             # VoIP ID is IP address
@@ -269,10 +269,12 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
 
         # Make the call
         sip_protocol: SipDatagramProtocol = self.hass.data[DOMAIN].protocol
+        _LOGGER.debug("Outgoing call to contact %s", self.voip_device.contact)
         call_info = sip_protocol.outgoing_call(
             source=source_endpoint,
             destination=destination_endpoint,
             rtp_port=self._rtp_port,
+            contact=self.voip_device.contact,
         )
 
         # Check if caller didn't pick up

--- a/homeassistant/components/voip/assist_satellite.py
+++ b/homeassistant/components/voip/assist_satellite.py
@@ -119,6 +119,8 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
         AssistSatelliteEntity.__init__(self)
         RtpDatagramProtocol.__init__(self)
 
+        _LOGGER.debug("Assist satellite with device: %s", voip_device)
+
         self.config_entry = config_entry
 
         self._audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()

--- a/homeassistant/components/voip/const.py
+++ b/homeassistant/components/voip/const.py
@@ -1,5 +1,7 @@
 """Constants for the Voice over IP integration."""
 
+from typing import Final
+
 DOMAIN = "voip"
 
 RATE = 16000
@@ -14,3 +16,5 @@ RTP_AUDIO_SETTINGS = {
 
 CONF_SIP_PORT = "sip_port"
 CONF_SIP_USER = "sip_user"
+
+STORAGE_VER: Final = 1

--- a/homeassistant/components/voip/devices.py
+++ b/homeassistant/components/voip/devices.py
@@ -86,7 +86,7 @@ class VoIPDevices:
         self.config_entry = config_entry
         self._new_device_listeners: list[Callable[[VoIPDevice], None]] = []
         self.devices: dict[str, VoIPDevice] = {}
-        self.device_stores: dict[str, Store] = {}
+        self.device_store: Store = Store(self.hass, STORAGE_VER, "voip_devices")
 
     async def async_setup(self) -> None:
         """Set up devices."""
@@ -98,10 +98,10 @@ class VoIPDevices:
             )
             if voip_id is None:
                 continue
-            device_store = self.device_stores[voip_id] = Store(
-                self.hass, STORAGE_VER, f"voip-device-{voip_id}"
+            devices_data: dict[str, dict[str, Any]] = (
+                await self.device_store.async_load() or {}
             )
-            device_data: dict[str, Any] = await device_store.async_load() or {}
+            device_data: dict[str, Any] = devices_data.setdefault(voip_id, {})
             self.devices[voip_id] = VoIPDevice(
                 voip_id=voip_id,
                 device_id=device.id,
@@ -226,15 +226,10 @@ class VoIPDevices:
     async def async_update_device_store(self, voip_id: str, contact_header: str):
         """Update the device store with the contact information."""
         _LOGGER.debug("Saving new VOIP device %s contact %s", voip_id, contact_header)
-        if voip_id not in self.device_stores:
-            _LOGGER.debug("Creating store for %s", voip_id)
-            self.device_stores[voip_id] = Store(
-                self.hass, STORAGE_VER, f"voip-device-{voip_id}"
-            )
-        device_store = self.device_stores[voip_id]
-        device_data: dict[str, Any] = await device_store.async_load() or {}
+        devices_data: dict[str, Any] = await self.device_store.async_load() or {}
+        device_data = devices_data.setdefault(voip_id, {})
         device_data["contact"] = contact_header
-        await device_store.async_save(device_data)
+        await self.device_store.async_save(devices_data)
         _LOGGER.debug("Saved new VOIP device contact")
 
     def __iter__(self) -> Iterator[VoIPDevice]:

--- a/homeassistant/components/voip/devices.py
+++ b/homeassistant/components/voip/devices.py
@@ -100,6 +100,7 @@ class VoIPDevices:
                 continue
             devices_data: DeviceContacts = await self.device_store.async_load_devices()
             device_data: DeviceContact | None = devices_data.get(voip_id)
+            _LOGGER.debug("Loaded device data for %s: %s", voip_id, device_data)
             self.devices[voip_id] = VoIPDevice(
                 voip_id=voip_id,
                 device_id=device.id,

--- a/homeassistant/components/voip/devices.py
+++ b/homeassistant/components/voip/devices.py
@@ -4,15 +4,20 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
+import logging
 from typing import Any
 
 from voip_utils import CallInfo, VoipDatagramProtocol
+from voip_utils.sip import SipEndpoint
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.storage import Store
 
-from .const import DOMAIN
+from .const import DOMAIN, STORAGE_VER
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -24,6 +29,7 @@ class VoIPDevice:
     is_active: bool = False
     update_listeners: list[Callable[[VoIPDevice], None]] = field(default_factory=list)
     protocol: VoipDatagramProtocol | None = None
+    contact: SipEndpoint | None = None
 
     @callback
     def set_is_active(self, active: bool) -> None:
@@ -80,9 +86,9 @@ class VoIPDevices:
         self.config_entry = config_entry
         self._new_device_listeners: list[Callable[[VoIPDevice], None]] = []
         self.devices: dict[str, VoIPDevice] = {}
+        self.device_stores: dict[str, Store] = {}
 
-    @callback
-    def async_setup(self) -> None:
+    async def async_setup(self) -> None:
         """Set up devices."""
         for device in dr.async_entries_for_config_entry(
             dr.async_get(self.hass), self.config_entry.entry_id
@@ -92,9 +98,16 @@ class VoIPDevices:
             )
             if voip_id is None:
                 continue
+            device_store = self.device_stores[voip_id] = Store(
+                self.hass, STORAGE_VER, f"voip-device-{voip_id}"
+            )
+            device_data: dict[str, Any] = await device_store.async_load() or {}
             self.devices[voip_id] = VoIPDevice(
                 voip_id=voip_id,
                 device_id=device.id,
+                contact=SipEndpoint(device_data.get("contact"))
+                if device_data.get("contact")
+                else None,
             )
 
         @callback
@@ -185,16 +198,44 @@ class VoIPDevices:
         )
 
         if voip_device is not None:
+            if voip_device.contact is None and call_info.contact_endpoint is not None:
+                # Update VOIP device with contact information from call info
+                voip_device.contact = call_info.contact_endpoint
+                self.hass.async_create_task(
+                    self.async_update_device_store(
+                        voip_id, call_info.contact_endpoint.sip_header
+                    )
+                )
             return voip_device
 
         voip_device = self.devices[voip_id] = VoIPDevice(
-            voip_id=voip_id,
-            device_id=device.id,
+            voip_id=voip_id, device_id=device.id, contact=call_info.contact_endpoint
         )
+        if call_info.contact_endpoint is not None:
+            self.hass.async_create_task(
+                self.async_update_device_store(
+                    voip_id, call_info.contact_endpoint.sip_header
+                )
+            )
+
         for listener in self._new_device_listeners:
             listener(voip_device)
 
         return voip_device
+
+    async def async_update_device_store(self, voip_id: str, contact_header: str):
+        """Update the device store with the contact information."""
+        _LOGGER.debug("Saving new VOIP device %s contact %s", voip_id, contact_header)
+        if voip_id not in self.device_stores:
+            _LOGGER.debug("Creating store for %s", voip_id)
+            self.device_stores[voip_id] = Store(
+                self.hass, STORAGE_VER, f"voip-device-{voip_id}"
+            )
+        device_store = self.device_stores[voip_id]
+        device_data: dict[str, Any] = await device_store.async_load() or {}
+        device_data["contact"] = contact_header
+        await device_store.async_save(device_data)
+        _LOGGER.debug("Saved new VOIP device contact")
 
     def __iter__(self) -> Iterator[VoIPDevice]:
         """Iterate over devices."""

--- a/homeassistant/components/voip/devices.py
+++ b/homeassistant/components/voip/devices.py
@@ -98,9 +98,7 @@ class VoIPDevices:
             )
             if voip_id is None:
                 continue
-            devices_data: DeviceContacts = (
-                await self.device_store.async_load() or DeviceContacts()
-            )
+            devices_data: DeviceContacts = await self.device_store.async_load_devices()
             device_data: DeviceContact | None = devices_data.get(voip_id)
             self.devices[voip_id] = VoIPDevice(
                 voip_id=voip_id,

--- a/homeassistant/components/voip/store.py
+++ b/homeassistant/components/voip/store.py
@@ -22,17 +22,24 @@ class DeviceContacts(dict[str, DeviceContact]):
     """Map of device contact data."""
 
 
-class VoipStore(Store[DeviceContacts]):
+class VoipStore(Store):
     """Store for VOIP device contact information."""
 
     def __init__(self, hass: HomeAssistant, storage_key: str) -> None:
         """Initialize the VOIP Storage."""
         super().__init__(hass, STORAGE_VER, f"voip-{storage_key}")
 
-    async def async_update_device(self, voip_id: str, contact_header: str):
+    async def async_load_devices(self) -> DeviceContacts:
+        """Load data from store as DeviceContacts."""
+        raw_data: dict[str, dict[str, str]] = await self.async_load() or {}
+        _LOGGER.debug("raw_data: %s", raw_data)
+        return self._dict_to_devices(raw_data)
+
+    async def async_update_device(self, voip_id: str, contact_header: str) -> None:
         """Update the device store with the contact information."""
         _LOGGER.debug("Saving new VOIP device %s contact %s", voip_id, contact_header)
-        devices_data: DeviceContacts = await self.async_load() or DeviceContacts()
+        devices_data: DeviceContacts = await self.async_load_devices()
+        _LOGGER.debug("devices_data: %s", devices_data)
         device_data: DeviceContact | None = devices_data.get(voip_id)
         if device_data is not None:
             device_data.contact = contact_header
@@ -40,3 +47,10 @@ class VoipStore(Store[DeviceContacts]):
             devices_data[voip_id] = DeviceContact(contact_header)
         await self.async_save(devices_data)
         _LOGGER.debug("Saved new VOIP device contact")
+
+    def _dict_to_devices(self, raw_data: dict[str, dict[str, str]]) -> DeviceContacts:
+        contacts = DeviceContacts()
+        for k, v in (raw_data or {}).items():
+            contacts[k] = DeviceContact(**v)
+        _LOGGER.debug("contacts: %s", contacts)
+        return contacts

--- a/homeassistant/components/voip/store.py
+++ b/homeassistant/components/voip/store.py
@@ -32,7 +32,6 @@ class VoipStore(Store):
     async def async_load_devices(self) -> DeviceContacts:
         """Load data from store as DeviceContacts."""
         raw_data: dict[str, dict[str, str]] = await self.async_load() or {}
-        _LOGGER.debug("raw_data: %s", raw_data)
         return self._dict_to_devices(raw_data)
 
     async def async_update_device(self, voip_id: str, contact_header: str) -> None:
@@ -52,5 +51,4 @@ class VoipStore(Store):
         contacts = DeviceContacts()
         for k, v in (raw_data or {}).items():
             contacts[k] = DeviceContact(**v)
-        _LOGGER.debug("contacts: %s", contacts)
         return contacts

--- a/homeassistant/components/voip/store.py
+++ b/homeassistant/components/voip/store.py
@@ -1,0 +1,42 @@
+"""VOIP contact storage."""
+
+from dataclasses import dataclass
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import STORAGE_VER
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class DeviceContact:
+    """Device contact data."""
+
+    contact: str
+
+
+class DeviceContacts(dict[str, DeviceContact]):
+    """Map of device contact data."""
+
+
+class VoipStore(Store[DeviceContacts]):
+    """Store for VOIP device contact information."""
+
+    def __init__(self, hass: HomeAssistant, storage_key: str) -> None:
+        """Initialize the VOIP Storage."""
+        super().__init__(hass, STORAGE_VER, f"voip-{storage_key}")
+
+    async def async_update_device(self, voip_id: str, contact_header: str):
+        """Update the device store with the contact information."""
+        _LOGGER.debug("Saving new VOIP device %s contact %s", voip_id, contact_header)
+        devices_data: DeviceContacts = await self.async_load() or DeviceContacts()
+        device_data: DeviceContact | None = devices_data.get(voip_id)
+        if device_data is not None:
+            device_data.contact = contact_header
+        else:
+            devices_data[voip_id] = DeviceContact(contact_header)
+        await self.async_save(devices_data)
+        _LOGGER.debug("Saved new VOIP device contact")

--- a/tests/components/voip/test_devices.py
+++ b/tests/components/voip/test_devices.py
@@ -106,11 +106,13 @@ async def test_device_load_contact(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test loading contact endpoint from Store."""
+    voip_id = call_info.caller_endpoint.uri
     mock_store = AsyncMock()
-    mock_store.async_load.return_value = {"contact": "Test <sip:example.com:5061>"}
+    mock_store.async_load.return_value = {
+        voip_id: {"contact": "Test <sip:example.com:5061>"}
+    }
 
     # Initialize voip device
-    voip_id = call_info.caller_endpoint.uri
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, voip_id)},

--- a/tests/components/voip/test_devices.py
+++ b/tests/components/voip/test_devices.py
@@ -10,6 +10,7 @@ from voip_utils.sip import SipEndpoint
 
 from homeassistant.components.voip import DOMAIN
 from homeassistant.components.voip.devices import VoIPDevice, VoIPDevices
+from homeassistant.components.voip.store import DeviceContact
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -109,8 +110,10 @@ async def test_device_load_contact(
     voip_id = call_info.caller_endpoint.uri
     mock_store = AsyncMock()
     mock_store.async_load.return_value = {
-        voip_id: {"contact": "Test <sip:example.com:5061>"}
+        voip_id: DeviceContact("Test <sip:example.com:5061>")
     }
+
+    config_entry.runtime_data = mock_store
 
     # Initialize voip device
     device_registry.async_get_or_create(
@@ -123,7 +126,9 @@ async def test_device_load_contact(
         configuration_url=f"http://{call_info.caller_ip}",
     )
 
-    with patch("homeassistant.components.voip.devices.Store", return_value=mock_store):
+    with patch(
+        "homeassistant.components.voip.devices.VoipStore", return_value=mock_store
+    ):
         voip = VoIPDevices(hass, config_entry)
 
         await voip.async_setup()


### PR DESCRIPTION
Use the contact header to determine the host and port to send SIP messages to for outgoing calls.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the host and port values from the Contact header for deciding where to connect to for outgoing VOIP calls. This intended use of the contact header field is described here https://datatracker.ietf.org/doc/html/rfc3261#section-8.1.1.8


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant-libs/voip-utils/issues/33
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
