### PR TITLE
Added model specification to generate_content service

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -52,6 +52,7 @@ from .entity import async_prepare_files_for_prompt
 SERVICE_GENERATE_CONTENT = "generate_content"
 CONF_IMAGE_FILENAME = "image_filename"
 CONF_FILENAMES = "filenames"
+CONF_MODEL = "model"
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 PLATFORMS = (
@@ -111,7 +112,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         try:
             response = await client.aio.models.generate_content(
-                model=RECOMMENDED_CHAT_MODEL, contents=prompt_parts
+                model=call.data[CONF_MODEL], contents=prompt_parts
             )
         except (
             APIError,
@@ -146,6 +147,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 vol.Optional(CONF_FILENAMES, default=[]): vol.All(
                     cv.ensure_list, [cv.string]
                 ),
+                vol.Optional(CONF_MODEL, default=RECOMMENDED_CHAT_MODEL): cv.string,
             }
         ),
         supports_response=SupportsResponse.ONLY,

--- a/homeassistant/components/google_generative_ai_conversation/services.yaml
+++ b/homeassistant/components/google_generative_ai_conversation/services.yaml
@@ -14,3 +14,8 @@ generate_content:
       selector:
         text:
           multiple: true
+    model:
+      required: false
+      selector:
+        text:
+          multiline: false

--- a/homeassistant/components/google_generative_ai_conversation/strings.json
+++ b/homeassistant/components/google_generative_ai_conversation/strings.json
@@ -169,6 +169,11 @@
           "name": "Attachment filenames",
           "description": "Attachments to add to the prompt (images, PDFs, etc)",
           "example": "/config/www/image.jpg"
+        },
+        "model": {
+          "name": "Model to use for the response",
+          "description": "The Gemini model to be used. See: ai.google.dev/gemini-api/docs/models",
+          "example": "gemini-2.5-pro"
         }
       }
     }


### PR DESCRIPTION
## Breaking change
<!-- None -->
This PR does not introduce breaking changes. Existing behavior using the default model remains unchanged.

## Proposed change
Adds support for specifying a custom Gemini model when calling the
`google_generative_ai_conversation.generate_content` service.

Previously, the service always used the recommended default model.
With this change, users can override it by passing a `model` parameter
(e.g., `gemini-2.5-pro`).  
Default behavior is unchanged if the parameter is omitted.

## Type of change
- [x] New feature (which adds functionality to an existing integration)

## Additional information
- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40772
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- N/A
