### PR TITLE
Add repair issue for Bluetooth adapters in degraded mode due to missing container permissions

### DIFF
--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -334,8 +334,9 @@ class HomeAssistantBluetoothManager(BluetoothManager):
             ir.async_delete_issue(self.hass, DOMAIN, issue_id)
             return
 
-        # Only create repair issues for Docker-based installations where users can fix permissions
-        # This includes: Home Assistant Supervised, Home Assistant Container, and third-party containers
+        # Only create repair issues for Docker-based installations where users
+        # can fix permissions. This includes: Home Assistant Supervised,
+        # Home Assistant Container, and third-party containers
         if not is_docker_env():
             return
 
@@ -352,7 +353,8 @@ class HomeAssistantBluetoothManager(BluetoothManager):
             self.hass,
             DOMAIN,
             issue_id,
-            is_fixable=False,  # Not fixable from within HA - requires container restart with new permissions
+            is_fixable=False,  # Not fixable from within HA - requires
+            # container restart with new permissions
             severity=ir.IssueSeverity.WARNING,
             translation_key="bluetooth_adapter_missing_permissions",
             translation_placeholders={

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -8,8 +8,8 @@ import itertools
 import logging
 
 from bleak_retry_connector import BleakSlotManager
-from bluetooth_adapters import BluetoothAdapters
-from habluetooth import BaseHaRemoteScanner, BaseHaScanner, BluetoothManager
+from bluetooth_adapters import BluetoothAdapters, adapter_human_name, adapter_model
+from habluetooth import BaseHaRemoteScanner, BaseHaScanner, BluetoothManager, HaScanner
 
 from homeassistant import config_entries
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, EVENT_LOGGING_CHANGED
@@ -19,8 +19,9 @@ from homeassistant.core import (
     HomeAssistant,
     callback as hass_callback,
 )
-from homeassistant.helpers import discovery_flow
+from homeassistant.helpers import discovery_flow, issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.util.package import is_docker_env
 
 from .const import (
     CONF_SOURCE,
@@ -314,3 +315,49 @@ class HomeAssistantBluetoothManager(BluetoothManager):
             address = discovery_key.key
             _LOGGER.debug("Rediscover address %s", address)
             self.async_rediscover_address(address)
+
+    def on_scanner_start(self, scanner: BaseHaScanner) -> None:
+        """Handle when a scanner starts.
+
+        Create or delete repair issues for local adapters based on degraded mode.
+        """
+        super().on_scanner_start(scanner)
+
+        # Only handle repair issues for local adapters (HaScanner instances)
+        if not isinstance(scanner, HaScanner):
+            return
+
+        issue_id = f"bluetooth_adapter_missing_permissions_{scanner.source}"
+
+        # Delete any existing issue if not in degraded mode
+        if not self.is_operating_degraded():
+            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            return
+
+        # Only create repair issues for Docker-based installations where users can fix permissions
+        # This includes: Home Assistant Supervised, Home Assistant Container, and third-party containers
+        if not is_docker_env():
+            return
+
+        # Create repair issue for degraded mode in Docker (including Supervised)
+        adapter_name = adapter_human_name(
+            scanner.adapter, scanner.mac_address or "00:00:00:00:00:00"
+        )
+
+        # Try to get adapter details from the bluetooth adapters
+        adapter_details = self._bluetooth_adapters.adapters.get(scanner.adapter)
+        model = adapter_model(adapter_details) if adapter_details else None
+
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,  # Not fixable from within HA - requires container restart with new permissions
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="bluetooth_adapter_missing_permissions",
+            translation_placeholders={
+                "adapter": adapter_name,
+                "model": model or "Unknown",
+                "docs_url": "https://www.home-assistant.io/integrations/bluetooth/#additional-details-for-container",
+            },
+        )

--- a/homeassistant/components/bluetooth/strings.json
+++ b/homeassistant/components/bluetooth/strings.json
@@ -42,7 +42,7 @@
   "issues": {
     "bluetooth_adapter_missing_permissions": {
       "title": "Bluetooth adapter requires additional permissions",
-      "description": "The Bluetooth adapter **{adapter}** ({model}) is operating in degraded mode because your container needs additional permissions for full functionality.\n\nYour container needs additional capabilities to fully access Bluetooth hardware.\n\nPlease follow the instructions in our documentation to add the required permissions:\n[Bluetooth permissions for Docker]({docs_url})\n\nAfter adding these permissions, restart your Home Assistant container for the changes to take effect."
+      "description": "The Bluetooth adapter **{adapter}** ({model}) is operating in degraded mode because your container needs additional permissions to fully access Bluetooth hardware.\n\nPlease follow the instructions in our documentation to add the required permissions:\n[Bluetooth permissions for Docker]({docs_url})\n\nAfter adding these permissions, restart your Home Assistant container for the changes to take effect."
     }
   }
 }

--- a/homeassistant/components/bluetooth/strings.json
+++ b/homeassistant/components/bluetooth/strings.json
@@ -38,5 +38,11 @@
       "remote_adapters_not_supported": "Bluetooth configuration for remote adapters is not supported.",
       "local_adapters_no_passive_support": "Local Bluetooth adapters that do not support passive scanning cannot be configured."
     }
+  },
+  "issues": {
+    "bluetooth_adapter_missing_permissions": {
+      "title": "Bluetooth adapter requires additional permissions",
+      "description": "The Bluetooth adapter **{adapter}** ({model}) is operating in degraded mode because your container needs additional permissions for full functionality.\n\nYour container needs additional capabilities to fully access Bluetooth hardware.\n\nPlease follow the instructions in our documentation to add the required permissions:\n[Bluetooth permissions for Docker]({docs_url})\n\nAfter adding these permissions, restart your Home Assistant container for the changes to take effect."
+    }
   }
 }

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -10,6 +10,7 @@ from bluetooth_adapters import AdvertisementHistory
 from freezegun import freeze_time
 
 # pylint: disable-next=no-name-in-module
+from habluetooth import HaScanner
 from habluetooth.advertisement_tracker import TRACKER_BUFFERING_WOBBLE_SECONDS
 import pytest
 
@@ -38,6 +39,7 @@ from homeassistant.components.bluetooth.const import (
 )
 from homeassistant.components.bluetooth.manager import HomeAssistantBluetoothManager
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -47,6 +49,7 @@ from homeassistant.util.json import json_loads
 from . import (
     HCI0_SOURCE_ADDRESS,
     HCI1_SOURCE_ADDRESS,
+    FakeRemoteScanner,
     FakeScanner,
     MockBleakClient,
     _get_manager,
@@ -1737,3 +1740,191 @@ async def test_async_register_disappeared_callback(
 
     cancel1()
     cancel2()
+
+
+@pytest.mark.usefixtures("one_adapter")
+async def test_repair_issue_created_for_degraded_scanner_in_docker(
+    hass: HomeAssistant,
+) -> None:
+    """Test repair issue is created when scanner is in degraded mode in Docker."""
+    await async_setup_component(hass, bluetooth.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    manager = _get_manager()
+
+    # Create a real HaScanner instance
+    scanner = HaScanner(
+        mode=BluetoothScanningMode.ACTIVE,
+        adapter="hci0",
+        address="00:11:22:33:44:55",
+    )
+    scanner.async_setup()
+
+    # Mock adapter details
+    mock_adapters = {
+        "hci0": {
+            "address": "00:11:22:33:44:55",
+            "sw_version": "homeassistant",
+            "hw_version": "usb:v0A5Cp21E8",
+            "passive_scan": False,
+            "manufacturer": "Broadcom",
+            "product": "BCM20702A0",
+            "vendor_id": "0A5C",
+            "product_id": "21E8",
+        }
+    }
+
+    # Mock is_operating_degraded to return True and is_docker_env
+    with (
+        patch("habluetooth.manager.IS_LINUX", True),
+        patch.object(type(manager), "is_operating_degraded", return_value=True),
+        patch(
+            "homeassistant.components.bluetooth.manager.is_docker_env",
+            return_value=True,
+        ),
+        patch.object(manager._bluetooth_adapters, "adapters", mock_adapters),
+    ):
+        manager.on_scanner_start(scanner)
+
+        # Check that repair issue was created
+        issue_id = f"bluetooth_adapter_missing_permissions_{scanner.source}"
+        registry = ir.async_get(hass)
+        issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
+        assert issue is not None
+        assert issue.severity == ir.IssueSeverity.WARNING
+        assert not issue.is_fixable
+        assert issue.translation_key == "bluetooth_adapter_missing_permissions"
+
+
+@pytest.mark.usefixtures("one_adapter")
+async def test_repair_issue_deleted_when_scanner_not_degraded(
+    hass: HomeAssistant,
+) -> None:
+    """Test repair issue is deleted when scanner is not in degraded mode."""
+    await async_setup_component(hass, bluetooth.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    manager = _get_manager()
+    registry = ir.async_get(hass)
+
+    # Create a real HaScanner instance
+    scanner = HaScanner(
+        mode=BluetoothScanningMode.ACTIVE,
+        adapter="hci0",
+        address="00:11:22:33:44:55",
+    )
+    scanner.async_setup()
+
+    # Mock adapter details
+    mock_adapters = {
+        "hci0": {
+            "address": "00:11:22:33:44:55",
+            "sw_version": "homeassistant",
+            "hw_version": "usb:v0A5Cp21E8",
+            "passive_scan": False,
+            "manufacturer": "Broadcom",
+            "product": "BCM20702A0",
+            "vendor_id": "0A5C",
+            "product_id": "21E8",
+        }
+    }
+
+    issue_id = f"bluetooth_adapter_missing_permissions_{scanner.source}"
+
+    # First create the issue by calling on_scanner_start with degraded mode
+    with (
+        patch("habluetooth.manager.IS_LINUX", True),
+        patch.object(type(manager), "is_operating_degraded", return_value=True),
+        patch(
+            "homeassistant.components.bluetooth.manager.is_docker_env",
+            return_value=True,
+        ),
+        patch.object(manager._bluetooth_adapters, "adapters", mock_adapters),
+    ):
+        manager.on_scanner_start(scanner)
+
+    # Verify it exists
+    assert registry.async_get_issue(bluetooth.DOMAIN, issue_id) is not None
+
+    # Now call again with NOT operating in degraded mode
+    with (
+        patch(
+            "homeassistant.components.bluetooth.manager.is_docker_env",
+            return_value=True,
+        ),
+        patch.object(type(manager), "is_operating_degraded", return_value=False),
+    ):
+        manager.on_scanner_start(scanner)
+
+    # Check that repair issue was deleted
+    assert registry.async_get_issue(bluetooth.DOMAIN, issue_id) is None
+
+
+@pytest.mark.usefixtures("one_adapter")
+async def test_no_repair_issue_when_not_docker(
+    hass: HomeAssistant,
+) -> None:
+    """Test no repair issue is created when not running in Docker."""
+    assert await async_setup_component(hass, bluetooth.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    manager = _get_manager()
+
+    # Create a real HaScanner instance
+    scanner = HaScanner(
+        mode=BluetoothScanningMode.ACTIVE,
+        adapter="hci0",
+        address="00:11:22:33:44:55",
+    )
+    scanner.async_setup()
+
+    # Mock that we're NOT in Docker but operating in degraded mode
+    with (
+        patch(
+            "homeassistant.components.bluetooth.manager.is_docker_env",
+            return_value=False,
+        ),
+        patch.object(type(manager), "is_operating_degraded", return_value=True),
+    ):
+        manager.on_scanner_start(scanner)
+
+        # Check that no repair issue was created
+        issue_id = f"bluetooth_adapter_missing_permissions_{scanner.source}"
+        registry = ir.async_get(hass)
+        assert registry.async_get_issue(bluetooth.DOMAIN, issue_id) is None
+
+
+@pytest.mark.usefixtures("one_adapter")
+async def test_no_repair_issue_for_remote_scanner(
+    hass: HomeAssistant,
+) -> None:
+    """Test no repair issue is created for remote scanners."""
+    assert await async_setup_component(hass, bluetooth.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    manager = _get_manager()
+
+    # Create a FakeRemoteScanner instance (not HaScanner)
+    connector = HaBluetoothConnector(MockBleakClient, "mock_connector", lambda: False)
+    scanner = FakeRemoteScanner("remote_scanner", "esp32", connector, True)
+
+    # Mock that we're in Docker and operating in degraded mode
+    with (
+        patch(
+            "homeassistant.components.bluetooth.manager.is_docker_env",
+            return_value=True,
+        ),
+        patch.object(type(manager), "is_operating_degraded", return_value=True),
+    ):
+        manager.on_scanner_start(scanner)
+
+        # Check that no repair issue was created (remote scanners are ignored)
+        registry = ir.async_get(hass)
+        # Check there are no bluetooth repair issues at all
+        issues = [
+            issue
+            for issue in registry.issues.values()
+            if issue.domain == bluetooth.DOMAIN
+            and "bluetooth_adapter_missing_permissions" in issue.issue_id
+        ]
+        assert len(issues) == 0

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -8,9 +8,9 @@ from unittest.mock import patch
 from bleak.backends.scanner import AdvertisementData, BLEDevice
 from bluetooth_adapters import AdvertisementHistory
 from freezegun import freeze_time
+from habluetooth import HaScanner
 
 # pylint: disable-next=no-name-in-module
-from habluetooth import HaScanner
 from habluetooth.advertisement_tracker import TRACKER_BUFFERING_WOBBLE_SECONDS
 import pytest
 
@@ -1752,7 +1752,6 @@ async def test_repair_issue_created_for_degraded_scanner_in_docker(
 
     manager = _get_manager()
 
-    # Create a real HaScanner instance
     scanner = HaScanner(
         mode=BluetoothScanningMode.ACTIVE,
         adapter="hci0",
@@ -1760,7 +1759,6 @@ async def test_repair_issue_created_for_degraded_scanner_in_docker(
     )
     scanner.async_setup()
 
-    # Mock adapter details
     mock_adapters = {
         "hci0": {
             "address": "00:11:22:33:44:55",
@@ -1774,7 +1772,6 @@ async def test_repair_issue_created_for_degraded_scanner_in_docker(
         }
     }
 
-    # Mock is_operating_degraded to return True and is_docker_env
     with (
         patch("habluetooth.manager.IS_LINUX", True),
         patch.object(type(manager), "is_operating_degraded", return_value=True),
@@ -1786,7 +1783,6 @@ async def test_repair_issue_created_for_degraded_scanner_in_docker(
     ):
         manager.on_scanner_start(scanner)
 
-        # Check that repair issue was created
         issue_id = f"bluetooth_adapter_missing_permissions_{scanner.source}"
         registry = ir.async_get(hass)
         issue = registry.async_get_issue(bluetooth.DOMAIN, issue_id)
@@ -1807,7 +1803,6 @@ async def test_repair_issue_deleted_when_scanner_not_degraded(
     manager = _get_manager()
     registry = ir.async_get(hass)
 
-    # Create a real HaScanner instance
     scanner = HaScanner(
         mode=BluetoothScanningMode.ACTIVE,
         adapter="hci0",
@@ -1815,7 +1810,6 @@ async def test_repair_issue_deleted_when_scanner_not_degraded(
     )
     scanner.async_setup()
 
-    # Mock adapter details
     mock_adapters = {
         "hci0": {
             "address": "00:11:22:33:44:55",
@@ -1831,7 +1825,6 @@ async def test_repair_issue_deleted_when_scanner_not_degraded(
 
     issue_id = f"bluetooth_adapter_missing_permissions_{scanner.source}"
 
-    # First create the issue by calling on_scanner_start with degraded mode
     with (
         patch("habluetooth.manager.IS_LINUX", True),
         patch.object(type(manager), "is_operating_degraded", return_value=True),
@@ -1843,10 +1836,8 @@ async def test_repair_issue_deleted_when_scanner_not_degraded(
     ):
         manager.on_scanner_start(scanner)
 
-    # Verify it exists
     assert registry.async_get_issue(bluetooth.DOMAIN, issue_id) is not None
 
-    # Now call again with NOT operating in degraded mode
     with (
         patch(
             "homeassistant.components.bluetooth.manager.is_docker_env",

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -1847,7 +1847,6 @@ async def test_repair_issue_deleted_when_scanner_not_degraded(
     ):
         manager.on_scanner_start(scanner)
 
-    # Check that repair issue was deleted
     assert registry.async_get_issue(bluetooth.DOMAIN, issue_id) is None
 
 
@@ -1861,7 +1860,6 @@ async def test_no_repair_issue_when_not_docker(
 
     manager = _get_manager()
 
-    # Create a real HaScanner instance
     scanner = HaScanner(
         mode=BluetoothScanningMode.ACTIVE,
         adapter="hci0",
@@ -1869,7 +1867,6 @@ async def test_no_repair_issue_when_not_docker(
     )
     scanner.async_setup()
 
-    # Mock that we're NOT in Docker but operating in degraded mode
     with (
         patch(
             "homeassistant.components.bluetooth.manager.is_docker_env",
@@ -1879,7 +1876,6 @@ async def test_no_repair_issue_when_not_docker(
     ):
         manager.on_scanner_start(scanner)
 
-        # Check that no repair issue was created
         issue_id = f"bluetooth_adapter_missing_permissions_{scanner.source}"
         registry = ir.async_get(hass)
         assert registry.async_get_issue(bluetooth.DOMAIN, issue_id) is None

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -1891,11 +1891,9 @@ async def test_no_repair_issue_for_remote_scanner(
 
     manager = _get_manager()
 
-    # Create a FakeRemoteScanner instance (not HaScanner)
     connector = HaBluetoothConnector(MockBleakClient, "mock_connector", lambda: False)
     scanner = FakeRemoteScanner("remote_scanner", "esp32", connector, True)
 
-    # Mock that we're in Docker and operating in degraded mode
     with (
         patch(
             "homeassistant.components.bluetooth.manager.is_docker_env",
@@ -1905,9 +1903,7 @@ async def test_no_repair_issue_for_remote_scanner(
     ):
         manager.on_scanner_start(scanner)
 
-        # Check that no repair issue was created (remote scanners are ignored)
         registry = ir.async_get(hass)
-        # Check there are no bluetooth repair issues at all
         issues = [
             issue
             for issue in registry.issues.values()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds repair issue notifications when Bluetooth adapters are operating in degraded mode due to missing container permissions (NET_ADMIN/NET_RAW capabilities). 

When Home Assistant is running in a Docker container (including Supervised installations) without the required permissions, the Bluetooth adapter operates in degraded mode with limited functionality. This change detects this condition using the new `is_operating_degraded()` from callbacks from habluetooth 5.6.0 and creates a repair issue to guide users through adding the necessary permissions.

The repair issue:
- Only appears for Docker-based installations where users can fix permissions (Container, Supervised, third-party containers)
- Includes hardware details (adapter name and model) to help users identify the affected adapter
- Links to documentation with instructions for adding the required permissions
- Automatically clears when the adapter recovers from degraded mode

<img width="600" height="91" alt="Screenshot 2025-09-08 at 6 17 00 PM" src="https://github.com/user-attachments/assets/d14efbd3-99db-45be-8252-cb888f3baddc" />
<img width="543" height="419" alt="Screenshot 2025-09-08 at 6 16 45 PM" src="https://github.com/user-attachments/assets/e640c6ff-b256-4b88-a0bf-a8aa6db4a6c5" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151738
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
