### PR TITLE
Add send_text_command service to Tuya

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -15,8 +15,9 @@ from tuya_sharing import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_APP_TYPE,
@@ -31,6 +32,9 @@ from .const import (
     TUYA_DISCOVERY_NEW,
     TUYA_HA_SIGNAL_UPDATE_ENTITY,
 )
+from .services import async_setup_services
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 # Suppress logs from the library, it logs unneeded on error
 logging.getLogger("tuya_sharing").setLevel(logging.CRITICAL)
@@ -43,6 +47,12 @@ class HomeAssistantTuyaData(NamedTuple):
 
     manager: Manager
     listener: SharingDeviceListener
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Tuya component."""
+    async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: TuyaConfigEntry) -> bool:

--- a/homeassistant/components/tuya/icons.json
+++ b/homeassistant/components/tuya/icons.json
@@ -381,5 +381,10 @@
         "default": "mdi:alarm-light"
       }
     }
+  },
+  "services": {
+    "send_text_command": {
+      "service": "mdi:pencil"
+    }
   }
 }

--- a/homeassistant/components/tuya/services.py
+++ b/homeassistant/components/tuya/services.py
@@ -1,4 +1,4 @@
-"""Support for the Abode Security System."""
+"""Support for Tuya services."""
 
 from __future__ import annotations
 

--- a/homeassistant/components/tuya/services.py
+++ b/homeassistant/components/tuya/services.py
@@ -77,7 +77,14 @@ async def _async_send_device_command(call: ServiceCall) -> None:
             for key in manager.device_map
             if (DOMAIN, key) in device_entry.identifiers
         ),
+        None,
     )
+    if tuya_device_id is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="tuya_device_not_found",
+            translation_placeholders={"device_id": device_entry.id},
+        )
     commands = [
         {
             "code": call.data[ATTR_CODE],

--- a/homeassistant/components/tuya/services.py
+++ b/homeassistant/components/tuya/services.py
@@ -1,0 +1,105 @@
+"""Support for the Abode Security System."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_DEVICE_ID
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv, device_registry as dr
+
+from .const import DOMAIN, LOGGER
+
+if TYPE_CHECKING:
+    from . import TuyaConfigEntry
+
+SEND_TEXT_COMMAND = "send_text_command"
+
+ATTR_CODE = "code"
+ATTR_VALUE = "value"
+
+
+SEND_TEXT_COMMAND_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+        vol.Required(ATTR_CODE): cv.string,
+        vol.Required(ATTR_VALUE): cv.string,
+    }
+)
+
+
+@callback
+def _async_get_device(
+    call: ServiceCall,
+) -> tuple[dr.DeviceEntry, TuyaConfigEntry]:
+    """Get the registry device and config entry related to a service call."""
+    device_registry = dr.async_get(call.hass)
+    device_id = call.data[ATTR_DEVICE_ID]
+    if (device_entry := device_registry.async_get(device_id)) is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_device_id",
+            translation_placeholders={"device_id": device_id},
+        )
+
+    entry: TuyaConfigEntry | None
+    for entry_id in device_entry.config_entries:
+        if (entry := call.hass.config_entries.async_get_entry(entry_id)) is None:
+            continue
+        if entry.domain == DOMAIN:
+            if entry.state is not ConfigEntryState.LOADED:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="entry_not_loaded",
+                    translation_placeholders={"entry": entry.title},
+                )
+
+            return device_entry, entry
+
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="config_entry_not_found",
+        translation_placeholders={"device_id": device_id},
+    )
+
+
+async def _async_send_device_command(call: ServiceCall) -> None:
+    """Send Tuya device command."""
+    device_entry, config_entry = _async_get_device(call)
+    manager = config_entry.runtime_data.manager
+    tuya_device_id = next(
+        (
+            key
+            for key in manager.device_map
+            if (DOMAIN, key) in device_entry.identifiers
+        ),
+    )
+    commands = [
+        {
+            "code": call.data[ATTR_CODE],
+            "value": call.data[ATTR_VALUE],
+        }
+    ]
+
+    LOGGER.debug("Sending commands for device %s: %s", tuya_device_id, commands)
+    await call.hass.async_add_executor_job(
+        config_entry.runtime_data.manager.send_commands,
+        tuya_device_id,
+        commands,
+    )
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Home Assistant services."""
+
+    hass.services.async_register(
+        DOMAIN,
+        SEND_TEXT_COMMAND,
+        _async_send_device_command,
+        schema=SEND_TEXT_COMMAND_SCHEMA,
+    )

--- a/homeassistant/components/tuya/services.yaml
+++ b/homeassistant/components/tuya/services.yaml
@@ -1,0 +1,17 @@
+send_text_command:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: tuya
+    code:
+      required: true
+      example: "up_down"
+      selector:
+        text:
+    value:
+      required: true
+      example: "up"
+      selector:
+        text:

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -1002,5 +1002,25 @@
     "action_dpcode_not_found": {
       "message": "Unable to process action as the device does not provide a corresponding function code (expected one of {expected} in {available})."
     }
+  },
+  "services": {
+    "send_text_command": {
+      "name": "Send text command",
+      "description": "Send a text command to a device.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The ID of the device to send the command to."
+        },
+        "code": {
+          "name": "Code",
+          "description": "The name of the data point."
+        },
+        "value": {
+          "name": "Value",
+          "description": "The new value of the data point."
+        }
+      }
+    }
   }
 }

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -18,7 +18,7 @@ async def test_device_registry(
     hass: HomeAssistant,
     mock_manager: Manager,
     mock_config_entry: MockConfigEntry,
-    mock_devices: CustomerDevice,
+    mock_devices: list[CustomerDevice],
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,

--- a/tests/components/tuya/test_services.py
+++ b/tests/components/tuya/test_services.py
@@ -1,0 +1,63 @@
+"""Test Tuya initialization."""
+
+from __future__ import annotations
+
+import pytest
+from tuya_sharing import CustomerDevice, Manager
+
+from homeassistant.components.tuya.const import DOMAIN
+from homeassistant.components.tuya.services import SEND_TEXT_COMMAND
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import initialize_entry
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_services(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup of Tuya services."""
+
+    await initialize_entry(hass, mock_manager, mock_config_entry, [])
+
+    assert (services := hass.services.async_services_for_domain(DOMAIN))
+    assert SEND_TEXT_COMMAND in services
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["sjz_ftbc8rp8ipksdfpv"],
+)
+async def test_send_device_command(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Validate send_device_command."""
+
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "vpfdskpi8pr8cbtfzjs")}
+    )
+    assert device_entry is not None
+
+    await hass.services.async_call(
+        DOMAIN,
+        SEND_TEXT_COMMAND,
+        {
+            "device_id": device_entry.id,
+            "code": "up_down",
+            "value": "up",
+        },
+        blocking=True,
+    )
+    mock_manager.send_commands.assert_called_once_with(
+        "vpfdskpi8pr8cbtfzjs", [{"code": "up_down", "value": "up"}]
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add send_text_command service to Tuya

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40890
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
