### PR TITLE
Fix duplicated IP port usage in Govee Light Local

### DIFF
--- a/homeassistant/components/govee_light_local/__init__.py
+++ b/homeassistant/components/govee_light_local/__init__.py
@@ -26,16 +26,11 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: GoveeLocalConfigEntry) -> bool:
     """Set up Govee light local from a config entry."""
 
-    # Get source IPs for all enabled adapters
-    source_ips = await network.async_get_enabled_source_ips(hass)
+    source_ips = await async_get_source_ips(hass)
     _LOGGER.debug("Enabled source IPs: %s", source_ips)
 
     coordinator: GoveeLocalApiCoordinator = GoveeLocalApiCoordinator(
-        hass=hass,
-        config_entry=entry,
-        source_ips=[
-            source_ip for source_ip in source_ips if isinstance(source_ip, IPv4Address)
-        ],
+        hass=hass, config_entry=entry, source_ips=source_ips
     )
 
     async def await_cleanup():
@@ -76,3 +71,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoveeLocalConfigEntry) -
 async def async_unload_entry(hass: HomeAssistant, entry: GoveeLocalConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_get_source_ips(
+    hass: HomeAssistant,
+) -> set[str]:
+    """Get the source ips for Govee local."""
+    source_ips = await network.async_get_enabled_source_ips(hass)
+    return {
+        str(source_ip) for source_ip in source_ips if isinstance(source_ip, IPv4Address)
+    }

--- a/homeassistant/components/govee_light_local/config_flow.py
+++ b/homeassistant/components/govee_light_local/config_flow.py
@@ -4,15 +4,14 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from ipaddress import IPv4Address
 import logging
 
 from govee_local_api import GoveeController
 
-from homeassistant.components import network
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 
+from . import async_get_source_ips
 from .const import (
     CONF_LISTENING_PORT_DEFAULT,
     CONF_MULTICAST_ADDRESS_DEFAULT,
@@ -24,11 +23,11 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def _async_discover(hass: HomeAssistant, adapter_ip: IPv4Address) -> bool:
+async def _async_discover(hass: HomeAssistant, adapter_ip: str) -> bool:
     controller: GoveeController = GoveeController(
         loop=hass.loop,
         logger=_LOGGER,
-        listening_address=str(adapter_ip),
+        listening_address=adapter_ip,
         broadcast_address=CONF_MULTICAST_ADDRESS_DEFAULT,
         broadcast_port=CONF_TARGET_PORT_DEFAULT,
         listening_port=CONF_LISTENING_PORT_DEFAULT,
@@ -62,14 +61,8 @@ async def _async_discover(hass: HomeAssistant, adapter_ip: IPv4Address) -> bool:
 async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if there are devices that can be discovered."""
 
-    # Get source IPs for all enabled adapters
-    source_ips = await network.async_get_enabled_source_ips(hass)
-    _LOGGER.debug("Enabled source IPs: %s", source_ips)
-
-    # Run discovery on every IPv4 address and gather results
-    results = await asyncio.gather(
-        *[_async_discover(hass, ip) for ip in source_ips if isinstance(ip, IPv4Address)]
-    )
+    source_ips = await async_get_source_ips(hass)
+    results = await asyncio.gather(*[_async_discover(hass, ip) for ip in source_ips])
 
     return any(results)
 

--- a/homeassistant/components/govee_light_local/coordinator.py
+++ b/homeassistant/components/govee_light_local/coordinator.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from collections.abc import Callable
-from ipaddress import IPv4Address
 import logging
 
 from govee_local_api import GoveeController, GoveeDevice
@@ -30,7 +29,7 @@ class GoveeLocalApiCoordinator(DataUpdateCoordinator[list[GoveeDevice]]):
         self,
         hass: HomeAssistant,
         config_entry: GoveeLocalConfigEntry,
-        source_ips: list[IPv4Address],
+        source_ips: set[str],
     ) -> None:
         """Initialize my coordinator."""
         super().__init__(
@@ -45,7 +44,7 @@ class GoveeLocalApiCoordinator(DataUpdateCoordinator[list[GoveeDevice]]):
             GoveeController(
                 loop=hass.loop,
                 logger=_LOGGER,
-                listening_address=str(source_ip),
+                listening_address=source_ip,
                 broadcast_address=CONF_MULTICAST_ADDRESS_DEFAULT,
                 broadcast_port=CONF_TARGET_PORT_DEFAULT,
                 listening_port=CONF_LISTENING_PORT_DEFAULT,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In some setups the same IP could be listed by multiple interfaces. That would cause the integration to create multiple controllers for the same IP which in turn would try to use the same port on the same IP, making it fail.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151732
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
