### PR TITLE
Fix Lutron Caseta shade stuttering and improve stop functionality

### DIFF
--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -1,5 +1,6 @@
 """Support for Lutron Caseta shades."""
 
+from enum import Enum
 from typing import Any
 
 from homeassistant.components.cover import (
@@ -17,6 +18,14 @@ from .entity import LutronCasetaUpdatableEntity
 from .models import LutronCasetaConfigEntry
 
 
+class ShadeMovementDirection(Enum):
+    """Enum for shade movement direction."""
+
+    OPENING = "opening"
+    CLOSING = "closing"
+    STOPPED = "stopped"
+
+
 class LutronCasetaShade(LutronCasetaUpdatableEntity, CoverEntity):
     """Representation of a Lutron shade with open/close functionality."""
 
@@ -27,6 +36,8 @@ class LutronCasetaShade(LutronCasetaUpdatableEntity, CoverEntity):
         | CoverEntityFeature.SET_POSITION
     )
     _attr_device_class = CoverDeviceClass.SHADE
+    _previous_position: int | None = None
+    _movement_direction: ShadeMovementDirection | None = None
 
     @property
     def is_closed(self) -> bool:
@@ -38,19 +49,56 @@ class LutronCasetaShade(LutronCasetaUpdatableEntity, CoverEntity):
         """Return the current position of cover."""
         return self._device["current_state"]
 
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await super().async_added_to_hass()
+        # Initialize the previous position
+        self._previous_position = self.current_cover_position
+
+    def _handle_bridge_update(self) -> None:
+        """Handle updated data from the bridge and track movement direction."""
+        current_position = self.current_cover_position
+
+        # Track movement direction based on position changes or endpoint status
+        if self._previous_position is not None:
+            if current_position > self._previous_position or current_position >= 100:
+                # Moving up or at fully open
+                self._movement_direction = ShadeMovementDirection.OPENING
+            elif current_position < self._previous_position or current_position <= 0:
+                # Moving down or at fully closed
+                self._movement_direction = ShadeMovementDirection.CLOSING
+            else:
+                # Stopped in the middle
+                self._movement_direction = ShadeMovementDirection.STOPPED
+
+        self._previous_position = current_position
+        super()._handle_bridge_update()
+
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        await self._smartbridge.lower_cover(self.device_id)
+        # Use set_value to avoid the stuttering issue
+        await self._smartbridge.set_value(self.device_id, 0)
         await self.async_update()
         self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
+        # Send appropriate directional command before stop to ensure it works correctly
+        # Use tracked direction if moving, otherwise use position-based heuristic
+        if self._movement_direction == ShadeMovementDirection.OPENING or (
+            self._movement_direction in (ShadeMovementDirection.STOPPED, None)
+            and self.current_cover_position >= 50
+        ):
+            await self._smartbridge.raise_cover(self.device_id)
+        else:
+            await self._smartbridge.lower_cover(self.device_id)
+
         await self._smartbridge.stop_cover(self.device_id)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self._smartbridge.raise_cover(self.device_id)
+        # Use set_value to avoid the stuttering issue
+        await self._smartbridge.set_value(self.device_id, 100)
         await self.async_update()
         self.async_write_ha_state()
 

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -49,12 +49,6 @@ class LutronCasetaShade(LutronCasetaUpdatableEntity, CoverEntity):
         """Return the current position of cover."""
         return self._device["current_state"]
 
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await super().async_added_to_hass()
-        # Initialize the previous position
-        self._previous_position = self.current_cover_position
-
     def _handle_bridge_update(self) -> None:
         """Handle updated data from the bridge and track movement direction."""
         current_position = self.current_cover_position
@@ -68,7 +62,7 @@ class LutronCasetaShade(LutronCasetaUpdatableEntity, CoverEntity):
                 # Moving down or at fully closed
                 self._movement_direction = ShadeMovementDirection.CLOSING
             else:
-                # Stopped in the middle
+                # Stopped
                 self._movement_direction = ShadeMovementDirection.STOPPED
 
         self._previous_position = current_position

--- a/homeassistant/components/lutron_caseta/entity.py
+++ b/homeassistant/components/lutron_caseta/entity.py
@@ -65,7 +65,11 @@ class LutronCasetaEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
-        self._smartbridge.add_subscriber(self.device_id, self.async_write_ha_state)
+        self._smartbridge.add_subscriber(self.device_id, self._handle_bridge_update)
+
+    def _handle_bridge_update(self) -> None:
+        """Handle updated data from the bridge."""
+        self.async_write_ha_state()
 
     def _handle_none_serial(self, serial: str | int | None) -> str | int:
         """Handle None serial returned by RA3 and QSX processors."""

--- a/tests/components/lutron_caseta/__init__.py
+++ b/tests/components/lutron_caseta/__init__.py
@@ -100,6 +100,7 @@ class MockBridge:
         self.scenes = self.get_scenes()
         self.devices = self.load_devices()
         self.buttons = self.load_buttons()
+        self._subscribers: dict[str, list] = {}
 
     async def connect(self):
         """Connect the mock bridge."""
@@ -110,9 +111,22 @@ class MockBridge:
 
     def add_subscriber(self, device_id: str, callback_):
         """Mock a listener to be notified of state changes."""
+        if device_id not in self._subscribers:
+            self._subscribers[device_id] = []
+        self._subscribers[device_id].append(callback_)
 
     def add_button_subscriber(self, button_id: str, callback_):
         """Mock a listener for button presses."""
+
+    def call_subscribers(self, device_id: str):
+        """Notify subscribers of a device state change."""
+        if device_id in self._subscribers:
+            for callback in self._subscribers[device_id]:
+                callback()
+
+    def get_device_by_id(self, device_id: str):
+        """Get a device by its ID."""
+        return self.devices.get(device_id)
 
     def is_connected(self):
         """Return whether the mock bridge is connected."""
@@ -308,6 +322,20 @@ class MockBridge:
 
     def tap_button(self, button_id: str):
         """Mock a button press and release message for the given button ID."""
+
+    async def set_value(self, device_id: str, value: int) -> None:
+        """Mock setting a device value."""
+        if device_id in self.devices:
+            self.devices[device_id]["current_state"] = value
+
+    async def raise_cover(self, device_id: str) -> None:
+        """Mock raising a cover."""
+
+    async def lower_cover(self, device_id: str) -> None:
+        """Mock lowering a cover."""
+
+    async def stop_cover(self, device_id: str) -> None:
+        """Mock stopping a cover."""
 
     async def close(self):
         """Close the mock bridge connection."""

--- a/tests/components/lutron_caseta/test_cover.py
+++ b/tests/components/lutron_caseta/test_cover.py
@@ -1,5 +1,14 @@
 """Tests for the Lutron Caseta integration."""
 
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_STOP_COVER,
+)
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -9,10 +18,222 @@ from . import MockBridge, async_setup_integration
 async def test_cover_unique_id(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test a light unique id."""
+    """Test a cover unique id."""
     await async_setup_integration(hass, MockBridge)
 
     cover_entity_id = "cover.basement_bedroom_left_shade"
 
     # Assert that Caseta covers will have the bridge serial hash and the zone id as the uniqueID
     assert entity_registry.async_get(cover_entity_id).unique_id == "000004d2_802"
+
+
+async def test_cover_open_close_using_set_value(hass: HomeAssistant) -> None:
+    """Test that open/close commands use set_value to avoid stuttering."""
+    with (
+        patch.object(MockBridge, "set_value", new=AsyncMock()) as mock_set_value,
+        patch.object(MockBridge, "raise_cover", new=AsyncMock()) as mock_raise_cover,
+        patch.object(MockBridge, "lower_cover", new=AsyncMock()) as mock_lower_cover,
+    ):
+        await async_setup_integration(hass, MockBridge)
+        await hass.async_block_till_done()
+
+        cover_entity_id = "cover.basement_bedroom_left_shade"
+
+        # Test opening the cover
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: cover_entity_id},
+            blocking=True,
+        )
+
+        # Should use set_value(100) instead of raise_cover
+        mock_set_value.assert_called_with("802", 100)
+        mock_raise_cover.assert_not_called()
+
+        mock_set_value.reset_mock()
+        mock_lower_cover.reset_mock()
+
+        # Test closing the cover
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: cover_entity_id},
+            blocking=True,
+        )
+
+        # Should use set_value(0) instead of lower_cover
+        mock_set_value.assert_called_with("802", 0)
+        mock_lower_cover.assert_not_called()
+
+
+async def test_cover_stop_with_direction_tracking(hass: HomeAssistant) -> None:
+    """Test that stop command sends appropriate directional command first."""
+    # Create instance to modify devices
+    mock_instance = MockBridge()
+
+    with (
+        patch.object(MockBridge, "__new__", return_value=mock_instance),
+        patch.object(mock_instance, "stop_cover", new=AsyncMock()) as mock_stop,
+        patch.object(mock_instance, "raise_cover", new=AsyncMock()) as mock_raise,
+        patch.object(mock_instance, "lower_cover", new=AsyncMock()) as mock_lower,
+    ):
+        await async_setup_integration(hass, MockBridge)
+        await hass.async_block_till_done()
+
+        cover_entity_id = "cover.basement_bedroom_left_shade"
+
+        # Simulate shade moving up (opening)
+        mock_instance.devices["802"]["current_state"] = 30
+        mock_instance.call_subscribers("802")
+        await hass.async_block_till_done()
+
+        mock_instance.devices["802"]["current_state"] = 60
+        mock_instance.call_subscribers("802")
+        await hass.async_block_till_done()
+
+        # Now stop while opening
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: cover_entity_id},
+            blocking=True,
+        )
+
+        # Should send raise_cover before stop_cover when opening
+        mock_raise.assert_called_with("802")
+        mock_stop.assert_called_with("802")
+        mock_lower.assert_not_called()
+
+        mock_raise.reset_mock()
+        mock_lower.reset_mock()
+        mock_stop.reset_mock()
+
+        # Simulate shade moving down (closing)
+        mock_instance.devices["802"]["current_state"] = 40
+        mock_instance.call_subscribers("802")
+        await hass.async_block_till_done()
+
+        mock_instance.devices["802"]["current_state"] = 20
+        mock_instance.call_subscribers("802")
+        await hass.async_block_till_done()
+
+        # Now stop while closing
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: cover_entity_id},
+            blocking=True,
+        )
+
+        # Should send lower_cover before stop_cover when closing
+        mock_lower.assert_called_with("802")
+        mock_stop.assert_called_with("802")
+        mock_raise.assert_not_called()
+
+
+async def test_cover_stop_at_endpoints(hass: HomeAssistant) -> None:
+    """Test stop command behavior when shade is at fully open or closed."""
+    # Create instance to modify devices
+    mock_instance = MockBridge()
+
+    with (
+        patch.object(MockBridge, "__new__", return_value=mock_instance),
+        patch.object(mock_instance, "stop_cover", new=AsyncMock()) as mock_stop,
+        patch.object(mock_instance, "raise_cover", new=AsyncMock()) as mock_raise,
+        patch.object(mock_instance, "lower_cover", new=AsyncMock()) as mock_lower,
+    ):
+        await async_setup_integration(hass, MockBridge)
+        await hass.async_block_till_done()
+
+        cover_entity_id = "cover.basement_bedroom_left_shade"
+
+        # Test stop at fully open (100) - should infer it was opening
+        mock_instance.devices["802"]["current_state"] = 100
+        mock_instance.call_subscribers("802")
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: cover_entity_id},
+            blocking=True,
+        )
+
+        # At fully open, should send raise_cover before stop
+        mock_raise.assert_called_with("802")
+        mock_stop.assert_called_with("802")
+
+        mock_raise.reset_mock()
+        mock_lower.reset_mock()
+        mock_stop.reset_mock()
+
+        # Test stop at fully closed (0) - should infer it was closing
+        mock_instance.devices["802"]["current_state"] = 0
+        mock_instance.call_subscribers("802")
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: cover_entity_id},
+            blocking=True,
+        )
+
+        # At fully closed, should send lower_cover before stop
+        mock_lower.assert_called_with("802")
+        mock_stop.assert_called_with("802")
+
+
+async def test_cover_position_heuristic_fallback(hass: HomeAssistant) -> None:
+    """Test stop command uses position heuristic when movement direction is unknown."""
+    # Create instance to modify devices
+    mock_instance = MockBridge()
+
+    with (
+        patch.object(MockBridge, "__new__", return_value=mock_instance),
+        patch.object(mock_instance, "stop_cover", new=AsyncMock()) as mock_stop,
+        patch.object(mock_instance, "raise_cover", new=AsyncMock()) as mock_raise,
+        patch.object(mock_instance, "lower_cover", new=AsyncMock()) as mock_lower,
+    ):
+        await async_setup_integration(hass, MockBridge)
+        await hass.async_block_till_done()
+
+        cover_entity_id = "cover.basement_bedroom_left_shade"
+
+        # Test stop at position < 50 with no movement
+        # Update the device data directly in the bridge's devices dict
+        mock_instance.devices["802"]["current_state"] = 30
+        mock_instance.call_subscribers("802")
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: cover_entity_id},
+            blocking=True,
+        )
+
+        # Position < 50, should send lower_cover
+        mock_lower.assert_called_with("802")
+        mock_stop.assert_called_with("802")
+
+        mock_raise.reset_mock()
+        mock_lower.reset_mock()
+        mock_stop.reset_mock()
+
+        # Test stop at position >= 50 with no movement
+        mock_instance.devices["802"]["current_state"] = 70
+        mock_instance.call_subscribers("802")
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: cover_entity_id},
+            blocking=True,
+        )
+
+        # Position >= 50, should send raise_cover
+        mock_raise.assert_called_with("802")
+        mock_stop.assert_called_with("802")

--- a/tests/components/lutron_caseta/test_cover.py
+++ b/tests/components/lutron_caseta/test_cover.py
@@ -19,38 +19,19 @@ from . import MockBridge, async_setup_integration
 
 
 @pytest.fixture
-async def mock_bridge_with_mocked_set_value(hass: HomeAssistant) -> MockBridge:
-    """Set up mock bridge with mocked set_value for testing open/close."""
+async def mock_bridge_with_cover_mocks(hass: HomeAssistant) -> MockBridge:
+    """Set up mock bridge with all cover methods mocked for testing."""
     instance = MockBridge()
 
     def factory(*args: Any, **kwargs: Any) -> MockBridge:
         """Return the mock bridge instance."""
         return instance
 
-    # Patch the methods on the instance with AsyncMocks
+    # Patch all cover methods on the instance with AsyncMocks
     instance.set_value = AsyncMock()
     instance.raise_cover = AsyncMock()
     instance.lower_cover = AsyncMock()
-
-    await async_setup_integration(hass, factory)
-    await hass.async_block_till_done()
-
-    return instance
-
-
-@pytest.fixture
-async def mock_bridge_with_mocked_covers(hass: HomeAssistant) -> MockBridge:
-    """Set up mock bridge with mocked cover methods for testing."""
-    instance = MockBridge()
-
-    def factory(*args: Any, **kwargs: Any) -> MockBridge:
-        """Return the mock bridge instance."""
-        return instance
-
-    # Patch the methods on the instance with AsyncMocks
     instance.stop_cover = AsyncMock()
-    instance.raise_cover = AsyncMock()
-    instance.lower_cover = AsyncMock()
 
     await async_setup_integration(hass, factory)
     await hass.async_block_till_done()
@@ -71,10 +52,10 @@ async def test_cover_unique_id(
 
 
 async def test_cover_open_close_using_set_value(
-    hass: HomeAssistant, mock_bridge_with_mocked_set_value: MockBridge
+    hass: HomeAssistant, mock_bridge_with_cover_mocks: MockBridge
 ) -> None:
     """Test that open/close commands use set_value to avoid stuttering."""
-    mock_instance = mock_bridge_with_mocked_set_value
+    mock_instance = mock_bridge_with_cover_mocks
     cover_entity_id = "cover.basement_bedroom_left_shade"
 
     # Test opening the cover
@@ -106,10 +87,10 @@ async def test_cover_open_close_using_set_value(
 
 
 async def test_cover_stop_with_direction_tracking(
-    hass: HomeAssistant, mock_bridge_with_mocked_covers: MockBridge
+    hass: HomeAssistant, mock_bridge_with_cover_mocks: MockBridge
 ) -> None:
     """Test that stop command sends appropriate directional command first."""
-    mock_instance = mock_bridge_with_mocked_covers
+    mock_instance = mock_bridge_with_cover_mocks
     cover_entity_id = "cover.basement_bedroom_left_shade"
 
     # Simulate shade moving up (opening)
@@ -162,10 +143,10 @@ async def test_cover_stop_with_direction_tracking(
 
 
 async def test_cover_stop_at_endpoints(
-    hass: HomeAssistant, mock_bridge_with_mocked_covers: MockBridge
+    hass: HomeAssistant, mock_bridge_with_cover_mocks: MockBridge
 ) -> None:
     """Test stop command behavior when shade is at fully open or closed."""
-    mock_instance = mock_bridge_with_mocked_covers
+    mock_instance = mock_bridge_with_cover_mocks
     cover_entity_id = "cover.basement_bedroom_left_shade"
 
     # Test stop at fully open (100) - should infer it was opening
@@ -206,10 +187,10 @@ async def test_cover_stop_at_endpoints(
 
 
 async def test_cover_position_heuristic_fallback(
-    hass: HomeAssistant, mock_bridge_with_mocked_covers: MockBridge
+    hass: HomeAssistant, mock_bridge_with_cover_mocks: MockBridge
 ) -> None:
     """Test stop command uses position heuristic when movement direction is unknown."""
-    mock_instance = mock_bridge_with_mocked_covers
+    mock_instance = mock_bridge_with_cover_mocks
     cover_entity_id = "cover.basement_bedroom_left_shade"
 
     # Test stop at position < 50 with no movement

--- a/tests/components/lutron_caseta/test_cover.py
+++ b/tests/components/lutron_caseta/test_cover.py
@@ -42,7 +42,7 @@ async def mock_bridge_with_cover_mocks(hass: HomeAssistant) -> MockBridge:
 async def test_cover_unique_id(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test a cover unique id."""
+    """Test a cover unique ID."""
     await async_setup_integration(hass, MockBridge)
 
     cover_entity_id = "cover.basement_bedroom_left_shade"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes the long-standing Lutron Caseta shade stuttering issue and ensures stop commands work reliably.

### Problem 1: Shade Stuttering
Shades exhibit a "nudge, pause, then continue" stuttering behavior when using open/close commands. This has been reported in multiple issues over the years.

**Solution**: Use `set_value(100)` for open and `set_value(0)` for close instead of `raise_cover`/`lower_cover`. This provides smooth, stutter-free operation.

### Problem 2: Stop Command Reliability  
When we changed open/close to use `set_value` (to fix stuttering), we lost the implicit directional context that `raise_cover`/`lower_cover` provided. However, the Lutron LEAP protocol requires a directional command before stop will work.

**The causal chain**:
1. We changed to `set_value(100)`/`set_value(0)` to fix stuttering
2. This removed the directional commands from open/close operations
3. But LEAP protocol requires sending a matching directional command (raise or lower) before stop
4. So we now must track movement direction to know which command to send

**How direction tracking works**:
- Monitor position changes from the bridge to detect movement direction
- Track whether shade is moving up, down, or stopped
- When stop is called, send the appropriate directional command first:
  - If moving up: send `raise_cover` then `stop_cover`
  - If moving down: send `lower_cover` then `stop_cover`

**Why tracking matters**:
In practice, sending either `raise_cover` or `lower_cover` before stop works - the commands execute so quickly on the hardwired Ethernet bridge that it's not noticeable. However, tracking the correct direction is about:
- **Correctness**: Sending the right command per the protocol
- **Network latency**: If Home Assistant is on WiFi or has other network delays, sending the wrong directional command could cause a visible "bump" in the wrong direction before stopping
- **Future compatibility**: Ensuring we follow the protocol correctly

**Important**: The movement direction tracking exists ONLY because we changed to `set_value` for open/close. It's the price we pay for smooth, stutter-free operation while maintaining stop functionality with Lutron's protocol requirements.

### Why this belongs in Home Assistant (not pylutron_caseta)
The pylutron_caseta library is intentionally a thin wrapper around LEAP protocol commands. This issue is specifically about mapping Home Assistant's entity model (open/close/stop) to Lutron's protocol requirements. The library correctly exposes the raw commands - it's Home Assistant's responsibility to use them appropriately for a good user experience.

**The mapping problem**:
- Home Assistant expects: `open_cover()`, `close_cover()`, `stop_cover()`
- Lutron provides: `set_value()`, `raise_cover()`, `lower_cover()`, `stop_cover()`
- The stuttering fix changes how we map open/close
- This creates a side effect for stop that needs HA-level state tracking

### History and context
This stuttering issue has been reported for years (#78971, #98365, #151462) with multiple failed attempts to fix it. After extensive testing and analysis, this solution finally addresses both the stuttering and maintains reliable stop functionality.

### Implementation details:
- Track actual position changes from the bridge (handles manual control via physical buttons/Lutron app)
- Add intermediate callback (`_handle_bridge_update`) to hook state updates without overriding core HA methods
- Fallback heuristics when direction is unknown (position-based inference)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #78971, fixes #98365, fixes #151462
- This PR is related to issue: #151468, #98790
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr