### PR TITLE
Open a repair issue if Shelly Wall Display firmware is older than 2.3.0

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -59,6 +59,7 @@ from .coordinator import (
 from .repairs import (
     async_manage_ble_scanner_firmware_unsupported_issue,
     async_manage_outbound_websocket_incorrectly_enabled_issue,
+    async_manage_wall_display_firmware_unsupported_issue,
 )
 from .utils import (
     async_create_issue_unsupported_firmware,
@@ -328,6 +329,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ShellyConfigEntry) 
         await hass.config_entries.async_forward_entry_setups(
             entry, runtime_data.platforms
         )
+        async_manage_wall_display_firmware_unsupported_issue(hass, entry)
         async_manage_ble_scanner_firmware_unsupported_issue(
             hass,
             entry,

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -232,6 +232,7 @@ class BLEScannerMode(StrEnum):
 
 
 BLE_SCANNER_MIN_FIRMWARE = "1.5.1"
+WALL_DISPLAY_MIN_FIRMWARE = "2.3.0"
 
 MAX_PUSH_UPDATE_FAILURES = 5
 PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"
@@ -243,6 +244,9 @@ FIRMWARE_UNSUPPORTED_ISSUE_ID = "firmware_unsupported_{unique}"
 BLE_SCANNER_FIRMWARE_UNSUPPORTED_ISSUE_ID = "ble_scanner_firmware_unsupported_{unique}"
 OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID = (
     "outbound_websocket_incorrectly_enabled_{unique}"
+)
+WALL_DISPLAY_FIRMWARE_UNSUPPORTED_ISSUE_ID = (
+    "wall_display_firmware_unsupported_{unique}"
 )
 
 GAS_VALVE_OPEN_STATES = ("opening", "opened")

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -82,7 +82,7 @@ def async_manage_wall_display_firmware_unsupported_issue(
 
     device = entry.runtime_data.rpc.device
 
-    if device.model == MODEL_WALL_DISPLAY:
+    if entry.data["model"] == MODEL_WALL_DISPLAY:
         firmware = AwesomeVersion(device.shelly["ver"])
         if firmware < WALL_DISPLAY_MIN_FIRMWARE:
             ir.async_create_issue(

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from aioshelly.const import MODEL_OUT_PLUG_S_G3, MODEL_PLUG_S_G3
+from aioshelly.const import MODEL_OUT_PLUG_S_G3, MODEL_PLUG_S_G3, MODEL_WALL_DISPLAY
 from aioshelly.exceptions import DeviceConnectionError, RpcCallError
 from aioshelly.rpc_device import RpcDevice
 from awesomeversion import AwesomeVersion
@@ -21,6 +21,8 @@ from .const import (
     CONF_BLE_SCANNER_MODE,
     DOMAIN,
     OUTBOUND_WEBSOCKET_INCORRECTLY_ENABLED_ISSUE_ID,
+    WALL_DISPLAY_FIRMWARE_UNSUPPORTED_ISSUE_ID,
+    WALL_DISPLAY_MIN_FIRMWARE,
     BLEScannerMode,
 )
 from .coordinator import ShellyConfigEntry
@@ -55,6 +57,42 @@ def async_manage_ble_scanner_firmware_unsupported_issue(
                 is_persistent=True,
                 severity=ir.IssueSeverity.WARNING,
                 translation_key="ble_scanner_firmware_unsupported",
+                translation_placeholders={
+                    "device_name": device.name,
+                    "ip_address": device.ip_address,
+                    "firmware": firmware,
+                },
+                data={"entry_id": entry.entry_id},
+            )
+            return
+
+    ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
+@callback
+def async_manage_wall_display_firmware_unsupported_issue(
+    hass: HomeAssistant,
+    entry: ShellyConfigEntry,
+) -> None:
+    """Manage the Wall Display firmware unsupported issue."""
+    issue_id = WALL_DISPLAY_FIRMWARE_UNSUPPORTED_ISSUE_ID.format(unique=entry.unique_id)
+
+    if TYPE_CHECKING:
+        assert entry.runtime_data.rpc is not None
+
+    device = entry.runtime_data.rpc.device
+
+    if device.model == MODEL_WALL_DISPLAY:
+        firmware = AwesomeVersion(device.shelly["ver"])
+        if firmware < WALL_DISPLAY_MIN_FIRMWARE:
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                issue_id,
+                is_fixable=True,
+                is_persistent=True,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="wall_display_firmware_unsupported",
                 translation_placeholders={
                     "device_name": device.name,
                     "ip_address": device.ip_address,
@@ -142,8 +180,8 @@ class ShellyRpcRepairsFlow(RepairsFlow):
         raise NotImplementedError
 
 
-class BleScannerFirmwareUpdateFlow(ShellyRpcRepairsFlow):
-    """Handler for BLE Scanner Firmware Update flow."""
+class FirmwareUpdateFlow(ShellyRpcRepairsFlow):
+    """Handler for Firmware Update flow."""
 
     async def _async_step_confirm(self) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""
@@ -201,8 +239,11 @@ async def async_create_fix_flow(
 
     device = entry.runtime_data.rpc.device
 
-    if "ble_scanner_firmware_unsupported" in issue_id:
-        return BleScannerFirmwareUpdateFlow(device)
+    if (
+        "ble_scanner_firmware_unsupported" in issue_id
+        or "wall_display_firmware_unsupported" in issue_id
+    ):
+        return FirmwareUpdateFlow(device)
 
     if "outbound_websocket_incorrectly_enabled" in issue_id:
         return DisableOutboundWebSocketFlow(device)

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -288,6 +288,21 @@
           "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
         }
       }
+    },
+    "wall_display_firmware_unsupported": {
+      "title": "{device_name} is running outdated firmware",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "{device_name} is running outdated firmware",
+            "description": "Your Shelly device {device_name} with IP address {ip_address} is running firmware {firmware}. This firmware version will not be supported by Shelly integration starting from Home Assistant 2025.11.0.\n\nSelect **Submit** button to start the OTA update to the latest stable firmware version."
+          }
+        },
+        "abort": {
+          "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+          "update_not_available": "Device does not offer firmware update. Check internet connectivity (gateway, DNS, time) and restart the device."
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -300,7 +300,7 @@
         },
         "abort": {
           "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-          "update_not_available": "Device does not offer firmware update. Check internet connectivity (gateway, DNS, time) and restart the device."
+          "update_not_available": "[%key:component::shelly::issues::ble_scanner_firmware_unsupported::fix_flow::abort::update_not_available]"
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We want to remove the workaround for the Shelly Wall Display and dynamic components issue from aioshelly, so in HA 2025.11.0 we will bump the minimum firmware version for this device to 2.3.0. This PR introduces a repair issue to prepare users for this.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
