### PR TITLE
Fix DoorBird being updated with wrong IP addresses during discovery

### DIFF
--- a/homeassistant/components/doorbird/config_flow.py
+++ b/homeassistant/components/doorbird/config_flow.py
@@ -114,7 +114,7 @@ class DoorBirdConfigFlow(ConfigFlow, domain=DOMAIN):
         """Verify discovered device matches existing entry before updating IP.
 
         This method performs the following verification steps:
-        1. Ensures that the provided credentials work before updating the entry.
+        1. Ensures that the stored credentials work before updating the entry.
         2. Verifies that the device at the discovered IP address has the expected MAC address.
         """
         info, errors = await self._async_validate_or_error(

--- a/homeassistant/components/doorbird/config_flow.py
+++ b/homeassistant/components/doorbird/config_flow.py
@@ -111,10 +111,14 @@ class DoorBirdConfigFlow(ConfigFlow, domain=DOMAIN):
         host: str,
         macaddress: str,
     ) -> None:
-        """Verify discovered device matches existing entry before updating IP."""
-        # Check if the host is actually changing
-        # Verify the device at the discovered IP actually has this MAC
-        # and that our credentials work before updating
+        """
+        Verify discovered device matches existing entry before updating IP.
+
+        This method performs the following verification steps:
+        1. Checks if the host is actually changing.
+        2. Verifies that the device at the discovered IP address has the expected MAC address.
+        3. Ensures that the provided credentials work before updating the entry.
+        """
         info, errors = await self._async_validate_or_error(
             {
                 **existing_entry.data,

--- a/homeassistant/components/doorbird/config_flow.py
+++ b/homeassistant/components/doorbird/config_flow.py
@@ -111,8 +111,7 @@ class DoorBirdConfigFlow(ConfigFlow, domain=DOMAIN):
         host: str,
         macaddress: str,
     ) -> None:
-        """
-        Verify discovered device matches existing entry before updating IP.
+        """Verify discovered device matches existing entry before updating IP.
 
         This method performs the following verification steps:
         1. Checks if the host is actually changing.

--- a/homeassistant/components/doorbird/config_flow.py
+++ b/homeassistant/components/doorbird/config_flow.py
@@ -114,9 +114,8 @@ class DoorBirdConfigFlow(ConfigFlow, domain=DOMAIN):
         """Verify discovered device matches existing entry before updating IP.
 
         This method performs the following verification steps:
-        1. Checks if the host is actually changing.
+        1. Ensures that the provided credentials work before updating the entry.
         2. Verifies that the device at the discovered IP address has the expected MAC address.
-        3. Ensures that the provided credentials work before updating the entry.
         """
         info, errors = await self._async_validate_or_error(
             {

--- a/homeassistant/components/doorbird/strings.json
+++ b/homeassistant/components/doorbird/strings.json
@@ -49,6 +49,8 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "link_local_address": "Link local addresses are not supported",
       "not_doorbird_device": "This device is not a DoorBird",
+      "not_ipv4_address": "Only IPv4 addresses are supported",
+      "wrong_device": "Device MAC address does not match",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "flow_title": "{name} ({host})",

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -108,7 +108,9 @@ async def test_form_zeroconf_link_local_ignored(hass: HomeAssistant) -> None:
     assert result["reason"] == "link_local_address"
 
 
-async def test_form_zeroconf_ipv4_address(hass: HomeAssistant) -> None:
+async def test_form_zeroconf_ipv4_address(
+    hass: HomeAssistant, doorbird_api: DoorBird
+) -> None:
     """Test we abort and update the ip address from zeroconf with an ipv4 address."""
 
     config_entry = MockConfigEntry(
@@ -118,6 +120,13 @@ async def test_form_zeroconf_ipv4_address(hass: HomeAssistant) -> None:
         options={CONF_EVENTS: ["event1", "event2", "event3"]},
     )
     config_entry.add_to_hass(hass)
+
+    # Mock the API to return the correct MAC when validating
+    doorbird_api.info.return_value = {
+        "PRIMARY_MAC_ADDR": "1CCAE3AAAAAA",
+        "WIFI_MAC_ADDR": "1CCAE3BBBBBB",
+    }
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
@@ -134,6 +143,79 @@ async def test_form_zeroconf_ipv4_address(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_HOST] == "4.4.4.4"
+
+
+async def test_form_zeroconf_ipv4_address_wrong_device(
+    hass: HomeAssistant, doorbird_api: DoorBird
+) -> None:
+    """Test we abort when the device MAC doesn't match during zeroconf update."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1CCAE3AAAAAA",
+        data=VALID_CONFIG,
+        options={CONF_EVENTS: ["event1", "event2", "event3"]},
+    )
+    config_entry.add_to_hass(hass)
+
+    # Mock the API to return a different MAC (wrong device)
+    doorbird_api.info.return_value = {
+        "PRIMARY_MAC_ADDR": "1CCAE3DIFFERENT",  # Different MAC!
+        "WIFI_MAC_ADDR": "1CCAE3BBBBBB",
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=ZeroconfServiceInfo(
+            ip_address=ip_address("4.4.4.4"),
+            ip_addresses=[ip_address("4.4.4.4")],
+            hostname="mock_hostname",
+            name="Doorstation - abc123._axis-video._tcp.local.",
+            port=None,
+            properties={"macaddress": "1CCAE3AAAAAA"},
+            type="mock_type",
+        ),
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+    # Host should not be updated since it's the wrong device
+    assert config_entry.data[CONF_HOST] == "1.2.3.4"
+
+
+async def test_form_zeroconf_ipv4_address_cannot_connect(
+    hass: HomeAssistant, doorbird_api: DoorBird
+) -> None:
+    """Test we abort when we cannot connect to validate during zeroconf update."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1CCAE3AAAAAA",
+        data=VALID_CONFIG,
+        options={CONF_EVENTS: ["event1", "event2", "event3"]},
+    )
+    config_entry.add_to_hass(hass)
+
+    # Mock the API to fail connection (e.g., wrong credentials or network error)
+    doorbird_api.info.side_effect = mock_unauthorized_exception()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=ZeroconfServiceInfo(
+            ip_address=ip_address("4.4.4.4"),
+            ip_addresses=[ip_address("4.4.4.4")],
+            hostname="mock_hostname",
+            name="Doorstation - abc123._axis-video._tcp.local.",
+            port=None,
+            properties={"macaddress": "1CCAE3AAAAAA"},
+            type="mock_type",
+        ),
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    # Host should not be updated since we couldn't validate
+    assert config_entry.data[CONF_HOST] == "1.2.3.4"
 
 
 async def test_form_zeroconf_non_ipv4_ignored(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where DoorBird config entries could be incorrectly updated with the wrong device's IP address during zeroconf discovery, causing authentication failures.

While zeroconf discovery typically provides reliable device information that we can trust for IP updates, some DoorBird devices appear to have issues where the advertised information doesn't match the actual device at the discovered IP address. This is particularly problematic when multiple DoorBird devices are present on the same network. 

**Note:** This issue appears to be device-specific and cannot be reproduced with all DoorBird devices, even with multiple units on the same network. However, since IP address changes are relatively rare events and the added verification overhead is minimal, this PR adds an extra safety check to make this problem impossible.

The PR adds verification before updating a config entry's IP address:
1. Verify the device at the new IP can be reached with existing credentials
2. Confirm the device's MAC address matches what zeroconf advertised

The verification only runs when an IP address change is detected, making the overhead negligible while completely preventing config entry cross-contamination between multiple DoorBird devices.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #136894
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

## Details

### What was happening
Users with multiple DoorBird devices on their network were experiencing random authentication failures after upgrading to Home Assistant 2025.1. Investigation revealed that config entries were being updated with incorrect IP addresses - Device A's entry would end up with Device B's IP address.

### Root cause
During zeroconf discovery, when a DoorBird device is found, the integration would update the existing config entry's IP address based on the MAC address advertised via zeroconf. However, in some network configurations or with certain DoorBird device combinations, the zeroconf advertisement doesn't reliably correspond to the actual device at the discovered IP. This appears to be a device firmware or network configuration issue specific to certain DoorBird installations.

### The fix
Added a verification step (`_async_verify_existing_device_for_discovery`) that:
- Only runs when the IP address is actually changing (optimization)
- Attempts to connect to the device with existing credentials
- Verifies the device's reported MAC matches the advertised MAC
- Uses `format_mac()` for consistent MAC address comparison
- Aborts the update if verification fails

Since IP changes are infrequent (typically only during DHCP lease renewals or network reconfiguration), this additional API call has negligible performance impact while providing robust protection against the reported issue.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr