### PR TITLE
Add Shelly support for virtual buttons

### DIFF
--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -195,7 +195,6 @@ async def async_setup_entry(
         coordinator.mac,
         BUTTON_PLATFORM,
         virtual_button_component_ids,
-        "button",
     )
 
 
@@ -323,7 +322,7 @@ class ShellyVirtualButton(ShellyBaseButton):
         """Initialize Shelly virtual component button."""
         super().__init__(coordinator, description)
 
-        self._attr_unique_id = f"{coordinator.mac}-{description.key}:{_id}-button"
+        self._attr_unique_id = f"{coordinator.mac}-{description.key}:{_id}"
         self._attr_device_info = get_entity_rpc_device_info(coordinator)
         self._attr_name = get_rpc_entity_name(
             coordinator.device, f"{description.key}:{_id}"

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -11,6 +11,7 @@ from aioshelly.const import BLU_TRV_IDENTIFIER, MODEL_BLU_GATEWAY_G3, RPC_GENERA
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError
 
 from homeassistant.components.button import (
+    DOMAIN as BUTTON_PLATFORM,
     ButtonDeviceClass,
     ButtonEntity,
     ButtonEntityDescription,
@@ -26,7 +27,14 @@ from homeassistant.util import slugify
 from .const import DOMAIN, LOGGER, SHELLY_GAS_MODELS
 from .coordinator import ShellyBlockCoordinator, ShellyConfigEntry, ShellyRpcCoordinator
 from .entity import get_entity_block_device_info, get_entity_rpc_device_info
-from .utils import get_blu_trv_device_info, get_device_entry_gen, get_rpc_key_ids
+from .utils import (
+    async_remove_orphaned_entities,
+    get_blu_trv_device_info,
+    get_device_entry_gen,
+    get_rpc_entity_name,
+    get_rpc_key_ids,
+    get_virtual_component_ids,
+)
 
 PARALLEL_UPDATES = 0
 
@@ -87,6 +95,13 @@ BLU_TRV_BUTTONS: Final[list[ShellyButtonDescription]] = [
     ),
 ]
 
+VIRTUAL_BUTTONS: Final[list[ShellyButtonDescription]] = [
+    ShellyButtonDescription[ShellyRpcCoordinator](
+        key="button",
+        press_action="single_push",
+    )
+]
+
 
 @callback
 def async_migrate_unique_ids(
@@ -138,7 +153,7 @@ async def async_setup_entry(
         hass, config_entry.entry_id, partial(async_migrate_unique_ids, coordinator)
     )
 
-    entities: list[ShellyButton | ShellyBluTrvButton] = []
+    entities: list[ShellyButton | ShellyBluTrvButton | ShellyVirtualButton] = []
 
     entities.extend(
         ShellyButton(coordinator, button)
@@ -146,10 +161,20 @@ async def async_setup_entry(
         if button.supported(coordinator)
     )
 
-    if blutrv_key_ids := get_rpc_key_ids(coordinator.device.status, BLU_TRV_IDENTIFIER):
-        if TYPE_CHECKING:
-            assert isinstance(coordinator, ShellyRpcCoordinator)
+    if not isinstance(coordinator, ShellyRpcCoordinator):
+        async_add_entities(entities)
+        return
 
+    # add virtual buttons
+    if virtual_button_ids := get_rpc_key_ids(coordinator.device.status, "button"):
+        entities.extend(
+            ShellyVirtualButton(coordinator, button, id_)
+            for id_ in virtual_button_ids
+            for button in VIRTUAL_BUTTONS
+        )
+
+    # add BLU TRV buttons
+    if blutrv_key_ids := get_rpc_key_ids(coordinator.device.status, BLU_TRV_IDENTIFIER):
         entities.extend(
             ShellyBluTrvButton(coordinator, button, id_)
             for id_ in blutrv_key_ids
@@ -158,6 +183,20 @@ async def async_setup_entry(
         )
 
     async_add_entities(entities)
+
+    # the user can remove virtual components from the device configuration, so
+    # we need to remove orphaned entities
+    virtual_button_component_ids = get_virtual_component_ids(
+        coordinator.device.config, BUTTON_PLATFORM
+    )
+    async_remove_orphaned_entities(
+        hass,
+        config_entry.entry_id,
+        coordinator.mac,
+        BUTTON_PLATFORM,
+        virtual_button_component_ids,
+        "button",
+    )
 
 
 class ShellyBaseButton(
@@ -270,3 +309,32 @@ class ShellyBluTrvButton(ShellyBaseButton):
             assert method is not None
 
         await method(self._id)
+
+
+class ShellyVirtualButton(ShellyBaseButton):
+    """Defines a Shelly virtual component button."""
+
+    def __init__(
+        self,
+        coordinator: ShellyRpcCoordinator,
+        description: ShellyButtonDescription,
+        _id: int,
+    ) -> None:
+        """Initialize Shelly virtual component button."""
+        super().__init__(coordinator, description)
+
+        self._attr_unique_id = f"{coordinator.mac}-{description.key}:{_id}-button"
+        self._attr_device_info = get_entity_rpc_device_info(coordinator)
+        self._attr_name = get_rpc_entity_name(
+            coordinator.device, f"{description.key}:{_id}"
+        )
+        self._id = _id
+
+    async def _press_method(self) -> None:
+        """Press method."""
+        if TYPE_CHECKING:
+            assert isinstance(self.coordinator, ShellyRpcCoordinator)
+
+        await self.coordinator.device.button_trigger(
+            self._id, self.entity_description.press_action
+        )

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -264,9 +264,10 @@ DEVICES_WITHOUT_FIRMWARE_CHANGELOG = (
 
 CONF_GEN = "gen"
 
-VIRTUAL_COMPONENTS = ("boolean", "enum", "input", "number", "text")
+VIRTUAL_COMPONENTS = ("boolean", "button", "enum", "input", "number", "text")
 VIRTUAL_COMPONENTS_MAP = {
     "binary_sensor": {"types": ["boolean"], "modes": ["label"]},
+    "button": {"types": ["button"], "modes": ["button"]},
     "number": {"types": ["number"], "modes": ["field", "slider"]},
     "select": {"types": ["enum"], "modes": ["dropdown"]},
     "sensor": {"types": ["enum", "number", "text"], "modes": ["label"]},

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -631,6 +631,11 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
         """Handle device events."""
         events: list[dict[str, Any]] = event_data["events"]
         for event in events:
+            # filter out button events as they are triggered by button entities
+            component = event.get("component")
+            if component is not None and component.startswith("button"):
+                continue
+
             event_type = event.get("event")
             if event_type is None:
                 continue

--- a/tests/components/shelly/snapshots/test_button.ambr
+++ b/tests/components/shelly/snapshots/test_button.ambr
@@ -96,3 +96,51 @@
     'state': 'unknown',
   })
 # ---
+# name: test_rpc_device_virtual_button[button.test_name_button-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_name_button',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Button',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-button:200-button',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_rpc_device_virtual_button[button.test_name_button-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test name Button',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_name_button',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/shelly/snapshots/test_button.ambr
+++ b/tests/components/shelly/snapshots/test_button.ambr
@@ -127,7 +127,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '123456789ABC-button:200-button',
+    'unique_id': '123456789ABC-button:200',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -332,7 +332,7 @@ async def test_rpc_remove_virtual_button_when_orphaned(
         hass,
         BUTTON_DOMAIN,
         "test_name_button_200",
-        "button:200-button",
+        "button:200",
         config_entry,
         device_id=device_entry.id,
     )

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -1,5 +1,6 @@
 """Tests for Shelly button platform."""
 
+from copy import deepcopy
 from unittest.mock import Mock
 
 from aioshelly.const import MODEL_BLU_GATEWAY_G3
@@ -13,9 +14,10 @@ from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
-from . import init_integration
+from . import init_integration, register_device, register_entity
 
 
 async def test_block_button(
@@ -278,3 +280,65 @@ async def test_rpc_blu_trv_button_auth_error(
     assert "context" in flow
     assert flow["context"].get("source") == SOURCE_REAUTH
     assert flow["context"].get("entry_id") == entry.entry_id
+
+
+async def test_rpc_device_virtual_button(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test a virtual button for RPC device."""
+    config = deepcopy(mock_rpc_device.config)
+    config["button:200"] = {
+        "name": "Button",
+        "meta": {"ui": {"view": "button"}},
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["button:200"] = {"value": None}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    await init_integration(hass, 3)
+    entity_id = "button.test_name_button"
+
+    assert (state := hass.states.get(entity_id))
+    assert state == snapshot(name=f"{entity_id}-state")
+
+    assert (entry := entity_registry.async_get(entity_id))
+    assert entry == snapshot(name=f"{entity_id}-entry")
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    mock_rpc_device.button_trigger.assert_called_once_with(200, "single_push")
+
+
+async def test_rpc_remove_virtual_button_when_orphaned(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    device_registry: DeviceRegistry,
+    mock_rpc_device: Mock,
+) -> None:
+    """Check whether the virtual button will be removed if it has been removed from the device configuration."""
+    config_entry = await init_integration(hass, 3, skip_setup=True)
+    device_entry = register_device(device_registry, config_entry)
+    entity_id = register_entity(
+        hass,
+        BUTTON_DOMAIN,
+        "test_name_button_200",
+        "button:200-button",
+        config_entry,
+        device_id=device_entry.id,
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get(entity_id)
+    assert not entry

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -553,6 +553,57 @@ async def test_rpc_click_event(
     }
 
 
+async def test_rpc_ignore_virtual_click_event(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_rpc_device: Mock,
+    events: list[Event],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test RPC virtual click events are ignored as they are triggered by the integration."""
+    await init_integration(hass, 2)
+
+    # Generate a virtual button event
+    inject_rpc_device_event(
+        monkeypatch,
+        mock_rpc_device,
+        {
+            "events": [
+                {
+                    "component": "button:200",
+                    "id": 200,
+                    "event": "single_push",
+                    "ts": 1757358109.89,
+                }
+            ],
+            "ts": 757358109.89,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(events) == 0
+
+    # Generate valid event
+    inject_rpc_device_event(
+        monkeypatch,
+        mock_rpc_device,
+        {
+            "events": [
+                {
+                    "data": [],
+                    "event": "single_push",
+                    "id": 0,
+                    "ts": 1668522399.2,
+                }
+            ],
+            "ts": 1668522399.2,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+
+
 async def test_rpc_update_entry_sleep_period(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for virtual buttons - https://shelly-api-docs.shelly.cloud/gen2/DynamicComponents/Virtual/Button#buttontrigger
This is already in use by FrankEver Smart water valve - https://www.shelly.com/products/frankever-smart-water-valve-fk-v02t

<img width="662" height="170" alt="image" src="https://github.com/user-attachments/assets/0e65d621-1929-45fa-9653-659f8682ea0d" />

Home Assistant:
<img width="321" height="204" alt="image" src="https://github.com/user-attachments/assets/8d5deb9d-ec53-49dc-8629-e869f84d711e" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40786
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
