### PR TITLE
chore(deps): bump python-roborock to 2.39.0

### DIFF
--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -19,7 +19,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==2.18.2",
+    "python-roborock==2.39.0",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2520,7 +2520,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==2.18.2
+python-roborock==2.39.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.44

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2090,7 +2090,7 @@ python-pooldose==0.5.0
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==2.18.2
+python-roborock==2.39.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.44


### PR DESCRIPTION
Updates integration to python-roborock 2.39.0.

- Update manifest requirement
- Regenerate requirement pins in requirements_all.txt and requirements_test_all.txt from manifest
- Scope: bump-only. No unrelated cleanups or refactors included.
- Breaking changes: none observed.

A follow-up cleanup PR will carry diagnostics/time tidy-ups and test adjustments.