### PR TITLE
Register androidtv entity services in async_setup

### DIFF
--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -33,9 +33,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.storage import STORAGE_DIR
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_ADB_SERVER_IP,
@@ -46,10 +48,12 @@ from .const import (
     DEFAULT_ADB_SERVER_PORT,
     DEVICE_ANDROIDTV,
     DEVICE_FIRETV,
+    DOMAIN,
     PROP_ETHMAC,
     PROP_WIFIMAC,
     SIGNAL_CONFIG_ENTITY,
 )
+from .services import async_setup_services
 
 ADB_PYTHON_EXCEPTIONS: tuple = (
     AdbTimeoutError,
@@ -62,6 +66,8 @@ ADB_PYTHON_EXCEPTIONS: tuple = (
     TcpTimeoutException,
 )
 ADB_TCP_EXCEPTIONS: tuple = (ConnectionResetError, RuntimeError)
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE]
 RELOAD_OPTIONS = [CONF_STATE_DETECTION_RULES]
@@ -185,6 +191,12 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.minor_version,
     )
 
+    return True
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Android TV / Fire TV integration."""
+    async_setup_services(hass)
     return True
 
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -8,7 +8,6 @@ import logging
 
 from androidtv.constants import APPS, KEYS
 from androidtv.setup_async import AndroidTVAsync, FireTVAsync
-import voluptuous as vol
 
 from homeassistant.components import persistent_notification
 from homeassistant.components.media_player import (
@@ -17,9 +16,7 @@ from homeassistant.components.media_player import (
     MediaPlayerEntityFeature,
     MediaPlayerState,
 )
-from homeassistant.const import ATTR_COMMAND
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.dt import utcnow
@@ -39,18 +36,9 @@ from .const import (
     SIGNAL_CONFIG_ENTITY,
 )
 from .entity import AndroidTVEntity, adb_decorator
+from .services import ATTR_ADB_RESPONSE, ATTR_HDMI_INPUT, SERVICE_LEARN_SENDEVENT
 
 _LOGGER = logging.getLogger(__name__)
-
-ATTR_ADB_RESPONSE = "adb_response"
-ATTR_DEVICE_PATH = "device_path"
-ATTR_HDMI_INPUT = "hdmi_input"
-ATTR_LOCAL_PATH = "local_path"
-
-SERVICE_ADB_COMMAND = "adb_command"
-SERVICE_DOWNLOAD = "download"
-SERVICE_LEARN_SENDEVENT = "learn_sendevent"
-SERVICE_UPLOAD = "upload"
 
 # Translate from `AndroidTV` / `FireTV` reported state to HA state.
 ANDROIDTV_STATES = {
@@ -75,32 +63,6 @@ async def async_setup_entry(
             if device_class == DEVICE_ANDROIDTV
             else FireTVDevice(entry)
         ]
-    )
-
-    platform = entity_platform.async_get_current_platform()
-    platform.async_register_entity_service(
-        SERVICE_ADB_COMMAND,
-        {vol.Required(ATTR_COMMAND): cv.string},
-        "adb_command",
-    )
-    platform.async_register_entity_service(
-        SERVICE_LEARN_SENDEVENT, None, "learn_sendevent"
-    )
-    platform.async_register_entity_service(
-        SERVICE_DOWNLOAD,
-        {
-            vol.Required(ATTR_DEVICE_PATH): cv.string,
-            vol.Required(ATTR_LOCAL_PATH): cv.string,
-        },
-        "service_download",
-    )
-    platform.async_register_entity_service(
-        SERVICE_UPLOAD,
-        {
-            vol.Required(ATTR_DEVICE_PATH): cv.string,
-            vol.Required(ATTR_LOCAL_PATH): cv.string,
-        },
-        "service_upload",
     )
 
 

--- a/homeassistant/components/androidtv/services.py
+++ b/homeassistant/components/androidtv/services.py
@@ -1,0 +1,66 @@
+"""Services for Android/Fire TV devices."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.const import ATTR_COMMAND
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, service
+
+from .const import DOMAIN
+
+ATTR_ADB_RESPONSE = "adb_response"
+ATTR_DEVICE_PATH = "device_path"
+ATTR_HDMI_INPUT = "hdmi_input"
+ATTR_LOCAL_PATH = "local_path"
+
+SERVICE_ADB_COMMAND = "adb_command"
+SERVICE_DOWNLOAD = "download"
+SERVICE_LEARN_SENDEVENT = "learn_sendevent"
+SERVICE_UPLOAD = "upload"
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the Android TV / Fire TV services."""
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_ADB_COMMAND,
+        entity_domain=MEDIA_PLAYER_DOMAIN,
+        schema={vol.Required(ATTR_COMMAND): cv.string},
+        func="adb_command",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_LEARN_SENDEVENT,
+        entity_domain=MEDIA_PLAYER_DOMAIN,
+        schema=None,
+        func="learn_sendevent",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_DOWNLOAD,
+        entity_domain=MEDIA_PLAYER_DOMAIN,
+        schema={
+            vol.Required(ATTR_DEVICE_PATH): cv.string,
+            vol.Required(ATTR_LOCAL_PATH): cv.string,
+        },
+        func="service_download",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_UPLOAD,
+        entity_domain=MEDIA_PLAYER_DOMAIN,
+        schema={
+            vol.Required(ATTR_DEVICE_PATH): cv.string,
+            vol.Required(ATTR_LOCAL_PATH): cv.string,
+        },
+        func="service_upload",
+    )

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -21,7 +21,7 @@ from homeassistant.components.androidtv.const import (
     DEFAULT_PORT,
     DOMAIN,
 )
-from homeassistant.components.androidtv.media_player import (
+from homeassistant.components.androidtv.services import (
     ATTR_DEVICE_PATH,
     ATTR_LOCAL_PATH,
     SERVICE_ADB_COMMAND,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Register androidtv entity services in async_setup

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
