### PR TITLE
Add support for tracking stats of party members in Habitica integration

### DIFF
--- a/homeassistant/components/habitica/__init__.py
+++ b/homeassistant/components/habitica/__init__.py
@@ -72,8 +72,7 @@ async def async_setup_entry(
     config_entry.runtime_data = coordinator
 
     party = coordinator.data.user.party.id
-    if HABITICA_KEY not in hass.data:
-        hass.data[HABITICA_KEY] = {}
+    hass.data.setdefault(HABITICA_KEY, {})
 
     if party is not None and party not in hass.data[HABITICA_KEY]:
         party_coordinator = HabiticaPartyCoordinator(hass, config_entry, api)
@@ -117,7 +116,18 @@ async def async_setup_entry(
     coordinator.async_add_listener(_party_update_listener)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
+    config_entry.async_on_unload(
+        config_entry.add_update_listener(_async_update_listener)
+    )
     return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: HabiticaConfigEntry
+) -> None:
+    """Handle update."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def shutdown_party_coordinator(hass: HomeAssistant, party_added: UUID) -> None:

--- a/homeassistant/components/habitica/config_flow.py
+++ b/homeassistant/components/habitica/config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 import logging
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from aiohttp import ClientError
 from habiticalib import (
@@ -17,7 +18,13 @@ from habiticalib import (
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    ConfigSubentryFlow,
+    SubentryFlowResult,
+)
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_NAME,
@@ -26,15 +33,21 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
 )
 
+from . import HABITICA_KEY
 from .const import (
     CONF_API_USER,
+    CONF_PARTY_MEMBER,
     DEFAULT_URL,
     DOMAIN,
     FORGOT_PASSWORD_URL,
@@ -374,3 +387,69 @@ class HabiticaConfigFlow(ConfigFlow, domain=DOMAIN):
             return errors, user.data
 
         return errors, None
+
+    @classmethod
+    @callback
+    def async_get_supported_subentry_types(
+        cls, config_entry: ConfigEntry
+    ) -> dict[str, type[ConfigSubentryFlow]]:
+        """Return subentries supported by this integration."""
+        return {"party_member": PartyMembersSubentryFlowHandler}
+
+
+class PartyMembersSubentryFlowHandler(ConfigSubentryFlow):
+    """Handle subentry flow for adding party members."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Subentry user flow."""
+
+        entry: HabiticaConfigEntry = self._get_entry()
+        if (
+            not (party := entry.runtime_data.data.user.party.id)
+            or party not in self.hass.data[HABITICA_KEY]
+        ):
+            return self.async_abort(reason="not_in_a_party")
+
+        party_members = self.hass.data[HABITICA_KEY][party].data.members
+
+        if user_input is not None:
+            config_entries = self.hass.config_entries.async_entries(DOMAIN)
+            if user_input[CONF_PARTY_MEMBER] in {
+                entry.unique_id for entry in config_entries
+            }:
+                return self.async_abort(reason="already_configured_as_entry")
+
+            for entry in config_entries:
+                if user_input[CONF_PARTY_MEMBER] in {
+                    subentry.unique_id for subentry in entry.subentries.values()
+                }:
+                    return self.async_abort(reason="already_configured")
+
+            return self.async_create_entry(
+                title=party_members[UUID(user_input[CONF_PARTY_MEMBER])].profile.name,
+                data={},
+                unique_id=user_input[CONF_PARTY_MEMBER],
+            )
+
+        options = [
+            SelectOptionDict(
+                value=str(member_id),
+                label=f"{member.profile.name} (@{member.auth.local.username})",
+            )
+            for member_id, member in party_members.items()
+            if member_id != str(entry.runtime_data.data.user.id)
+            and member.profile.name
+            and member.auth.local.username
+        ]
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_PARTY_MEMBER): SelectSelector(
+                        SelectSelectorConfig(options=options)
+                    )
+                }
+            ),
+        )

--- a/homeassistant/components/habitica/config_flow.py
+++ b/homeassistant/components/habitica/config_flow.py
@@ -409,10 +409,7 @@ class PartyMembersSubentryFlowHandler(ConfigSubentryFlow):
         entry: HabiticaConfigEntry = self._get_entry()
         if entry.state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="config_entry_disabled")
-        if (
-            not (party := entry.runtime_data.data.user.party.id)
-            or party not in self.hass.data[HABITICA_KEY]
-        ):
+        if (party := entry.runtime_data.data.user.party.id) is None:
             return self.async_abort(reason="not_in_a_party")
 
         party_members = self.hass.data[HABITICA_KEY][party].data.members

--- a/homeassistant/components/habitica/config_flow.py
+++ b/homeassistant/components/habitica/config_flow.py
@@ -20,6 +20,7 @@ import voluptuous as vol
 from homeassistant import data_entry_flow
 from homeassistant.config_entries import (
     ConfigEntry,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     ConfigSubentryFlow,
@@ -406,6 +407,8 @@ class PartyMembersSubentryFlowHandler(ConfigSubentryFlow):
         """Subentry user flow."""
 
         entry: HabiticaConfigEntry = self._get_entry()
+        if entry.state is not ConfigEntryState.LOADED:
+            return self.async_abort(reason="config_entry_disabled")
         if (
             not (party := entry.runtime_data.data.user.party.id)
             or party not in self.hass.data[HABITICA_KEY]

--- a/homeassistant/components/habitica/config_flow.py
+++ b/homeassistant/components/habitica/config_flow.py
@@ -416,12 +416,10 @@ class PartyMembersSubentryFlowHandler(ConfigSubentryFlow):
 
         if user_input is not None:
             config_entries = self.hass.config_entries.async_entries(DOMAIN)
-            if user_input[CONF_PARTY_MEMBER] in {
-                entry.unique_id for entry in config_entries
-            }:
-                return self.async_abort(reason="already_configured_as_entry")
 
             for entry in config_entries:
+                if user_input[CONF_PARTY_MEMBER] == entry.unique_id:
+                    return self.async_abort(reason="already_configured_as_entry")
                 if user_input[CONF_PARTY_MEMBER] in {
                     subentry.unique_id for subentry in entry.subentries.values()
                 }:

--- a/homeassistant/components/habitica/const.py
+++ b/homeassistant/components/habitica/const.py
@@ -3,6 +3,7 @@
 from homeassistant.const import APPLICATION_NAME, __version__
 
 CONF_API_USER = "api_user"
+CONF_PARTY_MEMBER = "party_member"
 
 DEFAULT_URL = "https://habitica.com"
 ASSETS_URL = "https://habitica-assets.s3.amazonaws.com/mobileApp/images/"

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -204,7 +204,7 @@ class HabiticaDataUpdateCoordinator(HabiticaBaseCoordinator[HabiticaData]):
 class HabiticaPartyCoordinator(HabiticaBaseCoordinator[HabiticaPartyData]):
     """Habitica Party Coordinator."""
 
-    _update_interval = timedelta(seconds=15)
+    _update_interval = timedelta(minutes=15)
 
     async def _update_data(self) -> HabiticaPartyData:
         """Fetch the latest party data."""

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -208,6 +208,7 @@ class HabiticaPartyCoordinator(HabiticaBaseCoordinator[HabiticaPartyData]):
 
     async def _update_data(self) -> HabiticaPartyData:
         """Fetch the latest party data."""
+
         return HabiticaPartyData(
             party=(await self.habitica.get_group()).data,
             members={

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -204,7 +204,7 @@ class HabiticaDataUpdateCoordinator(HabiticaBaseCoordinator[HabiticaData]):
 class HabiticaPartyCoordinator(HabiticaBaseCoordinator[HabiticaPartyData]):
     """Habitica Party Coordinator."""
 
-    _update_interval = timedelta(minutes=15)
+    _update_interval = timedelta(seconds=15)
 
     async def _update_data(self) -> HabiticaPartyData:
         """Fetch the latest party data."""

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -208,12 +208,13 @@ class HabiticaPartyCoordinator(HabiticaBaseCoordinator[HabiticaPartyData]):
 
     async def _update_data(self) -> HabiticaPartyData:
         """Fetch the latest party data."""
-
         return HabiticaPartyData(
             party=(await self.habitica.get_group()).data,
             members={
                 member.id: member
-                for member in (await self.habitica.get_group_members()).data
+                for member in (
+                    await self.habitica.get_group_members(public_fields=True)
+                ).data
                 if member.id
             },
         )

--- a/homeassistant/components/habitica/entity.py
+++ b/homeassistant/components/habitica/entity.py
@@ -64,7 +64,7 @@ class HabiticaBase(CoordinatorEntity[HabiticaDataUpdateCoordinator]):
                     via_device=(
                         (
                             DOMAIN,
-                            f"{coordinator.config_entry.unique_id}_{self.user.party.id!s}",
+                            f"{coordinator.config_entry.unique_id}_{self.user.party.id}",
                         )
                     )
                 )

--- a/homeassistant/components/habitica/entity.py
+++ b/homeassistant/components/habitica/entity.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import HABITICA_KEY
 from .const import DOMAIN, MANUFACTURER, NAME
 from .coordinator import (
     HabiticaConfigEntry,
@@ -101,11 +100,12 @@ class HabiticaPartyMemberBase(HabiticaBase):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-
+        if TYPE_CHECKING:
+            assert self.subentry
+            assert self.subentry.unique_id
         return (
             super().available
-            and (party := self.user.party.id) is not None
-            and party in self.hass.data[HABITICA_KEY]
+            and UUID(self.subentry.unique_id) in self.party_coordinator.data.members
         )
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/habitica/entity.py
+++ b/homeassistant/components/habitica/entity.py
@@ -37,6 +37,7 @@ class HabiticaBase(CoordinatorEntity[HabiticaDataUpdateCoordinator]):
         super().__init__(coordinator)
         if TYPE_CHECKING:
             assert coordinator.config_entry.unique_id
+            assert self.user
         self.entity_description = entity_description
         self.subentry = subentry
         unique_id = (
@@ -70,7 +71,7 @@ class HabiticaBase(CoordinatorEntity[HabiticaDataUpdateCoordinator]):
             )
 
     @property
-    def user(self) -> UserData:
+    def user(self) -> UserData | None:
         """Return the user data."""
         return self.coordinator.data.user
 
@@ -90,12 +91,12 @@ class HabiticaPartyMemberBase(HabiticaBase):
         super().__init__(coordinator, entity_description, subentry)
 
     @property
-    def user(self) -> UserData:
+    def user(self) -> UserData | None:
         """Return the user data of the party member."""
         if TYPE_CHECKING:
             assert self.subentry
             assert self.subentry.unique_id
-        return self.party_coordinator.data.members[UUID(self.subentry.unique_id)]
+        return self.party_coordinator.data.members.get(UUID(self.subentry.unique_id))
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/habitica/entity.py
+++ b/homeassistant/components/habitica/entity.py
@@ -101,13 +101,8 @@ class HabiticaPartyMemberBase(HabiticaBase):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        if TYPE_CHECKING:
-            assert self.subentry
-            assert self.subentry.unique_id
-        return (
-            super().available
-            and UUID(self.subentry.unique_id) in self.party_coordinator.data.members
-        )
+
+        return super().available and self.user is not None
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""

--- a/homeassistant/components/habitica/entity.py
+++ b/homeassistant/components/habitica/entity.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import UUID
 
-from habiticalib import ContentData
+from habiticalib import ContentData, UserData
 from yarl import URL
 
+from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_URL
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import HABITICA_KEY
 from .const import DOMAIN, MANUFACTURER, NAME
 from .coordinator import (
     HabiticaConfigEntry,
@@ -29,26 +32,87 @@ class HabiticaBase(CoordinatorEntity[HabiticaDataUpdateCoordinator]):
         self,
         coordinator: HabiticaDataUpdateCoordinator,
         entity_description: EntityDescription,
+        subentry: ConfigSubentry | None = None,
     ) -> None:
         """Initialize a Habitica entity."""
         super().__init__(coordinator)
         if TYPE_CHECKING:
             assert coordinator.config_entry.unique_id
         self.entity_description = entity_description
-        self._attr_unique_id = (
-            f"{coordinator.config_entry.unique_id}_{entity_description.key}"
+        self.subentry = subentry
+        unique_id = (
+            subentry.unique_id
+            if subentry is not None and subentry.unique_id
+            else coordinator.config_entry.unique_id
         )
+
+        self._attr_unique_id = f"{unique_id}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             manufacturer=MANUFACTURER,
             model=NAME,
-            name=coordinator.data.user.profile.name,
+            name=self.user.profile.name,
             configuration_url=(
-                URL(coordinator.config_entry.data[CONF_URL])
-                / "profile"
-                / coordinator.config_entry.unique_id
+                URL(coordinator.config_entry.data[CONF_URL]) / "profile" / unique_id
             ),
-            identifiers={(DOMAIN, coordinator.config_entry.unique_id)},
+            identifiers={(DOMAIN, unique_id)},
+        )
+
+        if subentry:
+            self._attr_device_info.update(
+                DeviceInfo(
+                    via_device=(
+                        (
+                            DOMAIN,
+                            f"{coordinator.config_entry.unique_id}_{self.user.party.id!s}",
+                        )
+                    )
+                )
+            )
+
+    @property
+    def user(self) -> UserData:
+        """Return the user data."""
+        return self.coordinator.data.user
+
+
+class HabiticaPartyMemberBase(HabiticaBase):
+    """Base Habitica party member entity."""
+
+    def __init__(
+        self,
+        coordinator: HabiticaDataUpdateCoordinator,
+        party_coordinator: HabiticaPartyCoordinator,
+        entity_description: EntityDescription,
+        subentry: ConfigSubentry | None = None,
+    ) -> None:
+        """Initialize a Habitica entity."""
+        self.party_coordinator = party_coordinator
+        super().__init__(coordinator, entity_description, subentry)
+
+    @property
+    def user(self) -> UserData:
+        """Return the user data of the party member."""
+        if TYPE_CHECKING:
+            assert self.subentry
+            assert self.subentry.unique_id
+        return self.party_coordinator.data.members[UUID(self.subentry.unique_id)]
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+
+        return (
+            super().available
+            and (party := self.user.party.id) is not None
+            and party in self.hass.data[HABITICA_KEY]
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.party_coordinator.async_add_listener(self._handle_coordinator_update)
         )
 
 

--- a/homeassistant/components/habitica/image.py
+++ b/homeassistant/components/habitica/image.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from habiticalib import Avatar, ContentData, extract_avatar
@@ -90,12 +91,14 @@ class HabiticaImage(HabiticaBase, ImageEntity):
         HabiticaBase.__init__(self, coordinator, self.entity_description, subentry)
         ImageEntity.__init__(self, hass)
         self._attr_image_last_updated = dt_util.utcnow()
+        if TYPE_CHECKING:
+            assert self.user
         self._avatar = extract_avatar(self.user)
 
     def _handle_coordinator_update(self) -> None:
         """Check if equipped gear and other things have changed since last avatar image generation."""
 
-        if self.available and self._avatar != self.user:
+        if self.user is not None and self._avatar != self.user:
             self._avatar = extract_avatar(self.user)
             self._attr_image_last_updated = dt_util.utcnow()
             self._cache = None

--- a/homeassistant/components/habitica/image.py
+++ b/homeassistant/components/habitica/image.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from habiticalib import Avatar, ContentData, extract_avatar
 
 from homeassistant.components.image import Image, ImageEntity, ImageEntityDescription
+from homeassistant.config_entries import ConfigSubentry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -18,7 +19,7 @@ from .coordinator import (
     HabiticaDataUpdateCoordinator,
     HabiticaPartyCoordinator,
 )
-from .entity import HabiticaBase, HabiticaPartyBase
+from .entity import HabiticaBase, HabiticaPartyBase, HabiticaPartyMemberBase
 
 PARALLEL_UPDATES = 1
 
@@ -47,6 +48,18 @@ async def async_setup_entry(
                 hass, party_coordinator, config_entry, coordinator.content
             )
         )
+        for subentry_id, subentry in config_entry.subentries.items():
+            async_add_entities(
+                [
+                    HabiticaPartyMemberImage(
+                        hass,
+                        coordinator,
+                        party_coordinator,
+                        subentry,
+                    )
+                ],
+                config_subentry_id=subentry_id,
+            )
 
     async_add_entities(entities)
 
@@ -66,18 +79,19 @@ class HabiticaImage(HabiticaBase, ImageEntity):
         self,
         hass: HomeAssistant,
         coordinator: HabiticaDataUpdateCoordinator,
+        subentry: ConfigSubentry | None = None,
     ) -> None:
         """Initialize the image entity."""
-        super().__init__(coordinator, self.entity_description)
+        HabiticaBase.__init__(self, coordinator, self.entity_description, subentry)
         ImageEntity.__init__(self, hass)
         self._attr_image_last_updated = dt_util.utcnow()
-        self._avatar = extract_avatar(self.coordinator.data.user)
+        self._avatar = extract_avatar(self.user)
 
     def _handle_coordinator_update(self) -> None:
         """Check if equipped gear and other things have changed since last avatar image generation."""
 
-        if self._avatar != self.coordinator.data.user:
-            self._avatar = extract_avatar(self.coordinator.data.user)
+        if self._avatar != self.user:
+            self._avatar = extract_avatar(self.user)
             self._attr_image_last_updated = dt_util.utcnow()
             self._cache = None
 
@@ -88,6 +102,24 @@ class HabiticaImage(HabiticaBase, ImageEntity):
         if not self._cache and self._avatar:
             self._cache = await self.coordinator.generate_avatar(self._avatar)
         return self._cache
+
+
+class HabiticaPartyMemberImage(HabiticaImage, HabiticaPartyMemberBase):
+    """A Habitica party member image entity."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: HabiticaDataUpdateCoordinator,
+        party_coordinator: HabiticaPartyCoordinator,
+        subentry: ConfigSubentry | None = None,
+    ) -> None:
+        """Initialize the image entity."""
+
+        HabiticaPartyMemberBase.__init__(
+            self, coordinator, party_coordinator, self.entity_description, subentry
+        )
+        super().__init__(hass, coordinator, subentry)
 
 
 class HabiticaPartyImage(HabiticaPartyBase, ImageEntity):

--- a/homeassistant/components/habitica/sensor.py
+++ b/homeassistant/components/habitica/sensor.py
@@ -24,7 +24,7 @@ from homeassistant.util import dt as dt_util
 from . import HABITICA_KEY
 from .const import ASSETS_URL
 from .coordinator import HabiticaConfigEntry
-from .entity import HabiticaBase, HabiticaPartyBase
+from .entity import HabiticaBase, HabiticaPartyBase, HabiticaPartyMemberBase
 from .util import (
     collected_quest_items,
     get_attribute_points,
@@ -118,12 +118,13 @@ class HabiticaSensorEntity(StrEnum):
     LAST_CHECKIN = "last_checkin"
 
 
-SENSOR_DESCRIPTIONS: tuple[HabiticaSensorEntityDescription, ...] = (
+SENSOR_DESCRIPTIONS_COMMON: tuple[HabiticaSensorEntityDescription, ...] = (
     HabiticaSensorEntityDescription(
         key=HabiticaSensorEntity.DISPLAY_NAME,
         translation_key=HabiticaSensorEntity.DISPLAY_NAME,
         value_fn=lambda user, _: user.profile.name,
         attributes_fn=lambda user, _: {
+            "username": f"@{user.auth.local.username}",
             "blurb": user.profile.blurb,
             "joined": (
                 dt_util.as_local(joined).date()
@@ -176,33 +177,11 @@ SENSOR_DESCRIPTIONS: tuple[HabiticaSensorEntityDescription, ...] = (
         value_fn=lambda user, _: user.stats.lvl,
     ),
     HabiticaSensorEntityDescription(
-        key=HabiticaSensorEntity.GOLD,
-        translation_key=HabiticaSensorEntity.GOLD,
-        suggested_display_precision=2,
-        value_fn=lambda user, _: user.stats.gp,
-        entity_picture=ha.GP,
-    ),
-    HabiticaSensorEntityDescription(
         key=HabiticaSensorEntity.CLASS,
         translation_key=HabiticaSensorEntity.CLASS,
         value_fn=lambda user, _: user.stats.Class.value if user.stats.Class else None,
         device_class=SensorDeviceClass.ENUM,
         options=[item.value for item in HabiticaClass],
-    ),
-    HabiticaSensorEntityDescription(
-        key=HabiticaSensorEntity.GEMS,
-        translation_key=HabiticaSensorEntity.GEMS,
-        value_fn=lambda user, _: None if (b := user.balance) is None else round(b * 4),
-        suggested_display_precision=0,
-        entity_picture="shop_gem.png",
-    ),
-    HabiticaSensorEntityDescription(
-        key=HabiticaSensorEntity.TRINKETS,
-        translation_key=HabiticaSensorEntity.TRINKETS,
-        value_fn=lambda user, _: user.purchased.plan.consecutive.trinkets,
-        suggested_display_precision=0,
-        native_unit_of_measurement="⧖",
-        entity_picture="notif_subscriber_reward.png",
     ),
     HabiticaSensorEntityDescription(
         key=HabiticaSensorEntity.STRENGTH,
@@ -235,6 +214,30 @@ SENSOR_DESCRIPTIONS: tuple[HabiticaSensorEntityDescription, ...] = (
         attributes_fn=lambda user, content: get_attribute_points(user, content, "con"),
         suggested_display_precision=0,
         native_unit_of_measurement="CON",
+    ),
+)
+SENSOR_DESCRIPTIONS: tuple[HabiticaSensorEntityDescription, ...] = (
+    HabiticaSensorEntityDescription(
+        key=HabiticaSensorEntity.GOLD,
+        translation_key=HabiticaSensorEntity.GOLD,
+        suggested_display_precision=2,
+        value_fn=lambda user, _: user.stats.gp,
+        entity_picture=ha.GP,
+    ),
+    HabiticaSensorEntityDescription(
+        key=HabiticaSensorEntity.GEMS,
+        translation_key=HabiticaSensorEntity.GEMS,
+        value_fn=lambda user, _: None if (b := user.balance) is None else round(b * 4),
+        suggested_display_precision=0,
+        entity_picture="shop_gem.png",
+    ),
+    HabiticaSensorEntityDescription(
+        key=HabiticaSensorEntity.TRINKETS,
+        translation_key=HabiticaSensorEntity.TRINKETS,
+        value_fn=lambda user, _: user.purchased.plan.consecutive.trinkets,
+        suggested_display_precision=0,
+        native_unit_of_measurement="⧖",
+        entity_picture="notif_subscriber_reward.png",
     ),
     HabiticaSensorEntityDescription(
         key=HabiticaSensorEntity.EGGS_TOTAL,
@@ -389,7 +392,8 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
 
     async_add_entities(
-        HabiticaSensor(coordinator, description) for description in SENSOR_DESCRIPTIONS
+        HabiticaSensor(coordinator, description)
+        for description in SENSOR_DESCRIPTIONS + SENSOR_DESCRIPTIONS_COMMON
     )
 
     if party := coordinator.data.user.party.id:
@@ -403,6 +407,19 @@ async def async_setup_entry(
             )
             for description in SENSOR_DESCRIPTIONS_PARTY
         )
+        for subentry_id, subentry in config_entry.subentries.items():
+            async_add_entities(
+                [
+                    HabiticaPartyMemberSensor(
+                        coordinator,
+                        party_coordinator,
+                        description,
+                        subentry,
+                    )
+                    for description in SENSOR_DESCRIPTIONS_COMMON
+                ],
+                config_subentry_id=subentry_id,
+            )
 
 
 class HabiticaSensor(HabiticaBase, SensorEntity):
@@ -414,27 +431,25 @@ class HabiticaSensor(HabiticaBase, SensorEntity):
     def native_value(self) -> StateType | datetime:
         """Return the state of the device."""
 
-        return self.entity_description.value_fn(
-            self.coordinator.data.user, self.coordinator.content
-        )
+        return self.entity_description.value_fn(self.user, self.coordinator.content)
 
     @property
     def extra_state_attributes(self) -> dict[str, float | None] | None:
         """Return entity specific state attributes."""
         if func := self.entity_description.attributes_fn:
-            return func(self.coordinator.data.user, self.coordinator.content)
+            return func(self.user, self.coordinator.content)
         return None
 
     @property
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
         if self.entity_description.key is HabiticaSensorEntity.CLASS and (
-            _class := self.coordinator.data.user.stats.Class
+            _class := self.user.stats.Class
         ):
             return SVG_CLASS[_class]
 
         if self.entity_description.key is HabiticaSensorEntity.DISPLAY_NAME and (
-            img_url := self.coordinator.data.user.profile.imageUrl
+            img_url := self.user.profile.imageUrl
         ):
             return img_url
 
@@ -446,6 +461,10 @@ class HabiticaSensor(HabiticaBase, SensorEntity):
             )
 
         return None
+
+
+class HabiticaPartyMemberSensor(HabiticaSensor, HabiticaPartyMemberBase):
+    """Habitica party member sensor."""
 
 
 class HabiticaPartySensor(HabiticaPartyBase, SensorEntity):

--- a/homeassistant/components/habitica/sensor.py
+++ b/homeassistant/components/habitica/sensor.py
@@ -436,12 +436,16 @@ class HabiticaSensor(HabiticaBase, SensorEntity):
     def native_value(self) -> StateType | datetime:
         """Return the state of the device."""
 
-        return self.entity_description.value_fn(self.user, self.coordinator.content)
+        return (
+            self.entity_description.value_fn(self.user, self.coordinator.content)
+            if self.user is not None
+            else None
+        )
 
     @property
     def extra_state_attributes(self) -> dict[str, float | None] | None:
         """Return entity specific state attributes."""
-        if func := self.entity_description.attributes_fn:
+        if self.user is not None and (func := self.entity_description.attributes_fn):
             return func(self.user, self.coordinator.content)
         return None
 
@@ -449,15 +453,15 @@ class HabiticaSensor(HabiticaBase, SensorEntity):
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
         if (
-            self.available
-            and self.entity_description.key is HabiticaSensorEntity.CLASS
+            self.entity_description.key is HabiticaSensorEntity.CLASS
+            and self.user is not None
             and (_class := self.user.stats.Class)
         ):
             return SVG_CLASS[_class]
 
         if (
-            self.available
-            and self.entity_description.key is HabiticaSensorEntity.DISPLAY_NAME
+            self.entity_description.key is HabiticaSensorEntity.DISPLAY_NAME
+            and self.user is not None
             and (img_url := self.user.profile.imageUrl)
         ):
             return img_url

--- a/homeassistant/components/habitica/sensor.py
+++ b/homeassistant/components/habitica/sensor.py
@@ -215,6 +215,16 @@ SENSOR_DESCRIPTIONS_COMMON: tuple[HabiticaSensorEntityDescription, ...] = (
         suggested_display_precision=0,
         native_unit_of_measurement="CON",
     ),
+    HabiticaSensorEntityDescription(
+        key=HabiticaSensorEntity.LAST_CHECKIN,
+        translation_key=HabiticaSensorEntity.LAST_CHECKIN,
+        value_fn=(
+            lambda user, _: dt_util.as_local(last)
+            if (last := user.auth.timestamps.loggedin)
+            else None
+        ),
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
 )
 SENSOR_DESCRIPTIONS: tuple[HabiticaSensorEntityDescription, ...] = (
     HabiticaSensorEntityDescription(
@@ -288,16 +298,6 @@ SENSOR_DESCRIPTIONS: tuple[HabiticaSensorEntityDescription, ...] = (
         key=HabiticaSensorEntity.PENDING_QUEST_ITEMS,
         translation_key=HabiticaSensorEntity.PENDING_QUEST_ITEMS,
         value_fn=pending_quest_items,
-    ),
-    HabiticaSensorEntityDescription(
-        key=HabiticaSensorEntity.LAST_CHECKIN,
-        translation_key=HabiticaSensorEntity.LAST_CHECKIN,
-        value_fn=(
-            lambda user, _: dt_util.as_local(last)
-            if (last := user.auth.timestamps.loggedin)
-            else None
-        ),
-        device_class=SensorDeviceClass.TIMESTAMP,
     ),
 )
 

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -174,6 +174,30 @@
       }
     }
   },
+  "config_subentries": {
+    "party_member": {
+      "step": {
+        "user": {
+          "title": "Party members",
+          "description": "Track the stats of the adventurers in your party.",
+          "data": {
+            "party_member": "Party member"
+          },
+          "data_description": {
+            "party_member": "Select an adventurer from your party to track health and other stats."
+          }
+        }
+      },
+      "initiate_flow": {
+        "user": "Add party member"
+      },
+      "entry_type": "Party member",
+      "abort": {
+        "already_configured_as_entry": "Already configured as a user. This adventurer cannot be added as a party member.",
+        "already_configured": "This adventurer is already configured as a party member in this or another account."
+      }
+    }
+  },
   "entity": {
     "binary_sensor": {
       "pending_quest": {
@@ -287,6 +311,9 @@
           },
           "total_logins": {
             "name": "Total logins"
+          },
+          "username": {
+            "name": "[%key:common::config_flow::data::username%]"
           }
         }
       },

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -194,7 +194,8 @@
       "entry_type": "Party member",
       "abort": {
         "already_configured_as_entry": "Already configured as a user. This adventurer cannot be added as a party member.",
-        "already_configured": "This adventurer is already configured as a party member in this or another account."
+        "already_configured": "This adventurer is already configured as a party member in this or another account.",
+        "config_entry_disabled": "Cannot add party members when the main account is disabled or not loaded."
       }
     }
   },

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -195,7 +195,8 @@
       "abort": {
         "already_configured_as_entry": "Already configured as a user. This adventurer cannot be added as a party member.",
         "already_configured": "This adventurer is already configured as a party member in this or another account.",
-        "config_entry_disabled": "Cannot add party members when the main account is disabled or not loaded."
+        "config_entry_disabled": "Cannot add party members when the main account is disabled or not loaded.",
+        "not_in_a_party": "You are currently not in a party. You can only add party members when your character is in a party."
       }
     }
   },

--- a/tests/components/habitica/conftest.py
+++ b/tests/components/habitica/conftest.py
@@ -30,6 +30,7 @@ from habiticalib import (
 import pytest
 
 from homeassistant.components.habitica.const import CONF_API_USER, DEFAULT_URL, DOMAIN
+from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.const import CONF_API_KEY, CONF_URL
 from homeassistant.core import HomeAssistant
 
@@ -56,6 +57,30 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_API_KEY: "cd0e5985-17de-4b4f-849e-5d506c5e4382",
         },
         unique_id="a380546a-94be-4b8e-8a0b-23e0d5c03303",
+    )
+
+
+@pytest.fixture(name="config_entry_with_subentry")
+def mock_config_entry_with_subentry() -> MockConfigEntry:
+    """Mock Habitica configuration entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        data={
+            CONF_URL: DEFAULT_URL,
+            CONF_API_USER: "a380546a-94be-4b8e-8a0b-23e0d5c03303",
+            CONF_API_KEY: "cd0e5985-17de-4b4f-849e-5d506c5e4382",
+        },
+        unique_id="a380546a-94be-4b8e-8a0b-23e0d5c03303",
+        subentries_data=[
+            ConfigSubentryData(
+                data={},
+                subentry_id="ABCDEF",
+                subentry_type="party_member",
+                title="test-partymember-displayname",
+                unique_id="ffce870c-3ff3-4fa4-bad1-87612e52b8e7",
+            )
+        ],
     )
 
 

--- a/tests/components/habitica/fixtures/content.json
+++ b/tests/components/habitica/fixtures/content.json
@@ -85,6 +85,48 @@
         }
       },
       "flat": {
+        "armor_base_0": {
+          "text": "Plain Clothing",
+          "notes": "Ordinary clothing. Confers no benefit.",
+          "value": 0,
+          "type": "armor",
+          "key": "armor_base_0",
+          "set": "base-0",
+          "klass": "base",
+          "index": "0",
+          "str": 0,
+          "int": 0,
+          "per": 0,
+          "con": 0
+        },
+        "head_base_0": {
+          "text": "No Headgear",
+          "notes": "No headgear.",
+          "value": 0,
+          "type": "head",
+          "key": "head_base_0",
+          "set": "base-0",
+          "klass": "base",
+          "index": "0",
+          "str": 0,
+          "int": 0,
+          "per": 0,
+          "con": 0
+        },
+        "shield_base_0": {
+          "text": "No Off-Hand Equipment",
+          "notes": "No shield or other off-hand item.",
+          "value": 0,
+          "type": "shield",
+          "key": "shield_base_0",
+          "set": "base-0",
+          "klass": "base",
+          "index": "0",
+          "str": 0,
+          "int": 0,
+          "per": 0,
+          "con": 0
+        },
         "weapon_warrior_5": {
           "text": "Ruby Sword",
           "notes": "Weapon whose forge-glow never fades. Increases Strength by 15. ",

--- a/tests/components/habitica/fixtures/party_members.json
+++ b/tests/components/habitica/fixtures/party_members.json
@@ -157,7 +157,7 @@
         },
         "order": "level",
         "orderAscending": "ascending",
-        "_id": "94cd398c-2240-4320-956e-6d345cf2c0de"
+        "_id": "1e87097c-4c03-4f8c-a475-67cc7da7f409"
       },
       "preferences": {
         "size": "slim",
@@ -361,7 +361,7 @@
         },
         "order": "level",
         "orderAscending": "ascending",
-        "_id": "94cd398c-2240-4320-956e-6d345cf2c0de"
+        "_id": "1e87097c-4c03-4f8c-a475-67cc7da7f409"
       },
       "preferences": {
         "size": "slim",

--- a/tests/components/habitica/snapshots/test_sensor.ambr
+++ b/tests/components/habitica/snapshots/test_sensor.ambr
@@ -1,4 +1,652 @@
 # serializer version: 1
+# name: test_sensors[sensor.test_partymember_displayname_class-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'warrior',
+        'rogue',
+        'wizard',
+        'healer',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_class',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Class',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.CLASS: 'class'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_class',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_class-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'entity_picture': 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiAgdmlld0JveD0iLTEyIC0xMiA3MiA3MiI+CiAgICA8ZGVmcz4KICAgICAgICA8cGF0aCBpZD0iYSIgZD0iTTMxLjM5MiA5LjExNWwtNi43OTEgNy4xMjR2Ni4zMTRsNi43OTEtNi43OTFWOS4xMTV6Ii8+CiAgICA8L2RlZnM+CiAgICA8ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAgMSkiPgogICAgICAgIDxwYXRoIGZpbGw9IiNGMDYxNjYiIGQ9Ik0xOC4zOSAyOC43NjJsNi4zMzQgMi45MmMuNTI2LjI0My44NjguNzMyLjk5OSAxLjI5Ny4yMTkuOTQ4Ljg4MyAzLjE1Ni45MzcgNC4zM2EuODguODggMCAwIDEtMS4yNC44NDRsLTEwLjU4OC01LjA3YTEuNzgxIDEuNzgxIDAgMCAxLS43NjItLjc2M0w5IDIxLjczM2EuODguODggMCAwIDEgLjg0NC0xLjI0YzEuMTczLjA1NCAzLjMzNS42ODMgNC4zMy45MzcuNTYuMTQyIDEuMDU0LjQ3MiAxLjI5Ni45OThsMi45MiA2LjMzNHoiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjQzgyQjJCIiBkPSJNMy4wNzMgNDQuMDg1bDIuNzMyIDIuNzMzIDcuMDg1LS41NTcuMzY0LTQuNjU2IDQuMDY5LTQuMDY3IDcuNDAxIDMuNTIyIDUuNTM2LTEuNDktMi4zMjItOS45OSAxNS41MTQtMTQuNDc3TDQ2LjQyMi43NDFsLS4wMDcuMDAyLjAwMy0uMDAzVi43MzRMMzIuMDU3IDMuNzAyIDE3LjU4IDE5LjIxOGwtOS45OS0yLjMyMkw2LjEgMjIuNDNsMy41MjIgNy40MDNMNS41NTUgMzMuOWwtNC42NTQuMzY3LS41NTkgNy4wODQgMi43MzIgMi43MzN6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0YwNjE2NiIgZD0iTTguOTI3IDQxLjc2OWwtMy41NDQtMy41NDQgOC43NjctOC43NjUgMy41NDIgMy41NDR6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0YwNjE2NiIgZD0iTTMuMzc3IDQwLjIzMWwuMjU1LTMuMjM1IDMuMjM2LS4yNTUgMy41NDQgMy41NDYtLjI1NSAzLjIzMy0zLjIzNC4yNTh6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGQjZCOCIgZD0iTTMzLjkzNSA2LjUyNmwuMyA2LjM5MSA4LjEwOC04LjEwOGMtLjE1LS4xNC02LjI2LjU2NS04LjQwOCAxLjcxNyIvPgogICAgICAgIDxwYXRoIGZpbGw9IiNGMjdCODYiIGQ9Ik0zMy43ODcgNi42MDJMMTYuNjYgMjQuNTY4bDQuMzkgMS41MzggMTMuMTg2LTEzLjE4OS0uMy02LjM5MmMtLjA0OC4wMjctLjE0OC4wNzctLjE0OC4wNzciLz4KICAgICAgICA8cGF0aCBmaWxsPSIjRjI3Qjg2IiBkPSJNMTYuNjYgMjQuNTY3bC0uMTQ4LjE2NCAxLjg2NCA0LjA0NSAyLjY3LTIuNjctNC4zODYtMS41Mzl6TTQwLjYyNCAxMy4yMmwtNi4zOTItLjMgOC4xMDktOC4xMDhjLjE0LjE1LS41NjUgNi4yNTktMS43MTcgOC40MDgiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjRTU0MTREIiBkPSJNNDAuNTQ4IDEzLjM2OEwyMi41ODIgMzAuNDk2bC0xLjUzOC00LjM5TDM0LjIzMyAxMi45Mmw2LjM5MS4zYTUuMDMyIDUuMDMyIDAgMCAwLS4wNzYuMTQ4Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0U1NDE0RCIgZD0iTTIyLjU4MiAzMC40OTVsLS4xNjMuMTQ4LTQuMDQ1LTEuODY0IDIuNjctMi42NyAxLjUzOCA0LjM4NnoiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjRkZCNkI4IiBkPSJNNi44NjcgMzYuNzQybC0uNzUgMi43NDItMi40ODYtMi40ODd6TTEwLjQwNiA0MC4yOGwtMi43NDIuNzUgMi40ODYgMi40ODZ6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGQjZCOCIgZD0iTTYuODY3IDM2Ljc0MmwzLjU0NiAzLjU0Ni0yLjc0OC43NDEtMS41NDctMS41NDV6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0YyN0I4NiIgZD0iTTMuMzgyIDQwLjIzN2wyLjc0Mi0uNzUtMi40ODYtMi40ODZ6TTYuOTIxIDQzLjc3NmwuNzUtMi43NDIgMi40ODYgMi40ODZ6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0YyN0I4NiIgZD0iTTMuMzgyIDQwLjIzN2wzLjU0NyAzLjU0Ni43NC0yLjc0OC0xLjU0NS0xLjU0N3oiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjRTU0MTREIiBkPSJNMTQuNzAxIDM2LjAxbC0zLjU1Mi0zLjU1MyAyLjE0My0yLjE0IDMuNTUyIDMuNTV6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0YwNjE2NiIgZD0iTTEyLjU2IDM4LjE1MUw5LjAwOCAzNC42bDIuMTQyLTIuMTQgMy41NTIgMy41NXoiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjRTU0MTREIiBkPSJNMTAuNDE4IDQwLjI5M0w2Ljg2NiAzNi43NGwyLjE0Mi0yLjE0IDMuNTUyIDMuNTV6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGQjZCOCIgZD0iTTE4LjM5NSAyOC43NjRsLTIuOTItNi4zMzRhMS42MjkgMS42MjkgMCAwIDAtLjQ2LS41NzYgMi4xMiAyLjEyIDAgMCAwLS44MzYtLjQyMmMtLjk5NS0uMjU0LTMuMTU3LS44ODMtNC4zMy0uOTM3YS44NzEuODcxIDAgMCAwLS43MjcuMzM2bDQuMjU4IDMuNjM0IDMuMTMgNi4xOTIgMS44OS0xLjg5LS4wMDUtLjAwM3oiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjRjA2MTY2IiBkPSJNMTMuMzggMjQuNDY2TDkuMTIgMjAuODNhLjg3MS44NzEgMCAwIDAtLjExNy45MDRsNS4wNyAxMC41ODdjLjA4NS4xNjUuMTk3LjMxMy4zMjcuNDQ0bDIuMTA5LTIuMTA4LTMuMTMtNi4xOTJ6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0YyN0I4NiIgZD0iTTI2LjY3NCAzNy4zMTJjLS4wNTQtMS4xNzMtLjY4NC0zLjMzNy0uOTM3LTQuMzNhMi4xMiAyLjEyIDAgMCAwLS40MjMtLjgzNiAxLjYyOSAxLjYyOSAwIDAgMC0uNTc2LS40NmwtNi4zMzQtMi45Mi0uMDAyLS4wMDUtMS44OTEgMS44OTEgNi4xOTIgMy4xMyAzLjYzNSA0LjI1OGEuODc0Ljg3NCAwIDAgMCAuMzM2LS43MjgiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjRTU0MTREIiBkPSJNMjIuNzAzIDMzLjc4MWwzLjYzNCA0LjI1OWEuODcxLjg3MSAwIDAgMS0uOTA0LjExN2wtMTAuNTg3LTUuMDdhMS43NjYgMS43NjYgMCAwIDEtLjQ0NC0uMzI3bDIuMTA5LTIuMTA4IDYuMTkyIDMuMTN6Ii8+CiAgICAgICAgPG1hc2sgaWQ9ImIiIGZpbGw9IiNmZmYiPgogICAgICAgICAgICA8dXNlIHhsaW5rOmhyZWY9IiNhIi8+CiAgICAgICAgPC9tYXNrPgogICAgICAgIDxwYXRoIGZpbGw9IiNGRkI2QjgiIGQ9Ik0yOS40NzIgMjMuMjhoLjk4N1Y1LjgyOGgtLjk4N3pNMjQuNjAxIDI3LjY5MmgyLjkyVjEwLjI0aC0yLjkyeiIgbWFzaz0idXJsKCNiKSIvPgogICAgPC9nPgo8L3N2Zz4=',
+      'friendly_name': 'test-partymember-displayname Class',
+      'options': list([
+        'warrior',
+        'rogue',
+        'wizard',
+        'healer',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_class',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'warrior',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_constitution-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_constitution',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Constitution',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.CONSTITUTION: 'constitution'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_constitution',
+    'unit_of_measurement': 'CON',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_constitution-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'allocated': 0,
+      'buffs': 1,
+      'class': 0,
+      'equipment': 0,
+      'friendly_name': 'test-partymember-displayname Constitution',
+      'level': 0,
+      'unit_of_measurement': 'CON',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_constitution',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_display_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_display_name',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Display name',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.DISPLAY_NAME: 'display_name'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_display_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_display_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'blurb': None,
+      'friendly_name': 'test-partymember-displayname Display name',
+      'joined': datetime.date(2024, 10, 10),
+      'last_login': datetime.date(2024, 10, 30),
+      'total_logins': 1,
+      'username': '@test-partymember-username',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_display_name',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'test-partymember-displayname',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_experience-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_experience',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Experience',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.EXPERIENCE: 'experience'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_experience',
+    'unit_of_measurement': 'XP',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_experience-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciICB2aWV3Qm94PSItNiAtNiAzNiAzNiI+CiAgICA8ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxwYXRoIGZpbGw9IiNGRkE2MjMiIGQ9Ik0xNiAxNmw4LTQtOC00LTQtOC00IDgtOCA0IDggNCA0IDh6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQuNSAxMmw1LTIuNUwxMiAxMnpNMTIgMTkuNWwtMi41LTVMMTIgMTJ6TTE5LjUgMTJsLTUgMi41TDEyIDEyek0xMiA0LjVsMi41IDVMMTIgMTJ6IiBvcGFjaXR5PSIuMjUiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjQkY3RDFBIiBkPSJNMTkuNSAxMmwtNS0yLjVMMTIgMTJ6IiBvcGFjaXR5PSIuMjUiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjQkY3RDFBIiBkPSJNMTIgMTkuNWwyLjUtNUwxMiAxMnoiIG9wYWNpdHk9Ii41Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQuNSAxMmw1IDIuNUwxMiAxMnpNMTIgNC41bC0yLjUgNUwxMiAxMnoiIG9wYWNpdHk9Ii41Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTEwLjggMTMuMkw4LjUgMTJsMi4zLTEuMkwxMiA4LjVsMS4yIDIuMyAyLjMgMS4yLTIuMyAxLjItMS4yIDIuM3oiIG9wYWNpdHk9Ii41Ii8+CiAgICA8L2c+Cjwvc3ZnPg==',
+      'friendly_name': 'test-partymember-displayname Experience',
+      'unit_of_measurement': 'XP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_experience',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '24',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_health-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_health',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Health',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.HEALTH: 'health'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_health',
+    'unit_of_measurement': 'HP',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_health-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciICB2aWV3Qm94PSItNiAtNiAzNiAzNiI+CiAgICA8ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxwYXRoIGZpbGw9IiNGNzRFNTIiIGQ9Ik0yIDQuNUw2LjE2NyAyIDEyIDUuMTY3IDE3LjgzMyAyIDIyIDQuNVYxMmwtNC4xNjcgNS44MzNMMTIgMjJsLTUuODMzLTQuMTY3TDIgMTJ6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGNjE2NSIgZD0iTTcuMzMzIDE2LjY2N0wzLjY2NyAxMS41VjUuNDE3bDIuNS0xLjVMMTIgNy4wODNsNS44MzMtMy4xNjYgMi41IDEuNVYxMS41bC0zLjY2NiA1LjE2N0wxMiAxOS45MTd6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTEyIDE0LjA4M2w0LjY2NyAyLjU4NEwxMiAxOS45MTd6IiBvcGFjaXR5PSIuNSIvPgogICAgICAgIDxwYXRoIGZpbGw9IiNCNTI0MjgiIGQ9Ik0xMiAxNC4wODNsLTQuNjY3IDIuNTg0TDEyIDE5LjkxN3oiIG9wYWNpdHk9Ii4zNSIvPgogICAgICAgIDxwYXRoIGZpbGw9IiNGRkYiIGQ9Ik03LjMzMyAxNi42NjdMMy42NjcgMTEuNSAxMiAxNC4wODN6IiBvcGFjaXR5PSIuMjUiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjQjUyNDI4IiBkPSJNMTYuNjY3IDE2LjY2N2wzLjY2Ni01LjE2N0wxMiAxNC4wODN6IiBvcGFjaXR5PSIuNSIvPgogICAgICAgIDxwYXRoIGZpbGw9IiNCNTI0MjgiIGQ9Ik0xMiAxNC4wODNsNS44MzMtMTAuMTY2IDIuNSAxLjVWMTEuNXoiIG9wYWNpdHk9Ii4zNSIvPgogICAgICAgIDxwYXRoIGZpbGw9IiNCNTI0MjgiIGQ9Ik0xMiAxNC4wODNMNi4xNjcgMy45MTdsLTIuNSAxLjVWMTEuNXoiIG9wYWNpdHk9Ii41Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTEyIDE0LjA4M0w2LjE2NyAzLjkxNyAxMiA3LjA4M3oiIG9wYWNpdHk9Ii41Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTEyIDE0LjA4M2w1LjgzMy0xMC4xNjZMMTIgNy4wODN6IiBvcGFjaXR5PSIuMjUiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjRkZGIiBkPSJNOS4xNjcgMTQuODMzbC0zLTQuMTY2VjYuODMzaC4wODNMMTIgOS45MTdsNS43NS0zLjA4NGguMDgzdjMuODM0bC0zIDQuMTY2TDEyIDE2LjkxN3oiIG9wYWNpdHk9Ii41Ii8+CiAgICA8L2c+Cjwvc3ZnPg==',
+      'friendly_name': 'test-partymember-displayname Health',
+      'unit_of_measurement': 'HP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_health',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_intelligence-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_intelligence',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Intelligence',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.INTELLIGENCE: 'intelligence'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_intelligence',
+    'unit_of_measurement': 'INT',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_intelligence-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'allocated': 0,
+      'buffs': 1,
+      'class': 0,
+      'equipment': 0,
+      'friendly_name': 'test-partymember-displayname Intelligence',
+      'level': 0,
+      'unit_of_measurement': 'INT',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_intelligence',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Level',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.LEVEL: 'level'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_level',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'test-partymember-displayname Level',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_mana-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_mana',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Mana',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.MANA: 'mana'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_mana',
+    'unit_of_measurement': 'MP',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_mana-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciICB2aWV3Qm94PSItNiAtNiAzNiAzNiI+CiAgICA8ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxwYXRoIGZpbGw9IiMyOTk1Q0QiIGQ9Ik0yMiAxNWwtMTAgOS0xMC05TDEyIDB6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iIzUwQjVFOSIgZD0iTTQuNiAxNC43bDcuNC0zdjkuNnoiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjMUY3MDlBIiBkPSJNMTIgMTEuN2w3LjQgMy03LjQgNi42eiIgb3BhY2l0eT0iLjI1Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTEyIDExLjdWMy42bDcuNCAxMS4xeiIgb3BhY2l0eT0iLjI1Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQuNiAxNC43TDEyIDMuNnY4LjF6IiBvcGFjaXR5PSIuNSIvPgogICAgICAgIDxwYXRoIGZpbGw9IiNGRkYiIGQ9Ik03LjIgMTQuM0wxMiA3LjJsNC44IDcuMS00LjggNC4zeiIgb3BhY2l0eT0iLjUiLz4KICAgIDwvZz4KPC9zdmc+',
+      'friendly_name': 'test-partymember-displayname Mana',
+      'unit_of_measurement': 'MP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_mana',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '24.0',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_max_mana-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_max_mana',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Max. mana',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.MANA_MAX: 'mana_max'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_mana_max',
+    'unit_of_measurement': 'MP',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_max_mana-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciICB2aWV3Qm94PSItNiAtNiAzNiAzNiI+CiAgICA8ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxwYXRoIGZpbGw9IiMyOTk1Q0QiIGQ9Ik0yMiAxNWwtMTAgOS0xMC05TDEyIDB6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iIzUwQjVFOSIgZD0iTTQuNiAxNC43bDcuNC0zdjkuNnoiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjMUY3MDlBIiBkPSJNMTIgMTEuN2w3LjQgMy03LjQgNi42eiIgb3BhY2l0eT0iLjI1Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTEyIDExLjdWMy42bDcuNCAxMS4xeiIgb3BhY2l0eT0iLjI1Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQuNiAxNC43TDEyIDMuNnY4LjF6IiBvcGFjaXR5PSIuNSIvPgogICAgICAgIDxwYXRoIGZpbGw9IiNGRkYiIGQ9Ik03LjIgMTQuM0wxMiA3LjJsNC44IDcuMS00LjggNC4zeiIgb3BhY2l0eT0iLjUiLz4KICAgIDwvZz4KPC9zdmc+',
+      'friendly_name': 'test-partymember-displayname Max. mana',
+      'unit_of_measurement': 'MP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_max_mana',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '32',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_next_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_next_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Next level',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.EXPERIENCE_MAX: 'experience_max'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_experience_max',
+    'unit_of_measurement': 'XP',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_next_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciICB2aWV3Qm94PSItNiAtNiAzNiAzNiI+CiAgICA8ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxwYXRoIGZpbGw9IiNGRkE2MjMiIGQ9Ik0xNiAxNmw4LTQtOC00LTQtOC00IDgtOCA0IDggNCA0IDh6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQuNSAxMmw1LTIuNUwxMiAxMnpNMTIgMTkuNWwtMi41LTVMMTIgMTJ6TTE5LjUgMTJsLTUgMi41TDEyIDEyek0xMiA0LjVsMi41IDVMMTIgMTJ6IiBvcGFjaXR5PSIuMjUiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjQkY3RDFBIiBkPSJNMTkuNSAxMmwtNS0yLjVMMTIgMTJ6IiBvcGFjaXR5PSIuMjUiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjQkY3RDFBIiBkPSJNMTIgMTkuNWwyLjUtNUwxMiAxMnoiIG9wYWNpdHk9Ii41Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQuNSAxMmw1IDIuNUwxMiAxMnpNMTIgNC41bC0yLjUgNUwxMiAxMnoiIG9wYWNpdHk9Ii41Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0ZGRiIgZD0iTTEwLjggMTMuMkw4LjUgMTJsMi4zLTEuMkwxMiA4LjVsMS4yIDIuMyAyLjMgMS4yLTIuMyAxLjItMS4yIDIuM3oiIG9wYWNpdHk9Ii41Ii8+CiAgICA8L2c+Cjwvc3ZnPg==',
+      'friendly_name': 'test-partymember-displayname Next level',
+      'unit_of_measurement': 'XP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_next_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_perception-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_perception',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Perception',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.PERCEPTION: 'perception'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_perception',
+    'unit_of_measurement': 'PER',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_perception-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'allocated': 0,
+      'buffs': 1,
+      'class': 0,
+      'equipment': 0,
+      'friendly_name': 'test-partymember-displayname Perception',
+      'level': 0,
+      'unit_of_measurement': 'PER',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_perception',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Strength',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.STRENGTH: 'strength'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_strength',
+    'unit_of_measurement': 'STR',
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'allocated': 0,
+      'buffs': 1,
+      'class': 0,
+      'equipment': 0,
+      'friendly_name': 'test-partymember-displayname Strength',
+      'level': 0,
+      'unit_of_measurement': 'STR',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
 # name: test_sensors[sensor.test_user_class-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -163,6 +811,7 @@
       'joined': datetime.date(2013, 12, 2),
       'last_login': datetime.date(2025, 2, 1),
       'total_logins': 241,
+      'username': '@test-username',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.test_user_display_name',

--- a/tests/components/habitica/snapshots/test_sensor.ambr
+++ b/tests/components/habitica/snapshots/test_sensor.ambr
@@ -332,6 +332,55 @@
     'state': '1',
   })
 # ---
+# name: test_sensors[sensor.test_partymember_displayname_last_check_in-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_partymember_displayname_last_check_in',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last check-in',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.LAST_CHECKIN: 'last_checkin'>,
+    'unique_id': 'ffce870c-3ff3-4fa4-bad1-87612e52b8e7_last_checkin',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_partymember_displayname_last_check_in-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'test-partymember-displayname Last check-in',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_partymember_displayname_last_check_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-10-30T19:37:01+00:00',
+  })
+# ---
 # name: test_sensors[sensor.test_partymember_displayname_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/habitica/test_config_flow.py
+++ b/tests/components/habitica/test_config_flow.py
@@ -3,17 +3,19 @@
 from typing import Any
 from unittest.mock import AsyncMock
 
+from habiticalib import HabiticaUserResponse
 import pytest
 
 from homeassistant.components.habitica.const import (
     CONF_API_USER,
+    CONF_PARTY_MEMBER,
     DEFAULT_URL,
     DOMAIN,
     SECTION_DANGER_ZONE,
     SECTION_REAUTH_API_KEY,
     SECTION_REAUTH_LOGIN,
 )
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, ConfigSubentry
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_PASSWORD,
@@ -26,7 +28,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import ERROR_BAD_REQUEST, ERROR_NOT_AUTHORIZED
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_load_fixture
 
 TEST_API_USER = "a380546a-94be-4b8e-8a0b-23e0d5c03303"
 TEST_API_KEY = "cd0e5985-17de-4b4f-849e-5d506c5e4382"
@@ -512,3 +514,121 @@ async def test_flow_reconfigure_errors(
     assert config_entry.data[CONF_VERIFY_SSL] is True
 
     assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.usefixtures("habitica")
+async def test_add_party_member_flow(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test add party member subentry flow."""
+
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, "party_member"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        user_input={CONF_PARTY_MEMBER: "ffce870c-3ff3-4fa4-bad1-87612e52b8e7"},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    subentry_id = list(config_entry.subentries)[0]
+    assert config_entry.subentries == {
+        subentry_id: ConfigSubentry(
+            data={},
+            subentry_id=subentry_id,
+            subentry_type="party_member",
+            title="test-partymember-displayname",
+            unique_id="ffce870c-3ff3-4fa4-bad1-87612e52b8e7",
+        )
+    }
+
+
+@pytest.mark.usefixtures("habitica")
+async def test_add_party_member_already_configured(
+    hass: HomeAssistant,
+    config_entry_with_subentry: MockConfigEntry,
+) -> None:
+    """Test add party member subentry flow abort when already configured."""
+
+    config_entry_with_subentry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry_with_subentry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry_with_subentry.entry_id, "party_member"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        user_input={CONF_PARTY_MEMBER: "ffce870c-3ff3-4fa4-bad1-87612e52b8e7"},
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("habitica")
+async def test_add_party_member_already_configured_as_entry(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test add party member subentry flow abort when already configured entry."""
+
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="ffce870c-3ff3-4fa4-bad1-87612e52b8e7",
+    ).add_to_hass(hass)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, "party_member"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        user_input={CONF_PARTY_MEMBER: "ffce870c-3ff3-4fa4-bad1-87612e52b8e7"},
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_as_entry"
+
+
+@pytest.mark.usefixtures("habitica")
+async def test_add_party_member_not_in_a_party(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    habitica: AsyncMock,
+) -> None:
+    """Test add party member subentry flow abort when user is not in a party."""
+    habitica.get_user.return_value = HabiticaUserResponse.from_json(
+        await async_load_fixture(hass, "user_no_party.json", DOMAIN)
+    )
+
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, "party_member"),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_in_a_party"

--- a/tests/components/habitica/test_sensor.py
+++ b/tests/components/habitica/test_sensor.py
@@ -27,16 +27,18 @@ def sensor_only() -> Generator[None]:
 @pytest.mark.usefixtures("habitica", "entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
-    config_entry: MockConfigEntry,
+    config_entry_with_subentry: MockConfigEntry,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test setup of the Habitica sensor platform."""
 
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
+    config_entry_with_subentry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry_with_subentry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry_with_subentry.state is ConfigEntryState.LOADED
 
-    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+    await snapshot_platform(
+        hass, entity_registry, snapshot, config_entry_with_subentry.entry_id
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds support for adding party members as subentries to the Habitica integration. Each party member is represented as a device with entities for health, mana, xp, their character stats (strength, perception, intelligence, constitution), their class, and an image entity of their avatar. These can be used for example keep an eye on your teammates health and other stats and know if they are doing well, have enough mana for the next fight or to automatically cast healing and support spells if they are low on health.

<img width="320" height="700" alt="Bildschirmfoto vom 2025-09-08 02-21-42" src="https://github.com/user-attachments/assets/721309aa-dc51-4eb1-9c2b-f4e13b162205" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40775
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
