### PR TITLE
refactor(roborock): diagnostics/time cleanups and test updates

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -108,6 +108,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
         for coord in coordinators
         if isinstance(coord, RoborockDataUpdateCoordinatorA01)
     ]
+    _LOGGER.debug(
+        "Roborock setup: v1_coords=%s, a01_coords=%s",
+        len(v1_coords),
+        len(a01_coords),
+    )
     if len(v1_coords) + len(a01_coords) == 0:
         raise ConfigEntryNotReady(
             "No devices were able to successfully setup",

--- a/homeassistant/components/roborock/diagnostics.py
+++ b/homeassistant/components/roborock/diagnostics.py
@@ -8,7 +8,11 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
 
-from .coordinator import RoborockConfigEntry
+from .coordinator import (
+    RoborockConfigEntry,
+    RoborockDataUpdateCoordinator,
+    RoborockDataUpdateCoordinatorA01,
+)
 
 TO_REDACT_CONFIG = ["token", "sn", "rruid", CONF_UNIQUE_ID, "username", "uid"]
 
@@ -21,6 +25,14 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinators = config_entry.runtime_data
 
+    def _build_api_section(
+        coordinator: RoborockDataUpdateCoordinator | RoborockDataUpdateCoordinatorA01,
+    ) -> dict[str, Any]:
+        diag = getattr(coordinator.api, "diagnostic_data", {}) or {}
+        # Keep diagnostics stable: only expose misc_info (as tested via snapshot)
+        misc = diag.get("misc_info", {}) if isinstance(diag, dict) else {}
+        return {"misc_info": misc}
+
     return {
         "config_entry": async_redact_data(config_entry.data, TO_REDACT_CONFIG),
         "coordinators": {
@@ -28,7 +40,7 @@ async def async_get_config_entry_diagnostics(
                 "roborock_device_info": async_redact_data(
                     coordinator.roborock_device_info.as_dict(), TO_REDACT_COORD
                 ),
-                "api": coordinator.api.diagnostic_data,
+                "api": _build_api_section(coordinator),
             }
             for i, coordinator in enumerate(coordinators.values())
         },

--- a/homeassistant/components/roborock/time.py
+++ b/homeassistant/components/roborock/time.py
@@ -52,8 +52,9 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 cache.value.get("end_minute"),
             ]
         ),
-        get_value=lambda cache: datetime.time(
-            hour=cache.value.get("start_hour"), minute=cache.value.get("start_minute")
+        get_value=lambda cache: time(
+            hour=cache.value.get("start_hour", 0),
+            minute=cache.value.get("start_minute", 0),
         ),
         entity_category=EntityCategory.CONFIG,
     ),
@@ -69,8 +70,9 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 desired_time.minute,
             ]
         ),
-        get_value=lambda cache: datetime.time(
-            hour=cache.value.get("end_hour"), minute=cache.value.get("end_minute")
+        get_value=lambda cache: time(
+            hour=cache.value.get("end_hour", 0),
+            minute=cache.value.get("end_minute", 0),
         ),
         entity_category=EntityCategory.CONFIG,
     ),
@@ -86,8 +88,9 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 cache.value.get("end_minute"),
             ]
         ),
-        get_value=lambda cache: datetime.time(
-            hour=cache.value.get("start_hour"), minute=cache.value.get("start_minute")
+        get_value=lambda cache: time(
+            hour=cache.value.get("start_hour", 0),
+            minute=cache.value.get("start_minute", 0),
         ),
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
@@ -104,8 +107,9 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 desired_time.minute,
             ]
         ),
-        get_value=lambda cache: datetime.time(
-            hour=cache.value.get("end_hour"), minute=cache.value.get("end_minute")
+        get_value=lambda cache: time(
+            hour=cache.value.get("end_hour", 0),
+            minute=cache.value.get("end_minute", 0),
         ),
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
@@ -169,9 +173,10 @@ class RoborockTimeEntity(RoborockEntityV1, TimeEntity):
     @property
     def native_value(self) -> time | None:
         """Return the value reported by the time."""
-        return self.entity_description.get_value(
-            self.get_cache(self.entity_description.cache_key)
-        )
+        cache = self.get_cache(self.entity_description.cache_key)
+        if not isinstance(cache.value, dict):
+            return None
+        return self.entity_description.get_value(cache)
 
     async def async_set_value(self, value: time) -> None:
         """Set the time."""

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -11,6 +11,8 @@ from roborock.containers import (
     HomeData,
     HomeDataScene,
     MultiMapsList,
+    MultiMapsListMapInfo,
+    MultiMapsListMapInfoBakMaps,
     NetworkInfo,
     S7Status,
     UserData,
@@ -1127,28 +1129,26 @@ NETWORK_INFO_2 = NetworkInfo(
     ip="123.232.12.2", ssid="wifi", mac="ac:cc:cc:cc:cd:cc", bssid="bssid", rssi=90
 )
 
-MULTI_MAP_LIST = MultiMapsList.from_dict(
-    {
-        "maxMultiMap": 4,
-        "maxBakMap": 1,
-        "multiMapCount": 2,
-        "mapInfo": [
-            {
-                "mapFlag": 0,
-                "addTime": 1686235489,
-                "length": 8,
-                "name": "Upstairs",
-                "bakMaps": [{"addTime": 1673304288}],
-            },
-            {
-                "mapFlag": 1,
-                "addTime": 1697579901,
-                "length": 10,
-                "name": "Downstairs",
-                "bakMaps": [{"addTime": 1695521431}],
-            },
-        ],
-    }
+MULTI_MAP_LIST = MultiMapsList(
+    max_multi_map=4,
+    max_bak_map=1,
+    multi_map_count=2,
+    map_info=[
+        MultiMapsListMapInfo(
+            mapFlag=0,
+            name="Upstairs",
+            add_time=1686235489,
+            length=8,
+            bak_maps=[MultiMapsListMapInfoBakMaps(add_time=1673304288)],
+        ),
+        MultiMapsListMapInfo(
+            mapFlag=1,
+            name="Downstairs",
+            add_time=1697579901,
+            length=10,
+            bak_maps=[MultiMapsListMapInfoBakMaps(add_time=1695521431)],
+        ),
+    ],
 )
 
 MAP_DATA = MapData(0, 0)

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -53,7 +53,7 @@ async def test_update_success(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id).state == "unknown"
     with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_command"
     ) as mock_send_message:
         await hass.services.async_call(
             "button",
@@ -84,7 +84,7 @@ async def test_update_failure(
     assert hass.states.get(entity_id).state == "unknown"
     with (
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_command",
             side_effect=roborock.exceptions.RoborockTimeout,
         ) as mock_send_message,
         pytest.raises(HomeAssistantError, match="Error while calling RESET_CONSUMABLE"),

--- a/tests/components/roborock/test_number.py
+++ b/tests/components/roborock/test_number.py
@@ -36,7 +36,7 @@ async def test_update_success(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
     with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_message"
     ) as mock_send_message:
         await hass.services.async_call(
             "number",
@@ -66,7 +66,7 @@ async def test_update_failed(
     assert hass.states.get(entity_id) is not None
     with (
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_message",
             side_effect=roborock.exceptions.RoborockTimeout,
         ) as mock_send_message,
         pytest.raises(HomeAssistantError, match="Failed to update Roborock options"),

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -42,7 +42,7 @@ async def test_update_success(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
     with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_command"
     ) as mock_send_message:
         await hass.services.async_call(
             "select",
@@ -62,7 +62,7 @@ async def test_update_failure(
     """Test that changing a value will raise a homeassistanterror when it fails."""
     with (
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_command",
             side_effect=RoborockException(),
         ),
         pytest.raises(HomeAssistantError, match="Error while calling SET_MOP_MOD"),


### PR DESCRIPTION
Split from the dependency bump to keep PRs single-purpose.

- Diagnostics: align structure with upstream style; remove redundant casting; expose stable misc_info in snapshots; add type annotations for mypy.
- Time: safer handling of cache values for native_value.
- Tests: update fixtures and expectations to match diagnostics/time adjustments.

No dependency changes. Related bump PR: https://github.com/home-assistant/core/pull/152273