### PR TITLE
Fix KNX UI schema missing DPT

### DIFF
--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -118,27 +118,31 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
     vol.Schema(
         {
             "section_binary_control": KNXSectionFlat(),
-            vol.Optional(CONF_GA_UP_DOWN): GASelector(state=False),
+            vol.Optional(CONF_GA_UP_DOWN): GASelector(state=False, valid_dpt="1"),
             vol.Optional(CoverConf.INVERT_UPDOWN): selector.BooleanSelector(),
             "section_stop_control": KNXSectionFlat(),
-            vol.Optional(CONF_GA_STOP): GASelector(state=False),
-            vol.Optional(CONF_GA_STEP): GASelector(state=False),
+            vol.Optional(CONF_GA_STOP): GASelector(state=False, valid_dpt="1"),
+            vol.Optional(CONF_GA_STEP): GASelector(state=False, valid_dpt="1"),
             "section_position_control": KNXSectionFlat(collapsible=True),
-            vol.Optional(CONF_GA_POSITION_SET): GASelector(state=False),
-            vol.Optional(CONF_GA_POSITION_STATE): GASelector(write=False),
+            vol.Optional(CONF_GA_POSITION_SET): GASelector(
+                state=False, valid_dpt="5.001"
+            ),
+            vol.Optional(CONF_GA_POSITION_STATE): GASelector(
+                write=False, valid_dpt="5.001"
+            ),
             vol.Optional(CoverConf.INVERT_POSITION): selector.BooleanSelector(),
             "section_tilt_control": KNXSectionFlat(collapsible=True),
-            vol.Optional(CONF_GA_ANGLE): GASelector(),
+            vol.Optional(CONF_GA_ANGLE): GASelector(valid_dpt="5.001"),
             vol.Optional(CoverConf.INVERT_ANGLE): selector.BooleanSelector(),
             "section_travel_time": KNXSectionFlat(),
-            vol.Optional(
+            vol.Required(
                 CoverConf.TRAVELLING_TIME_UP, default=25
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=0, max=1000, step=0.1, unit_of_measurement="s"
                 )
             ),
-            vol.Optional(
+            vol.Required(
                 CoverConf.TRAVELLING_TIME_DOWN, default=25
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
@@ -310,7 +314,7 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
 SWITCH_KNX_SCHEMA = vol.Schema(
     {
         "section_switch": KNXSectionFlat(),
-        vol.Required(CONF_GA_SWITCH): GASelector(write_required=True),
+        vol.Required(CONF_GA_SWITCH): GASelector(write_required=True, valid_dpt="1"),
         vol.Optional(CONF_INVERT, default=False): selector.BooleanSelector(),
         vol.Optional(CONF_RESPOND_TO_READ, default=False): selector.BooleanSelector(),
         vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -111,6 +111,12 @@
         'options': dict({
           'passive': True,
           'state': False,
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -140,6 +146,12 @@
         'options': dict({
           'passive': True,
           'state': False,
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -153,6 +165,12 @@
         'options': dict({
           'passive': True,
           'state': False,
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -172,6 +190,12 @@
         'options': dict({
           'passive': True,
           'state': False,
+          'validDPTs': list([
+            dict({
+              'main': 5,
+              'sub': 1,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -187,6 +211,12 @@
           'state': dict({
             'required': False,
           }),
+          'validDPTs': list([
+            dict({
+              'main': 5,
+              'sub': 1,
+            }),
+          ]),
           'write': False,
         }),
         'required': False,
@@ -216,6 +246,12 @@
           'state': dict({
             'required': False,
           }),
+          'validDPTs': list([
+            dict({
+              'main': 5,
+              'sub': 1,
+            }),
+          ]),
           'write': dict({
             'required': False,
           }),
@@ -242,8 +278,7 @@
       dict({
         'default': 25,
         'name': 'travelling_time_up',
-        'optional': True,
-        'required': False,
+        'required': True,
         'selector': dict({
           'number': dict({
             'max': 1000.0,
@@ -258,8 +293,7 @@
       dict({
         'default': 25,
         'name': 'travelling_time_down',
-        'optional': True,
-        'required': False,
+        'required': True,
         'selector': dict({
           'number': dict({
             'max': 1000.0,
@@ -746,6 +780,12 @@
           'state': dict({
             'required': False,
           }),
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
           'write': dict({
             'required': True,
           }),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Without specified DPT, the UI don't suggest valid group addresses.
- `Optional` selectors with default values show as optional in UI while disabling doesn't do anything - as the default value is used - so that's confusing for users and it should just be `Required` (cover travel time)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/XKNX/knx-integration/issues/33
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
