### PR TITLE
Permit long ping durations

### DIFF
--- a/homeassistant/components/ping/coordinator.py
+++ b/homeassistant/components/ping/coordinator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
@@ -9,6 +11,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import SLOW_UPDATE_WARNING
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .helpers import PingDataICMPLib, PingDataSubProcess
@@ -41,6 +44,7 @@ class PingUpdateCoordinator(DataUpdateCoordinator[PingResult]):
     ) -> None:
         """Initialize the Ping coordinator."""
         self.ping = ping
+        self._update_task: asyncio.Task[None] | None = None
 
         super().__init__(
             hass,
@@ -51,8 +55,28 @@ class PingUpdateCoordinator(DataUpdateCoordinator[PingResult]):
         )
 
     async def _async_update_data(self) -> PingResult:
-        """Trigger ping check."""
-        await self.ping.async_update()
+        """Update ping data within a timeout duration."""
+
+        if self._update_task is not None:
+            if not self._update_task.done():
+                # don't queue another task
+                return self._latest_ping_result()
+        else:
+            # queue a task for pinging.
+            # this is done so that pings can have a duration longer than SLOW_UPDATE_WARNING,
+            # but this method never executes for longer than SLOW_UPDATE_WARNING (we just
+            # might report stale results in the meanwhile)
+            self._update_task = asyncio.create_task(self.ping.async_update())
+
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                asyncio.shield(self._update_task), timeout=SLOW_UPDATE_WARNING - 1
+            )
+            self._update_task = None
+
+        return self._latest_ping_result()
+
+    def _latest_ping_result(self) -> PingResult:
         return PingResult(
             ip_address=self.ping.ip_address,
             is_alive=self.ping.is_alive,

--- a/homeassistant/components/ping/coordinator.py
+++ b/homeassistant/components/ping/coordinator.py
@@ -57,11 +57,7 @@ class PingUpdateCoordinator(DataUpdateCoordinator[PingResult]):
     async def _async_update_data(self) -> PingResult:
         """Update ping data within a timeout duration."""
 
-        if self._update_task is not None:
-            if not self._update_task.done():
-                # don't queue another task
-                return self._latest_ping_result()
-        else:
+        if self._update_task is None:
             # queue a task for pinging.
             # this is done so that pings can have a duration longer than SLOW_UPDATE_WARNING,
             # but this method never executes for longer than SLOW_UPDATE_WARNING (we just
@@ -76,6 +72,9 @@ class PingUpdateCoordinator(DataUpdateCoordinator[PingResult]):
             )
             self._update_task = None
 
+        # regardless of whether we exited the above block via a timeout or not,
+        # we return the latest results - either those we just got, or a
+        # previous set (in the case that we timed out above)
         return self._latest_ping_result()
 
     def _latest_ping_result(self) -> PingResult:

--- a/homeassistant/components/ping/coordinator.py
+++ b/homeassistant/components/ping/coordinator.py
@@ -69,8 +69,10 @@ class PingUpdateCoordinator(DataUpdateCoordinator[PingResult]):
             self._update_task = asyncio.create_task(self.ping.async_update())
 
         with suppress(asyncio.TimeoutError):
+            warning_buffer_time = 1
             await asyncio.wait_for(
-                asyncio.shield(self._update_task), timeout=SLOW_UPDATE_WARNING - 1
+                asyncio.shield(self._update_task),
+                timeout=SLOW_UPDATE_WARNING - warning_buffer_time,
             )
             self._update_task = None
 

--- a/tests/components/ping/test_binary_sensor.py
+++ b/tests/components/ping/test_binary_sensor.py
@@ -39,8 +39,9 @@ async def test_setup_and_update(
         return_value=Host(address="10.10.10.10", packets_sent=10, rtts=[]),
     ):
         freezer.tick(timedelta(minutes=6))
-        await hass.async_block_till_done()
-
+        # pump the _async_update_data() task through its steps
+        for _ in range(4):
+            await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.10_10_10_10")
     assert state == snapshot
 

--- a/tests/components/ping/test_device_tracker.py
+++ b/tests/components/ping/test_device_tracker.py
@@ -76,6 +76,15 @@ async def test_setup_and_update(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
+    freezer.tick(timedelta(minutes=1, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # pump the _async_update_data() task through its steps
+    freezer.tick(timedelta(minutes=1, seconds=1))
+    for _ in range(5):
+        await hass.async_block_till_done()
+
     assert (state := hass.states.get("device_tracker.10_10_10_10"))
     assert state.state == "home"
 
@@ -98,6 +107,10 @@ async def test_reload_not_triggering_home(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
+        # pump the _async_update_data() task through its steps
+        for _ in range(3):
+            await hass.async_block_till_done()
+
         assert hass.states.get("device_tracker.10_10_10_10").state == "not_home"
 
         # reload config entry
@@ -111,5 +124,9 @@ async def test_reload_not_triggering_home(
     freezer.tick(timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    # pump the _async_update_data() task through its steps
+    for _ in range(2):
+        await hass.async_block_till_done()
 
     assert hass.states.get("device_tracker.10_10_10_10").state == "home"


### PR DESCRIPTION
## Proposed change

Currently, if a user sets up ping such that the polling interval and ping count takes longer than 10 seconds, the logs fill with warnings about the binary_sensor not updating in a reasonable time frame.

This change waits for the ping and if it doesn't complete in this time, returns from the async task, allowing the ping to continue in the background (so a future update will receive the ping result that's being waited on)

Recreated #143616 (unable to reopen / comment on that PR)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #140319
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
