### PR TITLE
Add food dispensed today and next feeding sensors to litterrobot

### DIFF
--- a/homeassistant/components/litterrobot/icons.json
+++ b/homeassistant/components/litterrobot/icons.json
@@ -36,6 +36,9 @@
       }
     },
     "sensor": {
+      "food_dispensed_today": {
+        "default": "mdi:counter"
+      },
       "hopper_status": {
         "default": "mdi:filter",
         "state": {

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -164,6 +164,18 @@ ROBOT_SENSOR_MAP: dict[type[Robot], list[RobotSensorEntityDescription]] = {
     ],
     FeederRobot: [
         RobotSensorEntityDescription[FeederRobot](
+            key="food_dispensed_today",
+            translation_key="food_dispensed_today",
+            state_class=SensorStateClass.TOTAL,
+            native_unit_of_measurement="cups",
+            last_reset_fn=dt_util.start_of_local_day,
+            value_fn=(
+                lambda robot: (
+                    robot.get_food_dispensed_since(dt_util.start_of_local_day())
+                )
+            ),
+        ),
+        RobotSensorEntityDescription[FeederRobot](
             key="food_level",
             translation_key="food_level",
             native_unit_of_measurement=PERCENTAGE,
@@ -180,6 +192,12 @@ ROBOT_SENSOR_MAP: dict[type[Robot], list[RobotSensorEntityDescription]] = {
                     robot.last_feeding["timestamp"] if robot.last_feeding else None
                 )
             ),
+        ),
+        RobotSensorEntityDescription[FeederRobot](
+            key="next_feeding",
+            translation_key="next_feeding",
+            device_class=SensorDeviceClass.TIMESTAMP,
+            value_fn=lambda robot: robot.next_feeding,
         ),
     ],
 }

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -167,7 +167,6 @@ ROBOT_SENSOR_MAP: dict[type[Robot], list[RobotSensorEntityDescription]] = {
             key="food_dispensed_today",
             translation_key="food_dispensed_today",
             state_class=SensorStateClass.TOTAL,
-            native_unit_of_measurement="cups",
             last_reset_fn=dt_util.start_of_local_day,
             value_fn=(
                 lambda robot: (

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -60,7 +60,8 @@
     },
     "sensor": {
       "food_dispensed_today": {
-        "name": "Food dispensed today"
+        "name": "Food dispensed today",
+        "unit_of_measurement": "cups"
       },
       "food_level": {
         "name": "Food level"

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -59,6 +59,9 @@
       }
     },
     "sensor": {
+      "food_dispensed_today": {
+        "name": "Food dispensed today"
+      },
       "food_level": {
         "name": "Food level"
       },
@@ -81,6 +84,9 @@
       },
       "litter_level": {
         "name": "Litter level"
+      },
+      "next_feeding": {
+        "name": "Next feeding"
       },
       "pet_weight": {
         "name": "Pet weight"

--- a/tests/components/litterrobot/common.py
+++ b/tests/components/litterrobot/common.py
@@ -128,6 +128,25 @@ FEEDER_ROBOT_DATA = {
             "mealInsertSize": 1,
         },
         "updated_at": "2022-09-08T15:07:00.000000+00:00",
+        "active_schedule": {
+            "id": "1",
+            "name": "Feeding",
+            "meals": [
+                {
+                    "id": "1",
+                    "days": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+                    "hour": 6,
+                    "name": "Breakfast",
+                    "skip": None,
+                    "minute": 30,
+                    "paused": False,
+                    "portions": 3,
+                    "mealNumber": 1,
+                    "scheduleId": None,
+                }
+            ],
+            "created_at": "2021-12-17T07:07:31.047747+00:00",
+        },
     },
     "feeding_snack": [
         {"timestamp": "2022-09-04T03:03:00.000000+00:00", "amount": 0.125},

--- a/tests/components/litterrobot/test_sensor.py
+++ b/tests/components/litterrobot/test_sensor.py
@@ -104,6 +104,7 @@ async def test_litter_robot_sensor(
     assert sensor.attributes["state_class"] == SensorStateClass.TOTAL_INCREASING
 
 
+@pytest.mark.freeze_time("2022-09-08 19:00:00+00:00")
 async def test_feeder_robot_sensor(
     hass: HomeAssistant, mock_account_with_feederrobot: MagicMock
 ) -> None:
@@ -116,6 +117,16 @@ async def test_feeder_robot_sensor(
     sensor = hass.states.get("sensor.test_last_feeding")
     assert sensor.state == "2022-09-08T18:00:00+00:00"
     assert sensor.attributes["device_class"] == SensorDeviceClass.TIMESTAMP
+
+    sensor = hass.states.get("sensor.test_next_feeding")
+    assert sensor.state == "2022-09-09T12:30:00+00:00"
+    assert sensor.attributes["device_class"] == SensorDeviceClass.TIMESTAMP
+
+    sensor = hass.states.get("sensor.test_food_dispensed_today")
+    assert sensor.state == "0.375"
+    assert sensor.attributes["last_reset"] == "2022-09-08T00:00:00-07:00"
+    assert sensor.attributes["state_class"] == SensorStateClass.TOTAL
+    assert sensor.attributes["unit_of_measurement"] == "cups"
 
 
 async def test_pet_weight_sensor(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40801
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
