### PR TITLE
Bump aiounifi version to 87

### DIFF
--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["aiounifi"],
-  "requirements": ["aiounifi==86"],
+  "requirements": ["aiounifi==87"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -417,7 +417,7 @@ aiotedee==0.2.25
 aiotractive==0.6.0
 
 # homeassistant.components.unifi
-aiounifi==86
+aiounifi==87
 
 # homeassistant.components.usb
 aiousbwatcher==1.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -399,7 +399,7 @@ aiotedee==0.2.25
 aiotractive==0.6.0
 
 # homeassistant.components.unifi
-aiounifi==86
+aiounifi==87
 
 # homeassistant.components.usb
 aiousbwatcher==1.1.1

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1869,7 +1869,9 @@ async def test_port_control_switches(
     await hass.async_block_till_done()
     assert aioclient_mock.call_count == 1
     assert aioclient_mock.mock_calls[0][2] == {
-        "port_overrides": [{"enable": False, "port_idx": 1, "portconf_id": "1a1"}]
+        "port_overrides": [
+            {"port_idx": 1, "port_security_enabled": True, "portconf_id": "1a1"}
+        ]
     }
 
     # Turn on port
@@ -1890,12 +1892,12 @@ async def test_port_control_switches(
     assert aioclient_mock.call_count == 3
     assert aioclient_mock.mock_calls[1][2] == {
         "port_overrides": [
-            {"port_idx": 1, "enable": True, "portconf_id": "1a1"},
+            {"port_idx": 1, "port_security_enabled": False, "portconf_id": "1a1"},
         ]
     }
     assert aioclient_mock.mock_calls[2][2] == {
         "port_overrides": [
-            {"port_idx": 2, "enable": False, "portconf_id": "1a2"},
+            {"port_idx": 1, "port_security_enabled": True, "portconf_id": "1a2"},
         ]
     }
     # Device gets disabled

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1897,7 +1897,7 @@ async def test_port_control_switches(
     }
     assert aioclient_mock.mock_calls[2][2] == {
         "port_overrides": [
-            {"port_idx": 1, "port_security_enabled": True, "portconf_id": "1a2"},
+            {"port_idx": 2, "port_security_enabled": True, "portconf_id": "1a2"},
         ]
     }
     # Device gets disabled


### PR DESCRIPTION
## Breaking change
N/A - This is not a breaking change.



## Proposed change
Bump aiounifi dependency from version 84 to 86 for the UniFi Network integration to access latest library improvements



## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
This PR fixes or closes issue: fixes #151799 https://github.com/home-assistant/core/issues/151799
This PR is related to issue:
Link to documentation pull request:
Link to developer documentation pull request:
Link to frontend pull request:
aiounifi changelog: https://github.com/Kane610/aiounifi/releases/tag/v87

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

