### PR TITLE
Fix HomeKit Controller stale values at startup

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -20,7 +20,12 @@ from aiohomekit.exceptions import (
     EncryptionError,
 )
 from aiohomekit.model import Accessories, Accessory, Transport
-from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
+from aiohomekit.model.characteristics import (
+    EVENT_CHARACTERISTICS,
+    Characteristic,
+    CharacteristicPermissions,
+    CharacteristicsTypes,
+)
 from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.components.thread import async_get_preferred_dataset
@@ -179,6 +184,21 @@ class HKDevice:
         for aid_iid in characteristics:
             self.pollable_characteristics.discard(aid_iid)
 
+    def get_all_pollable_characteristics(self) -> set[tuple[int, int]]:
+        """Get all characteristics that can be polled.
+
+        This is used during startup to poll all readable characteristics
+        before entities have registered what they care about.
+        """
+        return {
+            (accessory.aid, char.iid)
+            for accessory in self.entity_map.accessories
+            for service in accessory.services
+            for char in service.characteristics
+            if CharacteristicPermissions.paired_read in char.perms
+            and char.type not in EVENT_CHARACTERISTICS
+        }
+
     def add_watchable_characteristics(
         self, characteristics: list[tuple[int, int]]
     ) -> None:
@@ -309,9 +329,13 @@ class HKDevice:
         await self.async_process_entity_map()
 
         if transport != Transport.BLE:
-            # Do a single poll to make sure the chars are
-            # up to date so we don't restore old data.
-            await self.async_update()
+            # When Home Assistant starts, we restore the accessory map from storage
+            # which contains characteristic values from when HA was last running.
+            # These values are stale and may be incorrect (e.g., Ecobee thermostats
+            # report 100°C when restarting). We need to poll for fresh values before
+            # creating entities. Use poll_all=True since entities haven't registered
+            # their characteristics yet.
+            await self.async_update(poll_all=True)
             self._async_start_polling()
 
         # If everything is up to date, we can create the entities
@@ -863,9 +887,23 @@ class HKDevice:
         """Request an debounced update from the accessory."""
         await self._debounced_update.async_call()
 
-    async def async_update(self, now: datetime | None = None) -> None:
-        """Poll state of all entities attached to this bridge/accessory."""
-        to_poll = self.pollable_characteristics
+    async def async_update(
+        self, now: datetime | None = None, *, poll_all: bool = False
+    ) -> None:
+        """Poll state of all entities attached to this bridge/accessory.
+
+        Args:
+            now: The current time (used by time interval callbacks).
+            poll_all: If True, poll all readable characteristics instead of just the registered ones.
+                     This is useful during initial setup before entities have registered their characteristics.
+        """
+        if poll_all:
+            # Poll all readable characteristics during initial startup
+            # excluding device trigger characteristics (buttons, doorbell, etc.)
+            to_poll = self.get_all_pollable_characteristics()
+        else:
+            to_poll = self.pollable_characteristics
+
         if not to_poll:
             self.async_update_available_state()
             _LOGGER.debug(

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -894,8 +894,10 @@ class HKDevice:
 
         Args:
             now: The current time (used by time interval callbacks).
-            poll_all: If True, poll all readable characteristics instead of just the registered ones.
-                     This is useful during initial setup before entities have registered their characteristics.
+            poll_all: If True, poll all readable characteristics instead
+                     of just the registered ones.
+                     This is useful during initial setup before entities have
+                     registered their characteristics.
         """
         if poll_all:
             # Poll all readable characteristics during initial startup

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -470,7 +470,7 @@ async def test_poll_all_on_startup_refreshes_stale_values(
     # Track what gets polled during setup
     polled_chars: list[tuple[int, int]] = []
 
-    # Setup the test accessories
+    # Set up the test accessories
     fake_controller = await setup_platform(hass)
 
     # Mock get_characteristics to track polling and return fresh temperature

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 import dataclasses
+from typing import Any
 from unittest import mock
 
 from aiohomekit.controller import TransportType
@@ -11,6 +12,7 @@ from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.testing import FakeController
 import pytest
 
+from homeassistant.components.climate import ATTR_CURRENT_TEMPERATURE
 from homeassistant.components.homekit_controller.const import (
     DEBOUNCE_COOLDOWN,
     DOMAIN,
@@ -439,3 +441,88 @@ async def test_manual_poll_all_chars(
         await time_changed(hass, DEBOUNCE_COOLDOWN)
         await hass.async_block_till_done()
         assert len(mock_get_characteristics.call_args_list[0][0][0]) > 1
+
+
+async def test_poll_all_on_startup_refreshes_stale_values(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Test that entities get fresh values on startup instead of stale stored values."""
+    # Load actual Ecobee accessory fixture
+    accessories = await setup_accessories_from_file(hass, "ecobee3.json")
+
+    # Pre-populate storage with the accessories data (already has stale values)
+    hass_storage["homekit_controller-entity-map"] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": "homekit_controller-entity-map",
+        "data": {
+            "pairings": {
+                "00:00:00:00:00:00": {
+                    "config_num": 1,
+                    "accessories": [
+                        a.to_accessory_and_service_list() for a in accessories
+                    ],
+                }
+            }
+        },
+    }
+
+    # Track what gets polled during setup
+    polled_chars: list[tuple[int, int]] = []
+
+    # Setup the test accessories
+    fake_controller = await setup_platform(hass)
+
+    # Mock get_characteristics to track polling and return fresh temperature
+    async def mock_get_characteristics(
+        chars: set[tuple[int, int]], **kwargs: Any
+    ) -> dict[tuple[int, int], dict[str, Any]]:
+        """Return fresh temperature value when polled."""
+        polled_chars.extend(chars)
+        # Return fresh values for all characteristics
+        result: dict[tuple[int, int], dict[str, Any]] = {}
+        for aid, iid in chars:
+            # Find the characteristic and return appropriate value
+            for accessory in accessories:
+                if accessory.aid != aid:
+                    continue
+                for service in accessory.services:
+                    for char in service.characteristics:
+                        if char.iid != iid:
+                            continue
+                        # Return fresh temperature instead of stale fixture value
+                        if char.type == CharacteristicsTypes.TEMPERATURE_CURRENT:
+                            result[(aid, iid)] = {"value": 22.5}  # Fresh value
+                        else:
+                            result[(aid, iid)] = {"value": char.value}
+                        break
+        return result
+
+    # Add the paired device with our mock
+    await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
+    config_entry = MockConfigEntry(
+        version=1,
+        domain="homekit_controller",
+        entry_id="TestData",
+        data={"AccessoryPairingID": "00:00:00:00:00:00"},
+        title="test",
+    )
+    config_entry.add_to_hass(hass)
+
+    # Get the pairing and patch its get_characteristics
+    pairing = fake_controller.pairings["00:00:00:00:00:00"]
+
+    with mock.patch.object(pairing, "get_characteristics", mock_get_characteristics):
+        # Setup the config entry (this should trigger poll_all=True)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Verify that polling happened during setup (poll_all=True was used)
+    assert (
+        len(polled_chars) == 79
+    )  # The Ecobee fixture has exactly 79 readable characteristics
+
+    # Check that the climate entity has the fresh temperature (22.5°C) not the stale fixture value (21.8°C)
+    state = hass.states.get("climate.homew")
+    assert state is not None
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 22.5

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -513,7 +513,7 @@ async def test_poll_all_on_startup_refreshes_stale_values(
     pairing = fake_controller.pairings["00:00:00:00:00:00"]
 
     with mock.patch.object(pairing, "get_characteristics", mock_get_characteristics):
-        # Setup the config entry (this should trigger poll_all=True)
+        # Set up the config entry (this should trigger poll_all=True)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix HomeKit Controller entities showing stale values at startup.

When Home Assistant restarts, HomeKit Controller entities briefly show stale cached values from storage before the first poll updates them. This causes issues like Eve Energy Strip devices showing incorrect energy readings at startup (e.g., "622 kWh in one minute").

PR #151087 (commit ede948c2772c5620ac1f56c0172056466aed6017) fixed some cases where stale values were being saved to storage, but didn't fix the startup issue because `self.pollable_characteristics` was empty - entities hadn't registered their characteristics yet.

This PR properly fixes the issue by:
- Adding `poll_all` parameter to poll all readable characteristics before entities are created
- Creating `get_all_pollable_characteristics()` helper to identify all pollable characteristics
- Calling `async_update(poll_all=True)` during startup to refresh stale values

Now entities display fresh values immediately at startup instead of briefly showing stale cached data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #134288
- This PR is related to issue: Followup to #151087 which fixed some stale value storage but didn't address the startup display issue. Note: This won't fix issue #139797 (Ecobee 100°C) as that's a firmware bug where the device itself reports incorrect values after it reboots.
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr