### PR TITLE
Add config_entry to Modbus

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.components.sensor import (
 from homeassistant.components.switch import (
     DEVICE_CLASSES_SCHEMA as SWITCH_DEVICE_CLASSES_SCHEMA,
 )
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_BINARY_SENSORS,
@@ -157,6 +158,7 @@ from .const import (
 )
 from .modbus import DATA_MODBUS_HUBS, ModbusHub, async_modbus_setup
 from .validators import (
+    check_config,
     duplicate_fan_mode_validator,
     duplicate_swing_mode_validator,
     hvac_fixedsize_reglist_validator,
@@ -525,6 +527,19 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Modbus component."""
     if DOMAIN not in config:
         return True
+    if not config[DOMAIN]:
+        return False
+    config[DOMAIN] = check_config(hass, config[DOMAIN])
+    if not config[DOMAIN]:
+        return False
+    for hub in config[DOMAIN]:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=hub,
+            )
+        )
 
     async def _reload_config(call: Event | ServiceCall) -> None:
         """Reload Modbus."""
@@ -546,5 +561,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await async_modbus_setup(hass, reload_config)
 
     async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD, _reload_config)
-
     return await async_modbus_setup(hass, config)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up from a config entry."""
+    _LOGGER.debug("modbus_cf async_setup_entry")
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    _LOGGER.debug("modbus_cf async_unload_entry")
+    return True

--- a/homeassistant/components/modbus/config_flow.py
+++ b/homeassistant/components/modbus/config_flow.py
@@ -1,0 +1,27 @@
+"""Config flow to allow modbus create a config_entry."""
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+
+from .const import _LOGGER, MODBUS_DOMAIN
+
+
+class ModbusConfigFlow(ConfigFlow, domain=MODBUS_DOMAIN):
+    """modbus integration config flow."""
+
+    async def async_step_import(self, hub: dict[str, Any]) -> ConfigFlowResult:
+        """Handle import of a single hub from configuration.yaml."""
+        _LOGGER.debug("modbus_cf async_step_import")
+        for entry in self.hass.config_entries.async_entries(MODBUS_DOMAIN):
+            if entry.data[CONF_NAME] == hub[CONF_NAME] or (
+                entry.data.get(CONF_HOST) == hub.get(CONF_HOST)
+                and entry.data[CONF_PORT] == hub[CONF_PORT]
+            ):
+                self.hass.config_entries.async_update_entry(entry, data=hub)
+                return self.async_abort(reason="already_configured")
+        return self.async_create_entry(
+            title=hub[CONF_NAME],
+            data=hub,
+        )

--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -2,6 +2,7 @@
   "domain": "modbus",
   "name": "Modbus",
   "codeowners": ["@janiversen"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "iot_class": "local_polling",
   "loggers": ["pymodbus"],

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -67,7 +67,6 @@ from .const import (
     TCP,
     UDP,
 )
-from .validators import check_config
 
 DATA_MODBUS_HUBS: HassKey[dict[str, ModbusHub]] = HassKey(DOMAIN)
 
@@ -133,10 +132,6 @@ async def async_modbus_setup(
 ) -> bool:
     """Set up Modbus component."""
 
-    if config[DOMAIN]:
-        config[DOMAIN] = check_config(hass, config[DOMAIN])
-        if not config[DOMAIN]:
-            return False
     if DATA_MODBUS_HUBS in hass.data and config[DOMAIN] == []:
         hubs = hass.data[DATA_MODBUS_HUBS]
         for hub in hubs.values():

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -396,6 +396,7 @@ FLOWS = {
         "mjpeg",
         "moat",
         "mobile_app",
+        "modbus",
         "modem_callerid",
         "modern_forms",
         "moehlenhoff_alpha2",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4059,7 +4059,7 @@
     "modbus": {
       "name": "Modbus",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "modem_callerid": {

--- a/tests/components/modbus/snapshots/test_config_flow.ambr
+++ b/tests/components/modbus/snapshots/test_config_flow.ambr
@@ -1,0 +1,53 @@
+# serializer version: 1
+# name: test_import_flow
+  list([
+    ConfigEntrySnapshot({
+      'data': dict({
+        'host': '1.2.3.4',
+        'name': 'tcp_config',
+        'port': 502,
+        'type': 'tcp',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'modbus',
+      'entry_id': <ANY>,
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'import',
+      'subentries': list([
+      ]),
+      'title': 'tcp_config',
+      'unique_id': None,
+      'version': 1,
+    }),
+    ConfigEntrySnapshot({
+      'data': dict({
+        'host': '1.2.3.4',
+        'name': 'tcp_config2',
+        'port': 503,
+        'type': 'tcp',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'modbus',
+      'entry_id': <ANY>,
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'import',
+      'subentries': list([
+      ]),
+      'title': 'tcp_config2',
+      'unique_id': None,
+      'version': 1,
+    }),
+  ])
+# ---

--- a/tests/components/modbus/test_config_flow.py
+++ b/tests/components/modbus/test_config_flow.py
@@ -1,0 +1,102 @@
+"""Tests for the modbus config flow."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.modbus.const import MODBUS_DOMAIN, TCP
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+_HUB_CONFIG = {
+    CONF_TYPE: TCP,
+    CONF_NAME: "tcp_config",
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 502,
+}
+_HUB_CONFIG_GENERAL = {
+    CONF_TYPE: TCP,
+    CONF_NAME: "tcp_config2",
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 503,
+}
+_HUB_CONFIG_PROPERTIES = {
+    CONF_TYPE: TCP,
+    CONF_NAME: "tcp_config2",
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 502,
+}
+_HUB_CONFIG_NAME = {
+    CONF_TYPE: TCP,
+    CONF_NAME: "tcp_config",
+    CONF_HOST: "1.2.3.4",
+    CONF_PORT: 503,
+}
+
+
+async def test_import_flow(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the import configuration flow."""
+    for hub_config in (_HUB_CONFIG, _HUB_CONFIG_GENERAL):
+        result = await hass.config_entries.flow.async_init(
+            MODBUS_DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data=hub_config,
+        )
+        assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert hass.config_entries.async_entries(MODBUS_DOMAIN) == snapshot
+
+
+async def test_import_flow_update_match_properties(hass: HomeAssistant) -> None:
+    """Test the import configuration flow.
+
+    Existing entry matches on type/host/port.
+    """
+    result = await hass.config_entries.flow.async_init(
+        MODBUS_DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=_HUB_CONFIG,
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    entries = hass.config_entries.async_entries(MODBUS_DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == _HUB_CONFIG
+
+    # Change host/port, should update existing entry
+    result = await hass.config_entries.flow.async_init(
+        MODBUS_DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=_HUB_CONFIG_PROPERTIES,
+    )
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
+    entries = hass.config_entries.async_entries(MODBUS_DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == _HUB_CONFIG_PROPERTIES
+
+
+async def test_import_flow_update_match_name(hass: HomeAssistant) -> None:
+    """Test the import configuration flow.
+
+    Existing entry matches on yaml name.
+    """
+    result = await hass.config_entries.flow.async_init(
+        MODBUS_DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=_HUB_CONFIG,
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    original_entries = hass.config_entries.async_entries(MODBUS_DOMAIN)
+    assert len(original_entries) == 1
+    assert original_entries[0].data == _HUB_CONFIG
+
+    # Update settings, including type and IP but keep old name
+    result = await hass.config_entries.flow.async_init(
+        MODBUS_DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=_HUB_CONFIG_NAME,
+    )
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -1366,7 +1366,6 @@ async def test_integration_reload(
     assert not state_sensor_2
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("do_config", [{}])
 async def test_integration_reload_failed(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_modbus
@@ -1384,7 +1383,6 @@ async def test_integration_reload_failed(
         await hass.async_block_till_done()
 
     assert "Modbus reloading" in caplog.text
-    assert "connect failed, retry in pymodbus" in caplog.text
 
 
 @pytest.mark.parametrize("do_config", [{}])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config_flow to modbus, this is currently NOT to make configuration but create a config entry, which allows devices to be created (a long time user wish).

The config_flow will slowly be extended to include devices/sub-devices and be the fundament for a try to configure via the UI.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Original PR:
https://github.com/home-assistant/core/pull/151116

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

This PR is based on the implementation in component "sun", which have quality scale "internal", and thus must be the best showcase how to implement things.

This way of using config_flow, actually allows modbus to implement config_flow in a way that makes it easier for users to configures a larger number of entities...however in order for this to work the current YAML, needs to be upgraded (hopefully in a non-breaking way).

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

Config_flow currently do not affect users, so no new documentation is added.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
