### PR TITLE
LLM prefix caching optimization using new GetDateTime tool

### DIFF
--- a/homeassistant/components/conversation/chat_log.py
+++ b/homeassistant/components/conversation/chat_log.py
@@ -572,7 +572,7 @@ class ChatLog:
         llm_api_ids = (
             (
                 [api.id for api in llm_api.api.llm_apis]
-                if hasattr(llm_api.api, "llm_apis")
+                if isinstance(llm_api.api, llm.MergedAPI)
                 else [llm_api.api.id]
             )
             if llm_api

--- a/homeassistant/components/conversation/chat_log.py
+++ b/homeassistant/components/conversation/chat_log.py
@@ -569,7 +569,17 @@ class ChatLog:
         if llm_api:
             prompt_parts.append(llm_api.api_prompt)
 
-        if not llm_api or llm_api.api.id != llm.LLM_API_ASSIST:
+        api_ids = (
+            (
+                [api.id for api in llm_api.api.llm_apis]
+                if hasattr(llm_api.api, "llm_apis")
+                else [llm_api.api.id]
+            )
+            if llm_api
+            else []
+        )
+
+        if llm.LLM_API_ASSIST not in api_ids:
             prompt_parts.append(
                 await self._async_expand_prompt_template(
                     llm_context,

--- a/homeassistant/components/conversation/chat_log.py
+++ b/homeassistant/components/conversation/chat_log.py
@@ -569,17 +569,9 @@ class ChatLog:
         if llm_api:
             prompt_parts.append(llm_api.api_prompt)
 
-        llm_api_ids = (
-            (
-                [api.id for api in llm_api.api.llm_apis]
-                if isinstance(llm_api.api, llm.MergedAPI)
-                else [llm_api.api.id]
-            )
-            if llm_api
-            else []
-        )
-
-        if llm.LLM_API_ASSIST not in llm_api_ids:
+        # Append current date and time to the prompt if the corresponding tool is not provided
+        llm_tools: list[llm.Tool] = llm_api.tools if llm_api else []
+        if not any(tool.name.endswith("GetDateTime") for tool in llm_tools):
             prompt_parts.append(
                 await self._async_expand_prompt_template(
                     llm_context,

--- a/homeassistant/components/conversation/chat_log.py
+++ b/homeassistant/components/conversation/chat_log.py
@@ -569,15 +569,6 @@ class ChatLog:
         if llm_api:
             prompt_parts.append(llm_api.api_prompt)
 
-        prompt_parts.append(
-            await self._async_expand_prompt_template(
-                llm_context,
-                llm.BASE_PROMPT,
-                llm_context.language,
-                user_name,
-            )
-        )
-
         if extra_system_prompt := (
             # Take new system prompt if one was given
             user_extra_system_prompt or self.extra_system_prompt

--- a/homeassistant/components/conversation/chat_log.py
+++ b/homeassistant/components/conversation/chat_log.py
@@ -575,7 +575,7 @@ class ChatLog:
             prompt_parts.append(
                 await self._async_expand_prompt_template(
                     llm_context,
-                    llm.BASE_PROMPT,
+                    llm.DATE_TIME_PROMPT,
                     llm_context.language,
                     user_name,
                 )

--- a/homeassistant/components/conversation/chat_log.py
+++ b/homeassistant/components/conversation/chat_log.py
@@ -569,7 +569,7 @@ class ChatLog:
         if llm_api:
             prompt_parts.append(llm_api.api_prompt)
 
-        api_ids = (
+        llm_api_ids = (
             (
                 [api.id for api in llm_api.api.llm_apis]
                 if hasattr(llm_api.api, "llm_apis")
@@ -579,7 +579,7 @@ class ChatLog:
             else []
         )
 
-        if llm.LLM_API_ASSIST not in api_ids:
+        if llm.LLM_API_ASSIST not in llm_api_ids:
             prompt_parts.append(
                 await self._async_expand_prompt_template(
                     llm_context,

--- a/homeassistant/components/conversation/chat_log.py
+++ b/homeassistant/components/conversation/chat_log.py
@@ -569,6 +569,16 @@ class ChatLog:
         if llm_api:
             prompt_parts.append(llm_api.api_prompt)
 
+        if not llm_api or llm_api.api.id != llm.LLM_API_ASSIST:
+            prompt_parts.append(
+                await self._async_expand_prompt_template(
+                    llm_context,
+                    llm.BASE_PROMPT,
+                    llm_context.language,
+                    user_name,
+                )
+            )
+
         if extra_system_prompt := (
             # Take new system prompt if one was given
             user_extra_system_prompt or self.extra_system_prompt

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -58,6 +58,11 @@ ACTION_PARAMETERS_CACHE: HassKey[
 
 LLM_API_ASSIST = "assist"
 
+BASE_PROMPT = (
+    'Current time is {{ now().strftime("%H:%M:%S") }}. '
+    'Today\'s date is {{ now().strftime("%Y-%m-%d") }}.\n'
+)
+
 DEFAULT_INSTRUCTIONS_PROMPT = """You are a voice assistant for Home Assistant.
 Answer questions about the world truthfully.
 Answer in plain text. Keep it simple and to the point.

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -58,11 +58,6 @@ ACTION_PARAMETERS_CACHE: HassKey[
 
 LLM_API_ASSIST = "assist"
 
-BASE_PROMPT = (
-    'Current time is {{ now().strftime("%H:%M:%S") }}. '
-    'Today\'s date is {{ now().strftime("%Y-%m-%d") }}.\n'
-)
-
 DEFAULT_INSTRUCTIONS_PROMPT = """You are a voice assistant for Home Assistant.
 Answer questions about the world truthfully.
 Answer in plain text. Keep it simple and to the point.

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -587,6 +587,8 @@ class AssistAPI(API):
             for intent_handler in intent_handlers
         ]
 
+        tools.append(GetDateTimeTool())
+
         if exposed_entities:
             if exposed_entities[CALENDAR_DOMAIN]:
                 names = []
@@ -1175,4 +1177,28 @@ class GetLiveContextTool(Tool):
         return {
             "success": True,
             "result": "\n".join(prompt),
+        }
+
+
+class GetDateTimeTool(Tool):
+    """Tool for getting the current date and time."""
+
+    name = "GetDateTime"
+    description = "Provides the current date and time."
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: ToolInput,
+        llm_context: LLMContext,
+    ) -> JsonObjectType:
+        """Get the current date and time."""
+        now = dt_util.now()
+
+        return {
+            "success": True,
+            "result": {
+                "date": now.strftime("%Y-%m-%d"),
+                "time": now.strftime("%H:%M:%S"),
+            },
         }

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -58,7 +58,7 @@ ACTION_PARAMETERS_CACHE: HassKey[
 
 LLM_API_ASSIST = "assist"
 
-BASE_PROMPT = (
+DATE_TIME_PROMPT = (
     'Current time is {{ now().strftime("%H:%M:%S") }}. '
     'Today\'s date is {{ now().strftime("%Y-%m-%d") }}.\n'
 )

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -1200,5 +1200,7 @@ class GetDateTimeTool(Tool):
             "result": {
                 "date": now.strftime("%Y-%m-%d"),
                 "time": now.strftime("%H:%M:%S"),
+                "timezone": now.strftime("%Z"),
+                "weekday": now.strftime("%A"),
             },
         }

--- a/tests/components/anthropic/snapshots/test_conversation.ambr
+++ b/tests/components/anthropic/snapshots/test_conversation.ambr
@@ -7,7 +7,6 @@
         Answer questions about the world truthfully.
         Answer in plain text. Keep it simple and to the point.
         Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
-        Current time is 16:00:00. Today's date is 2024-06-03.
       ''',
       'role': 'system',
     }),

--- a/tests/components/anthropic/snapshots/test_conversation.ambr
+++ b/tests/components/anthropic/snapshots/test_conversation.ambr
@@ -7,6 +7,7 @@
         Answer questions about the world truthfully.
         Answer in plain text. Keep it simple and to the point.
         Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
+        Current time is 16:00:00. Today's date is 2024-06-03.
       ''',
       'role': 'system',
     }),

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -454,7 +454,10 @@ async def test_function_call(
             agent_id=agent_id,
         )
 
-    assert "Today's date is 2024-06-03." in mock_create.mock_calls[1][2]["system"]
+    assert (
+        "You are a voice assistant for Home Assistant."
+        in mock_create.mock_calls[1][2]["system"]
+    )
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
     assert (

--- a/tests/components/conversation/test_chat_log.py
+++ b/tests/components/conversation/test_chat_log.py
@@ -156,6 +156,115 @@ async def test_multiple_llm_apis(
     assert chat_log.llm_api.api.id == "assist|my-api"
 
 
+async def test_dynamic_time_injection(
+    hass: HomeAssistant, mock_conversation_input: ConversationInput
+) -> None:
+    """Test that dynamic time injection works correctly."""
+
+    class MyTool(llm.Tool):
+        """Test tool."""
+
+        name = "test_tool"
+        description = "Test function"
+        parameters = vol.Schema(
+            {vol.Optional("param1", description="Test parameters"): str}
+        )
+
+    class MyAPI(llm.API):
+        """Test API."""
+
+        async def async_get_api_instance(
+            self, llm_context: llm.LLMContext
+        ) -> llm.APIInstance:
+            """Return a list of tools."""
+            return llm.APIInstance(self, "My API Prompt", llm_context, [MyTool()])
+
+    not_assist_1_api = MyAPI(hass=hass, id="not-assist-1", name="Not Assist 1")
+    llm.async_register_api(hass, not_assist_1_api)
+
+    not_assist_2_api = MyAPI(hass=hass, id="not-assist-2", name="Not Assist 2")
+    llm.async_register_api(hass, not_assist_2_api)
+
+    # Helper to track which prompts are rendered
+    rendered_prompts = []
+
+    async def fake_expand_prompt_template(
+        llm_context, prompt, language, user_name=None
+    ):
+        rendered_prompts.append(prompt)
+        return prompt
+
+    # Case 1: No API used -> prompt should contain the time
+    with (
+        chat_session.async_get_chat_session(hass) as session,
+        async_get_chat_log(hass, session, mock_conversation_input) as chat_log,
+    ):
+        chat_log._async_expand_prompt_template = fake_expand_prompt_template
+        rendered_prompts.clear()
+        await chat_log.async_provide_llm_data(
+            mock_conversation_input.as_llm_context("test"),
+            user_llm_hass_api=None,
+            user_llm_prompt=None,
+        )
+        assert llm.BASE_PROMPT in rendered_prompts
+
+    # Case 2: Single API (not assist) -> prompt should contain the time
+    with (
+        chat_session.async_get_chat_session(hass) as session,
+        async_get_chat_log(hass, session, mock_conversation_input) as chat_log,
+    ):
+        chat_log._async_expand_prompt_template = fake_expand_prompt_template
+        rendered_prompts.clear()
+        await chat_log.async_provide_llm_data(
+            mock_conversation_input.as_llm_context("test"),
+            user_llm_hass_api=["not-assist-1"],
+            user_llm_prompt=None,
+        )
+        assert llm.BASE_PROMPT in rendered_prompts
+
+    # Case 3: Single API (assist) -> prompt should NOT contain the time
+    with (
+        chat_session.async_get_chat_session(hass) as session,
+        async_get_chat_log(hass, session, mock_conversation_input) as chat_log,
+    ):
+        chat_log._async_expand_prompt_template = fake_expand_prompt_template
+        rendered_prompts.clear()
+        await chat_log.async_provide_llm_data(
+            mock_conversation_input.as_llm_context("test"),
+            user_llm_hass_api=[llm.LLM_API_ASSIST],
+            user_llm_prompt=None,
+        )
+        assert llm.BASE_PROMPT not in rendered_prompts
+
+    # Case 4: Merged API (without assist) -> prompt should contain the time
+    with (
+        chat_session.async_get_chat_session(hass) as session,
+        async_get_chat_log(hass, session, mock_conversation_input) as chat_log,
+    ):
+        chat_log._async_expand_prompt_template = fake_expand_prompt_template
+        rendered_prompts.clear()
+        await chat_log.async_provide_llm_data(
+            mock_conversation_input.as_llm_context("test"),
+            user_llm_hass_api=["not-assist-1", "not-assist-2"],
+            user_llm_prompt=None,
+        )
+        assert llm.BASE_PROMPT in rendered_prompts
+
+    # Case 5: Merged API (with assist) -> prompt should NOT contain the time
+    with (
+        chat_session.async_get_chat_session(hass) as session,
+        async_get_chat_log(hass, session, mock_conversation_input) as chat_log,
+    ):
+        chat_log._async_expand_prompt_template = fake_expand_prompt_template
+        rendered_prompts.clear()
+        await chat_log.async_provide_llm_data(
+            mock_conversation_input.as_llm_context("test"),
+            user_llm_hass_api=[llm.LLM_API_ASSIST, "not-assist-1"],
+            user_llm_prompt=None,
+        )
+        assert llm.BASE_PROMPT not in rendered_prompts
+
+
 async def test_template_error(
     hass: HomeAssistant,
     mock_conversation_input: ConversationInput,

--- a/tests/components/conversation/test_chat_log.py
+++ b/tests/components/conversation/test_chat_log.py
@@ -197,7 +197,7 @@ async def test_dynamic_time_injection(
             user_llm_hass_api=None,
             user_llm_prompt=None,
         )
-        assert llm.BASE_PROMPT in rendered_prompts
+        assert llm.DATE_TIME_PROMPT in rendered_prompts
 
     # Case 2: Single API (not assist) -> prompt should contain the time
     with (
@@ -211,7 +211,7 @@ async def test_dynamic_time_injection(
             user_llm_hass_api=["not-assist-1"],
             user_llm_prompt=None,
         )
-        assert llm.BASE_PROMPT in rendered_prompts
+        assert llm.DATE_TIME_PROMPT in rendered_prompts
 
     # Case 3: Single API (assist) -> prompt should NOT contain the time
     with (
@@ -225,7 +225,7 @@ async def test_dynamic_time_injection(
             user_llm_hass_api=[llm.LLM_API_ASSIST],
             user_llm_prompt=None,
         )
-        assert llm.BASE_PROMPT not in rendered_prompts
+        assert llm.DATE_TIME_PROMPT not in rendered_prompts
 
     # Case 4: Merged API (without assist) -> prompt should contain the time
     with (
@@ -239,7 +239,7 @@ async def test_dynamic_time_injection(
             user_llm_hass_api=["not-assist-1", "not-assist-2"],
             user_llm_prompt=None,
         )
-        assert llm.BASE_PROMPT in rendered_prompts
+        assert llm.DATE_TIME_PROMPT in rendered_prompts
 
     # Case 5: Merged API (with assist) -> prompt should NOT contain the time
     with (
@@ -253,7 +253,7 @@ async def test_dynamic_time_injection(
             user_llm_hass_api=[llm.LLM_API_ASSIST, "not-assist-1"],
             user_llm_prompt=None,
         )
-        assert llm.BASE_PROMPT not in rendered_prompts
+        assert llm.DATE_TIME_PROMPT not in rendered_prompts
 
 
 async def test_template_error(

--- a/tests/components/conversation/test_chat_log.py
+++ b/tests/components/conversation/test_chat_log.py
@@ -161,15 +161,6 @@ async def test_dynamic_time_injection(
 ) -> None:
     """Test that dynamic time injection works correctly."""
 
-    class MyTool(llm.Tool):
-        """Test tool."""
-
-        name = "test_tool"
-        description = "Test function"
-        parameters = vol.Schema(
-            {vol.Optional("param1", description="Test parameters"): str}
-        )
-
     class MyAPI(llm.API):
         """Test API."""
 
@@ -177,7 +168,7 @@ async def test_dynamic_time_injection(
             self, llm_context: llm.LLMContext
         ) -> llm.APIInstance:
             """Return a list of tools."""
-            return llm.APIInstance(self, "My API Prompt", llm_context, [MyTool()])
+            return llm.APIInstance(self, "My API Prompt", llm_context, [])
 
     not_assist_1_api = MyAPI(hass=hass, id="not-assist-1", name="Not Assist 1")
     llm.async_register_api(hass, not_assist_1_api)

--- a/tests/components/ollama/test_conversation.py
+++ b/tests/components/ollama/test_conversation.py
@@ -95,7 +95,10 @@ async def test_chat(
     ]
     # AGENT_DETAIL event contains the raw prompt passed to the model
     detail_event = trace_events[1]
-    assert "Current time is" in detail_event["data"]["messages"][0]["content"]
+    assert (
+        "You are a voice assistant for Home Assistant."
+        in detail_event["data"]["messages"][0]["content"]
+    )
 
 
 async def test_chat_stream(

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1492,11 +1492,15 @@ async def test_get_date_time_tool(hass: HomeAssistant) -> None:
             llm.ToolInput("GetDateTime", {}),
             llm_context,
         )
-        assert result["success"] is True
-        assert result["result"]["date"] == "2025-09-22"
-        assert result["result"]["time"] == "12:30:45"
-        assert result["result"]["timezone"] == "UTC"
-        assert result["result"]["weekday"] == "Monday"
+        assert result == {
+            "success": True,
+            "result": {
+                "date": "2025-09-22",
+                "time": "12:30:45",
+                "timezone": "UTC",
+                "weekday": "Monday",
+            },
+        }
 
 
 async def test_no_tools_exposed(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -183,19 +183,23 @@ async def test_assist_api(
 
     assert len(llm.async_get_apis(hass)) == 1
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert [tool.name for tool in api.tools] == ["GetLiveContext"]
+    assert [tool.name for tool in api.tools] == ["GetDateTime", "GetLiveContext"]
 
     # Match all
     intent_handler.platforms = None
 
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert [tool.name for tool in api.tools] == ["test_intent", "GetLiveContext"]
+    assert [tool.name for tool in api.tools] == [
+        "test_intent",
+        "GetDateTime",
+        "GetLiveContext",
+    ]
 
     # Match specific domain
     intent_handler.platforms = {"light"}
 
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert len(api.tools) == 2
+    assert len(api.tools) == 3
     tool = api.tools[0]
     assert tool.name == "test_intent"
     assert tool.description == "Execute Home Assistant test_intent intent"
@@ -374,6 +378,7 @@ async def test_assist_api_tools(
         "HassUnpauseTimer",
         "HassTimerStatus",
         "Super_crazy_intent_with_unique_name",
+        "GetDateTime",
     ]
 
 
@@ -390,7 +395,7 @@ async def test_assist_api_description(
 
     assert len(llm.async_get_apis(hass)) == 1
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert len(api.tools) == 1
+    assert len(api.tools) == 2
     tool = api.tools[0]
     assert tool.name == "test_intent"
     assert tool.description == "my intent handler"
@@ -1475,7 +1480,7 @@ async def test_no_tools_exposed(hass: HomeAssistant) -> None:
         device_id=None,
     )
     api = await llm.async_get_api(hass, "assist", llm_context)
-    assert api.tools == []
+    assert [tool.name for tool in api.tools] == ["GetDateTime"]
 
 
 async def test_merged_api(hass: HomeAssistant, llm_context: llm.LLMContext) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
~~LLM-based Assist configurations without local fallback or tool calling will no longer have access to the date and time (could be remedied if deemed necessary, but doing so would result in the loss of caching).~~

No longer breaking, the BASE_PROMPT is kept if the GetDateTime tool is not present.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up on https://github.com/home-assistant/core/issues/134847 and https://github.com/home-assistant/core/pull/141156.

While the original PR did improve the amount of prompt getting cached, neither the tool descriptions nor the chat messages get cached due to the date and time being inserted beforehand. In my case, the tool definitions represent almost 3 quarters of the system prompt.

This PR is a proposal to remove the date and time from the prompt entirely (aka removing the BASE_PROMPT) and to introduce a new tool, named `GetDateTime`, that the LLM can call to get the date/time when requested. 

### Pros 
- The entire prompt can be cached, considerably reducing latency and token usage for single command interactions. 
(500ms to 100ms in my non-statistically significant testing using Ollama and qwen3:4b-instruct on a RTX 3070 TI with only the default tools enabled)
- Long interactions can also be cached, latency remains constant throughout the conversation while it would grow otherwise.

### Cons
- Getting the time requires calling the tool (or local fallback if enabled)
	- Higher latency for requests requiring the time (somewhat mitigated by the caching)
- The prompt is slightly longer and potentially requires some tuning to make sure the LLM calls the tool. The model I'm using is not that smart so I had to add a sentence to explain it.

It is my first HA PR, I tried to follow the guidelines but it's very possible I missed something, tell me if so!


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
