### PR TITLE
Add schema validation for Object selectors

### DIFF
--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -648,7 +648,40 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
     [
-        ({}, ("abc123",), ()),
+        ({}, ("abc123", 123, 10.0, True, False, {}, [], None), ()),
+        (
+            {
+                "fields": {
+                    "name": {
+                        "required": True,
+                        "selector": {"text": {}},
+                    },
+                    "percentage": {
+                        "selector": {"number": {}},
+                    },
+                },
+                "label_field": "name",
+                "description_field": "percentage",
+            },
+            (
+                {"name": "abc"},
+                {"name": "abc", "percentage": 50},
+            ),
+            (
+                {"name": None},
+                {"name": None, "percentage": 50},
+                {"percentage": 50},
+                {"name": "abc", "percentage": 50, "unknown": "123"},
+                "abc123",
+                123,
+                10.0,
+                True,
+                False,
+                {},
+                [],
+                None,
+            ),
+        ),
         (
             {
                 "fields": {
@@ -664,8 +697,21 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
                 "label_field": "name",
                 "description_field": "percentage",
             },
-            (),
-            (),
+            (
+                # [{"name": "abc"}],
+                # [
+                #     {"name": "abc", "percentage": 50},
+                #     {"name": "abc"},
+                #     {"name": "abc", "percentage": None},
+                # ],
+                [],
+            ),
+            (
+                {"name": "abc", "percentage": 50},
+                [{"name": None}, {"name": "abc"}],
+                [{"name": None, "percentage": 50}],
+                [{"percentage": 50}],
+            ),
         ),
     ],
     [],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
[Object selectors](https://www.home-assistant.io/docs/blueprint/selectors/#object-selector) now enforce that the input data adheres to the field schemas when `fields` is specified. This fixes a previous oversight to align the behavior with user expectations, but may expose incorrect usages.

The following examples illustrate the changes in behavior:

* **`fields` specified and `multiple: false` (or not specified)**

  ```yaml
  object:
    fields:
      name:
        required: true
        selector:
          number:
  ```
  
  | Scenario | Example | Accepted under<br>old behavior | Accepted under<br>new behavior |
  | -------- | ------- | ------------ | ---- |
  | **Valid input** | `{"name": "abc"}` | :heavy_check_mark: | :heavy_check_mark: |
  | **Missing required keys** | `{}` | :heavy_check_mark: | :x: |
  | **Unknown extra keys** | `{"name": "abc", "unknown": "123"}` | :heavy_check_mark: | :x: |
  | **Not a YAML map** | `"abc123"`, `123`, `10.0`, `[]` | :heavy_check_mark: | :x: |

- **`fields` specified and `multiple: true`**

  ```yaml
  object:
    multiple: true
    fields:
      name:
        required: true
        selector:
          number:
  ```

  | Scenario | Example | Accepted under<br>old behavior | Accepted under<br>new behavior |
  | -------- | ------- | ------------ | ---- |
  | **Valid input** | `[{"name": "abc"}]`, `[]` | :heavy_check_mark: | :heavy_check_mark: |
  | **Missing required keys** | `[{}]` | :heavy_check_mark: | :x: |
  | **Unknown extra keys** | `[{"name": "abc", "unknown": "123"}]` | :heavy_check_mark: | :x: | | **Wrong type** | `["abc123"]`, `[123]`, `[10.0]` | :heavy_check_mark: | :x: |
  | **Not a list** | `"abc123"`, `123`, `10.0`, `{}` | :heavy_check_mark: | :x: |

- **`fields` _not_ specified and `multiple: false` (or not specified)**

  ```yaml
  object:
    multiple: false
  ```

  | Scenario | Example | Accepted under<br>old behavior | Accepted under<br>new behavior |
  | -------- | ------- | ------------ | ---- |
  | **Valid** | `{"name": "abc"}`, `{}` | :heavy_check_mark: | :heavy_check_mark: |
  | **Arbitrary inputs** | `"abc123"`, `123`, `10.0`, `[]` | :heavy_check_mark: | :heavy_check_mark: |



- **`fields` _not_ specified and `multiple: true`**

  ```yaml
  object:
    multiple: true
  ```

  | Scenario | Example | Accepted under<br>old behavior | Accepted under<br>new behavior |
  | -------- | ------- | ------------ | ---- |
  | **List** | `["abc123"]`, `[123]`, `[10.0]`, `[{}]`, `[]` | :heavy_check_mark: | :heavy_check_mark: |
  | **Not a list** | `"abc123"`, `123`, `10.0`, `{}` | :heavy_check_mark: | :x: |

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For some reason, when the `fields` option was added to `ObjectSelector` in #147215, schema validation was not actually implemented. Although the schema was effectively enforced when using the UI editor, it was possible to input arbitrary data using the YAML editor. This commit adds validation to ensure that the fields provided in the selector match the schema defined in the `ObjectSelector`.

Note that this only affects places that actually validate the input data against the provided schema.

- Scripts for example do NOT validate that their input fields match the specified schema.

  This can be verified by testing the following two scripts:

  ```yaml
  # script.invoke_accept_some_number
  sequence:
    - action: script.bug_some_number
      metadata: {}
      data:
        some_number: abc # Not a number!
  ```

  ```yaml
  # script.accept_some_number
  fields:
    some_number:
      selector:
        number:
          min: 1
          max: 100
  sequence:
    - action: system_log.write
      metadata: {}
      data:
        level: error
        message: "Test message: some_number={{ some_number }}"
  ```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] ~~Documentation added/updated for [www.home-assistant.io][docs-repository]~~ Documentation already specifies that specifiying `fields` will force the input to adhere to that schema.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
