### PR TITLE
Only use media path for TTS stream override

### DIFF
--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -43,7 +43,6 @@ from .common import (
 )
 
 from tests.common import MockModule, async_mock_service, mock_integration, mock_platform
-from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 ORIG_WRITE_TAGS = tts.SpeechManager.write_tags
@@ -2070,9 +2069,7 @@ async def test_async_internal_get_tts_audio_called(
 
 
 async def test_stream_override(
-    hass: HomeAssistant,
-    mock_tts_entity: MockTTSEntity,
-    aioclient_mock: AiohttpClientMocker,
+    hass: HomeAssistant, mock_tts_entity: MockTTSEntity
 ) -> None:
     """Test overriding streams with a media id."""
     await mock_config_entry_setup(hass, mock_tts_entity)
@@ -2081,16 +2078,36 @@ async def test_stream_override(
     stream.async_set_message("beer")
     stream.async_override_result("test-media-id")
 
-    url = "http://www.home-assistant.io/resolved.mp3"
-    test_data = b"override-data"
-    aioclient_mock.get(url, content=test_data)
+    # Use a temp file here since ffmpeg will read it directly
+    with tempfile.NamedTemporaryFile(mode="wb+", suffix=".wav") as wav_file:
+        with wave.open(wav_file, "wb") as wav_writer:
+            wav_writer.setframerate(16000)
+            wav_writer.setsampwidth(2)
+            wav_writer.setnchannels(1)
+            wav_writer.writeframes(bytes(16000 * 2))  # 1 second @ 16Khz/mono
 
-    with patch(
-        "homeassistant.components.tts.async_resolve_media",
-        return_value=media_source.PlayMedia(url=url, mime_type="audio/mp3"),
-    ):
-        result_data = b"".join([chunk async for chunk in stream.async_stream_result()])
-        assert result_data == test_data
+        wav_file.seek(0)
+
+        url = f"file://{wav_file.name}"
+        with (
+            patch("homeassistant.components.tts.is_media_source_id", return_value=True),
+            patch(
+                "homeassistant.components.tts.async_resolve_media",
+                return_value=media_source.PlayMedia(url=url, mime_type="audio/wav"),
+            ),
+        ):
+            result_data = b"".join(
+                [chunk async for chunk in stream.async_stream_result()]
+            )
+
+    # Verify the result
+    with io.BytesIO(result_data) as wav_io, wave.open(wav_io, "rb") as wav_reader:
+        assert wav_reader.getframerate() == 16000
+        assert wav_reader.getsampwidth() == 2
+        assert wav_reader.getnchannels() == 1
+        assert wav_reader.readframes(wav_reader.getnframes()) == bytes(
+            16000 * 2
+        )  # 1 second @ 16Khz/mono
 
 
 async def test_stream_override_with_conversion(
@@ -2110,7 +2127,6 @@ async def test_stream_override_with_conversion(
         },
     )
     stream.async_set_message("beer")
-    stream.async_override_result("test-media-id")
 
     # Use a temp file here since ffmpeg will read it directly
     with tempfile.NamedTemporaryFile(mode="wb+", suffix=".wav") as wav_file:
@@ -2121,17 +2137,10 @@ async def test_stream_override_with_conversion(
             wav_writer.writeframes(bytes(16000 * 2))  # 1 second @ 16Khz/mono
 
         wav_file.seek(0)
+        stream.async_override_result(f"file://{wav_file.name}")
+        result_data = b"".join([chunk async for chunk in stream.async_stream_result()])
 
-        url = f"file://{wav_file.name}"
-        with patch(
-            "homeassistant.components.tts.async_resolve_media",
-            return_value=media_source.PlayMedia(url=url, mime_type="audio/wav"),
-        ):
-            result_data = b"".join(
-                [chunk async for chunk in stream.async_stream_result()]
-            )
-
-    # Verify the preferred format
+    # Verify the result has the preferred format
     with io.BytesIO(result_data) as wav_io, wave.open(wav_io, "rb") as wav_reader:
         assert wav_reader.getframerate() == 22050
         assert wav_reader.getsampwidth() == 2
@@ -2166,19 +2175,22 @@ async def test_stream_override_with_conversion_path_preferred(
         wav_file.seek(0)
 
         # Path is preferred over URL
-        with patch(
-            "homeassistant.components.tts.async_resolve_media",
-            return_value=media_source.PlayMedia(
-                path=Path(wav_file.name),
-                url="http://bad-url.com",
-                mime_type="audio/wav",
+        with (
+            patch("homeassistant.components.tts.is_media_source_id", return_value=True),
+            patch(
+                "homeassistant.components.tts.async_resolve_media",
+                return_value=media_source.PlayMedia(
+                    path=Path(wav_file.name),
+                    url="http://bad-url.com",
+                    mime_type="audio/wav",
+                ),
             ),
         ):
             result_data = b"".join(
                 [chunk async for chunk in stream.async_stream_result()]
             )
 
-    # Verify the preferred format
+    # Verify the result
     with io.BytesIO(result_data) as wav_io, wave.open(wav_io, "rb") as wav_reader:
         assert wav_reader.getframerate() == 16000
         assert wav_reader.getsampwidth() == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify TTS result stream overrides by only allowing a media path instead of media id. This avoids having to resolve and possibly fetch media from a URL.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
