### PR TITLE
Suppress warning if `object_id` is still added when `default_entity_id` is used in MQTT discovery

### DIFF
--- a/homeassistant/components/mqtt/entity.py
+++ b/homeassistant/components/mqtt/entity.py
@@ -1445,7 +1445,7 @@ class MqttEntity(
                     },
                     translation_key="deprecated_object_id",
                 )
-            else:
+            elif CONF_DEFAULT_ENTITY_ID not in self._config:
                 if CONF_ORIGIN in self._config:
                     origin_name = self._config[CONF_ORIGIN][CONF_NAME]
                     url = self._config[CONF_ORIGIN].get(CONF_URL)

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1331,7 +1331,7 @@ async def test_discover_alarm_control_panel(
 
 
 @pytest.mark.parametrize(
-    ("topic", "config", "entity_id", "name", "domain"),
+    ("topic", "config", "entity_id", "name", "domain", "deprecation_warning"),
     [
         (
             "homeassistant/alarm_control_panel/object/bla/config",
@@ -1339,6 +1339,7 @@ async def test_discover_alarm_control_panel(
             "alarm_control_panel.hello_id",
             "Hello World 1",
             "alarm_control_panel",
+            True,
         ),
         (
             "homeassistant/binary_sensor/object/bla/config",
@@ -1346,6 +1347,7 @@ async def test_discover_alarm_control_panel(
             "binary_sensor.hello_id",
             "Hello World 2",
             "binary_sensor",
+            True,
         ),
         (
             "homeassistant/button/object/bla/config",
@@ -1353,6 +1355,7 @@ async def test_discover_alarm_control_panel(
             "button.hello_id",
             "Hello World button",
             "button",
+            True,
         ),
         (
             "homeassistant/camera/object/bla/config",
@@ -1360,6 +1363,7 @@ async def test_discover_alarm_control_panel(
             "camera.hello_id",
             "Hello World 3",
             "camera",
+            True,
         ),
         (
             "homeassistant/climate/object/bla/config",
@@ -1367,6 +1371,7 @@ async def test_discover_alarm_control_panel(
             "climate.hello_id",
             "Hello World 4",
             "climate",
+            True,
         ),
         (
             "homeassistant/cover/object/bla/config",
@@ -1374,6 +1379,7 @@ async def test_discover_alarm_control_panel(
             "cover.hello_id",
             "Hello World 5",
             "cover",
+            True,
         ),
         (
             "homeassistant/fan/object/bla/config",
@@ -1381,6 +1387,7 @@ async def test_discover_alarm_control_panel(
             "fan.hello_id",
             "Hello World 6",
             "fan",
+            True,
         ),
         (
             "homeassistant/humidifier/object/bla/config",
@@ -1388,6 +1395,7 @@ async def test_discover_alarm_control_panel(
             "humidifier.hello_id",
             "Hello World 7",
             "humidifier",
+            True,
         ),
         (
             "homeassistant/number/object/bla/config",
@@ -1395,6 +1403,7 @@ async def test_discover_alarm_control_panel(
             "number.hello_id",
             "Hello World 8",
             "number",
+            True,
         ),
         (
             "homeassistant/scene/object/bla/config",
@@ -1402,6 +1411,7 @@ async def test_discover_alarm_control_panel(
             "scene.hello_id",
             "Hello World 9",
             "scene",
+            True,
         ),
         (
             "homeassistant/select/object/bla/config",
@@ -1409,6 +1419,7 @@ async def test_discover_alarm_control_panel(
             "select.hello_id",
             "Hello World 10",
             "select",
+            True,
         ),
         (
             "homeassistant/sensor/object/bla/config",
@@ -1416,6 +1427,7 @@ async def test_discover_alarm_control_panel(
             "sensor.hello_id",
             "Hello World 11",
             "sensor",
+            True,
         ),
         (
             "homeassistant/switch/object/bla/config",
@@ -1423,6 +1435,7 @@ async def test_discover_alarm_control_panel(
             "switch.hello_id",
             "Hello World 12",
             "switch",
+            True,
         ),
         (
             "homeassistant/light/object/bla/config",
@@ -1430,6 +1443,7 @@ async def test_discover_alarm_control_panel(
             "light.hello_id",
             "Hello World 13",
             "light",
+            True,
         ),
         (
             "homeassistant/light/object/bla/config",
@@ -1437,6 +1451,7 @@ async def test_discover_alarm_control_panel(
             "light.hello_id",
             "Hello World 14",
             "light",
+            True,
         ),
         (
             "homeassistant/light/object/bla/config",
@@ -1444,6 +1459,7 @@ async def test_discover_alarm_control_panel(
             "light.hello_id",
             "Hello World 15",
             "light",
+            True,
         ),
         (
             "homeassistant/vacuum/object/bla/config",
@@ -1451,6 +1467,7 @@ async def test_discover_alarm_control_panel(
             "vacuum.hello_id",
             "Hello World 16",
             "vacuum",
+            True,
         ),
         (
             "homeassistant/valve/object/bla/config",
@@ -1458,6 +1475,7 @@ async def test_discover_alarm_control_panel(
             "valve.hello_id",
             "Hello World 17",
             "valve",
+            True,
         ),
         (
             "homeassistant/lock/object/bla/config",
@@ -1465,6 +1483,7 @@ async def test_discover_alarm_control_panel(
             "lock.hello_id",
             "Hello World 18",
             "lock",
+            True,
         ),
         (
             "homeassistant/device_tracker/object/bla/config",
@@ -1472,6 +1491,7 @@ async def test_discover_alarm_control_panel(
             "device_tracker.hello_id",
             "Hello World 19",
             "device_tracker",
+            True,
         ),
         (
             "homeassistant/binary_sensor/object/bla/config",
@@ -1480,6 +1500,7 @@ async def test_discover_alarm_control_panel(
             "binary_sensor.hello_id",
             "Hello World 2",
             "binary_sensor",
+            True,
         ),
         (
             "homeassistant/button/object/bla/config",
@@ -1489,6 +1510,7 @@ async def test_discover_alarm_control_panel(
             "button.hello_id",
             "Hello World button",
             "button",
+            True,
         ),
         (
             "homeassistant/alarm_control_panel/object/bla/config",
@@ -1497,6 +1519,7 @@ async def test_discover_alarm_control_panel(
             "alarm_control_panel.hello_id",
             "Hello World 1",
             "alarm_control_panel",
+            False,
         ),
         (
             "homeassistant/binary_sensor/object/bla/config",
@@ -1505,6 +1528,7 @@ async def test_discover_alarm_control_panel(
             "binary_sensor.hello_id",
             "Hello World 2",
             "binary_sensor",
+            False,
         ),
         (
             "homeassistant/button/object/bla/config",
@@ -1514,17 +1538,31 @@ async def test_discover_alarm_control_panel(
             "button.hello_id",
             "Hello World button",
             "button",
+            False,
+        ),
+        (
+            "homeassistant/button/object/bla/config",
+            '{ "name": "Hello World button", "def_ent_id": "button.hello_id", '
+            '"obj_id": "hello_id_old", '
+            '"o": {"name": "X2mqtt", "url": "https://example.com/x2mqtt"}, '
+            '"command_topic": "test-topic" }',
+            "button.hello_id",
+            "Hello World button",
+            "button",
+            False,
         ),
     ],
 )
 async def test_discovery_with_object_id(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
     topic: str,
     config: str,
     entity_id: str,
     name: str,
     domain: str,
+    deprecation_warning: bool,
 ) -> None:
     """Test discovering an MQTT entity with object_id."""
     await mqtt_mock_entry()
@@ -1536,6 +1574,11 @@ async def test_discovery_with_object_id(
     assert state is not None
     assert state.name == name
     assert (domain, "object bla") in hass.data["mqtt"].discovery_already_discovered
+
+    assert (
+        f"The configuration for entity {domain}.hello_id uses the deprecated option `object_id`"
+        in caplog.text
+    ) is deprecation_warning
 
 
 async def test_discovery_with_default_entity_id_for_previous_deleted_entity(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As a follow up to https://github.com/home-assistant/core/pull/151775 this PR suppresses the warning that `object_id` is used in a discovery message. The approach is that integrations already can add the new `default_entity_id` option and keep `object_id` for a smooth migration with backward compatibility. As this is preferred, we should not log warnings if `object_id` is still used when the new option `default_entity_id` is added, as it is clear that a migration is in progress.

Cc: @Koenkk 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
