### PR TITLE
Refactor template engine: Extract regex functions into RegexExtension

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -2286,46 +2286,6 @@ def _is_string_like(value: Any) -> bool:
     return isinstance(value, (str, bytes, bytearray))
 
 
-def regex_match(value, find="", ignorecase=False):
-    """Match value using regex."""
-    if not isinstance(value, str):
-        value = str(value)
-    flags = re.IGNORECASE if ignorecase else 0
-    return bool(_regex_cache(find, flags).match(value))
-
-
-_regex_cache = lru_cache(maxsize=128)(re.compile)
-
-
-def regex_replace(value="", find="", replace="", ignorecase=False):
-    """Replace using regex."""
-    if not isinstance(value, str):
-        value = str(value)
-    flags = re.IGNORECASE if ignorecase else 0
-    return _regex_cache(find, flags).sub(replace, value)
-
-
-def regex_search(value, find="", ignorecase=False):
-    """Search using regex."""
-    if not isinstance(value, str):
-        value = str(value)
-    flags = re.IGNORECASE if ignorecase else 0
-    return bool(_regex_cache(find, flags).search(value))
-
-
-def regex_findall_index(value, find="", index=0, ignorecase=False):
-    """Find all matches using regex and then pick specific match index."""
-    return regex_findall(value, find, ignorecase)[index]
-
-
-def regex_findall(value, find="", ignorecase=False):
-    """Find all matches using regex."""
-    if not isinstance(value, str):
-        value = str(value)
-    flags = re.IGNORECASE if ignorecase else 0
-    return _regex_cache(find, flags).findall(value)
-
-
 def struct_pack(value: Any | None, format_string: str) -> bytes | None:
     """Pack an object into a bytes object."""
     try:
@@ -2828,6 +2788,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.add_extension("homeassistant.helpers.template.extensions.Base64Extension")
         self.add_extension("homeassistant.helpers.template.extensions.CryptoExtension")
         self.add_extension("homeassistant.helpers.template.extensions.MathExtension")
+        self.add_extension("homeassistant.helpers.template.extensions.RegexExtension")
 
         self.globals["as_datetime"] = as_datetime
         self.globals["as_function"] = as_function
@@ -2884,11 +2845,6 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["ordinal"] = ordinal
         self.filters["pack"] = struct_pack
         self.filters["random"] = random_every_time
-        self.filters["regex_findall_index"] = regex_findall_index
-        self.filters["regex_findall"] = regex_findall
-        self.filters["regex_match"] = regex_match
-        self.filters["regex_replace"] = regex_replace
-        self.filters["regex_search"] = regex_search
         self.filters["round"] = forgiving_round
         self.filters["shuffle"] = shuffle
         self.filters["slugify"] = slugify
@@ -2907,8 +2863,6 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.tests["datetime"] = _is_datetime
         self.tests["is_number"] = is_number
         self.tests["list"] = _is_list
-        self.tests["match"] = regex_match
-        self.tests["search"] = regex_search
         self.tests["set"] = _is_set
         self.tests["string_like"] = _is_string_like
         self.tests["tuple"] = _is_tuple

--- a/homeassistant/helpers/template/extensions/__init__.py
+++ b/homeassistant/helpers/template/extensions/__init__.py
@@ -3,5 +3,6 @@
 from .base64 import Base64Extension
 from .crypto import CryptoExtension
 from .math import MathExtension
+from .regex import RegexExtension
 
-__all__ = ["Base64Extension", "CryptoExtension", "MathExtension"]
+__all__ = ["Base64Extension", "CryptoExtension", "MathExtension", "RegexExtension"]

--- a/homeassistant/helpers/template/extensions/regex.py
+++ b/homeassistant/helpers/template/extensions/regex.py
@@ -1,0 +1,109 @@
+"""Jinja2 extension for regular expression functions."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+import re
+from typing import TYPE_CHECKING, Any
+
+from .base import BaseTemplateExtension, TemplateFunction
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.template import TemplateEnvironment
+
+# Module-level regex cache shared across all instances
+_regex_cache = lru_cache(maxsize=128)(re.compile)
+
+
+class RegexExtension(BaseTemplateExtension):
+    """Jinja2 extension for regular expression functions."""
+
+    def __init__(self, environment: TemplateEnvironment) -> None:
+        """Initialize the regex extension."""
+
+        super().__init__(
+            environment,
+            functions=[
+                TemplateFunction(
+                    "regex_match",
+                    self.regex_match,
+                    as_filter=True,
+                ),
+                TemplateFunction(
+                    "regex_search",
+                    self.regex_search,
+                    as_filter=True,
+                ),
+                # Register tests with different names
+                TemplateFunction(
+                    "match",
+                    self.regex_match,
+                    as_test=True,
+                ),
+                TemplateFunction(
+                    "search",
+                    self.regex_search,
+                    as_test=True,
+                ),
+                TemplateFunction(
+                    "regex_replace",
+                    self.regex_replace,
+                    as_filter=True,
+                ),
+                TemplateFunction(
+                    "regex_findall",
+                    self.regex_findall,
+                    as_filter=True,
+                ),
+                TemplateFunction(
+                    "regex_findall_index",
+                    self.regex_findall_index,
+                    as_filter=True,
+                ),
+            ],
+        )
+
+    def regex_match(self, value: Any, find: str = "", ignorecase: bool = False) -> bool:
+        """Match value using regex."""
+        if not isinstance(value, str):
+            value = str(value)
+        flags = re.IGNORECASE if ignorecase else 0
+        return bool(_regex_cache(find, flags).match(value))
+
+    def regex_replace(
+        self,
+        value: Any = "",
+        find: str = "",
+        replace: str = "",
+        ignorecase: bool = False,
+    ) -> str:
+        """Replace using regex."""
+        if not isinstance(value, str):
+            value = str(value)
+        flags = re.IGNORECASE if ignorecase else 0
+        result = _regex_cache(find, flags).sub(replace, value)
+        return str(result)
+
+    def regex_search(
+        self, value: Any, find: str = "", ignorecase: bool = False
+    ) -> bool:
+        """Search using regex."""
+        if not isinstance(value, str):
+            value = str(value)
+        flags = re.IGNORECASE if ignorecase else 0
+        return bool(_regex_cache(find, flags).search(value))
+
+    def regex_findall_index(
+        self, value: Any, find: str = "", index: int = 0, ignorecase: bool = False
+    ) -> str:
+        """Find all matches using regex and then pick specific match index."""
+        return self.regex_findall(value, find, ignorecase)[index]
+
+    def regex_findall(
+        self, value: Any, find: str = "", ignorecase: bool = False
+    ) -> list[str]:
+        """Find all matches using regex."""
+        if not isinstance(value, str):
+            value = str(value)
+        flags = re.IGNORECASE if ignorecase else 0
+        return _regex_cache(find, flags).findall(value)

--- a/tests/helpers/template/extensions/test_regex.py
+++ b/tests/helpers/template/extensions/test_regex.py
@@ -1,0 +1,265 @@
+"""Test regex template extension."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import template
+
+
+def test_regex_match(hass: HomeAssistant) -> None:
+    """Test regex_match method."""
+    tpl = template.Template(
+        r"""
+{{ '123-456-7890' | regex_match('(\\d{3})-(\\d{3})-(\\d{4})') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+{{ 'Home Assistant test' | regex_match('home', True) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+    {{ 'Another Home Assistant test' | regex_match('Home') }}
+                    """,
+        hass,
+    )
+    assert tpl.async_render() is False
+
+    tpl = template.Template(
+        """
+{{ ['Home Assistant test'] | regex_match('.*Assist') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+
+def test_match_test(hass: HomeAssistant) -> None:
+    """Test match test."""
+    tpl = template.Template(
+        r"""
+{{ '123-456-7890' is match('(\\d{3})-(\\d{3})-(\\d{4})') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+
+def test_regex_search(hass: HomeAssistant) -> None:
+    """Test regex_search method."""
+    tpl = template.Template(
+        r"""
+{{ '123-456-7890' | regex_search('(\\d{3})-(\\d{3})-(\\d{4})') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+{{ 'Home Assistant test' | regex_search('home', True) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+    {{ 'Another Home Assistant test' | regex_search('Home') }}
+                    """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+{{ ['Home Assistant test'] | regex_search('Assist') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+
+def test_search_test(hass: HomeAssistant) -> None:
+    """Test search test."""
+    tpl = template.Template(
+        r"""
+{{ '123-456-7890' is search('(\\d{3})-(\\d{3})-(\\d{4})') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+
+def test_regex_replace(hass: HomeAssistant) -> None:
+    """Test regex_replace method."""
+    tpl = template.Template(
+        r"""
+{{ 'Hello World' | regex_replace('(Hello\\s)',) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == "World"
+
+    tpl = template.Template(
+        """
+{{ ['Home hinderant test'] | regex_replace('hinder', 'Assist') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == ["Home Assistant test"]
+
+
+def test_regex_findall(hass: HomeAssistant) -> None:
+    """Test regex_findall method."""
+    tpl = template.Template(
+        """
+{{ 'Flight from JFK to LHR' | regex_findall('([A-Z]{3})') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == ["JFK", "LHR"]
+
+
+def test_regex_findall_index(hass: HomeAssistant) -> None:
+    """Test regex_findall_index method."""
+    tpl = template.Template(
+        """
+{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 0) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == "JFK"
+
+    tpl = template.Template(
+        """
+{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 1) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == "LHR"
+
+
+def test_regex_ignorecase_parameter(hass: HomeAssistant) -> None:
+    """Test ignorecase parameter across all regex functions."""
+    # Test regex_match with ignorecase
+    tpl = template.Template(
+        """
+{{ 'TEST' | regex_match('test', True) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    # Test regex_search with ignorecase
+    tpl = template.Template(
+        """
+{{ 'TEST STRING' | regex_search('test', True) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    # Test regex_replace with ignorecase
+    tpl = template.Template(
+        """
+{{ 'TEST' | regex_replace('test', 'replaced', True) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == "replaced"
+
+    # Test regex_findall with ignorecase
+    tpl = template.Template(
+        """
+{{ 'TEST test Test' | regex_findall('test', True) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == ["TEST", "test", "Test"]
+
+
+def test_regex_with_non_string_input(hass: HomeAssistant) -> None:
+    """Test regex functions with non-string input (automatic conversion)."""
+    # Test with integer
+    tpl = template.Template(
+        """
+{{ 12345 | regex_match('\\d+') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    # Test with list (string conversion)
+    tpl = template.Template(
+        """
+{{ [1, 2, 3] | regex_search('\\d') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+
+def test_regex_edge_cases(hass: HomeAssistant) -> None:
+    """Test regex functions with edge cases."""
+    # Test with empty string
+    tpl = template.Template(
+        """
+{{ '' | regex_match('.*') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    # Test regex_findall_index with out of bounds index
+    tpl = template.Template(
+        """
+{{ 'test' | regex_findall_index('t', 5) }}
+            """,
+        hass,
+    )
+    with pytest.raises(TemplateError):
+        tpl.async_render()
+
+    # Test with invalid regex pattern
+    tpl = template.Template(
+        """
+{{ 'test' | regex_match('[') }}
+            """,
+        hass,
+    )
+    with pytest.raises(TemplateError):  # re.error wrapped in TemplateError
+        tpl.async_render()
+
+
+def test_regex_groups_and_replacement_patterns(hass: HomeAssistant) -> None:
+    """Test regex with groups and replacement patterns."""
+    # Test replacement with groups
+    tpl = template.Template(
+        r"""
+{{ 'John Doe' | regex_replace('(\\w+) (\\w+)', '\\2, \\1') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() == "Doe, John"
+
+    # Test findall with groups
+    tpl = template.Template(
+        r"""
+{{ 'Email: test@example.com, Phone: 123-456-7890' | regex_findall('(\\w+@\\w+\\.\\w+)|(\\d{3}-\\d{3}-\\d{4})') }}
+            """,
+        hass,
+    )
+    result = tpl.async_render()
+    # The result will contain tuples with empty strings for non-matching groups
+    assert len(result) == 2

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -2393,155 +2393,6 @@ def test_version(hass: HomeAssistant) -> None:
         ).async_render()
 
 
-def test_regex_match(hass: HomeAssistant) -> None:
-    """Test regex_match method."""
-    tpl = template.Template(
-        r"""
-{{ '123-456-7890' | regex_match('(\\d{3})-(\\d{3})-(\\d{4})') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
-        """
-{{ 'Home Assistant test' | regex_match('home', True) }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
-        """
-    {{ 'Another Home Assistant test' | regex_match('Home') }}
-                    """,
-        hass,
-    )
-    assert tpl.async_render() is False
-
-    tpl = template.Template(
-        """
-{{ ['Home Assistant test'] | regex_match('.*Assist') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-
-def test_match_test(hass: HomeAssistant) -> None:
-    """Test match test."""
-    tpl = template.Template(
-        r"""
-{{ '123-456-7890' is match('(\\d{3})-(\\d{3})-(\\d{4})') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-
-def test_regex_search(hass: HomeAssistant) -> None:
-    """Test regex_search method."""
-    tpl = template.Template(
-        r"""
-{{ '123-456-7890' | regex_search('(\\d{3})-(\\d{3})-(\\d{4})') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
-        """
-{{ 'Home Assistant test' | regex_search('home', True) }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
-        """
-    {{ 'Another Home Assistant test' | regex_search('Home') }}
-                    """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
-        """
-{{ ['Home Assistant test'] | regex_search('Assist') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-
-def test_search_test(hass: HomeAssistant) -> None:
-    """Test search test."""
-    tpl = template.Template(
-        r"""
-{{ '123-456-7890' is search('(\\d{3})-(\\d{3})-(\\d{4})') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-
-def test_regex_replace(hass: HomeAssistant) -> None:
-    """Test regex_replace method."""
-    tpl = template.Template(
-        r"""
-{{ 'Hello World' | regex_replace('(Hello\\s)',) }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() == "World"
-
-    tpl = template.Template(
-        """
-{{ ['Home hinderant test'] | regex_replace('hinder', 'Assist') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() == ["Home Assistant test"]
-
-
-def test_regex_findall(hass: HomeAssistant) -> None:
-    """Test regex_findall method."""
-    tpl = template.Template(
-        """
-{{ 'Flight from JFK to LHR' | regex_findall('([A-Z]{3})') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() == ["JFK", "LHR"]
-
-
-def test_regex_findall_index(hass: HomeAssistant) -> None:
-    """Test regex_findall_index method."""
-    tpl = template.Template(
-        """
-{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 0) }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() == "JFK"
-
-    tpl = template.Template(
-        """
-{{ 'Flight from JFK to LHR' | regex_findall_index('([A-Z]{3})', 1) }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() == "LHR"
-
-    tpl = template.Template(
-        """
-{{ ['JFK', 'LHR'] | regex_findall_index('([A-Z]{3})', 1) }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() == "LHR"
-
-
 def test_pack(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     """Test struct pack method."""
 
@@ -4070,7 +3921,7 @@ async def test_async_render_to_info_with_wildcard_matching_entity_id(
     template_complex_str = r"""
 
 {% for state in states.cover %}
-  {% if state.entity_id | regex_match('.*\\.office_') %}
+  {% if 'office_' in state.entity_id %}
     {{ state.entity_id }}={{ state.state }}
   {% endif %}
 {% endfor %}
@@ -4094,7 +3945,7 @@ async def test_async_render_to_info_with_wildcard_matching_state(
     template_complex_str = """
 
 {% for state in states %}
-  {% if state.state | regex_match('ope.*') %}
+  {% if state.state.startswith('ope') %}
     {{ state.entity_id }}={{ state.state }}
   {% endif %}
 {% endfor %}
@@ -4125,7 +3976,7 @@ async def test_async_render_to_info_with_wildcard_matching_state(
     template_cover_str = """
 
 {% for state in states.cover %}
-  {% if state.state | regex_match('ope.*') %}
+  {% if state.state.startswith('ope') %}
     {{ state.entity_id }}={{ state.state }}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Part 3 in an on-going effort in refactor our template engine with the goal of getting rid of the huge monolith it is.

For this part, I've extracted all regex functions and tests into an Jinja2 Regex extension.
Tests have moved as well. Backwards compatibility has been fully retained.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
