### PR TITLE
Add Shelly removal condition for virtual components

### DIFF
--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -40,6 +40,7 @@ from .utils import (
     get_virtual_component_ids,
     is_block_momentary_input,
     is_rpc_momentary_input,
+    is_view_for_platform,
 )
 
 PARALLEL_UPDATES = 0
@@ -273,6 +274,9 @@ RPC_SENSORS: Final = {
     "boolean": RpcBinarySensorDescription(
         key="boolean",
         sub_key="value",
+        removal_condition=lambda config, _status, key: not is_view_for_platform(
+            config, key, BINARY_SENSOR_PLATFORM
+        ),
     ),
     "calibration": RpcBinarySensorDescription(
         key="blutrv",

--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -41,6 +41,7 @@ from .utils import (
     get_device_entry_gen,
     get_virtual_component_ids,
     get_virtual_component_unit,
+    is_view_for_platform,
 )
 
 PARALLEL_UPDATES = 0
@@ -185,6 +186,9 @@ RPC_NUMBERS: Final = {
     "number": RpcNumberDescription(
         key="number",
         sub_key="value",
+        removal_condition=lambda config, _status, key: not is_view_for_platform(
+            config, key, NUMBER_PLATFORM
+        ),
         max_fn=lambda config: config["max"],
         min_fn=lambda config: config["min"],
         mode_fn=lambda config: VIRTUAL_NUMBER_MODE_MAP.get(

--- a/homeassistant/components/shelly/select.py
+++ b/homeassistant/components/shelly/select.py
@@ -26,6 +26,7 @@ from .utils import (
     async_remove_orphaned_entities,
     get_device_entry_gen,
     get_virtual_component_ids,
+    is_view_for_platform,
 )
 
 PARALLEL_UPDATES = 0
@@ -40,6 +41,9 @@ RPC_SELECT_ENTITIES: Final = {
     "enum": RpcSelectDescription(
         key="enum",
         sub_key="value",
+        removal_condition=lambda config, _status, key: not is_view_for_platform(
+            config, key, SELECT_PLATFORM
+        ),
     ),
 }
 

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -63,6 +63,7 @@ from .utils import (
     get_virtual_component_ids,
     get_virtual_component_unit,
     is_rpc_wifi_stations_disabled,
+    is_view_for_platform,
 )
 
 PARALLEL_UPDATES = 0
@@ -1385,10 +1386,16 @@ RPC_SENSORS: Final = {
     "text": RpcSensorDescription(
         key="text",
         sub_key="value",
+        removal_condition=lambda config, _status, key: not is_view_for_platform(
+            config, key, SENSOR_PLATFORM
+        ),
     ),
     "number": RpcSensorDescription(
         key="number",
         sub_key="value",
+        removal_condition=lambda config, _status, key: not is_view_for_platform(
+            config, key, SENSOR_PLATFORM
+        ),
         unit=get_virtual_component_unit,
         device_class_fn=lambda config: ROLE_TO_DEVICE_CLASS_MAP.get(config["role"])
         if "role" in config
@@ -1397,6 +1404,9 @@ RPC_SENSORS: Final = {
     "enum": RpcSensorDescription(
         key="enum",
         sub_key="value",
+        removal_condition=lambda config, _status, key: not is_view_for_platform(
+            config, key, SENSOR_PLATFORM
+        ),
         options_fn=lambda config: config["options"],
         device_class=SensorDeviceClass.ENUM,
     ),

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -37,6 +37,7 @@ from .utils import (
     get_virtual_component_ids,
     is_block_exclude_from_relay,
     is_rpc_exclude_from_relay,
+    is_view_for_platform,
 )
 
 PARALLEL_UPDATES = 0
@@ -89,6 +90,9 @@ RPC_SWITCHES = {
     "boolean": RpcSwitchDescription(
         key="boolean",
         sub_key="value",
+        removal_condition=lambda config, _status, key: not is_view_for_platform(
+            config, key, SWITCH_PLATFORM
+        ),
         is_on=lambda status: bool(status["value"]),
         method_on="Boolean.Set",
         method_off="Boolean.Set",

--- a/homeassistant/components/shelly/text.py
+++ b/homeassistant/components/shelly/text.py
@@ -26,6 +26,7 @@ from .utils import (
     async_remove_orphaned_entities,
     get_device_entry_gen,
     get_virtual_component_ids,
+    is_view_for_platform,
 )
 
 PARALLEL_UPDATES = 0
@@ -40,6 +41,9 @@ RPC_TEXT_ENTITIES: Final = {
     "text": RpcTextDescription(
         key="text",
         sub_key="value",
+        removal_condition=lambda config, _status, key: not is_view_for_platform(
+            config, key, TEXT_PLATFORM
+        ),
     ),
 }
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -654,6 +654,13 @@ def get_virtual_component_ids(config: dict[str, Any], platform: str) -> list[str
     return ids
 
 
+def is_view_for_platform(config: dict[str, Any], key: str, platform: str) -> bool:
+    """Return true if the virtual component view match the platform."""
+    component = VIRTUAL_COMPONENTS_MAP[platform]
+    view = config[key]["meta"]["ui"]["view"]
+    return view in component["modes"]
+
+
 def get_virtual_component_unit(config: dict[str, Any]) -> str | None:
     """Return the unit of a virtual component.
 

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -762,3 +762,16 @@ def mock_setup() -> Generator[AsyncMock]:
         "homeassistant.components.shelly.async_setup", return_value=True
     ) as mock_setup:
         yield mock_setup
+
+
+@pytest.fixture
+def disable_async_remove_shelly_rpc_entities() -> Generator[None]:
+    """Patch out async_remove_shelly_rpc_entities.
+
+    This is used by virtual componetns tests that should not create entities,
+    without it async_remove_shelly_rpc_entities will clean up the entities.
+    """
+    with patch(
+        "homeassistant.components.shelly.utils.async_remove_shelly_rpc_entities"
+    ):
+        yield

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -768,7 +768,7 @@ def mock_setup() -> Generator[AsyncMock]:
 def disable_async_remove_shelly_rpc_entities() -> Generator[None]:
     """Patch out async_remove_shelly_rpc_entities.
 
-    This is used by virtual componetns tests that should not create entities,
+    This is used by virtual components tests that should not create entities,
     without it async_remove_shelly_rpc_entities will clean up the entities.
     """
     with patch(

--- a/tests/components/shelly/test_binary_sensor.py
+++ b/tests/components/shelly/test_binary_sensor.py
@@ -435,6 +435,7 @@ async def test_rpc_device_virtual_binary_sensor(
     assert state.state == STATE_OFF
 
 
+@pytest.mark.usefixtures("disable_async_remove_shelly_rpc_entities")
 async def test_rpc_remove_virtual_binary_sensor_when_mode_toggle(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -340,6 +340,7 @@ async def test_rpc_device_virtual_number(
     assert state.state == "56.7"
 
 
+@pytest.mark.usefixtures("disable_async_remove_shelly_rpc_entities")
 async def test_rpc_remove_virtual_number_when_mode_label(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,

--- a/tests/components/shelly/test_select.py
+++ b/tests/components/shelly/test_select.py
@@ -92,6 +92,7 @@ async def test_rpc_device_virtual_enum(
     assert state.state == "Title 1"
 
 
+@pytest.mark.usefixtures("disable_async_remove_shelly_rpc_entities")
 async def test_rpc_remove_virtual_enum_when_mode_label(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1077,6 +1077,7 @@ async def test_rpc_device_virtual_text_sensor(
     assert state.state == "dolor sit amet"
 
 
+@pytest.mark.usefixtures("disable_async_remove_shelly_rpc_entities")
 async def test_rpc_remove_text_virtual_sensor_when_mode_field(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,
@@ -1181,6 +1182,7 @@ async def test_rpc_device_virtual_number_sensor(
     assert state.state == "56.7"
 
 
+@pytest.mark.usefixtures("disable_async_remove_shelly_rpc_entities")
 async def test_rpc_remove_number_virtual_sensor_when_mode_field(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,
@@ -1294,6 +1296,7 @@ async def test_rpc_device_virtual_enum_sensor(
     assert state.state == "two"
 
 
+@pytest.mark.usefixtures("disable_async_remove_shelly_rpc_entities")
 async def test_rpc_remove_enum_virtual_sensor_when_mode_dropdown(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -659,6 +659,7 @@ async def test_rpc_device_virtual_switch(
     assert state.state == STATE_ON
 
 
+@pytest.mark.usefixtures("disable_async_remove_shelly_rpc_entities")
 async def test_rpc_device_virtual_binary_sensor(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
@@ -680,6 +681,7 @@ async def test_rpc_device_virtual_binary_sensor(
     assert hass.states.get(entity_id) is None
 
 
+@pytest.mark.usefixtures("disable_async_remove_shelly_rpc_entities")
 async def test_rpc_remove_virtual_switch_when_mode_label(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,

--- a/tests/components/shelly/test_text.py
+++ b/tests/components/shelly/test_text.py
@@ -77,6 +77,7 @@ async def test_rpc_device_virtual_text(
     assert state.state == "sed do eiusmod"
 
 
+@pytest.mark.usefixtures("disable_async_remove_shelly_rpc_entities")
 async def test_rpc_remove_virtual_text_when_mode_label(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Related to https://github.com/home-assistant/core/pull/152195
Shelly virtual components have different view modes, (e.g., a number component can be slider, field or label).
For each mode we create a different HA entity (e.g., number as field creates a sensor entity, as slider a number entity)
There was a bug that if the mode is incorrect we first create the entity and than remove it when cleaning up orphaned entities (entities that no longer exists on the device).
To test this without cleanup, a fixture to disable cleanup for the relevant tests is introduced (`disable_async_remove_shelly_rpc_entities`) I run all the relevant tests with this fixture to first make sure they fail:
Examples from the `switch` and `sensor` platforms:
<img width="809" height="86" alt="switch-fail" src="https://github.com/user-attachments/assets/a5e419f1-01a0-48e8-86fb-37c23c6b41ba" />
<img width="836" height="78" alt="sensor-fail" src="https://github.com/user-attachments/assets/8cc6c700-caa9-407c-b7c9-a316996a27b2" />
After that added a new method that uses the entity removal condition to make sure entities are not created
Tested on Gen3 device with all types of supported virtual components and view modes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
