### PR TITLE
Improve type hints in zha tests

### DIFF
--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -1,6 +1,6 @@
 """Test configuration for the ZHA component."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Coroutine, Generator
 import itertools
 import time
 from typing import Any
@@ -241,11 +241,11 @@ def setup_zha(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_zigpy_connect: ControllerApplication,
-):
+) -> Callable[..., Coroutine[None]]:
     """Set up ZHA component."""
     zha_config = {zha_const.CONF_ENABLE_QUIRKS: False}
 
-    async def _setup(config=None):
+    async def _setup(config=None) -> None:
         config_entry.add_to_hass(hass)
         config = config or {}
 
@@ -353,7 +353,7 @@ def network_backup() -> zigpy.backups.NetworkBackup:
 
 
 @pytest.fixture
-def zigpy_device_mock(zigpy_app_controller):
+def zigpy_device_mock(zigpy_app_controller) -> Callable[..., zigpy.device.Device]:
     """Make a fake device using the specified cluster classes."""
 
     def _mock_dev(

--- a/tests/components/zha/test_alarm_control_panel.py
+++ b/tests/components/zha/test_alarm_control_panel.py
@@ -1,8 +1,10 @@
 """Test ZHA alarm control panel."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import AsyncMock, call, patch, sentinel
 
 import pytest
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl import Cluster
 from zigpy.zcl.clusters import security
@@ -45,7 +47,9 @@ def alarm_control_panel_platform_only():
     new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )
 async def test_alarm_control_panel(
-    hass: HomeAssistant, setup_zha, zigpy_device_mock
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA alarm control panel platform."""
 

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -26,7 +27,7 @@ def required_platform_only():
 
 
 async def test_async_get_network_settings_active(
-    hass: HomeAssistant, setup_zha
+    hass: HomeAssistant, setup_zha: Callable[..., Coroutine[None]]
 ) -> None:
     """Test reading settings with an active ZHA installation."""
     await setup_zha()
@@ -36,7 +37,9 @@ async def test_async_get_network_settings_active(
 
 
 async def test_async_get_network_settings_inactive(
-    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_app_controller: ControllerApplication,
 ) -> None:
     """Test reading settings with an inactive ZHA installation."""
     await setup_zha()
@@ -63,7 +66,9 @@ async def test_async_get_network_settings_inactive(
 
 
 async def test_async_get_network_settings_missing(
-    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_app_controller: ControllerApplication,
 ) -> None:
     """Test reading settings with an inactive ZHA installation, no valid channel."""
     await setup_zha()
@@ -86,7 +91,9 @@ async def test_async_get_network_settings_failure(hass: HomeAssistant) -> None:
         await api.async_get_network_settings(hass)
 
 
-async def test_async_get_radio_type_active(hass: HomeAssistant, setup_zha) -> None:
+async def test_async_get_radio_type_active(
+    hass: HomeAssistant, setup_zha: Callable[..., Coroutine[None]]
+) -> None:
     """Test reading the radio type with an active ZHA installation."""
     await setup_zha()
 
@@ -94,7 +101,9 @@ async def test_async_get_radio_type_active(hass: HomeAssistant, setup_zha) -> No
     assert radio_type == RadioType.ezsp
 
 
-async def test_async_get_radio_path_active(hass: HomeAssistant, setup_zha) -> None:
+async def test_async_get_radio_path_active(
+    hass: HomeAssistant, setup_zha: Callable[..., Coroutine[None]]
+) -> None:
     """Test reading the radio path with an active ZHA installation."""
     await setup_zha()
 
@@ -103,7 +112,9 @@ async def test_async_get_radio_path_active(hass: HomeAssistant, setup_zha) -> No
 
 
 async def test_change_channel(
-    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_app_controller: ControllerApplication,
 ) -> None:
     """Test changing the channel."""
     await setup_zha()
@@ -113,7 +124,9 @@ async def test_change_channel(
 
 
 async def test_change_channel_auto(
-    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_app_controller: ControllerApplication,
 ) -> None:
     """Test changing the channel automatically using an energy scan."""
     await setup_zha()

--- a/tests/components/zha/test_backup.py
+++ b/tests/components/zha/test_backup.py
@@ -1,5 +1,6 @@
 """Unit tests for ZHA backup platform."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import AsyncMock, patch
 
 from zigpy.application import ControllerApplication
@@ -9,7 +10,9 @@ from homeassistant.core import HomeAssistant
 
 
 async def test_pre_backup(
-    hass: HomeAssistant, zigpy_app_controller: ControllerApplication, setup_zha
+    hass: HomeAssistant,
+    zigpy_app_controller: ControllerApplication,
+    setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test backup creation when `async_pre_backup` is called."""
     await setup_zha()
@@ -23,13 +26,17 @@ async def test_pre_backup(
 
 
 @patch("homeassistant.components.zha.backup.get_zha_gateway", side_effect=ValueError())
-async def test_pre_backup_no_gateway(hass: HomeAssistant, setup_zha) -> None:
+async def test_pre_backup_no_gateway(
+    hass: HomeAssistant, setup_zha: Callable[..., Coroutine[None]]
+) -> None:
     """Test graceful backup failure when no gateway exists."""
     await setup_zha()
     await async_pre_backup(hass)
 
 
-async def test_post_backup(hass: HomeAssistant, setup_zha) -> None:
+async def test_post_backup(
+    hass: HomeAssistant, setup_zha: Callable[..., Coroutine[None]]
+) -> None:
     """Test no-op `async_post_backup`."""
     await setup_zha()
     await async_post_backup(hass)

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -1,8 +1,10 @@
 """Test ZHA binary sensor."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 
@@ -39,8 +41,8 @@ def binary_sensor_platform_only():
 async def test_binary_sensor(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA binary_sensor platform."""
     await setup_zha()

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -1,10 +1,12 @@
 """Test ZHA button."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 from freezegun import freeze_time
 import pytest
 from zigpy.const import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 import zigpy.zcl.foundation as zcl_f
@@ -44,7 +46,9 @@ def button_platform_only():
 
 
 @pytest.fixture
-async def setup_zha_integration(hass: HomeAssistant, setup_zha):
+async def setup_zha_integration(
+    hass: HomeAssistant, setup_zha: Callable[..., Coroutine[None]]
+):
     """Set up ZHA component."""
 
     # if we call this in the test itself the test hangs forever
@@ -56,7 +60,7 @@ async def test_button(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     setup_zha_integration,  # pylint: disable=unused-argument
-    zigpy_device_mock,
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA button platform."""
 

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -1,5 +1,6 @@
 """Test ZHA climate."""
 
+from collections.abc import Callable, Coroutine
 from typing import Literal
 from unittest.mock import patch
 
@@ -7,6 +8,7 @@ import pytest
 from zha.application.platforms.climate.const import HVAC_MODE_2_SYSTEM, SEQ_OF_OPERATION
 import zhaquirks.sinope.thermostat
 import zhaquirks.tuya.ts0601_trv
+from zigpy.device import Device
 import zigpy.profiles
 from zigpy.profiles import zha
 import zigpy.types
@@ -147,7 +149,11 @@ def climate_platform_only():
 
 
 @pytest.fixture
-def device_climate_mock(hass: HomeAssistant, setup_zha, zigpy_device_mock):
+def device_climate_mock(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+):
     """Test regular thermostat device."""
 
     async def _dev(clusters, plug=None, manuf=None, quirk=None):

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -1,8 +1,10 @@
 """Test ZHA cover."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import closures
 import zigpy.zcl.foundation as zcl_f
@@ -60,7 +62,11 @@ WCT = closures.WindowCovering.WindowCoveringType
 WCCS = closures.WindowCovering.ConfigStatus
 
 
-async def test_cover(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
+async def test_cover(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
     """Test ZHA cover platform."""
 
     await setup_zha()
@@ -327,7 +333,9 @@ async def test_cover(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
 
 
 async def test_cover_failures(
-    hass: HomeAssistant, setup_zha, zigpy_device_mock
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA cover platform failure cases."""
     await setup_zha()

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -1,9 +1,11 @@
 """The test for ZHA device automation actions."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
 from pytest_unordered import unordered
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general, security
 import zigpy.zcl.foundation as zcl_f
@@ -56,8 +58,8 @@ async def test_get_actions(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test we get the expected actions from a ZHA device."""
 
@@ -142,8 +144,8 @@ async def test_get_actions(
 async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test for executing a ZHA device action."""
     await setup_zha()
@@ -221,7 +223,9 @@ async def test_action(
 
 
 async def test_invalid_zha_event_type(
-    hass: HomeAssistant, setup_zha, zigpy_device_mock
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that unexpected types are not passed to `zha_send_event`."""
     await setup_zha()
@@ -261,7 +265,9 @@ async def test_invalid_zha_event_type(
 
 
 async def test_client_unique_id_suffix_stripped(
-    hass: HomeAssistant, setup_zha, zigpy_device_mock
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test that the `_CLIENT_` unique ID suffix is stripped."""
     assert await async_setup_component(

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -1,11 +1,13 @@
 """Test ZHA Device Tracker."""
 
+from collections.abc import Callable, Coroutine
 from datetime import timedelta
 import time
 from unittest.mock import patch
 
 import pytest
 from zha.application.registries import SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 
@@ -44,7 +46,9 @@ def device_tracker_platforms_only():
 
 
 async def test_device_tracker(
-    hass: HomeAssistant, setup_zha, zigpy_device_mock
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA device tracker platform."""
 

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -1,5 +1,6 @@
 """ZHA device automation trigger tests."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
@@ -59,7 +60,7 @@ def _same_lists(list_a, list_b):
 async def test_triggers(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    setup_zha,
+    setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test ZHA device triggers."""
 
@@ -145,7 +146,9 @@ async def test_triggers(
 
 
 async def test_no_triggers(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, setup_zha
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test ZHA device with no triggers."""
     await setup_zha()
@@ -185,7 +188,7 @@ async def test_if_fires_on_event(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
-    setup_zha,
+    setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test for remote triggers firing."""
 
@@ -261,7 +264,7 @@ async def test_device_offline_fires(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
-    setup_zha,
+    setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test for device offline triggers firing."""
 
@@ -317,7 +320,7 @@ async def test_exception_no_triggers(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     caplog: pytest.LogCaptureFixture,
-    setup_zha,
+    setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test for exception when validating device triggers."""
 
@@ -370,7 +373,7 @@ async def test_exception_bad_trigger(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     caplog: pytest.LogCaptureFixture,
-    setup_zha,
+    setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test for exception when validating device triggers."""
 
@@ -431,7 +434,7 @@ async def test_validate_trigger_config_missing_info(
     device_registry: dr.DeviceRegistry,
     config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
-    setup_zha,
+    setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test device triggers referring to a missing device."""
 
@@ -499,7 +502,7 @@ async def test_validate_trigger_config_unloaded_bad_info(
     config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
     zigpy_app_controller: ControllerApplication,
-    setup_zha,
+    setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test device triggers referring to a missing device."""
 

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -1,10 +1,12 @@
 """Tests for the diagnostics data provided by the ESPHome integration."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.types import EUI64, NWK
 from zigpy.zcl.clusters import security
@@ -42,8 +44,8 @@ async def test_diagnostics_for_config_entry(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     config_entry: MockConfigEntry,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics for config entry."""
@@ -90,8 +92,8 @@ async def test_diagnostics_for_device(
     hass_client: ClientSessionGenerator,
     device_registry: dr.DeviceRegistry,
     config_entry: MockConfigEntry,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics for device."""

--- a/tests/components/zha/test_entity.py
+++ b/tests/components/zha/test_entity.py
@@ -1,5 +1,8 @@
 """Test ZHA entities."""
 
+from collections.abc import Callable, Coroutine
+
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 
@@ -12,8 +15,8 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 async def test_device_registry_via_device(
     hass: HomeAssistant,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test ZHA `via_device` is set correctly."""

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -1,9 +1,11 @@
 """Test ZHA fan."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import call, patch
 
 import pytest
 from zha.application.platforms.fan.const import PRESET_MODE_ON
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general, hvac
 
@@ -58,7 +60,11 @@ def fan_platform_only():
         yield
 
 
-async def test_fan(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
+async def test_fan(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
     """Test ZHA fan platform."""
 
     await setup_zha()

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -1,6 +1,7 @@
 """Tests for ZHA integration init."""
 
 import asyncio
+from collections.abc import Callable
 import typing
 from unittest.mock import AsyncMock, Mock, patch
 import zoneinfo
@@ -8,6 +9,7 @@ import zoneinfo
 import pytest
 from zigpy.application import ControllerApplication
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
+from zigpy.device import Device
 from zigpy.exceptions import TransientConnectionError
 
 from homeassistant.components.zha.const import (
@@ -231,7 +233,7 @@ async def test_migration_baudrate_and_flow_control(
 async def test_zha_retry_unique_ids(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    zigpy_device_mock,
+    zigpy_device_mock: Callable[..., Device],
     mock_zigpy_connect: ControllerApplication,
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -1,9 +1,11 @@
 """Test ZHA light."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import AsyncMock, call, patch, sentinel
 
 import pytest
 from zha.application.platforms.light.const import FLASH_EFFECTS
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl import Cluster
 from zigpy.zcl.clusters import general, lighting
@@ -114,8 +116,8 @@ def light_platform_only():
 )
 async def test_light(
     hass: HomeAssistant,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
     device,
     reporting,
 ) -> None:
@@ -193,7 +195,9 @@ async def test_light(
     new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )
 async def test_on_with_off_color(
-    hass: HomeAssistant, setup_zha, zigpy_device_mock
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test turning on the light and sending color commands before on/level commands for supporting lights."""
 
@@ -576,8 +580,8 @@ async def async_test_flash_from_hass(
 )
 async def test_light_exception_on_creation(
     hass: HomeAssistant,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test ZHA light entity creation exception."""

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -1,8 +1,10 @@
 """Test ZHA lock."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl import Cluster
 from zigpy.zcl.clusters import closures, general
@@ -36,7 +38,11 @@ def lock_platform_only():
         yield
 
 
-async def test_lock(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
+async def test_lock(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
     """Test ZHA lock platform."""
 
     await setup_zha()

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -1,9 +1,11 @@
 """ZHA logbook describe events tests."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
 from zha.application.const import ZHA_EVENT
+from zigpy.device import Device
 import zigpy.profiles.zha
 from zigpy.zcl.clusters import general
 
@@ -46,7 +48,11 @@ def sensor_platform_only():
 
 
 @pytest.fixture
-async def mock_devices(hass: HomeAssistant, setup_zha, zigpy_device_mock):
+async def mock_devices(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+):
     """IAS device fixture."""
 
     await setup_zha()

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -1,8 +1,10 @@
 """Test ZHA analog output."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import call, patch
 
 import pytest
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 import zigpy.zcl.foundation as zcl_f
@@ -39,7 +41,11 @@ def number_platform_only():
         yield
 
 
-async def test_number(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
+async def test_number(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
     """Test ZHA number platform."""
 
     await setup_zha()

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -1,9 +1,11 @@
 """Test ZHA select entities."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
 from zigpy.const import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general, security
 
@@ -49,8 +51,8 @@ def select_select_only():
 async def test_select(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA select platform."""
 
@@ -127,8 +129,8 @@ async def test_select(
 async def test_select_restore_state(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
     restored_state: str,
     expected_state: str,
 ) -> None:

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -1,8 +1,10 @@
 """Test ZHA sensor."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl import Cluster
 from zigpy.zcl.clusters import general, homeautomation, hvac, measurement, smartenergy
@@ -519,8 +521,8 @@ async def async_test_pi_heating_demand(
 )
 async def test_sensor(
     hass: HomeAssistant,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
     cluster_id,
     entity_suffix,
     test_func,

--- a/tests/components/zha/test_silabs_multiprotocol.py
+++ b/tests/components/zha/test_silabs_multiprotocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING
 from unittest.mock import call, patch
 
@@ -25,7 +26,9 @@ def required_platform_only():
         yield
 
 
-async def test_async_get_channel_active(hass: HomeAssistant, setup_zha) -> None:
+async def test_async_get_channel_active(
+    hass: HomeAssistant, setup_zha: Callable[..., Coroutine[None]]
+) -> None:
     """Test reading channel with an active ZHA installation."""
     await setup_zha()
 
@@ -33,7 +36,9 @@ async def test_async_get_channel_active(hass: HomeAssistant, setup_zha) -> None:
 
 
 async def test_async_get_channel_missing(
-    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_app_controller: ControllerApplication,
 ) -> None:
     """Test reading channel with an inactive ZHA installation, no valid channel."""
     await setup_zha()
@@ -52,7 +57,9 @@ async def test_async_get_channel_no_zha(hass: HomeAssistant) -> None:
     assert await silabs_multiprotocol.async_get_channel(hass) is None
 
 
-async def test_async_using_multipan_active(hass: HomeAssistant, setup_zha) -> None:
+async def test_async_using_multipan_active(
+    hass: HomeAssistant, setup_zha: Callable[..., Coroutine[None]]
+) -> None:
     """Test async_using_multipan with an active ZHA installation."""
     await setup_zha()
 
@@ -65,7 +72,9 @@ async def test_async_using_multipan_no_zha(hass: HomeAssistant) -> None:
 
 
 async def test_change_channel(
-    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_app_controller: ControllerApplication,
 ) -> None:
     """Test changing the channel."""
     await setup_zha()
@@ -89,7 +98,7 @@ async def test_change_channel_no_zha(
 @pytest.mark.parametrize(("delay", "sleep"), [(0, 0), (5, 0), (15, 15 - 10.27)])
 async def test_change_channel_delay(
     hass: HomeAssistant,
-    setup_zha,
+    setup_zha: Callable[..., Coroutine[None]],
     zigpy_app_controller: ControllerApplication,
     delay: float,
     sleep: float,

--- a/tests/components/zha/test_siren.py
+++ b/tests/components/zha/test_siren.py
@@ -1,5 +1,6 @@
 """Test zha siren."""
 
+from collections.abc import Callable, Coroutine
 from datetime import timedelta
 from unittest.mock import ANY, call, patch
 
@@ -9,6 +10,7 @@ from zha.application.const import (
     WARNING_DEVICE_SOUND_MEDIUM,
 )
 from zigpy.const import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from zigpy.device import Device
 from zigpy.profiles import zha
 import zigpy.zcl
 from zigpy.zcl.clusters import general, security
@@ -51,7 +53,11 @@ def siren_platform_only():
         yield
 
 
-async def test_siren(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
+async def test_siren(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
     """Test zha siren platform."""
 
     await setup_zha()

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -1,8 +1,10 @@
 """Test ZHA switch."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import call, patch
 
 import pytest
+from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 import zigpy.zcl.foundation as zcl_f
@@ -40,7 +42,11 @@ def switch_platform_only():
         yield
 
 
-async def test_switch(hass: HomeAssistant, setup_zha, zigpy_device_mock) -> None:
+async def test_switch(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
     """Test ZHA switch platform."""
 
     await setup_zha()

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -1,11 +1,13 @@
 """Test ZHA firmware updates."""
 
+from collections.abc import Callable, Coroutine
 from unittest.mock import AsyncMock, PropertyMock, call, patch
 
 import pytest
 from zha.application.platforms.update import (
     FirmwareUpdateEntity as ZhaFirmwareUpdateEntity,
 )
+from zigpy.device import Device
 from zigpy.exceptions import DeliveryError
 from zigpy.ota import OtaImagesResult, OtaImageWithMetadata
 import zigpy.ota.image as firmware
@@ -73,7 +75,7 @@ def update_platform_only():
 
 async def setup_test_data(
     hass: HomeAssistant,
-    zigpy_device_mock,
+    zigpy_device_mock: Callable[..., Device],
     skip_attribute_plugs=False,
     file_not_found=False,
 ):
@@ -163,8 +165,8 @@ async def setup_test_data(
 
 async def test_firmware_update_notification_from_zigpy(
     hass: HomeAssistant,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA update platform - firmware update notification."""
     await setup_zha()
@@ -206,8 +208,8 @@ async def test_firmware_update_notification_from_zigpy(
 
 async def test_firmware_update_notification_from_service_call(
     hass: HomeAssistant,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA update platform - firmware update manual check."""
     await setup_zha()
@@ -294,8 +296,8 @@ def make_packet(zigpy_device, cluster, cmd_name: str, **kwargs):
 @patch("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0.01)
 async def test_firmware_update_success(
     hass: HomeAssistant,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA update platform - firmware update success."""
     await setup_zha()
@@ -491,8 +493,8 @@ async def test_firmware_update_success(
 
 async def test_firmware_update_raises(
     hass: HomeAssistant,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA update platform - firmware update raises."""
     await setup_zha()
@@ -587,8 +589,8 @@ async def test_firmware_update_raises(
 async def test_update_release_notes(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test ZHA update platform release notes."""
     await setup_zha()
@@ -647,8 +649,8 @@ async def test_update_release_notes(
 
 async def test_update_version_sync_device_registry(
     hass: HomeAssistant,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test firmware version syncing between the ZHA device and Home Assistant."""

--- a/tests/components/zha/test_websocket_api.py
+++ b/tests/components/zha/test_websocket_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from binascii import unhexlify
+from collections.abc import Callable, Coroutine
 from copy import deepcopy
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
@@ -23,7 +24,7 @@ from zha.application.const import (
     CLUSTER_TYPE_IN,
 )
 from zha.zigbee.cluster_handlers import ClusterBindEvent, ClusterConfigureReportingEvent
-from zha.zigbee.device import ClusterHandlerConfigurationComplete
+from zha.zigbee.device import ClusterHandlerConfigurationComplete, Device
 import zigpy.backups
 from zigpy.const import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 import zigpy.profiles.zha
@@ -97,8 +98,8 @@ def required_platform_only():
 async def zha_client(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    setup_zha,
-    zigpy_device_mock,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
 ) -> MockHAClientWebSocket:
     """Get ZHA WebSocket client."""
 
@@ -261,7 +262,9 @@ async def test_get_zha_config(zha_client) -> None:
 
 
 async def test_get_zha_config_with_alarm(
-    hass: HomeAssistant, zha_client, zigpy_device_mock
+    hass: HomeAssistant,
+    zha_client,
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test getting ZHA custom configuration."""
 
@@ -596,7 +599,9 @@ async def test_remove_group_member(hass: HomeAssistant, zha_client) -> None:
 
 @pytest.fixture
 async def app_controller(
-    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_app_controller: ControllerApplication,
 ) -> ControllerApplication:
     """Fixture for zigpy Application Controller."""
     await setup_zha()
@@ -1138,7 +1143,9 @@ async def test_websocket_bind_unbind_group(
 
 
 async def test_websocket_reconfigure(
-    hass: HomeAssistant, zha_client: MockHAClientWebSocket, zigpy_device_mock
+    hass: HomeAssistant,
+    zha_client: MockHAClientWebSocket,
+    zigpy_device_mock: Callable[..., Device],
 ) -> None:
     """Test websocket API to reconfigure a device."""
     gateway = get_zha_gateway(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Focus on `setup_zha` and `zigpy_device_mock` fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
