### PR TITLE
Add air/water filter state in percent to LG ThinQ

### DIFF
--- a/homeassistant/components/lg_thinq/icons.json
+++ b/homeassistant/components/lg_thinq/icons.json
@@ -282,7 +282,19 @@
       "filter_lifetime": {
         "default": "mdi:air-filter"
       },
+      "top_filter_remain_percent": {
+        "default": "mdi:air-filter"
+      },
       "used_time": {
+        "default": "mdi:air-filter"
+      },
+      "water_filter_state": {
+        "default": "mdi:air-filter"
+      },
+      "water_filter_2_remain_percent": {
+        "default": "mdi:air-filter"
+      },
+      "water_filter_3_remain_percent": {
         "default": "mdi:air-filter"
       },
       "current_job_mode": {

--- a/homeassistant/components/lg_thinq/icons.json
+++ b/homeassistant/components/lg_thinq/icons.json
@@ -291,6 +291,9 @@
       "water_filter_state": {
         "default": "mdi:air-filter"
       },
+      "water_filter_1_remain_percent": {
+        "default": "mdi:air-filter"
+      },
       "water_filter_2_remain_percent": {
         "default": "mdi:air-filter"
       },

--- a/homeassistant/components/lg_thinq/sensor.py
+++ b/homeassistant/components/lg_thinq/sensor.py
@@ -105,6 +105,11 @@ FILTER_INFO_SENSOR_DESC: dict[ThinQProperty, SensorEntityDescription] = {
         native_unit_of_measurement=PERCENTAGE,
         translation_key=ThinQProperty.FILTER_LIFETIME,
     ),
+    ThinQProperty.TOP_FILTER_REMAIN_PERCENT: SensorEntityDescription(
+        key=ThinQProperty.TOP_FILTER_REMAIN_PERCENT,
+        native_unit_of_measurement=PERCENTAGE,
+        translation_key=ThinQProperty.TOP_FILTER_REMAIN_PERCENT,
+    ),
 }
 HUMIDITY_SENSOR_DESC: dict[ThinQProperty, SensorEntityDescription] = {
     ThinQProperty.CURRENT_HUMIDITY: SensorEntityDescription(
@@ -216,6 +221,11 @@ REFRIGERATION_SENSOR_DESC: dict[ThinQProperty, SensorEntityDescription] = {
         device_class=SensorDeviceClass.ENUM,
         translation_key=ThinQProperty.FRESH_AIR_FILTER,
     ),
+    ThinQProperty.FRESH_AIR_FILTER_REMAIN_PERCENT: SensorEntityDescription(
+        key=ThinQProperty.FRESH_AIR_FILTER_REMAIN_PERCENT,
+        native_unit_of_measurement=PERCENTAGE,
+        translation_key=ThinQProperty.FRESH_AIR_FILTER,
+    ),
 }
 RUN_STATE_SENSOR_DESC: dict[ThinQProperty, SensorEntityDescription] = {
     ThinQProperty.CURRENT_STATE: SensorEntityDescription(
@@ -297,6 +307,25 @@ WATER_FILTER_INFO_SENSOR_DESC: dict[ThinQProperty, SensorEntityDescription] = {
         key=ThinQProperty.USED_TIME,
         native_unit_of_measurement=UnitOfTime.MONTHS,
         translation_key=ThinQProperty.USED_TIME,
+    ),
+    ThinQProperty.WATER_FILTER_STATE: SensorEntityDescription(
+        key=ThinQProperty.WATER_FILTER_STATE,
+        translation_key=ThinQProperty.WATER_FILTER_STATE,
+    ),
+    ThinQProperty.WATER_FILTER_1_REMAIN_PERCENT: SensorEntityDescription(
+        key=ThinQProperty.WATER_FILTER_1_REMAIN_PERCENT,
+        native_unit_of_measurement=PERCENTAGE,
+        translation_key=ThinQProperty.WATER_FILTER_STATE,
+    ),
+    ThinQProperty.WATER_FILTER_2_REMAIN_PERCENT: SensorEntityDescription(
+        key=ThinQProperty.WATER_FILTER_2_REMAIN_PERCENT,
+        native_unit_of_measurement=PERCENTAGE,
+        translation_key=ThinQProperty.WATER_FILTER_2_REMAIN_PERCENT,
+    ),
+    ThinQProperty.WATER_FILTER_3_REMAIN_PERCENT: SensorEntityDescription(
+        key=ThinQProperty.WATER_FILTER_3_REMAIN_PERCENT,
+        native_unit_of_measurement=PERCENTAGE,
+        translation_key=ThinQProperty.WATER_FILTER_3_REMAIN_PERCENT,
     ),
 }
 WATER_INFO_SENSOR_DESC: dict[ThinQProperty, SensorEntityDescription] = {
@@ -432,6 +461,7 @@ DEVICE_TYPE_SENSOR_MAP: dict[DeviceType, tuple[SensorEntityDescription, ...]] = 
         AIR_QUALITY_SENSOR_DESC[ThinQProperty.ODOR_LEVEL],
         AIR_QUALITY_SENSOR_DESC[ThinQProperty.TOTAL_POLLUTION_LEVEL],
         FILTER_INFO_SENSOR_DESC[ThinQProperty.FILTER_REMAIN_PERCENT],
+        FILTER_INFO_SENSOR_DESC[ThinQProperty.TOP_FILTER_REMAIN_PERCENT],
         JOB_MODE_SENSOR_DESC[ThinQProperty.CURRENT_JOB_MODE],
         JOB_MODE_SENSOR_DESC[ThinQProperty.PERSONALIZATION_MODE],
         TIME_SENSOR_DESC[TimerProperty.ABSOLUTE_TO_START],
@@ -508,7 +538,12 @@ DEVICE_TYPE_SENSOR_MAP: dict[DeviceType, tuple[SensorEntityDescription, ...]] = 
     ),
     DeviceType.REFRIGERATOR: (
         REFRIGERATION_SENSOR_DESC[ThinQProperty.FRESH_AIR_FILTER],
+        REFRIGERATION_SENSOR_DESC[ThinQProperty.FRESH_AIR_FILTER_REMAIN_PERCENT],
         WATER_FILTER_INFO_SENSOR_DESC[ThinQProperty.USED_TIME],
+        WATER_FILTER_INFO_SENSOR_DESC[ThinQProperty.WATER_FILTER_STATE],
+        WATER_FILTER_INFO_SENSOR_DESC[ThinQProperty.WATER_FILTER_1_REMAIN_PERCENT],
+        WATER_FILTER_INFO_SENSOR_DESC[ThinQProperty.WATER_FILTER_2_REMAIN_PERCENT],
+        WATER_FILTER_INFO_SENSOR_DESC[ThinQProperty.WATER_FILTER_3_REMAIN_PERCENT],
     ),
     DeviceType.ROBOT_CLEANER: (
         RUN_STATE_SENSOR_DESC[ThinQProperty.CURRENT_STATE],

--- a/homeassistant/components/lg_thinq/sensor.py
+++ b/homeassistant/components/lg_thinq/sensor.py
@@ -315,7 +315,7 @@ WATER_FILTER_INFO_SENSOR_DESC: dict[ThinQProperty, SensorEntityDescription] = {
     ThinQProperty.WATER_FILTER_1_REMAIN_PERCENT: SensorEntityDescription(
         key=ThinQProperty.WATER_FILTER_1_REMAIN_PERCENT,
         native_unit_of_measurement=PERCENTAGE,
-        translation_key=ThinQProperty.WATER_FILTER_STATE,
+        translation_key=ThinQProperty.WATER_FILTER_1_REMAIN_PERCENT,
     ),
     ThinQProperty.WATER_FILTER_2_REMAIN_PERCENT: SensorEntityDescription(
         key=ThinQProperty.WATER_FILTER_2_REMAIN_PERCENT,

--- a/homeassistant/components/lg_thinq/strings.json
+++ b/homeassistant/components/lg_thinq/strings.json
@@ -241,7 +241,9 @@
               "timer_is_complete": "Timer has been completed",
               "washing_is_complete": "Washing is completed",
               "water_is_full": "Water is full",
-              "water_leak_has_occurred": "The dishwasher has detected a water leak"
+              "water_leak_has_occurred": "The dishwasher has detected a water leak",
+              "filter_reset_complete": "Reset the air filter",
+              "water_filter_reset_complete": "Reset water filter"
             }
           }
         }
@@ -608,8 +610,20 @@
       "filter_lifetime": {
         "name": "Filter remaining"
       },
+      "top_filter_remain_percent": {
+        "name": "Upper filter remaining"
+      },
       "used_time": {
         "name": "Water filter used"
+      },
+      "water_filter_state": {
+        "name": "Water filter"
+      },
+      "water_filter_2_remain_percent": {
+        "name": "Water filter stage 2"
+      },
+      "water_filter_3_remain_percent": {
+        "name": "Water filter stage 3"
       },
       "current_job_mode": {
         "name": "Operating mode",

--- a/homeassistant/components/lg_thinq/strings.json
+++ b/homeassistant/components/lg_thinq/strings.json
@@ -242,8 +242,8 @@
               "washing_is_complete": "Washing is completed",
               "water_is_full": "Water is full",
               "water_leak_has_occurred": "The dishwasher has detected a water leak",
-              "filter_reset_complete": "Reset the air filter",
-              "water_filter_reset_complete": "Reset water filter"
+              "filter_reset_complete": "The filter has been reset",
+              "water_filter_reset_complete": "The water filter has been reset"
             }
           }
         }

--- a/homeassistant/components/lg_thinq/strings.json
+++ b/homeassistant/components/lg_thinq/strings.json
@@ -620,7 +620,7 @@
         "name": "Water filter"
       },
       "water_filter_1_remain_percent": {
-        "name": "Water filter"
+        "name": "[%key:component::lg_thinq::entity::sensor::water_filter_state::name%]"
       },
       "water_filter_2_remain_percent": {
         "name": "Water filter stage 2"

--- a/homeassistant/components/lg_thinq/strings.json
+++ b/homeassistant/components/lg_thinq/strings.json
@@ -619,6 +619,9 @@
       "water_filter_state": {
         "name": "Water filter"
       },
+      "water_filter_1_remain_percent": {
+        "name": "Water filter"
+      },
       "water_filter_2_remain_percent": {
         "name": "Water filter stage 2"
       },

--- a/homeassistant/components/lg_thinq/strings.json
+++ b/homeassistant/components/lg_thinq/strings.json
@@ -242,8 +242,8 @@
               "washing_is_complete": "Washing is completed",
               "water_is_full": "Water is full",
               "water_leak_has_occurred": "The dishwasher has detected a water leak",
-              "filter_reset_complete": "The filter has been reset",
-              "water_filter_reset_complete": "The water filter has been reset"
+              "filter_reset_complete": "The filter lifetime has been reset",
+              "water_filter_reset_complete": "The water filter lifetime has been reset"
             }
           }
         }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The refrigerator's filter status sensor is also supported in percent format.
> 1. Air purifier: Upper filter remaining
> 2. Refrigerator: Water filter / Fresh air filter


- Filter-related notifications have been added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #149082
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
