### PR TITLE
Only update Music Assistant URL on zeroconf discovery when current URL is unreachable

### DIFF
--- a/homeassistant/components/music_assistant/config_flow.py
+++ b/homeassistant/components/music_assistant/config_flow.py
@@ -68,7 +68,7 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.server_info.server_id, raise_on_progress=False
                 )
                 self._abort_if_unique_id_configured(
-                    updates={CONF_URL: self.server_info.base_url},
+                    updates={CONF_URL: user_input[CONF_URL]},
                     reload_on_update=True,
                 )
             except CannotConnect:
@@ -82,7 +82,7 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=DEFAULT_TITLE,
                     data={
-                        CONF_URL: self.server_info.base_url,
+                        CONF_URL: user_input[CONF_URL],
                     },
                 )
 
@@ -103,14 +103,36 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         # abort if discovery info is not what we expect
         if "server_id" not in discovery_info.properties:
             return self.async_abort(reason="missing_server_id")
-        # abort if we already have exactly this server_id
-        # reload the integration if the host got updated
+
         self.server_info = ServerInfoMessage.from_dict(discovery_info.properties)
         await self.async_set_unique_id(self.server_info.server_id)
-        self._abort_if_unique_id_configured(
-            updates={CONF_URL: self.server_info.base_url},
-            reload_on_update=True,
+
+        # Check if we already have a config entry for this server_id
+        existing_entry = self.hass.config_entries.async_entry_for_domain_unique_id(
+            DOMAIN, self.server_info.server_id
         )
+
+        if existing_entry:
+            # Test connectivity to the current URL first
+            current_url = existing_entry.data[CONF_URL]
+            try:
+                await get_server_info(self.hass, current_url)
+                # Current URL is working, no need to update
+                return self.async_abort(reason="already_configured")
+            except CannotConnect:
+                # Current URL is not working, update to the discovered URL
+                # and continue to discovery confirm
+                self.hass.config_entries.async_update_entry(
+                    existing_entry,
+                    data={**existing_entry.data, CONF_URL: self.server_info.base_url},
+                )
+                # Schedule reload since URL changed
+                self.hass.config_entries.async_schedule_reload(existing_entry.entry_id)
+        else:
+            # No existing entry, proceed with normal flow
+            self._abort_if_unique_id_configured()
+
+        # Test connectivity to the discovered URL
         try:
             await get_server_info(self.hass, self.server_info.base_url)
         except CannotConnect:

--- a/tests/components/music_assistant/test_config_flow.py
+++ b/tests/components/music_assistant/test_config_flow.py
@@ -215,3 +215,150 @@ async def test_flow_zeroconf_connect_issue(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
+
+
+async def test_user_url_different_from_server_base_url(
+    hass: HomeAssistant,
+    mock_get_server_info: AsyncMock,
+) -> None:
+    """Test that user-provided URL is used even when different from server base_url."""
+    # Mock server info with a different base_url than what user will provide
+    server_info = ServerInfoMessage.from_json(
+        await async_load_fixture(hass, "server_info_message.json", DOMAIN)
+    )
+    server_info.base_url = "http://different-server:8095"
+    mock_get_server_info.return_value = server_info
+
+    user_url = "http://user-provided-server:8095"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_URL: user_url},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+    # Verify that the user-provided URL is stored, not the server's base_url
+    assert result["data"] == {
+        CONF_URL: user_url,
+    }
+    assert result["result"].unique_id == "1234"
+
+
+async def test_duplicate_user_with_different_urls(
+    hass: HomeAssistant,
+    mock_get_server_info: AsyncMock,
+) -> None:
+    """Test duplicate detection works with different user URLs."""
+    # Set up existing config entry with one URL
+    existing_url = "http://existing-server:8095"
+    existing_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Music Assistant",
+        data={CONF_URL: existing_url},
+        unique_id="1234",
+    )
+    existing_config_entry.add_to_hass(hass)
+
+    # Mock server info with different base_url
+    server_info = ServerInfoMessage.from_json(
+        await async_load_fixture(hass, "server_info_message.json", DOMAIN)
+    )
+    server_info.base_url = "http://server-reported-url:8095"
+    mock_get_server_info.return_value = server_info
+
+    # Try to configure with a different user URL but same server_id
+    new_user_url = "http://new-user-url:8095"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_URL: new_user_url},
+    )
+    await hass.async_block_till_done()
+
+    # Should detect as duplicate because server_id is the same
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_existing_entry_working_url(
+    hass: HomeAssistant,
+    mock_get_server_info: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test zeroconf flow when existing entry has working URL."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Mock server info with different base_url
+    server_info = ServerInfoMessage.from_json(
+        await async_load_fixture(hass, "server_info_message.json", DOMAIN)
+    )
+    server_info.base_url = "http://different-discovered-url:8095"
+    mock_get_server_info.return_value = server_info
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DATA,
+    )
+    await hass.async_block_till_done()
+
+    # Should abort because current URL is working
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    # Verify the URL was not changed
+    assert mock_config_entry.data[CONF_URL] == "http://localhost:8095"
+
+
+async def test_zeroconf_existing_entry_broken_url(
+    hass: HomeAssistant,
+    mock_get_server_info: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test zeroconf flow when existing entry has broken URL."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Create modified zeroconf data with different base_url
+    modified_zeroconf_data = deepcopy(ZEROCONF_DATA)
+    modified_zeroconf_data.properties["base_url"] = "http://discovered-working-url:8095"
+
+    # Mock server info with the discovered URL
+    server_info = ServerInfoMessage.from_json(
+        await async_load_fixture(hass, "server_info_message.json", DOMAIN)
+    )
+    server_info.base_url = "http://discovered-working-url:8095"
+    mock_get_server_info.return_value = server_info
+
+    # First call (testing current URL) should fail, second call (testing discovered URL) should succeed
+    mock_get_server_info.side_effect = [
+        CannotConnect("cannot_connect"),  # Current URL fails
+        server_info,  # Discovered URL works
+    ]
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=modified_zeroconf_data,
+    )
+    await hass.async_block_till_done()
+
+    # Should proceed to discovery confirm because current URL is broken
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+    # Verify the URL was updated in the config entry
+    updated_entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert updated_entry.data[CONF_URL] == "http://discovered-working-url:8095"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Previously, the zeroconf discovery flow would automatically update the config entry URL whenever a different URL was discovered for the same server, even if the current URL was still working. This caused unnecessary reloads and potential disruption to the user experience. It also completely broke things in situations where the Music Assistant set "base url" was not accessible to Home Assistant but the user provided url was.

Changes:
- Test connectivity to current URL before updating on zeroconf discovery
- Only update URL and schedule reload when current URL is unreachable
- Proceed to discovery confirm step when URL update is needed
- Maintain existing behavior for new server discoveries

This improves stability by preventing unnecessary URL changes while still providing automatic recovery when the current connection becomes unavailable.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/orgs/music-assistant/discussions/4229
- This PR is related to issue: 
- Link to documentation pull request:  N/A
- Link to developer documentation pull request:  N/A
- Link to frontend pull request:  N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
