### PR TITLE
Cache apt install [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -552,6 +552,7 @@ jobs:
             bluez \
             ffmpeg \
             libturbojpeg \
+            libxml2-utils \
             libavcodec-dev \
             libavdevice-dev \
             libavfilter-dev \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,9 @@ env:
   POSTGRESQL_VERSIONS: "['postgres:12.14','postgres:15.2']"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   UV_CACHE_DIR: /tmp/uv-cache
+  APT_CACHE_BASE: /home/runner/work/apt
+  APT_CACHE_DIR: /home/runner/work/apt/cache
+  APT_LIST_CACHE_DIR: /home/runner/work/apt/lists
   SQLALCHEMY_WARN_20: 1
   PYTHONASYNCIODEBUG: 1
   HASS_CI: 1
@@ -78,6 +81,7 @@ jobs:
       core: ${{ steps.core.outputs.changes }}
       integrations_glob: ${{ steps.info.outputs.integrations_glob }}
       integrations: ${{ steps.integrations.outputs.changes }}
+      apt_cache_key: ${{ steps.generate_apt_cache_key.outputs.key }}
       pre-commit_cache_key: ${{ steps.generate_pre-commit_cache_key.outputs.key }}
       python_cache_key: ${{ steps.generate_python_cache_key.outputs.key }}
       requirements: ${{ steps.core.outputs.requirements }}
@@ -111,6 +115,10 @@ jobs:
         run: >-
           echo "key=pre-commit-${{ env.CACHE_VERSION }}-${{
             hashFiles('.pre-commit-config.yaml') }}"  >> $GITHUB_OUTPUT
+      - name: Generate partial apt restore key
+        id: generate_apt_cache_key
+        run: |
+          echo "key=$(lsb_release -rs)-apt-${{ env.CACHE_VERSION }}-${{ env.HA_SHORT_VERSION }}" >> $GITHUB_OUTPUT
       - name: Filter for core changes
         uses: dorny/paths-filter@v3.0.2
         id: core
@@ -515,13 +523,32 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-${{ steps.python.outputs.python-version }}-uv-${{
             env.UV_CACHE_VERSION }}-${{ steps.generate-uv-key.outputs.version }}-${{
             env.HA_SHORT_VERSION }}-
+      - name: Restore apt cache
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        id: cache-apt
+        uses: actions/cache@v4.2.4
+        with:
+          path: |
+            ${{ env.APT_CACHE_DIR }}
+            ${{ env.APT_LIST_CACHE_DIR }}
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
+          if [[ "${{ steps.cache-apt.outputs.cache-hit }}" != 'true' ]]; then
+            mkdir -p ${{ env.APT_CACHE_DIR }}
+            mkdir -p ${{ env.APT_LIST_CACHE_DIR }}
+          fi
+
+          sudo apt-get update \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }}
           sudo apt-get -y install \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }} \
             bluez \
             ffmpeg \
             libturbojpeg \
@@ -534,6 +561,10 @@ jobs:
             libswresample-dev \
             libswscale-dev \
             libudev-dev
+
+          if [[ "${{ steps.cache-apt.outputs.cache-hit }}" != 'true' ]]; then
+            sudo chmod -R 755 ${{ env.APT_CACHE_BASE }}
+          fi
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -578,12 +609,25 @@ jobs:
       - info
       - base
     steps:
+      - name: Restore apt cache
+        uses: actions/cache/restore@v4.2.4
+        with:
+          path: |
+            ${{ env.APT_CACHE_DIR }}
+            ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
+          sudo apt-get update \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }}
           sudo apt-get -y install \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }} \
             libturbojpeg
       - name: Check out code from GitHub
         uses: actions/checkout@v5.0.0
@@ -878,12 +922,25 @@ jobs:
       - mypy
     name: Split tests for full run
     steps:
+      - name: Restore apt cache
+        uses: actions/cache/restore@v4.2.4
+        with:
+          path: |
+            ${{ env.APT_CACHE_DIR }}
+            ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
+          sudo apt-get update \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }}
           sudo apt-get -y install \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }} \
             bluez \
             ffmpeg \
             libturbojpeg \
@@ -939,12 +996,25 @@ jobs:
     name: >-
       Run tests Python ${{ matrix.python-version }} (${{ matrix.group }})
     steps:
+      - name: Restore apt cache
+        uses: actions/cache/restore@v4.2.4
+        with:
+          path: |
+            ${{ env.APT_CACHE_DIR }}
+            ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
+          sudo apt-get update \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }}
           sudo apt-get -y install \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }} \
             bluez \
             ffmpeg \
             libturbojpeg \
@@ -1073,12 +1143,25 @@ jobs:
     name: >-
       Run ${{ matrix.mariadb-group }} tests Python ${{ matrix.python-version }}
     steps:
+      - name: Restore apt cache
+        uses: actions/cache/restore@v4.2.4
+        with:
+          path: |
+            ${{ env.APT_CACHE_DIR }}
+            ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
+          sudo apt-get update \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }}
           sudo apt-get -y install \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }} \
             bluez \
             ffmpeg \
             libturbojpeg \
@@ -1214,12 +1297,25 @@ jobs:
     name: >-
       Run ${{ matrix.postgresql-group }} tests Python ${{ matrix.python-version }}
     steps:
+      - name: Restore apt cache
+        uses: actions/cache/restore@v4.2.4
+        with:
+          path: |
+            ${{ env.APT_CACHE_DIR }}
+            ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
+          sudo apt-get update \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }}
           sudo apt-get -y install \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }} \
             bluez \
             ffmpeg \
             libturbojpeg \
@@ -1376,12 +1472,25 @@ jobs:
     name: >-
       Run tests Python ${{ matrix.python-version }} (${{ matrix.group }})
     steps:
+      - name: Restore apt cache
+        uses: actions/cache/restore@v4.2.4
+        with:
+          path: |
+            ${{ env.APT_CACHE_DIR }}
+            ${{ env.APT_LIST_CACHE_DIR }}
+          fail-on-cache-miss: true
+          key: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{ needs.info.outputs.apt_cache_key }}
       - name: Install additional OS dependencies
         timeout-minutes: 10
         run: |
           sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
+          sudo apt-get update \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }}
           sudo apt-get -y install \
+            -o Dir::Cache=${{ env.APT_CACHE_DIR }} \
+            -o Dir::State::Lists=${{ env.APT_LIST_CACHE_DIR }} \
             bluez \
             ffmpeg \
             libturbojpeg \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ on:
         type: boolean
 
 env:
-  CACHE_VERSION: 7
+  CACHE_VERSION: 8
   UV_CACHE_VERSION: 1
   MYPY_CACHE_VERSION: 1
   HA_SHORT_VERSION: "2025.10"


### PR DESCRIPTION
## Proposed change
Followup to https://github.com/home-assistant/core/pull/151982#issuecomment-3275012135

An initial implementation to cache the `apt update` and `apt install` downloads. It works for the most part. There is one small permissions issue left which can be resolved at a later point. The permissions on the cached `apt/lists` dir aren't set correctly which forces the download of one additional file AFAICT.

> [!NOTE]
> If at some point the runner image is updated, say to `ubuntu-26.04` (when that's available), the cache key should be bumped to force regenerate the apt cache. Without it, the subsequent jobs would just fail. Similarly if a new base dependency is added, the cache key should be updated as well.

<details>
<summary>Before</summary>

https://github.com/home-assistant/core/actions/runs/17642874122/job/50133935265#step:2:25

```
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Hit:6 https://packages.microsoft.com/repos/azure-cli noble InRelease
Get:7 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1389 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [274 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [175 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 c-n-f Metadata [15.2 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1482 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [298 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [377 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 c-n-f Metadata [31.0 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Components [212 B]
Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
Get:17 http://azure.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [7076 B]
Get:18 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [19.2 kB]
Get:19 http://azure.archive.ubuntu.com/ubuntu noble-backports/restricted amd64 Components [216 B]
Get:20 http://azure.archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Components [212 B]
Get:21 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Packages [1118 kB]
Get:22 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Components [21.6 kB]
Get:23 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 c-n-f Metadata [8708 B]
Get:24 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Packages [879 kB]
Get:25 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Components [52.2 kB]
Get:26 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Components [212 B]
Get:27 http://azure.archive.ubuntu.com/ubuntu noble-security/multiverse amd64 Components [208 B]
Fetched 6528 kB in 1s (7658 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  i965-va-driver intel-media-va-driver libaacs0 libass9 libasyncns0
  libavc1394-0 libavcodec60 libavdevice60 libavfilter9 libavformat60
  libavutil58 libbdplus0 libblas3 libbluetooth3 libbluray2 libbs2b0 libcaca0
  libcdio-cdda2t64 libcdio-paranoia2t64 libcdio19t64 libchromaprint1 libcjson1
  libcodec2-1.2 libdav1d7 libdbi1t64 libdc1394-25 libdecor-0-0
  libdecor-0-plugin-1-gtk libflac12t64 libflite1 libgammu-i18n libgammu8t64
  libgme0 libgsm1 libgsmsd8t64 libhwy1t64 libiec61883-0 libigdgmm12
  libjack-jackd2-0 libjxl0.7 liblapack3 liblilv-0-0 libmbedcrypto7t64
  libmp3lame0 libmpg123-0t64 libmysofa1 libopenal-data libopenal1
  libopenmpt0t64 libopus0 libplacebo338 libpocketsphinx3 libpostproc57
  libpulse0 librav1e0 libraw1394-11 librist4 librsvg2-2 librsvg2-common
  librubberband2 libsamplerate0 libsdl2-2.0-0 libserd-0-0 libshine3
  libsndfile1 libsndio7.0 libsord-0-0 libsoxr0 libspeex1 libsphinxbase3t64
  libsratom-0-0 libsrt1.5-gnutls libssh-gcrypt-4 libsvtav1enc1d1
  libswresample4 libswscale7 libtheora0 libtwolame0 libudfread0 libunibreak5
  libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvorbisenc2 libvpl2
  libvpx9 libx264-164 libx265-199 libxcb-shape0 libxv1 libxvidcore4 libzimg2
  libzix-0-0 libzvbi-common libzvbi0t64 mesa-va-drivers mesa-vdpau-drivers
  ocl-icd-libopencl1 pocketsphinx-en-us va-driver-all vdpau-driver-all
Suggested packages:
  pulseaudio-module-bluetooth ffmpeg-doc i965-va-driver-shaders libcuda1
  libnvcuvid1 libnvidia-encode1 libbluray-bdj gammu-doc gammu gammu-smsd
  jackd2 libportaudio2 opus-tools pulseaudio libraw1394-doc librsvg2-bin serdi
  sndiod sordi speex opencl-icd libvdpau-va-gl1
The following NEW packages will be installed:
  bluez ffmpeg i965-va-driver intel-media-va-driver libaacs0 libass9
  libasyncns0 libavc1394-0 libavcodec60 libavdevice60 libavfilter9
  libavformat60 libavutil58 libbdplus0 libblas3 libbluetooth3 libbluray2
  libbs2b0 libcaca0 libcdio-cdda2t64 libcdio-paranoia2t64 libcdio19t64
  libchromaprint1 libcjson1 libcodec2-1.2 libdav1d7 libdbi1t64 libdc1394-25
  libdecor-0-0 libdecor-0-plugin-1-gtk libflac12t64 libflite1 libgammu-dev
  libgammu-i18n libgammu8t64 libgme0 libgsm1 libgsmsd8t64 libhwy1t64
  libiec61883-0 libigdgmm12 libjack-jackd2-0 libjxl0.7 liblapack3 liblilv-0-0
  libmbedcrypto7t64 libmp3lame0 libmpg123-0t64 libmysofa1 libopenal-data
  libopenal1 libopenmpt0t64 libopus0 libplacebo338 libpocketsphinx3
  libpostproc57 libpulse0 librav1e0 libraw1394-11 librist4 librsvg2-2
  librsvg2-common librubberband2 libsamplerate0 libsdl2-2.0-0 libserd-0-0
  libshine3 libsndfile1 libsndio7.0 libsord-0-0 libsoxr0 libspeex1
  libsphinxbase3t64 libsratom-0-0 libsrt1.5-gnutls libssh-gcrypt-4
  libsvtav1enc1d1 libswresample4 libswscale7 libtheora0 libturbojpeg
  libtwolame0 libudfread0 libunibreak5 libva-drm2 libva-x11-2 libva2 libvdpau1
  libvidstab1.1 libvorbisenc2 libvpl2 libvpx9 libx264-164 libx265-199
  libxcb-shape0 libxv1 libxvidcore4 libzimg2 libzix-0-0 libzvbi-common
  libzvbi0t64 mesa-va-drivers mesa-vdpau-drivers ocl-icd-libopencl1
  pocketsphinx-en-us va-driver-all vdpau-driver-all
0 upgraded, 107 newly installed, 0 to remove and 16 not upgraded.
Need to get 96.7 MB of archives.
After this operation, 237 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 bluez amd64 5.72-0ubuntu5.4 [1360 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva2 amd64 2.20.0-2build1 [66.2 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva-drm2 amd64 2.20.0-2build1 [7124 B]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva-x11-2 amd64 2.20.0-2build1 [12.0 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvdpau1 amd64 1.5-2build1 [27.8 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvpl2 amd64 2023.3.0-1build1 [99.8 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 ocl-icd-libopencl1 amd64 2.3.2-1build1 [38.5 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavutil58 amd64 7:6.1.1-3ubuntu5 [401 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcodec2-1.2 amd64 1.2.0-2build1 [8998 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdav1d7 amd64 1.4.1-1build1 [604 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgsm1 amd64 1.0.22-1build1 [27.8 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libhwy1t64 amd64 1.0.7-8.1build1 [584 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libjxl0.7 amd64 0.7.0-10.2ubuntu6.1 [1001 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libmp3lame0 amd64 3.100-6build1 [142 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libopus0 amd64 1.4-1build1 [208 kB]
Get:17 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librav1e0 amd64 0.7.1-2 [1022 kB]
Get:18 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-2 amd64 2.58.0+dfsg-1build1 [2135 kB]
Get:19 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libshine3 amd64 3.1.1-2build1 [23.2 kB]
Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libspeex1 amd64 1.2.1-2ubuntu2.24.04.1 [59.6 kB]
Get:21 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsvtav1enc1d1 amd64 1.7.0+dfsg-2build1 [2425 kB]
Get:22 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsoxr0 amd64 0.1.3-4build3 [80.0 kB]
Get:23 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswresample4 amd64 7:6.1.1-3ubuntu5 [63.8 kB]
Get:24 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtheora0 amd64 1.1.1+dfsg.1-16.1build3 [211 kB]
Get:25 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtwolame0 amd64 0.4.0-2build3 [52.3 kB]
Get:26 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvorbisenc2 amd64 1.3.7-1build3 [80.8 kB]
Get:27 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libvpx9 amd64 1.14.0-1ubuntu2.2 [1143 kB]
Get:28 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx264-164 amd64 2:0.164.3108+git31e19f9-1 [604 kB]
Get:29 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx265-199 amd64 3.5-2build1 [1226 kB]
Get:30 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libxvidcore4 amd64 2:1.3.7-1build1 [219 kB]
Get:31 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi-common all 0.2.42-2 [42.4 kB]
Get:32 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi0t64 amd64 0.2.42-2 [261 kB]
Get:33 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavcodec60 amd64 7:6.1.1-3ubuntu5 [5851 kB]
Get:34 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libraw1394-11 amd64 2.1.2-2build3 [26.2 kB]
Get:35 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libavc1394-0 amd64 0.5.4-5build3 [15.4 kB]
Get:36 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libunibreak5 amd64 5.1-2build1 [25.0 kB]
Get:37 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libass9 amd64 1:0.17.1-2build1 [104 kB]
Get:38 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libudfread0 amd64 1.1.2-1build1 [19.0 kB]
Get:39 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbluray2 amd64 1:1.3.4-1build1 [159 kB]
Get:40 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libchromaprint1 amd64 1.5.1-5 [30.5 kB]
Get:41 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgme0 amd64 0.6.3-7build1 [134 kB]
Get:42 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libmpg123-0t64 amd64 1.32.5-1ubuntu1.1 [169 kB]
Get:43 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenmpt0t64 amd64 0.7.3-1.1build3 [647 kB]
Get:44 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcjson1 amd64 1.7.17-1 [24.8 kB]
Get:45 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmbedcrypto7t64 amd64 2.28.8-1 [209 kB]
Get:46 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librist4 amd64 0.2.10+dfsg-2 [74.9 kB]
Get:47 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsrt1.5-gnutls amd64 1.5.3-1build2 [316 kB]
Get:48 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libssh-gcrypt-4 amd64 0.10.6-2ubuntu0.1 [224 kB]
Get:49 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavformat60 amd64 7:6.1.1-3ubuntu5 [1153 kB]
Get:50 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbs2b0 amd64 3.1.0+dfsg-7build1 [10.6 kB]
Get:51 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libflite1 amd64 2.2-6build3 [13.6 MB]
Get:52 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libserd-0-0 amd64 0.32.2-1 [43.6 kB]
Get:53 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzix-0-0 amd64 0.4.2-2build1 [23.6 kB]
Get:54 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsord-0-0 amd64 0.16.16-2build1 [15.8 kB]
Get:55 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsratom-0-0 amd64 0.6.16-1build1 [17.3 kB]
Get:56 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 liblilv-0-0 amd64 0.24.22-1build1 [41.0 kB]
Get:57 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmysofa1 amd64 1.3.2+dfsg-2ubuntu2 [1158 kB]
Get:58 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libplacebo338 amd64 6.338.2-2build1 [2654 kB]
Get:59 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libblas3 amd64 3.12.0-3build1.1 [238 kB]
Get:60 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liblapack3 amd64 3.12.0-3build1.1 [2646 kB]
Get:61 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libasyncns0 amd64 0.8-6build4 [11.3 kB]
Get:62 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libflac12t64 amd64 1.4.3+ds-2.1ubuntu2 [197 kB]
Get:63 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsndfile1 amd64 1.2.2-1ubuntu5.24.04.1 [209 kB]
Get:64 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpulse0 amd64 1:16.1+dfsg1-2ubuntu10.1 [292 kB]
Get:65 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsphinxbase3t64 amd64 0.8+5prealpha+1-17build2 [126 kB]
Get:66 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpocketsphinx3 amd64 0.8.0+real5prealpha+1-15ubuntu5 [133 kB]
Get:67 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpostproc57 amd64 7:6.1.1-3ubuntu5 [49.9 kB]
Get:68 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsamplerate0 amd64 0.2.2-4build1 [1344 kB]
Get:69 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librubberband2 amd64 3.3.0+dfsg-2build1 [130 kB]
Get:70 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswscale7 amd64 7:6.1.1-3ubuntu5 [193 kB]
Get:71 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvidstab1.1 amd64 1.1.0-2build1 [38.5 kB]
Get:72 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzimg2 amd64 3.0.5+ds1-1build1 [254 kB]
Get:73 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavfilter9 amd64 7:6.1.1-3ubuntu5 [4235 kB]
Get:74 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcaca0 amd64 0.99.beta20-4build2 [208 kB]
Get:75 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libcdio19t64 amd64 2.1.0-4.1ubuntu1.2 [62.4 kB]
Get:76 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcdio-cdda2t64 amd64 10.2+2.0.1-1.1build2 [16.5 kB]
Get:77 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcdio-paranoia2t64 amd64 10.2+2.0.1-1.1build2 [16.6 kB]
Get:78 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdc1394-25 amd64 2.2.6-4build1 [90.1 kB]
Get:79 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libiec61883-0 amd64 1.2.0-6build1 [24.5 kB]
Get:80 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libjack-jackd2-0 amd64 1.9.21~dfsg-3ubuntu3 [289 kB]
Get:81 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal-data all 1:1.23.1-4build1 [161 kB]
Get:82 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsndio7.0 amd64 1.9.0-0.3build3 [29.6 kB]
Get:83 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal1 amd64 1:1.23.1-4build1 [540 kB]
Get:84 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdecor-0-0 amd64 0.2.2-1build2 [16.5 kB]
Get:85 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsdl2-2.0-0 amd64 2.30.0+dfsg-1ubuntu3.1 [686 kB]
Get:86 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxcb-shape0 amd64 1.15-1ubuntu2 [6100 B]
Get:87 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxv1 amd64 2:1.0.11-1.1build1 [10.7 kB]
Get:88 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavdevice60 amd64 7:6.1.1-3ubuntu5 [82.3 kB]
Get:89 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 ffmpeg amd64 7:6.1.1-3ubuntu5 [1879 kB]
Get:90 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libigdgmm12 amd64 22.3.17+ds1-1 [145 kB]
Get:91 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 intel-media-va-driver amd64 24.1.0+dfsg1-1ubuntu0.1 [3163 kB]
Get:92 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libaacs0 amd64 0.11.1-2build1 [62.9 kB]
Get:93 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbdplus0 amd64 0.2.0-3build1 [52.2 kB]
Get:94 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libbluetooth3 amd64 5.72-0ubuntu5.4 [85.3 kB]
Get:95 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdbi1t64 amd64 0.9.0-6.1build1 [25.7 kB]
Get:96 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdecor-0-plugin-1-gtk amd64 0.2.2-1build2 [22.2 kB]
Get:97 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgammu8t64 amd64 1.42.0-8.1ubuntu2 [462 kB]
Get:98 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgsmsd8t64 amd64 1.42.0-8.1ubuntu2 [48.5 kB]
Get:99 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgammu-dev amd64 1.42.0-8.1ubuntu2 [199 kB]
Get:100 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgammu-i18n all 1.42.0-8.1ubuntu2 [254 kB]
Get:101 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-common amd64 2.58.0+dfsg-1build1 [11.8 kB]
Get:102 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libturbojpeg amd64 1:2.1.5-2ubuntu2 [192 kB]
Get:103 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 mesa-va-drivers amd64 25.0.7-0ubuntu0.24.04.2 [5934 B]
Get:104 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 mesa-vdpau-drivers amd64 25.0.7-0ubuntu0.24.04.2 [21.0 kB]
Get:105 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 i965-va-driver amd64 2.4.1+dfsg1-1build2 [332 kB]
Get:106 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 va-driver-all amd64 2.20.0-2build1 [4844 B]
Get:107 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 vdpau-driver-all amd64 1.5-2build1 [4414 B]
Get:108 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 pocketsphinx-en-us all 0.8.0+real5prealpha+1-15ubuntu5 [27.4 MB]
Fetched 96.7 MB in 16s (6209 kB/s)
...
```
</details>

<details>
<summary>After</summary>

https://github.com/home-assistant/core/actions/runs/17643067705/job/50134729962?pr=152113#step:3:32

```
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Hit:6 https://packages.microsoft.com/repos/azure-cli noble InRelease
Hit:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease
Hit:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
Reading package lists...
W: Download is performed unsandboxed as root as file '/home/runner/work/apt/lists/partial/packages.microsoft.com_repos_azure-cli_dists_noble_InRelease' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  i965-va-driver intel-media-va-driver libaacs0 libass9 libasyncns0
  libavc1394-0 libavcodec60 libavdevice60 libavfilter9 libavformat60
  libavutil58 libbdplus0 libblas3 libbluetooth3 libbluray2 libbs2b0 libcaca0
  libcdio-cdda2t64 libcdio-paranoia2t64 libcdio19t64 libchromaprint1 libcjson1
  libcodec2-1.2 libdav1d7 libdbi1t64 libdc1394-25 libdecor-0-0
  libdecor-0-plugin-1-gtk libflac12t64 libflite1 libgammu-i18n libgammu8t64
  libgme0 libgsm1 libgsmsd8t64 libhwy1t64 libiec61883-0 libigdgmm12
  libjack-jackd2-0 libjxl0.7 liblapack3 liblilv-0-0 libmbedcrypto7t64
  libmp3lame0 libmpg123-0t64 libmysofa1 libopenal-data libopenal1
  libopenmpt0t64 libopus0 libplacebo338 libpocketsphinx3 libpostproc57
  libpulse0 librav1e0 libraw1394-11 librist4 librsvg2-2 librsvg2-common
  librubberband2 libsamplerate0 libsdl2-2.0-0 libserd-0-0 libshine3
  libsndfile1 libsndio7.0 libsord-0-0 libsoxr0 libspeex1 libsphinxbase3t64
  libsratom-0-0 libsrt1.5-gnutls libssh-gcrypt-4 libsvtav1enc1d1
  libswresample4 libswscale7 libtheora0 libtwolame0 libudfread0 libunibreak5
  libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvorbisenc2 libvpl2
  libvpx9 libx264-164 libx265-199 libxcb-shape0 libxv1 libxvidcore4 libzimg2
  libzix-0-0 libzvbi-common libzvbi0t64 mesa-va-drivers mesa-vdpau-drivers
  ocl-icd-libopencl1 pocketsphinx-en-us va-driver-all vdpau-driver-all
Suggested packages:
  pulseaudio-module-bluetooth ffmpeg-doc i965-va-driver-shaders libcuda1
  libnvcuvid1 libnvidia-encode1 libbluray-bdj gammu-doc gammu gammu-smsd
  jackd2 libportaudio2 opus-tools pulseaudio libraw1394-doc librsvg2-bin serdi
  sndiod sordi speex opencl-icd libvdpau-va-gl1
The following NEW packages will be installed:
  bluez ffmpeg i965-va-driver intel-media-va-driver libaacs0 libass9
  libasyncns0 libavc1394-0 libavcodec60 libavdevice60 libavfilter9
  libavformat60 libavutil58 libbdplus0 libblas3 libbluetooth3 libbluray2
  libbs2b0 libcaca0 libcdio-cdda2t64 libcdio-paranoia2t64 libcdio19t64
  libchromaprint1 libcjson1 libcodec2-1.2 libdav1d7 libdbi1t64 libdc1394-25
  libdecor-0-0 libdecor-0-plugin-1-gtk libflac12t64 libflite1 libgammu-dev
  libgammu-i18n libgammu8t64 libgme0 libgsm1 libgsmsd8t64 libhwy1t64
  libiec61883-0 libigdgmm12 libjack-jackd2-0 libjxl0.7 liblapack3 liblilv-0-0
  libmbedcrypto7t64 libmp3lame0 libmpg123-0t64 libmysofa1 libopenal-data
  libopenal1 libopenmpt0t64 libopus0 libplacebo338 libpocketsphinx3
  libpostproc57 libpulse0 librav1e0 libraw1394-11 librist4 librsvg2-2
  librsvg2-common librubberband2 libsamplerate0 libsdl2-2.0-0 libserd-0-0
  libshine3 libsndfile1 libsndio7.0 libsord-0-0 libsoxr0 libspeex1
  libsphinxbase3t64 libsratom-0-0 libsrt1.5-gnutls libssh-gcrypt-4
  libsvtav1enc1d1 libswresample4 libswscale7 libtheora0 libturbojpeg
  libtwolame0 libudfread0 libunibreak5 libva-drm2 libva-x11-2 libva2 libvdpau1
  libvidstab1.1 libvorbisenc2 libvpl2 libvpx9 libx264-164 libx265-199
  libxcb-shape0 libxv1 libxvidcore4 libzimg2 libzix-0-0 libzvbi-common
  libzvbi0t64 mesa-va-drivers mesa-vdpau-drivers ocl-icd-libopencl1
  pocketsphinx-en-us va-driver-all vdpau-driver-all
0 upgraded, 107 newly installed, 0 to remove and 16 not upgraded.
Need to get 0 B/96.7 MB of archives.
After this operation, 237 MB of additional disk space will be used.
Selecting previously unselected package bluez.
...
```
</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
