### PR TITLE
Deprecate Litter-Robot 4 night light mode switch

### DIFF
--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -209,5 +209,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "deprecated_entity": {
+      "title": "{name} is deprecated",
+      "description": "The Litter-Robot entity `{entity}` is deprecated and will be removed in a future release.\nPlease update your dashboards, automations and scripts, disable `{entity}` and reload the integration/restart Home Assistant to fix this issue."
+    }
   }
 }

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -6,13 +6,24 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any, Generic
 
-from pylitterbot import FeederRobot, LitterRobot, Robot
+from pylitterbot import FeederRobot, LitterRobot, LitterRobot3, LitterRobot4, Robot
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 
+from .const import DOMAIN
 from .coordinator import LitterRobotConfigEntry
 from .entity import LitterRobotEntity, _WhiskerEntityT
 
@@ -26,6 +37,15 @@ class RobotSwitchEntityDescription(SwitchEntityDescription, Generic[_WhiskerEnti
     value_fn: Callable[[_WhiskerEntityT], bool]
 
 
+NIGHT_LIGHT_MODE_ENTITY_DESCRIPTION = RobotSwitchEntityDescription[
+    LitterRobot | FeederRobot
+](
+    key="night_light_mode_enabled",
+    translation_key="night_light_mode",
+    set_fn=lambda robot, value: robot.set_night_light(value),
+    value_fn=lambda robot: robot.night_light_mode_enabled,
+)
+
 SWITCH_MAP: dict[type[Robot], tuple[RobotSwitchEntityDescription, ...]] = {
     FeederRobot: (
         RobotSwitchEntityDescription[FeederRobot](
@@ -34,14 +54,10 @@ SWITCH_MAP: dict[type[Robot], tuple[RobotSwitchEntityDescription, ...]] = {
             set_fn=lambda robot, value: robot.set_gravity_mode(value),
             value_fn=lambda robot: robot.gravity_mode_enabled,
         ),
+        NIGHT_LIGHT_MODE_ENTITY_DESCRIPTION,
     ),
+    LitterRobot3: (NIGHT_LIGHT_MODE_ENTITY_DESCRIPTION,),
     Robot: (  # type: ignore[type-abstract]  # only used for isinstance check
-        RobotSwitchEntityDescription[LitterRobot | FeederRobot](
-            key="night_light_mode_enabled",
-            translation_key="night_light_mode",
-            set_fn=lambda robot, value: robot.set_night_light(value),
-            value_fn=lambda robot: robot.night_light_mode_enabled,
-        ),
         RobotSwitchEntityDescription[LitterRobot | FeederRobot](
             key="panel_lock_enabled",
             translation_key="panel_lockout",
@@ -59,13 +75,54 @@ async def async_setup_entry(
 ) -> None:
     """Set up Litter-Robot switches using config entry."""
     coordinator = entry.runtime_data
-    async_add_entities(
+    entities = [
         RobotSwitchEntity(robot=robot, coordinator=coordinator, description=description)
         for robot in coordinator.account.robots
         for robot_type, entity_descriptions in SWITCH_MAP.items()
         if isinstance(robot, robot_type)
         for description in entity_descriptions
-    )
+    ]
+
+    ent_reg = er.async_get(hass)
+
+    def add_deprecated_entity(
+        robot: LitterRobot4,
+        description: RobotSwitchEntityDescription,
+        entity_cls: type[RobotSwitchEntity],
+    ) -> None:
+        """Add deprecated entities."""
+        unique_id = f"{robot.serial}-{description.key}"
+        if entity_id := ent_reg.async_get_entity_id(SWITCH_DOMAIN, DOMAIN, unique_id):
+            entity_entry = ent_reg.async_get(entity_id)
+            if entity_entry and entity_entry.disabled:
+                ent_reg.async_remove(entity_id)
+                async_delete_issue(
+                    hass,
+                    DOMAIN,
+                    f"deprecated_entity_{unique_id}",
+                )
+            elif entity_entry:
+                entities.append(entity_cls(robot, coordinator, description))
+                async_create_issue(
+                    hass,
+                    DOMAIN,
+                    f"deprecated_entity_{unique_id}",
+                    breaks_in_ha_version="2026.4.0",
+                    is_fixable=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="deprecated_entity",
+                    translation_placeholders={
+                        "name": f"{robot.name} {entity_entry.name or entity_entry.original_name}",
+                        "entity": entity_id,
+                    },
+                )
+
+    for robot in coordinator.account.get_robots(LitterRobot4):
+        add_deprecated_entity(
+            robot, NIGHT_LIGHT_MODE_ENTITY_DESCRIPTION, RobotSwitchEntity
+        )
+
+    async_add_entities(entities)
 
 
 class RobotSwitchEntity(LitterRobotEntity[_WhiskerEntityT], SwitchEntity):

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -84,6 +84,9 @@ def create_mock_account(
         if skip_robots
         else [create_mock_robot(robot_data, account, v4, feeder, side_effect)]
     )
+    account.get_robots = lambda robot_class: [
+        robot for robot in account.robots if isinstance(robot, robot_class)
+    ]
     account.pets = [create_mock_pet(PET_DATA, account, side_effect)] if pet else []
     return account
 

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from pylitterbot import FeederRobot, Robot
 import pytest
 
+from homeassistant.components.litterrobot import DOMAIN
 from homeassistant.components.switch import (
     DOMAIN as PLATFORM_DOMAIN,
     SERVICE_TURN_OFF,
@@ -12,7 +13,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 from .conftest import setup_integration
 
@@ -90,3 +91,47 @@ async def test_feeder_robot_switch(
         assert robot.set_gravity_mode.call_count == count + 1
         assert (state := hass.states.get(gravity_mode_switch))
         assert state.state == new_state
+
+
+@pytest.mark.parametrize(
+    ("preexisting_entity", "disabled_by", "expected_entity", "expected_issue"),
+    [
+        (True, None, True, True),
+        (True, er.RegistryEntryDisabler.USER, False, False),
+        (False, None, False, False),
+    ],
+)
+async def test_litterrobot_4_deprecated_switch(
+    hass: HomeAssistant,
+    mock_account_with_litterrobot_4: MagicMock,
+    issue_registry: ir.IssueRegistry,
+    entity_registry: er.EntityRegistry,
+    preexisting_entity: bool,
+    disabled_by: er.RegistryEntryDisabler,
+    expected_entity: bool,
+    expected_issue: bool,
+) -> None:
+    """Test switch deprecation issue."""
+    entity_uid = "LR4C010001-night_light_mode_enabled"
+    if preexisting_entity:
+        suggested_id = NIGHT_LIGHT_MODE_ENTITY_ID.replace(f"{PLATFORM_DOMAIN}.", "")
+        entity_registry.async_get_or_create(
+            PLATFORM_DOMAIN,
+            DOMAIN,
+            entity_uid,
+            suggested_object_id=suggested_id,
+            disabled_by=disabled_by,
+        )
+
+    await setup_integration(hass, mock_account_with_litterrobot_4, PLATFORM_DOMAIN)
+
+    assert (
+        entity_registry.async_get(NIGHT_LIGHT_MODE_ENTITY_ID) is not None
+    ) is expected_entity
+    assert (
+        issue_registry.async_get_issue(
+            domain=DOMAIN,
+            issue_id=f"deprecated_entity_{entity_uid}",
+        )
+        is not None
+    ) is expected_issue


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Litter-Robot 4: Night light mode switch entity has been replaced by Globe light select entity (supports on/off/auto).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40852
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
